### PR TITLE
Fix frontend installation and docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -39,3 +39,8 @@
 /testbench.yaml export-ignore
 /tsconfig.json export-ignore
 /vite.config.ts export-ignore
+
+# Keep frontend tests out of the Composer distribution
+/resources/js/test/** export-ignore
+*.test.ts export-ignore
+*.test.tsx export-ignore

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 </p>
 
 <p align="center">
-  <a href="https://packagist.org/packages/bambamboole/lattice"><img alt="Latest version on Packagist" src="https://img.shields.io/packagist/v/bambamboole/lattice.svg?style=flat-square"></a>
+  <a href="https://packagist.org/packages/lattice/lattice"><img alt="Latest version on Packagist" src="https://img.shields.io/packagist/v/lattice/lattice.svg?style=flat-square"></a>
   <a href="https://github.com/lattice-php/lattice/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/lattice-php/lattice/ci.yml?branch=main&label=CI&style=flat-square"></a>
-  <a href="https://packagist.org/packages/bambamboole/lattice"><img alt="Total downloads" src="https://img.shields.io/packagist/dt/bambamboole/lattice.svg?style=flat-square"></a>
-  <a href="https://packagist.org/packages/bambamboole/lattice"><img alt="License" src="https://img.shields.io/packagist/l/bambamboole/lattice.svg?style=flat-square"></a>
+  <a href="https://packagist.org/packages/lattice/lattice"><img alt="Total downloads" src="https://img.shields.io/packagist/dt/lattice/lattice.svg?style=flat-square"></a>
+  <a href="https://packagist.org/packages/lattice/lattice"><img alt="License" src="https://img.shields.io/packagist/l/lattice/lattice.svg?style=flat-square"></a>
 </p>
 
 <p align="center">

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
-    "name": "bambamboole/lattice",
+    "name": "lattice/lattice",
     "description": "Server-driven React components for Laravel and Inertia.",
     "type": "library",
     "license": "MIT",

--- a/docs/content/docs/getting-started/frontend-setup.md
+++ b/docs/content/docs/getting-started/frontend-setup.md
@@ -3,21 +3,95 @@ title: Frontend Setup
 description: Wire the Lattice React renderer into your Inertia entrypoint.
 ---
 
-Lattice serializes pages to typed component trees on the server. The browser needs the Lattice React renderer to turn those trees into rendered UI. This page wires it into your Inertia application once.
+Lattice serializes pages to typed component trees on the server. The browser needs the Lattice React renderer to turn those trees into rendered UI. The renderer ships as TypeScript source inside the Composer package (`vendor/bambamboole/lattice/resources/js`), and your own Vite build compiles it. This page wires it in once.
+
+There are four steps: install the JavaScript dependencies, alias the package, import the stylesheet, and register the page component.
 
 ## Install JavaScript dependencies
 
-Lattice's renderer is built on Inertia's React adapter and React 19:
+Because Vite compiles the renderer source directly, its libraries must be present in your app's `node_modules`. Install them alongside Inertia's React adapter:
 
 ```bash
-npm install @inertiajs/react react react-dom
+npm install @inertiajs/react react react-dom \
+  lucide-react class-variance-authority clsx tailwind-merge \
+  @radix-ui/react-checkbox @radix-ui/react-label @radix-ui/react-slot \
+  @tiptap/react @tiptap/pm @tiptap/starter-kit \
+  @tiptap/extension-details @tiptap/extension-highlight @tiptap/extension-link \
+  @tiptap/extension-table @tiptap/extension-text-align
 ```
+
+Styling is driven by Tailwind CSS v4:
+
+```bash
+npm install -D tailwindcss @tailwindcss/vite tw-animate-css
+```
+
+:::note
+Lattice targets React 19, Inertia v3, Tailwind 4, and Tiptap 3. If you already started from an Inertia React kit you will have some of these — `npm install` is safe to re-run. The package's `package.json` is the source of truth for the exact versions Lattice is built against.
+:::
+
+## Alias the package
+
+Point `@bambamboole/lattice` at the renderer source in your Vite config. Keep your existing plugins; only the `resolve.alias` block is new:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import laravel from "laravel-vite-plugin";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [
+    laravel({ input: ["resources/css/app.css", "resources/js/app.tsx"], refresh: true }),
+    react(),
+    tailwindcss(),
+  ],
+  resolve: {
+    alias: {
+      "@bambamboole/lattice": path.resolve(
+        __dirname,
+        "vendor/bambamboole/lattice/resources/js",
+      ),
+    },
+  },
+});
+```
+
+Mirror the alias in `tsconfig.json` so your editor and `tsc` resolve the same imports:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@bambamboole/lattice": ["./vendor/bambamboole/lattice/resources/js/index.ts"],
+      "@bambamboole/lattice/*": ["./vendor/bambamboole/lattice/resources/js/*"]
+    }
+  }
+}
+```
+
+## Import the stylesheet
+
+Import Lattice's stylesheet from your main CSS entry, after Tailwind. It defines the theme tokens the components use and registers their source files with Tailwind automatically, so no extra `@source` line is needed:
+
+```css
+/* resources/css/app.css */
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "../../vendor/bambamboole/lattice/resources/css/lattice.css";
+```
+
+The component tokens (`--lt-*`) fall back to sensible defaults, so the UI is styled out of the box. They also read from shadcn-style variables (`--background`, `--primary`, …) when you define them, which lets Lattice inherit an existing theme.
 
 ## Register the renderer
 
 Every Lattice route resolves to the same Inertia page component, `lattice/page`, which the package provides. In your Inertia entrypoint, resolve that name to Lattice's page component and fall back to your own pages for anything else:
 
 ```tsx
+// resources/js/app.tsx
+import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
 import { createRoot } from "react-dom/client";
 import LatticePage from "@bambamboole/lattice/page";
@@ -52,5 +126,6 @@ import { Provider, Renderer, registry, createRegistry, extendRegistry } from "@b
 Wrap your tree in `Provider` with a custom registry to register your own component types, or use `extendRegistry` to add to the defaults. Building custom components is covered in the Advanced section.
 
 :::note
-The package's React source lives in the repository's `resources/js` directory, and the Testbench `workbench/resources/js/app.tsx` is the canonical, working reference for the wiring shown above.
+The Testbench app at `workbench/resources/js/app.tsx` and `workbench/resources/css/app.css` in the [repository](https://github.com/lattice-php/lattice) is the canonical, working reference for the wiring shown here. It imports the renderer through a repo-local alias rather than `vendor/`, but the setup is otherwise identical.
 :::
+</content>

--- a/docs/content/docs/getting-started/frontend-setup.md
+++ b/docs/content/docs/getting-started/frontend-setup.md
@@ -3,7 +3,7 @@ title: Frontend Setup
 description: Wire the Lattice React renderer into your Inertia entrypoint.
 ---
 
-Lattice serializes pages to typed component trees on the server. The browser needs the Lattice React renderer to turn those trees into rendered UI. The renderer ships as TypeScript source inside the Composer package (`vendor/bambamboole/lattice/resources/js`), and your own Vite build compiles it. This page wires it in once.
+Lattice serializes pages to typed component trees on the server. The browser needs the Lattice React renderer to turn those trees into rendered UI. The renderer ships as TypeScript source inside the Composer package (`vendor/lattice/lattice/resources/js`), and your own Vite build compiles it. This page wires it in once.
 
 There are four steps: install the JavaScript dependencies, alias the package, import the stylesheet, and register the page component.
 
@@ -32,7 +32,7 @@ Lattice targets React 19, Inertia v3, Tailwind 4, and Tiptap 3. If you already s
 
 ## Alias the package
 
-Point `@bambamboole/lattice` at the renderer source in your Vite config. Keep your existing plugins; only the `resolve.alias` block is new:
+Point `@lattice/lattice` at the renderer source in your Vite config. Keep your existing plugins; only the `resolve.alias` block is new:
 
 ```ts
 // vite.config.ts
@@ -50,9 +50,9 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@bambamboole/lattice": path.resolve(
+      "@lattice/lattice": path.resolve(
         __dirname,
-        "vendor/bambamboole/lattice/resources/js",
+        "vendor/lattice/lattice/resources/js",
       ),
     },
   },
@@ -65,8 +65,8 @@ Mirror the alias in `tsconfig.json` so your editor and `tsc` resolve the same im
 {
   "compilerOptions": {
     "paths": {
-      "@bambamboole/lattice": ["./vendor/bambamboole/lattice/resources/js/index.ts"],
-      "@bambamboole/lattice/*": ["./vendor/bambamboole/lattice/resources/js/*"]
+      "@lattice/lattice": ["./vendor/lattice/lattice/resources/js/index.ts"],
+      "@lattice/lattice/*": ["./vendor/lattice/lattice/resources/js/*"]
     }
   }
 }
@@ -80,7 +80,7 @@ Import Lattice's stylesheet from your main CSS entry, after Tailwind. It defines
 /* resources/css/app.css */
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "../../vendor/bambamboole/lattice/resources/css/lattice.css";
+@import "../../vendor/lattice/lattice/resources/css/lattice.css";
 ```
 
 The component tokens (`--lt-*`) fall back to sensible defaults, so the UI is styled out of the box. They also read from shadcn-style variables (`--background`, `--primary`, …) when you define them, which lets Lattice inherit an existing theme.
@@ -94,7 +94,7 @@ Every Lattice route resolves to the same Inertia page component, `lattice/page`,
 import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
 import { createRoot } from "react-dom/client";
-import LatticePage from "@bambamboole/lattice/page";
+import LatticePage from "@lattice/lattice/page";
 
 createInertiaApp({
   resolve: (name) => {
@@ -120,7 +120,7 @@ That single `resolve` branch is all an application needs for every page Lattice 
 The renderer resolves component types from a registry. Lattice exports the pieces you need to extend or replace it:
 
 ```ts
-import { Provider, Renderer, registry, createRegistry, extendRegistry } from "@bambamboole/lattice";
+import { Provider, Renderer, registry, createRegistry, extendRegistry } from "@lattice/lattice";
 ```
 
 Wrap your tree in `Provider` with a custom registry to register your own component types, or use `extendRegistry` to add to the defaults. Building custom components is covered in the Advanced section.

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -9,10 +9,20 @@ Lattice is a Composer package that adds a server-driven UI layer to a Laravel ap
 
 | Requirement | Version |
 | --- | --- |
-| PHP | 8.3+ |
+| PHP | 8.4+ |
 | Laravel | 11, 12, or 13 |
 | Inertia (Laravel + React) | v3 |
 | React | 19 |
+| Tailwind CSS | 4 |
+
+## How Lattice is delivered
+
+Lattice ships as a single Composer package that contains both halves of the framework:
+
+- The **PHP layer** that describes pages, forms, tables, actions, and menus and serializes them to typed component trees.
+- The **React renderer** (TypeScript source under `resources/js`) that turns those trees into rendered UI in the browser.
+
+There is no separate npm package. Because both halves arrive from one `composer require`, the renderer always matches the server that serialized the page — the two can never drift apart. You point your existing Vite build at the renderer source with a single alias, covered in [Frontend Setup](/getting-started/frontend-setup/).
 
 ## Install the package
 
@@ -34,10 +44,12 @@ See [Configuration](/getting-started/configuration/) for what each option contro
 
 ## Set up the frontend
 
-Lattice ships the React renderer that turns serialized component trees into rendered UI. You wire it into your Inertia entrypoint once. Follow [Frontend Setup](/getting-started/frontend-setup/) to install the JavaScript dependencies and register the renderer.
+The React renderer lives inside the installed package. You wire it into your Inertia entrypoint once: install its JavaScript dependencies, alias the package, import its stylesheet, and register the page component. Follow [Frontend Setup](/getting-started/frontend-setup/).
 
 ## Next steps
 
+- [Frontend Setup](/getting-started/frontend-setup/) — wire the React renderer into Inertia.
 - [Quickstart](/getting-started/quickstart/) — build and route your first page.
 - [Configuration](/getting-started/configuration/) — discovery, endpoints, and middleware.
-- [Frontend Setup](/getting-started/frontend-setup/) — wire the React renderer into Inertia.
+</content>
+</invoke>

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ There is no separate npm package. Because both halves arrive from one `composer 
 ## Install the package
 
 ```bash
-composer require bambamboole/lattice
+composer require lattice/lattice
 ```
 
 The service provider is registered automatically through Laravel package discovery, so there is nothing to add to `bootstrap/providers.php`.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/bambamboole/lattice
+      link: https://github.com/lattice-php/lattice
       icon: external
       variant: minimal
 ---

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -1,3 +1,10 @@
+/*
+ * Register Lattice's component sources with Tailwind. Consumers import this
+ * stylesheet from the Composer-installed package, so the path resolves into
+ * vendor and Tailwind generates the utilities the components use.
+ */
+@source "../js";
+
 :root,
 [data-theme="light"] {
   --lt-bg: var(--background, oklch(1 0 0));

--- a/resources/js/action/components/action-group.test.tsx
+++ b/resources/js/action/components/action-group.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import ActionGroupComponent from "./action-group";
 
 describe("Lattice action group component", () => {

--- a/resources/js/action/components/action-group.test.tsx
+++ b/resources/js/action/components/action-group.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import ActionGroupComponent from "./action-group";
 
 describe("Lattice action group component", () => {

--- a/resources/js/action/components/action-group.tsx
+++ b/resources/js/action/components/action-group.tsx
@@ -1,11 +1,11 @@
 import { MoreHorizontal } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Button } from "@lattice/core/components/button";
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { Button } from "@bambamboole/lattice/core/components/button";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "action.group": {
       label?: string;

--- a/resources/js/action/components/action-group.tsx
+++ b/resources/js/action/components/action-group.tsx
@@ -1,11 +1,11 @@
 import { MoreHorizontal } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Button } from "@bambamboole/lattice/core/components/button";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { Button } from "@lattice/lattice/core/components/button";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "action.group": {
       label?: string;

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { router } from "@inertiajs/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@lattice/core/types";
-import { IconRendererProvider } from "@lattice/icons";
-import type { IconRendererFunction } from "@lattice/icons";
+import type { Node } from "@bambamboole/lattice/core/types";
+import { IconRendererProvider } from "@bambamboole/lattice/icons";
+import type { IconRendererFunction } from "@bambamboole/lattice/icons";
 import ActionComponent from "./action";
 
 const http = vi.hoisted(() => ({

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { router } from "@inertiajs/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
-import { IconRendererProvider } from "@bambamboole/lattice/icons";
-import type { IconRendererFunction } from "@bambamboole/lattice/icons";
+import type { Node } from "@lattice/lattice/core/types";
+import { IconRendererProvider } from "@lattice/lattice/icons";
+import type { IconRendererFunction } from "@lattice/lattice/icons";
 import ActionComponent from "./action";
 
 const http = vi.hoisted(() => ({

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -1,13 +1,13 @@
 import { router, useHttp } from "@inertiajs/react";
 import type { Method } from "@inertiajs/core";
 import { useState } from "react";
-import { withRefHeader } from "@lattice/core/component-ref";
-import { Button } from "@lattice/core/components/button";
-import { ConfirmDialog } from "@lattice/core/components/confirm-dialog";
-import { Spinner } from "@lattice/core/components/spinner";
-import { getStringProp } from "@lattice/core/props";
-import type { NodeProps, RendererComponent } from "@lattice/core/types";
-import { IconRenderer } from "@lattice/icons";
+import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
+import { Button } from "@bambamboole/lattice/core/components/button";
+import { ConfirmDialog } from "@bambamboole/lattice/core/components/confirm-dialog";
+import { Spinner } from "@bambamboole/lattice/core/components/spinner";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { NodeProps, RendererComponent } from "@bambamboole/lattice/core/types";
+import { IconRenderer } from "@bambamboole/lattice/icons";
 import { dispatchActionEffects, dispatchActionError, getActionEffects } from "../effects";
 import type { ActionEffect } from "../effects";
 
@@ -28,7 +28,7 @@ type ActionResponse = {
 
 type ActionData = Record<string, never>;
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     action: {
       confirmation?: ActionConfirmation;

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -1,13 +1,13 @@
 import { router, useHttp } from "@inertiajs/react";
 import type { Method } from "@inertiajs/core";
 import { useState } from "react";
-import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
-import { Button } from "@bambamboole/lattice/core/components/button";
-import { ConfirmDialog } from "@bambamboole/lattice/core/components/confirm-dialog";
-import { Spinner } from "@bambamboole/lattice/core/components/spinner";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { NodeProps, RendererComponent } from "@bambamboole/lattice/core/types";
-import { IconRenderer } from "@bambamboole/lattice/icons";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import { Button } from "@lattice/lattice/core/components/button";
+import { ConfirmDialog } from "@lattice/lattice/core/components/confirm-dialog";
+import { Spinner } from "@lattice/lattice/core/components/spinner";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { NodeProps, RendererComponent } from "@lattice/lattice/core/types";
+import { IconRenderer } from "@lattice/lattice/icons";
 import { dispatchActionEffects, dispatchActionError, getActionEffects } from "../effects";
 import type { ActionEffect } from "../effects";
 
@@ -28,7 +28,7 @@ type ActionResponse = {
 
 type ActionData = Record<string, never>;
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     action: {
       confirmation?: ActionConfirmation;

--- a/resources/js/action/effects.ts
+++ b/resources/js/action/effects.ts
@@ -1,6 +1,6 @@
 import { router } from "@inertiajs/react";
-import type { EffectType, ToastVariant } from "@lattice/generated/enums";
-import { LATTICE_EVENT } from "@lattice/events/event-names";
+import type { EffectType, ToastVariant } from "@bambamboole/lattice/generated/enums";
+import { LATTICE_EVENT } from "@bambamboole/lattice/events/event-names";
 
 export type ActionEffect =
   | {

--- a/resources/js/action/effects.ts
+++ b/resources/js/action/effects.ts
@@ -1,6 +1,6 @@
 import { router } from "@inertiajs/react";
-import type { EffectType, ToastVariant } from "@bambamboole/lattice/generated/enums";
-import { LATTICE_EVENT } from "@bambamboole/lattice/events/event-names";
+import type { EffectType, ToastVariant } from "@lattice/lattice/generated/enums";
+import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 
 export type ActionEffect =
   | {

--- a/resources/js/action/index.ts
+++ b/resources/js/action/index.ts
@@ -1,4 +1,4 @@
-import { createPlugin, eagerComponent } from "@lattice/core/registry";
+import { createPlugin, eagerComponent } from "@bambamboole/lattice/core/registry";
 import ActionComponent from "./components/action";
 import ActionGroupComponent from "./components/action-group";
 

--- a/resources/js/action/index.ts
+++ b/resources/js/action/index.ts
@@ -1,4 +1,4 @@
-import { createPlugin, eagerComponent } from "@bambamboole/lattice/core/registry";
+import { createPlugin, eagerComponent } from "@lattice/lattice/core/registry";
 import ActionComponent from "./components/action";
 import ActionGroupComponent from "./components/action-group";
 

--- a/resources/js/core/components/badge.tsx
+++ b/resources/js/core/components/badge.tsx
@@ -1,9 +1,9 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-lt-sm border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger transition-[color,box-shadow] overflow-hidden",
@@ -37,7 +37,7 @@ function Badge({
   );
 }
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     badge: {
       label?: string;

--- a/resources/js/core/components/badge.tsx
+++ b/resources/js/core/components/badge.tsx
@@ -1,9 +1,9 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { cn } from "@lattice/lib/utils";
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-lt-sm border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger transition-[color,box-shadow] overflow-hidden",
@@ -37,7 +37,7 @@ function Badge({
   );
 }
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     badge: {
       label?: string;

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -2,9 +2,9 @@ import { Link } from "@inertiajs/react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { cn } from "@lattice/lib/utils";
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
 export type ButtonVariant = "default" | "destructive" | "ghost" | "link" | "outline" | "secondary";
 
@@ -57,7 +57,7 @@ function Button({
   );
 }
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     button: {
       href?: string;

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -2,9 +2,9 @@ import { Link } from "@inertiajs/react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
 export type ButtonVariant = "default" | "destructive" | "ghost" | "link" | "outline" | "secondary";
 
@@ -57,7 +57,7 @@ function Button({
   );
 }
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     button: {
       href?: string;

--- a/resources/js/core/components/card.tsx
+++ b/resources/js/core/components/card.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     card: {
       description?: string;

--- a/resources/js/core/components/card.tsx
+++ b/resources/js/core/components/card.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import { cn } from "@lattice/lib/utils";
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     card: {
       description?: string;

--- a/resources/js/core/components/fragment.tsx
+++ b/resources/js/core/components/fragment.tsx
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
-import { withRefHeader } from "@lattice/core/component-ref";
-import { getStringProp } from "@lattice/core/props";
-import { Renderer, useRendererContext } from "@lattice/core/renderer";
-import type { Node, RendererComponent } from "@lattice/core/types";
-import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice/events/event-names";
+import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import { Renderer, useRendererContext } from "@bambamboole/lattice/core/renderer";
+import type { Node, RendererComponent } from "@bambamboole/lattice/core/types";
+import { LATTICE_EVENT, type ReloadComponentEvent } from "@bambamboole/lattice/events/event-names";
 
 type FragmentResponse = {
   components?: Node[];
 };
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     fragment: {
       endpoint?: string;

--- a/resources/js/core/components/fragment.tsx
+++ b/resources/js/core/components/fragment.tsx
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
-import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import { Renderer, useRendererContext } from "@bambamboole/lattice/core/renderer";
-import type { Node, RendererComponent } from "@bambamboole/lattice/core/types";
-import { LATTICE_EVENT, type ReloadComponentEvent } from "@bambamboole/lattice/events/event-names";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import { getStringProp } from "@lattice/lattice/core/props";
+import { Renderer, useRendererContext } from "@lattice/lattice/core/renderer";
+import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice/lattice/events/event-names";
 
 type FragmentResponse = {
   components?: Node[];
 };
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     fragment: {
       endpoint?: string;

--- a/resources/js/core/components/grid.tsx
+++ b/resources/js/core/components/grid.tsx
@@ -1,8 +1,8 @@
-import { getNumberProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
-import { cn } from "@lattice/lib/utils";
+import { getNumberProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     grid: {
       columns?: number;

--- a/resources/js/core/components/grid.tsx
+++ b/resources/js/core/components/grid.tsx
@@ -1,8 +1,8 @@
-import { getNumberProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { getNumberProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     grid: {
       columns?: number;

--- a/resources/js/core/components/heading.tsx
+++ b/resources/js/core/components/heading.tsx
@@ -1,8 +1,8 @@
-import { getNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
-import { cn } from "@lattice/lib/utils";
+import { getNumberProp, getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     heading: {
       level?: number;

--- a/resources/js/core/components/heading.tsx
+++ b/resources/js/core/components/heading.tsx
@@ -1,8 +1,8 @@
-import { getNumberProp, getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { getNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     heading: {
       level?: number;

--- a/resources/js/core/components/index.ts
+++ b/resources/js/core/components/index.ts
@@ -1,4 +1,4 @@
-import { createPlugin, eagerComponent } from "@bambamboole/lattice/core/registry";
+import { createPlugin, eagerComponent } from "@lattice/lattice/core/registry";
 import BadgeComponent from "./badge";
 import ButtonComponent from "./button";
 import CardComponent from "./card";

--- a/resources/js/core/components/index.ts
+++ b/resources/js/core/components/index.ts
@@ -1,4 +1,4 @@
-import { createPlugin, eagerComponent } from "@lattice/core/registry";
+import { createPlugin, eagerComponent } from "@bambamboole/lattice/core/registry";
 import BadgeComponent from "./badge";
 import ButtonComponent from "./button";
 import CardComponent from "./card";

--- a/resources/js/core/components/link.test.tsx
+++ b/resources/js/core/components/link.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import LinkComponent from "./link";
 
 describe("Lattice link component", () => {

--- a/resources/js/core/components/link.test.tsx
+++ b/resources/js/core/components/link.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import LinkComponent from "./link";
 
 describe("Lattice link component", () => {

--- a/resources/js/core/components/link.tsx
+++ b/resources/js/core/components/link.tsx
@@ -1,11 +1,11 @@
 import type { Method } from "@inertiajs/core";
 import { Link } from "@inertiajs/react";
 import type { ComponentProps } from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import { getOptionalNumberProp, getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+import { getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     link: {
       href?: string;

--- a/resources/js/core/components/link.tsx
+++ b/resources/js/core/components/link.tsx
@@ -1,11 +1,11 @@
 import type { Method } from "@inertiajs/core";
 import { Link } from "@inertiajs/react";
 import type { ComponentProps } from "react";
-import { cn } from "@lattice/lib/utils";
-import { getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import { getOptionalNumberProp, getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     link: {
       href?: string;

--- a/resources/js/core/components/modal-fragment.test.tsx
+++ b/resources/js/core/components/modal-fragment.test.tsx
@@ -1,8 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRegistry, eagerComponent } from "@lattice/core/registry";
-import { Renderer } from "@lattice/core/renderer";
-import type { RendererComponent } from "@lattice/core/types";
+import { createRegistry, eagerComponent } from "@bambamboole/lattice/core/registry";
+import { Renderer } from "@bambamboole/lattice/core/renderer";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import FragmentComponent from "./fragment";
 import ModalComponent from "./modal";
 import TextComponent from "./text";

--- a/resources/js/core/components/modal-fragment.test.tsx
+++ b/resources/js/core/components/modal-fragment.test.tsx
@@ -1,8 +1,8 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRegistry, eagerComponent } from "@bambamboole/lattice/core/registry";
-import { Renderer } from "@bambamboole/lattice/core/renderer";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import FragmentComponent from "./fragment";
 import ModalComponent from "./modal";
 import TextComponent from "./text";

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -1,15 +1,15 @@
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Button } from "@lattice/core/components/button";
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
-import { LATTICE_EVENT } from "@lattice/events/event-names";
+import { Button } from "@bambamboole/lattice/core/components/button";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { LATTICE_EVENT } from "@bambamboole/lattice/events/event-names";
 
 type ModalEvent = CustomEvent<{
   modal?: string;
 }>;
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     modal: {
       closeLabel?: string;

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -1,15 +1,15 @@
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Button } from "@bambamboole/lattice/core/components/button";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
-import { LATTICE_EVENT } from "@bambamboole/lattice/events/event-names";
+import { Button } from "@lattice/lattice/core/components/button";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 
 type ModalEvent = CustomEvent<{
   modal?: string;
 }>;
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     modal: {
       closeLabel?: string;

--- a/resources/js/core/components/segmented-control.test.tsx
+++ b/resources/js/core/components/segmented-control.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import SegmentedControlComponent from "./segmented-control";
 
 describe("SegmentedControl", () => {

--- a/resources/js/core/components/segmented-control.test.tsx
+++ b/resources/js/core/components/segmented-control.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import SegmentedControlComponent from "./segmented-control";
 
 describe("SegmentedControl", () => {

--- a/resources/js/core/components/segmented-control.tsx
+++ b/resources/js/core/components/segmented-control.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
-import { type Option, getOptionalNumberProp, getOptions, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import {
+  type Option,
+  getOptionalNumberProp,
+  getOptions,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { SegmentedPills } from "./segmented-pills";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "segmented-control": {
       emits?: string;

--- a/resources/js/core/components/segmented-control.tsx
+++ b/resources/js/core/components/segmented-control.tsx
@@ -4,11 +4,11 @@ import {
   getOptionalNumberProp,
   getOptions,
   getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+} from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { SegmentedPills } from "./segmented-pills";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "segmented-control": {
       emits?: string;

--- a/resources/js/core/components/segmented-pills.tsx
+++ b/resources/js/core/components/segmented-pills.tsx
@@ -1,5 +1,5 @@
-import type { Option } from "@bambamboole/lattice/core/props";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import type { Option } from "@lattice/lattice/core/props";
+import { cn } from "@lattice/lattice/lib/utils";
 
 /**
  * Presentational segmented pill group. Used by the form choice field (bound to a

--- a/resources/js/core/components/segmented-pills.tsx
+++ b/resources/js/core/components/segmented-pills.tsx
@@ -1,5 +1,5 @@
-import type { Option } from "@lattice/core/props";
-import { cn } from "@lattice/lib/utils";
+import type { Option } from "@bambamboole/lattice/core/props";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 /**
  * Presentational segmented pill group. Used by the form choice field (bound to a

--- a/resources/js/core/components/spinner.tsx
+++ b/resources/js/core/components/spinner.tsx
@@ -1,6 +1,6 @@
 import { Loader2Icon } from "lucide-react";
 
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (

--- a/resources/js/core/components/spinner.tsx
+++ b/resources/js/core/components/spinner.tsx
@@ -1,6 +1,6 @@
 import { Loader2Icon } from "lucide-react";
 
-import { cn } from "@lattice/lib/utils";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (

--- a/resources/js/core/components/stack.test.tsx
+++ b/resources/js/core/components/stack.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import StackComponent from "./stack";
 
 describe("Lattice stack component", () => {

--- a/resources/js/core/components/stack.test.tsx
+++ b/resources/js/core/components/stack.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import StackComponent from "./stack";
 
 describe("Lattice stack component", () => {

--- a/resources/js/core/components/stack.tsx
+++ b/resources/js/core/components/stack.tsx
@@ -1,8 +1,8 @@
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     stack: {
       align?: string;

--- a/resources/js/core/components/stack.tsx
+++ b/resources/js/core/components/stack.tsx
@@ -1,8 +1,8 @@
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
-import { cn } from "@lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     stack: {
       align?: string;

--- a/resources/js/core/components/tabs.test.tsx
+++ b/resources/js/core/components/tabs.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { router } from "@inertiajs/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createRegistry, eagerComponent } from "@lattice/core/registry";
-import { Renderer } from "@lattice/core/renderer";
-import type { RendererComponent } from "@lattice/core/types";
+import { createRegistry, eagerComponent } from "@bambamboole/lattice/core/registry";
+import { Renderer } from "@bambamboole/lattice/core/renderer";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import TabComponent, { TabsComponent } from "./tabs";
 
 vi.mock("@inertiajs/react", () => ({

--- a/resources/js/core/components/tabs.test.tsx
+++ b/resources/js/core/components/tabs.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { router } from "@inertiajs/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createRegistry, eagerComponent } from "@bambamboole/lattice/core/registry";
-import { Renderer } from "@bambamboole/lattice/core/renderer";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import TabComponent, { TabsComponent } from "./tabs";
 
 vi.mock("@inertiajs/react", () => ({

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -1,9 +1,9 @@
 import { router } from "@inertiajs/react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { getStringProp } from "@lattice/core/props";
-import type { Node, RendererComponent } from "@lattice/core/types";
-import { cn } from "@lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { Node, RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 type TabsContextValue = {
   activeValue: string;
@@ -93,7 +93,7 @@ function queryUrl(queryKey: string, value: string): string {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     tab: {
       confirm?: {

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -1,9 +1,9 @@
 import { router } from "@inertiajs/react";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { Node, RendererComponent } from "@bambamboole/lattice/core/types";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
 
 type TabsContextValue = {
   activeValue: string;
@@ -93,7 +93,7 @@ function queryUrl(queryKey: string, value: string): string {
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     tab: {
       confirm?: {

--- a/resources/js/core/components/text.test.tsx
+++ b/resources/js/core/components/text.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import TextComponent from "./text";
 
 describe("Lattice text component", () => {

--- a/resources/js/core/components/text.test.tsx
+++ b/resources/js/core/components/text.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import TextComponent from "./text";
 
 describe("Lattice text component", () => {

--- a/resources/js/core/components/text.tsx
+++ b/resources/js/core/components/text.tsx
@@ -1,8 +1,8 @@
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
-import { cn } from "@lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     text: {
       align?: string;

--- a/resources/js/core/components/text.tsx
+++ b/resources/js/core/components/text.tsx
@@ -1,8 +1,8 @@
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     text: {
       align?: string;

--- a/resources/js/core/components/theming.test.tsx
+++ b/resources/js/core/components/theming.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import CardComponent, { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./card";
 import { TabsComponent } from "./tabs";
 

--- a/resources/js/core/components/theming.test.tsx
+++ b/resources/js/core/components/theming.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import CardComponent, { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./card";
 import { TabsComponent } from "./tabs";
 

--- a/resources/js/core/registry.test.ts
+++ b/resources/js/core/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createPlugin, createRegistry, eagerComponent, lazyComponent } from "@lattice";
+import { createPlugin, createRegistry, eagerComponent, lazyComponent } from "@bambamboole/lattice";
 import type { RendererComponent } from "./types";
 
 const EagerComponent: RendererComponent<"test.eager"> = () => null;

--- a/resources/js/core/registry.test.ts
+++ b/resources/js/core/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createPlugin, createRegistry, eagerComponent, lazyComponent } from "@bambamboole/lattice";
+import { createPlugin, createRegistry, eagerComponent, lazyComponent } from "@lattice/lattice";
 import type { RendererComponent } from "./types";
 
 const EagerComponent: RendererComponent<"test.eager"> = () => null;

--- a/resources/js/core/renderer.test.tsx
+++ b/resources/js/core/renderer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { createRegistry, eagerComponent, lazyComponent } from "@bambamboole/lattice";
-import { Renderer } from "@bambamboole/lattice";
+import { createRegistry, eagerComponent, lazyComponent } from "@lattice/lattice";
+import { Renderer } from "@lattice/lattice";
 import type { RendererComponent, RendererComponentModule } from "./types";
 
 const TestComponent: RendererComponent<"test.component"> = ({ children, node }) => (

--- a/resources/js/core/renderer.test.tsx
+++ b/resources/js/core/renderer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { createRegistry, eagerComponent, lazyComponent } from "@lattice";
-import { Renderer } from "@lattice";
+import { createRegistry, eagerComponent, lazyComponent } from "@bambamboole/lattice";
+import { Renderer } from "@bambamboole/lattice";
 import type { RendererComponent, RendererComponentModule } from "./types";
 
 const TestComponent: RendererComponent<"test.component"> = ({ children, node }) => (

--- a/resources/js/events/event-bridge.test.tsx
+++ b/resources/js/events/event-bridge.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EventBridge } from "@lattice";
+import { EventBridge } from "@bambamboole/lattice";
 
 type FlashListener = (
   event: CustomEvent<{

--- a/resources/js/events/event-bridge.test.tsx
+++ b/resources/js/events/event-bridge.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EventBridge } from "@bambamboole/lattice";
+import { EventBridge } from "@lattice/lattice";
 
 type FlashListener = (
   event: CustomEvent<{

--- a/resources/js/form/components/base/checkbox.tsx
+++ b/resources/js/form/components/base/checkbox.tsx
@@ -2,7 +2,7 @@ import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "@lattice/lib/utils";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (

--- a/resources/js/form/components/base/checkbox.tsx
+++ b/resources/js/form/components/base/checkbox.tsx
@@ -2,7 +2,7 @@ import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "lucide-react";
 import * as React from "react";
 
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
   return (

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -1,6 +1,6 @@
-import InputError from "@bambamboole/lattice/form/components/base/input-error";
-import { TextLink } from "@bambamboole/lattice/core/components/link";
-import { Label } from "@bambamboole/lattice/form/components/base/label";
+import InputError from "@lattice/lattice/form/components/base/input-error";
+import { TextLink } from "@lattice/lattice/core/components/link";
+import { Label } from "@lattice/lattice/form/components/base/label";
 import type { FormLabelAction } from "../types";
 
 export function FormFieldFrame({

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -1,6 +1,6 @@
-import InputError from "@lattice/form/components/base/input-error";
-import { TextLink } from "@lattice/core/components/link";
-import { Label } from "@lattice/form/components/base/label";
+import InputError from "@bambamboole/lattice/form/components/base/input-error";
+import { TextLink } from "@bambamboole/lattice/core/components/link";
+import { Label } from "@bambamboole/lattice/form/components/base/label";
 import type { FormLabelAction } from "../types";
 
 export function FormFieldFrame({

--- a/resources/js/form/components/base/input-error.tsx
+++ b/resources/js/form/components/base/input-error.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 
 export default function InputError({
   message,

--- a/resources/js/form/components/base/input-error.tsx
+++ b/resources/js/form/components/base/input-error.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from "react";
-import { cn } from "@lattice/lib/utils";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 export default function InputError({
   message,

--- a/resources/js/form/components/base/input.tsx
+++ b/resources/js/form/components/base/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@lattice/lib/utils";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/resources/js/form/components/base/input.tsx
+++ b/resources/js/form/components/base/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (

--- a/resources/js/form/components/base/label.tsx
+++ b/resources/js/form/components/base/label.tsx
@@ -1,7 +1,7 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
 import * as React from "react";
 
-import { cn } from "@lattice/lib/utils";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (

--- a/resources/js/form/components/base/label.tsx
+++ b/resources/js/form/components/base/label.tsx
@@ -1,7 +1,7 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
 import * as React from "react";
 
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 
 function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (

--- a/resources/js/form/components/base/password-input.tsx
+++ b/resources/js/form/components/base/password-input.tsx
@@ -1,8 +1,8 @@
 import { Eye, EyeOff } from "lucide-react";
 import type { ComponentProps, Ref } from "react";
 import { useState } from "react";
-import { Input } from "@bambamboole/lattice/form/components/base/input";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { Input } from "@lattice/lattice/form/components/base/input";
+import { cn } from "@lattice/lattice/lib/utils";
 
 type PasswordInputProps = Omit<ComponentProps<"input">, "type"> & {
   passwordrules?: string;

--- a/resources/js/form/components/base/password-input.tsx
+++ b/resources/js/form/components/base/password-input.tsx
@@ -1,8 +1,8 @@
 import { Eye, EyeOff } from "lucide-react";
 import type { ComponentProps, Ref } from "react";
 import { useState } from "react";
-import { Input } from "@lattice/form/components/base/input";
-import { cn } from "@lattice/lib/utils";
+import { Input } from "@bambamboole/lattice/form/components/base/input";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 type PasswordInputProps = Omit<ComponentProps<"input">, "type"> & {
   passwordrules?: string;

--- a/resources/js/form/components/base/submit-button.tsx
+++ b/resources/js/form/components/base/submit-button.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@lattice/core/components/button";
-import { Spinner } from "@lattice/core/components/spinner";
+import { Button } from "@bambamboole/lattice/core/components/button";
+import { Spinner } from "@bambamboole/lattice/core/components/spinner";
 import { useFormContext } from "../context";
 
 type SubmitButtonVariant = "default" | "destructive" | "ghost" | "link" | "outline" | "secondary";

--- a/resources/js/form/components/base/submit-button.tsx
+++ b/resources/js/form/components/base/submit-button.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@bambamboole/lattice/core/components/button";
-import { Spinner } from "@bambamboole/lattice/core/components/spinner";
+import { Button } from "@lattice/lattice/core/components/button";
+import { Spinner } from "@lattice/lattice/core/components/spinner";
 import { useFormContext } from "../context";
 
 type SubmitButtonVariant = "default" | "destructive" | "ghost" | "link" | "outline" | "secondary";

--- a/resources/js/form/components/base/textarea.tsx
+++ b/resources/js/form/components/base/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@lattice/lib/utils";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/resources/js/form/components/base/textarea.tsx
+++ b/resources/js/form/components/base/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (

--- a/resources/js/form/components/fields/checkbox.tsx
+++ b/resources/js/form/components/fields/checkbox.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
-import { getOptionalNumberProp, getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { Checkbox } from "../base/checkbox";
 import { Label } from "../base/label";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFormValue, useSetFormValue } from "../values";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.checkbox": {
       checked?: boolean;

--- a/resources/js/form/components/fields/checkbox.tsx
+++ b/resources/js/form/components/fields/checkbox.tsx
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
-import { getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { getOptionalNumberProp, getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { Checkbox } from "../base/checkbox";
 import { Label } from "../base/label";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFormValue, useSetFormValue } from "../values";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.checkbox": {
       checked?: boolean;

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -4,15 +4,15 @@ import {
   getOptionalNumberProp,
   getOptions,
   getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
-import { SegmentedPills } from "@bambamboole/lattice/core/components/segmented-pills";
+} from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { SegmentedPills } from "@lattice/lattice/core/components/segmented-pills";
 import { FormFieldFrame } from "../base/field";
 import { useControlledField } from "../use-controlled-field";
 import { useResolvedNode } from "../resolved-nodes";
 import { useFormValue, useSetFormValue } from "../values";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.choice": {
       label?: string;

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useMemo } from "react";
-import { type Option, getOptionalNumberProp, getOptions, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
-import { SegmentedPills } from "@lattice/core/components/segmented-pills";
+import {
+  type Option,
+  getOptionalNumberProp,
+  getOptions,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { SegmentedPills } from "@bambamboole/lattice/core/components/segmented-pills";
 import { FormFieldFrame } from "../base/field";
 import { useControlledField } from "../use-controlled-field";
 import { useResolvedNode } from "../resolved-nodes";
 import { useFormValue, useSetFormValue } from "../values";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.choice": {
       label?: string;

--- a/resources/js/form/components/fields/date-input.test.tsx
+++ b/resources/js/form/components/fields/date-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { DateInputComponent } from "./date-input";
 

--- a/resources/js/form/components/fields/date-input.test.tsx
+++ b/resources/js/form/components/fields/date-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { DateInputComponent } from "./date-input";
 

--- a/resources/js/form/components/fields/date-input.tsx
+++ b/resources/js/form/components/fields/date-input.tsx
@@ -1,10 +1,14 @@
-import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import {
+  getBooleanProp,
+  getOptionalNumberProp,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Input } from "../base/input";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.date-input": {
       autoFocus?: boolean;

--- a/resources/js/form/components/fields/date-input.tsx
+++ b/resources/js/form/components/fields/date-input.tsx
@@ -1,14 +1,10 @@
-import {
-  getBooleanProp,
-  getOptionalNumberProp,
-  getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Input } from "../base/input";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.date-input": {
       autoFocus?: boolean;

--- a/resources/js/form/components/fields/hidden-input.tsx
+++ b/resources/js/form/components/fields/hidden-input.tsx
@@ -1,7 +1,7 @@
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.hidden-input": {
       name?: string;

--- a/resources/js/form/components/fields/hidden-input.tsx
+++ b/resources/js/form/components/fields/hidden-input.tsx
@@ -1,7 +1,7 @@
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.hidden-input": {
       name?: string;

--- a/resources/js/form/components/fields/number-input.test.tsx
+++ b/resources/js/form/components/fields/number-input.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { NumberInputComponent } from "./number-input";
 

--- a/resources/js/form/components/fields/number-input.test.tsx
+++ b/resources/js/form/components/fields/number-input.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { NumberInputComponent } from "./number-input";
 

--- a/resources/js/form/components/fields/number-input.tsx
+++ b/resources/js/form/components/fields/number-input.tsx
@@ -1,14 +1,10 @@
-import {
-  getBooleanProp,
-  getOptionalNumberProp,
-  getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Input } from "../base/input";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.number-input": {
       autoFocus?: boolean;

--- a/resources/js/form/components/fields/number-input.tsx
+++ b/resources/js/form/components/fields/number-input.tsx
@@ -1,10 +1,14 @@
-import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import {
+  getBooleanProp,
+  getOptionalNumberProp,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Input } from "../base/input";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.number-input": {
       autoFocus?: boolean;

--- a/resources/js/form/components/fields/password-input.test.tsx
+++ b/resources/js/form/components/fields/password-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { PasswordInputComponent } from "./password-input";
 

--- a/resources/js/form/components/fields/password-input.test.tsx
+++ b/resources/js/form/components/fields/password-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { PasswordInputComponent } from "./password-input";
 

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -1,5 +1,9 @@
-import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { NodeProps, RendererComponent } from "@lattice/core/types";
+import {
+  getBooleanProp,
+  getOptionalNumberProp,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { NodeProps, RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import PasswordInput from "../base/password-input";
 import { useDependentField } from "../use-dependent-field";
@@ -30,7 +34,7 @@ function getPasswordConfirmation(props: NodeProps | undefined): PasswordConfirma
   };
 }
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.password-input": {
       autoComplete?: string;

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -1,9 +1,5 @@
-import {
-  getBooleanProp,
-  getOptionalNumberProp,
-  getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { NodeProps, RendererComponent } from "@bambamboole/lattice/core/types";
+import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { NodeProps, RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import PasswordInput from "../base/password-input";
 import { useDependentField } from "../use-dependent-field";
@@ -34,7 +30,7 @@ function getPasswordConfirmation(props: NodeProps | undefined): PasswordConfirma
   };
 }
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.password-input": {
       autoComplete?: string;

--- a/resources/js/form/components/fields/rich-editor.test.tsx
+++ b/resources/js/form/components/fields/rich-editor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { RichEditorComponent } from "./rich-editor";
 

--- a/resources/js/form/components/fields/rich-editor.test.tsx
+++ b/resources/js/form/components/fields/rich-editor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { RichEditorComponent } from "./rich-editor";
 

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -32,16 +32,16 @@ import {
   Underline as UnderlineIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { cn } from "@lattice/lib/utils";
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFormValue } from "../values";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.rich-editor": {
       conditions?: unknown;

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -32,16 +32,16 @@ import {
   Underline as UnderlineIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFormValue } from "../values";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.rich-editor": {
       conditions?: unknown;

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -1,8 +1,13 @@
 import { Check, ChevronsUpDown, Loader2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { cn } from "@lattice/lib/utils";
-import { type Option, getBooleanProp, getOptions, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import {
+  type Option,
+  getBooleanProp,
+  getOptions,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { FORM_DEBOUNCE_MS, postFormAction } from "../form-transport";
@@ -13,7 +18,7 @@ import { useFormValue } from "../values";
 
 type SelectOption = Option;
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.select": {
       conditions?: unknown;

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -1,13 +1,13 @@
 import { Check, ChevronsUpDown, Loader2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { cn } from "@lattice/lattice/lib/utils";
 import {
   type Option,
   getBooleanProp,
   getOptions,
   getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+} from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { FORM_DEBOUNCE_MS, postFormAction } from "../form-transport";
@@ -18,7 +18,7 @@ import { useFormValue } from "../values";
 
 type SelectOption = Option;
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.select": {
       conditions?: unknown;

--- a/resources/js/form/components/fields/submit-button.tsx
+++ b/resources/js/form/components/fields/submit-button.tsx
@@ -1,8 +1,8 @@
-import { getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormSubmitButton } from "../base/submit-button";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.submit-button": {
       label?: string;

--- a/resources/js/form/components/fields/submit-button.tsx
+++ b/resources/js/form/components/fields/submit-button.tsx
@@ -1,8 +1,8 @@
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormSubmitButton } from "../base/submit-button";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.submit-button": {
       label?: string;

--- a/resources/js/form/components/fields/text-input.test.tsx
+++ b/resources/js/form/components/fields/text-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { TextInputComponent } from "./text-input";
 

--- a/resources/js/form/components/fields/text-input.test.tsx
+++ b/resources/js/form/components/fields/text-input.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { TextInputComponent } from "./text-input";
 

--- a/resources/js/form/components/fields/text-input.tsx
+++ b/resources/js/form/components/fields/text-input.tsx
@@ -1,10 +1,14 @@
-import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import {
+  getBooleanProp,
+  getOptionalNumberProp,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Input } from "../base/input";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.text-input": {
       autoComplete?: string;

--- a/resources/js/form/components/fields/text-input.tsx
+++ b/resources/js/form/components/fields/text-input.tsx
@@ -1,14 +1,10 @@
-import {
-  getBooleanProp,
-  getOptionalNumberProp,
-  getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Input } from "../base/input";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.text-input": {
       autoComplete?: string;

--- a/resources/js/form/components/fields/textarea.test.tsx
+++ b/resources/js/form/components/fields/textarea.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { TextareaComponent } from "./textarea";
 

--- a/resources/js/form/components/fields/textarea.test.tsx
+++ b/resources/js/form/components/fields/textarea.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { FormValuesProvider } from "../values";
 import { TextareaComponent } from "./textarea";
 

--- a/resources/js/form/components/fields/textarea.tsx
+++ b/resources/js/form/components/fields/textarea.tsx
@@ -1,10 +1,14 @@
-import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import type { RendererComponent } from "@lattice/core/types";
+import {
+  getBooleanProp,
+  getOptionalNumberProp,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Textarea } from "../base/textarea";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     "form.textarea": {
       autoFocus?: boolean;

--- a/resources/js/form/components/fields/textarea.tsx
+++ b/resources/js/form/components/fields/textarea.tsx
@@ -1,14 +1,10 @@
-import {
-  getBooleanProp,
-  getOptionalNumberProp,
-  getStringProp,
-} from "@bambamboole/lattice/core/props";
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { Textarea } from "../base/textarea";
 import { useControlledField } from "../use-controlled-field";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     "form.textarea": {
       autoFocus?: boolean;

--- a/resources/js/form/components/form-transport.ts
+++ b/resources/js/form/components/form-transport.ts
@@ -4,7 +4,7 @@
  * CSRF header, component-ref header, and request shape live here in one place.
  */
 
-import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
 
 export const FORM_DEBOUNCE_MS = 250;
 

--- a/resources/js/form/components/form-transport.ts
+++ b/resources/js/form/components/form-transport.ts
@@ -4,7 +4,7 @@
  * CSRF header, component-ref header, and request shape live here in one place.
  */
 
-import { withRefHeader } from "@lattice/core/component-ref";
+import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
 
 export const FORM_DEBOUNCE_MS = 250;
 

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import {
   CheckboxComponent,
   ChoiceComponent,

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import {
   CheckboxComponent,
   ChoiceComponent,

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -1,8 +1,12 @@
 import { Form as InertiaForm } from "@inertiajs/react";
-import { withRefHeader } from "@lattice/core/component-ref";
-import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/core/props";
-import { LATTICE_EVENT } from "@lattice/events/event-names";
-import type { Node, NodeProps, RendererComponent } from "@lattice/core/types";
+import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
+import {
+  getBooleanProp,
+  getOptionalNumberProp,
+  getStringProp,
+} from "@bambamboole/lattice/core/props";
+import { LATTICE_EVENT } from "@bambamboole/lattice/events/event-names";
+import type { Node, NodeProps, RendererComponent } from "@bambamboole/lattice/core/types";
 import { useEffect, useMemo } from "react";
 import { FormSubmitButton } from "./base/submit-button";
 import { FormProvider } from "./context";
@@ -11,7 +15,7 @@ import type { FormMethod } from "./types";
 import { useFormResolver } from "./use-form-resolver";
 import { FormValuesProvider } from "./values";
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     form: {
       action?: string;

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -1,12 +1,8 @@
 import { Form as InertiaForm } from "@inertiajs/react";
-import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
-import {
-  getBooleanProp,
-  getOptionalNumberProp,
-  getStringProp,
-} from "@bambamboole/lattice/core/props";
-import { LATTICE_EVENT } from "@bambamboole/lattice/events/event-names";
-import type { Node, NodeProps, RendererComponent } from "@bambamboole/lattice/core/types";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import { getBooleanProp, getOptionalNumberProp, getStringProp } from "@lattice/lattice/core/props";
+import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
+import type { Node, NodeProps, RendererComponent } from "@lattice/lattice/core/types";
 import { useEffect, useMemo } from "react";
 import { FormSubmitButton } from "./base/submit-button";
 import { FormProvider } from "./context";
@@ -15,7 +11,7 @@ import type { FormMethod } from "./types";
 import { useFormResolver } from "./use-form-resolver";
 import { FormValuesProvider } from "./values";
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     form: {
       action?: string;

--- a/resources/js/form/components/resolved-nodes.test.tsx
+++ b/resources/js/form/components/resolved-nodes.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { ResolvedNodesProvider, useResolvedNode } from "./resolved-nodes";
 
 function Probe({ node }: { node: Node }) {

--- a/resources/js/form/components/resolved-nodes.test.tsx
+++ b/resources/js/form/components/resolved-nodes.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import { ResolvedNodesProvider, useResolvedNode } from "./resolved-nodes";
 
 function Probe({ node }: { node: Node }) {

--- a/resources/js/form/components/resolved-nodes.tsx
+++ b/resources/js/form/components/resolved-nodes.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
-import { getStringProp } from "@lattice/core/props";
-import type { Node } from "@lattice/core/types";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { Node } from "@bambamboole/lattice/core/types";
 
 const ResolvedNodesContext = createContext<Record<string, Node>>({});
 

--- a/resources/js/form/components/resolved-nodes.tsx
+++ b/resources/js/form/components/resolved-nodes.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { Node } from "@bambamboole/lattice/core/types";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { Node } from "@lattice/lattice/core/types";
 
 const ResolvedNodesContext = createContext<Record<string, Node>>({});
 

--- a/resources/js/form/components/use-controlled-field.ts
+++ b/resources/js/form/components/use-controlled-field.ts
@@ -1,5 +1,5 @@
-import { getStringProp } from "@bambamboole/lattice/core/props";
-import type { Node } from "@bambamboole/lattice/core/types";
+import { getStringProp } from "@lattice/lattice/core/props";
+import type { Node } from "@lattice/lattice/core/types";
 import type { FieldState } from "./conditions";
 import { useFormContext } from "./context";
 import { useDependentField } from "./use-dependent-field";

--- a/resources/js/form/components/use-controlled-field.ts
+++ b/resources/js/form/components/use-controlled-field.ts
@@ -1,5 +1,5 @@
-import { getStringProp } from "@lattice/core/props";
-import type { Node } from "@lattice/core/types";
+import { getStringProp } from "@bambamboole/lattice/core/props";
+import type { Node } from "@bambamboole/lattice/core/types";
 import type { FieldState } from "./conditions";
 import { useFormContext } from "./context";
 import { useDependentField } from "./use-dependent-field";

--- a/resources/js/form/components/use-dependent-field.ts
+++ b/resources/js/form/components/use-dependent-field.ts
@@ -1,5 +1,5 @@
-import { getBooleanProp } from "@lattice/core/props";
-import type { Node } from "@lattice/core/types";
+import { getBooleanProp } from "@bambamboole/lattice/core/props";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { type FieldConditions, type FieldState, evaluateConditions } from "./conditions";
 import { useFormValues } from "./values";
 

--- a/resources/js/form/components/use-dependent-field.ts
+++ b/resources/js/form/components/use-dependent-field.ts
@@ -1,5 +1,5 @@
-import { getBooleanProp } from "@bambamboole/lattice/core/props";
-import type { Node } from "@bambamboole/lattice/core/types";
+import { getBooleanProp } from "@lattice/lattice/core/props";
+import type { Node } from "@lattice/lattice/core/types";
 import { type FieldConditions, type FieldState, evaluateConditions } from "./conditions";
 import { useFormValues } from "./values";
 

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { getBooleanProp } from "@bambamboole/lattice/core/props";
-import type { Node } from "@bambamboole/lattice/core/types";
+import { getBooleanProp } from "@lattice/lattice/core/props";
+import type { Node } from "@lattice/lattice/core/types";
 import { FORM_DEBOUNCE_MS, postFormAction } from "./form-transport";
 import { useFormValues, useSetFormValue } from "./values";
 

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { getBooleanProp } from "@lattice/core/props";
-import type { Node } from "@lattice/core/types";
+import { getBooleanProp } from "@bambamboole/lattice/core/props";
+import type { Node } from "@bambamboole/lattice/core/types";
 import { FORM_DEBOUNCE_MS, postFormAction } from "./form-transport";
 import { useFormValues, useSetFormValue } from "./values";
 

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -1,5 +1,5 @@
-import { createPlugin, lazyComponent } from "@bambamboole/lattice/core/registry";
-import type { RendererComponent, RendererComponentModule } from "@bambamboole/lattice/core/types";
+import { createPlugin, lazyComponent } from "@lattice/lattice/core/registry";
+import type { RendererComponent, RendererComponentModule } from "@lattice/lattice/core/types";
 import { FormSkeletonComponent } from "./skeleton";
 
 type FormComponentName =

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -1,5 +1,5 @@
-import { createPlugin, lazyComponent } from "@lattice/core/registry";
-import type { RendererComponent, RendererComponentModule } from "@lattice/core/types";
+import { createPlugin, lazyComponent } from "@bambamboole/lattice/core/registry";
+import type { RendererComponent, RendererComponentModule } from "@bambamboole/lattice/core/types";
 import { FormSkeletonComponent } from "./skeleton";
 
 type FormComponentName =

--- a/resources/js/form/skeleton.tsx
+++ b/resources/js/form/skeleton.tsx
@@ -1,4 +1,4 @@
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 
 export const FormSkeletonComponent: RendererComponent<"form"> = ({ node }) => {
   const fieldCount = Math.max(

--- a/resources/js/form/skeleton.tsx
+++ b/resources/js/form/skeleton.tsx
@@ -1,4 +1,4 @@
-import type { RendererComponent } from "@lattice/core/types";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 
 export const FormSkeletonComponent: RendererComponent<"form"> = ({ node }) => {
   const fieldCount = Math.max(

--- a/resources/js/icons/default-icons.tsx
+++ b/resources/js/icons/default-icons.tsx
@@ -17,8 +17,8 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import type { IconRendererProps } from "@bambamboole/lattice";
+import { cn } from "@lattice/lattice/lib/utils";
+import type { IconRendererProps } from "@lattice/lattice";
 
 const bundledIcons = {
   "arrow-down": ArrowDown,

--- a/resources/js/icons/default-icons.tsx
+++ b/resources/js/icons/default-icons.tsx
@@ -17,8 +17,8 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { cn } from "@lattice/lib/utils";
-import type { IconRendererProps } from "@lattice";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import type { IconRendererProps } from "@bambamboole/lattice";
 
 const bundledIcons = {
   "arrow-down": ArrowDown,

--- a/resources/js/icons/dynamic-lucide-renderer.tsx
+++ b/resources/js/icons/dynamic-lucide-renderer.tsx
@@ -1,6 +1,6 @@
 import { DynamicIcon, iconNames } from "lucide-react/dynamic";
-import { cn } from "@lattice/lib/utils";
-import type { IconRendererProps } from "@lattice";
+import { cn } from "@bambamboole/lattice/lib/utils";
+import type { IconRendererProps } from "@bambamboole/lattice";
 
 type LucideIconName = (typeof iconNames)[number];
 

--- a/resources/js/icons/dynamic-lucide-renderer.tsx
+++ b/resources/js/icons/dynamic-lucide-renderer.tsx
@@ -1,6 +1,6 @@
 import { DynamicIcon, iconNames } from "lucide-react/dynamic";
-import { cn } from "@bambamboole/lattice/lib/utils";
-import type { IconRendererProps } from "@bambamboole/lattice";
+import { cn } from "@lattice/lattice/lib/utils";
+import type { IconRendererProps } from "@lattice/lattice";
 
 type LucideIconName = (typeof iconNames)[number];
 

--- a/resources/js/icons/icon-renderer.test.tsx
+++ b/resources/js/icons/icon-renderer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { IconRenderer, IconRendererProvider } from "@bambamboole/lattice";
-import type { IconRendererFunction } from "@bambamboole/lattice";
+import { IconRenderer, IconRendererProvider } from "@lattice/lattice";
+import type { IconRendererFunction } from "@lattice/lattice";
 
 describe("Lattice icon renderer", () => {
   afterEach(() => {

--- a/resources/js/icons/icon-renderer.test.tsx
+++ b/resources/js/icons/icon-renderer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { IconRenderer, IconRendererProvider } from "@lattice";
-import type { IconRendererFunction } from "@lattice";
+import { IconRenderer, IconRendererProvider } from "@bambamboole/lattice";
+import type { IconRendererFunction } from "@bambamboole/lattice";
 
 describe("Lattice icon renderer", () => {
   afterEach(() => {

--- a/resources/js/menu/use-menu.test.tsx
+++ b/resources/js/menu/use-menu.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { useMenu } from "@lattice";
+import { useMenu } from "@bambamboole/lattice";
 
 vi.mock("@inertiajs/react", () => ({
   usePage: () => ({

--- a/resources/js/menu/use-menu.test.tsx
+++ b/resources/js/menu/use-menu.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { useMenu } from "@bambamboole/lattice";
+import { useMenu } from "@lattice/lattice";
 
 vi.mock("@inertiajs/react", () => ({
   usePage: () => ({

--- a/resources/js/menu/use-menu.ts
+++ b/resources/js/menu/use-menu.ts
@@ -1,5 +1,5 @@
 import { usePage } from "@inertiajs/react";
-import type { MenuPayload, PagePayload } from "@bambamboole/lattice/core/types";
+import type { MenuPayload, PagePayload } from "@lattice/lattice/core/types";
 
 export function useMenu(location: string): MenuPayload | null {
   const page = usePage();

--- a/resources/js/menu/use-menu.ts
+++ b/resources/js/menu/use-menu.ts
@@ -1,5 +1,5 @@
 import { usePage } from "@inertiajs/react";
-import type { MenuPayload, PagePayload } from "@lattice/core/types";
+import type { MenuPayload, PagePayload } from "@bambamboole/lattice/core/types";
 
 export function useMenu(location: string): MenuPayload | null {
   const page = usePage();

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { createPlugin, createRegistry, eagerComponent, Provider } from "@bambamboole/lattice";
-import type { PagePayload, RendererComponent } from "@bambamboole/lattice";
+import { createPlugin, createRegistry, eagerComponent, Provider } from "@lattice/lattice";
+import type { PagePayload, RendererComponent } from "@lattice/lattice";
 import Page from "./page";
 
 vi.mock("@inertiajs/react", () => ({

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { createPlugin, createRegistry, eagerComponent, Provider } from "@lattice";
-import type { PagePayload, RendererComponent } from "@lattice";
+import { createPlugin, createRegistry, eagerComponent, Provider } from "@bambamboole/lattice";
+import type { PagePayload, RendererComponent } from "@bambamboole/lattice";
 import Page from "./page";
 
 vi.mock("@inertiajs/react", () => ({

--- a/resources/js/page.tsx
+++ b/resources/js/page.tsx
@@ -1,8 +1,8 @@
 import { Head } from "@inertiajs/react";
-import { Renderer } from "@lattice/core/renderer";
-import { useRegistry } from "@lattice/provider";
-import type { PagePayload } from "@lattice";
-import { cn } from "@lattice/lib/utils";
+import { Renderer } from "@bambamboole/lattice/core/renderer";
+import { useRegistry } from "@bambamboole/lattice/provider";
+import type { PagePayload } from "@bambamboole/lattice";
+import { cn } from "@bambamboole/lattice/lib/utils";
 
 type Props = {
   lattice: PagePayload;

--- a/resources/js/page.tsx
+++ b/resources/js/page.tsx
@@ -1,8 +1,8 @@
 import { Head } from "@inertiajs/react";
-import { Renderer } from "@bambamboole/lattice/core/renderer";
-import { useRegistry } from "@bambamboole/lattice/provider";
-import type { PagePayload } from "@bambamboole/lattice";
-import { cn } from "@bambamboole/lattice/lib/utils";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import { useRegistry } from "@lattice/lattice/provider";
+import type { PagePayload } from "@lattice/lattice";
+import { cn } from "@lattice/lattice/lib/utils";
 
 type Props = {
   lattice: PagePayload;

--- a/resources/js/registry.ts
+++ b/resources/js/registry.ts
@@ -1,4 +1,4 @@
-import { createRegistry } from "@lattice/core/registry";
+import { createRegistry } from "@bambamboole/lattice/core/registry";
 import { actionComponents } from "./action";
 import { coreComponents } from "./core/components";
 import { formComponents } from "./form";

--- a/resources/js/registry.ts
+++ b/resources/js/registry.ts
@@ -1,4 +1,4 @@
-import { createRegistry } from "@bambamboole/lattice/core/registry";
+import { createRegistry } from "@lattice/lattice/core/registry";
 import { actionComponents } from "./action";
 import { coreComponents } from "./core/components";
 import { formComponents } from "./form";

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -4,12 +4,12 @@ import {
   dispatchActionEffects,
   dispatchActionError,
   getActionEffects,
-} from "@lattice/action/effects";
-import type { ActionEffect } from "@lattice/action/effects";
-import { withRefHeader } from "@lattice/core/component-ref";
-import { Button } from "@lattice/core/components/button";
-import { ConfirmDialog } from "@lattice/core/components/confirm-dialog";
-import { Spinner } from "@lattice/core/components/spinner";
+} from "@bambamboole/lattice/action/effects";
+import type { ActionEffect } from "@bambamboole/lattice/action/effects";
+import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
+import { Button } from "@bambamboole/lattice/core/components/button";
+import { ConfirmDialog } from "@bambamboole/lattice/core/components/confirm-dialog";
+import { Spinner } from "@bambamboole/lattice/core/components/spinner";
 import type { BulkAction } from "../bulk";
 
 type BulkResponse = {

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -4,12 +4,12 @@ import {
   dispatchActionEffects,
   dispatchActionError,
   getActionEffects,
-} from "@bambamboole/lattice/action/effects";
-import type { ActionEffect } from "@bambamboole/lattice/action/effects";
-import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
-import { Button } from "@bambamboole/lattice/core/components/button";
-import { ConfirmDialog } from "@bambamboole/lattice/core/components/confirm-dialog";
-import { Spinner } from "@bambamboole/lattice/core/components/spinner";
+} from "@lattice/lattice/action/effects";
+import type { ActionEffect } from "@lattice/lattice/action/effects";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import { Button } from "@lattice/lattice/core/components/button";
+import { ConfirmDialog } from "@lattice/lattice/core/components/confirm-dialog";
+import { Spinner } from "@lattice/lattice/core/components/spinner";
 import type { BulkAction } from "../bulk";
 
 type BulkResponse = {

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import type { PaginationType } from "@lattice/lattice/generated/enums";
 import type { TablePagination as TablePaginationData } from "../types";
 
 export function TablePagination({
@@ -15,7 +16,7 @@ export function TablePagination({
   pagination: TablePaginationData;
   currentPage: number;
   processing: boolean;
-  mode: "infinite" | "none" | "simple" | "table";
+  mode: PaginationType;
   hasNextPage: boolean;
   visiblePages: number[];
   infiniteLoaderRef: RefObject<HTMLDivElement | null>;

--- a/resources/js/table/components/table-action-node.tsx
+++ b/resources/js/table/components/table-action-node.tsx
@@ -1,7 +1,7 @@
-import type { Node } from "@bambamboole/lattice/core/types";
-import ActionComponent from "@bambamboole/lattice/action/components/action";
-import ActionGroupComponent from "@bambamboole/lattice/action/components/action-group";
-import LinkComponent from "@bambamboole/lattice/core/components/link";
+import type { Node } from "@lattice/lattice/core/types";
+import ActionComponent from "@lattice/lattice/action/components/action";
+import ActionGroupComponent from "@lattice/lattice/action/components/action-group";
+import LinkComponent from "@lattice/lattice/core/components/link";
 
 export function TableActionNode({ node }: { node: Node }) {
   if (node.type === "action") {

--- a/resources/js/table/components/table-action-node.tsx
+++ b/resources/js/table/components/table-action-node.tsx
@@ -1,7 +1,7 @@
-import type { Node } from "@lattice/core/types";
-import ActionComponent from "@lattice/action/components/action";
-import ActionGroupComponent from "@lattice/action/components/action-group";
-import LinkComponent from "@lattice/core/components/link";
+import type { Node } from "@bambamboole/lattice/core/types";
+import ActionComponent from "@bambamboole/lattice/action/components/action";
+import ActionGroupComponent from "@bambamboole/lattice/action/components/action-group";
+import LinkComponent from "@bambamboole/lattice/core/components/link";
 
 export function TableActionNode({ node }: { node: Node }) {
   if (node.type === "action") {

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 
 const http = vi.hoisted(() => ({
   processing: false,

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 
 const http = vi.hoisted(() => ({
   processing: false,

--- a/resources/js/table/components/table-cell.tsx
+++ b/resources/js/table/components/table-cell.tsx
@@ -1,4 +1,4 @@
-import { copyToClipboard } from "@lattice/clipboard";
+import { copyToClipboard } from "@bambamboole/lattice/clipboard";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 import { formatCell, resolveLink } from "../format";

--- a/resources/js/table/components/table-cell.tsx
+++ b/resources/js/table/components/table-cell.tsx
@@ -1,4 +1,4 @@
-import { copyToClipboard } from "@bambamboole/lattice/clipboard";
+import { copyToClipboard } from "@lattice/lattice/clipboard";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useState } from "react";
 import { formatCell, resolveLink } from "../format";

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
 import TableComponent from "./table";
 
 describe("Lattice table component", () => {

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 import TableComponent from "./table";
 
 describe("Lattice table component", () => {

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -1,4 +1,4 @@
-import type { RendererComponent } from "@bambamboole/lattice/core/types";
+import type { RendererComponent } from "@lattice/lattice/core/types";
 import { getBulkActions } from "../bulk";
 import { getRowKey, getRowMeta } from "../payload";
 import { getColumnGridTemplate, getQueryParams, getVisiblePages } from "../query";

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -1,4 +1,4 @@
-import type { RendererComponent } from "@lattice/core/types";
+import type { RendererComponent } from "@bambamboole/lattice/core/types";
 import { getBulkActions } from "../bulk";
 import { getRowKey, getRowMeta } from "../payload";
 import { getColumnGridTemplate, getQueryParams, getVisiblePages } from "../query";

--- a/resources/js/table/index.ts
+++ b/resources/js/table/index.ts
@@ -1,4 +1,4 @@
-import { createPlugin, lazyComponent } from "@lattice/core/registry";
+import { createPlugin, lazyComponent } from "@bambamboole/lattice/core/registry";
 
 export const tableComponents = createPlugin({
   components: {

--- a/resources/js/table/index.ts
+++ b/resources/js/table/index.ts
@@ -1,4 +1,4 @@
-import { createPlugin, lazyComponent } from "@bambamboole/lattice/core/registry";
+import { createPlugin, lazyComponent } from "@lattice/lattice/core/registry";
 
 export const tableComponents = createPlugin({
   components: {

--- a/resources/js/table/types.ts
+++ b/resources/js/table/types.ts
@@ -1,4 +1,5 @@
-import type { Node } from "@bambamboole/lattice/core/types";
+import type { Node } from "@lattice/lattice/core/types";
+import type { PaginationType } from "@lattice/lattice/generated/enums";
 
 export type TableColumn = {
   columns?: TableColumn[];
@@ -53,7 +54,7 @@ export type TablePagination = {
   currentPage?: number;
   hasMore?: boolean;
   lastPage?: number;
-  mode?: "infinite" | "none" | "simple" | "table";
+  mode?: PaginationType;
   nextPage?: number | null;
   perPage?: number;
   total?: number;
@@ -68,7 +69,7 @@ export type TableResponse = {
   state?: Partial<TableState>;
 };
 
-declare module "@bambamboole/lattice/core/types" {
+declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
     table: {
       bulkActions?: Array<Record<string, unknown>>;

--- a/resources/js/table/types.ts
+++ b/resources/js/table/types.ts
@@ -1,4 +1,4 @@
-import type { Node } from "@lattice/core/types";
+import type { Node } from "@bambamboole/lattice/core/types";
 
 export type TableColumn = {
   columns?: TableColumn[];
@@ -68,7 +68,7 @@ export type TableResponse = {
   state?: Partial<TableState>;
 };
 
-declare module "@lattice/core/types" {
+declare module "@bambamboole/lattice/core/types" {
   interface ComponentProps {
     table: {
       bulkActions?: Array<Record<string, unknown>>;

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -1,6 +1,6 @@
-import { withRefHeader } from "@lattice/core/component-ref";
-import type { Node } from "@lattice/core/types";
-import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice/events/event-names";
+import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
+import type { Node } from "@bambamboole/lattice/core/types";
+import { LATTICE_EVENT, type ReloadComponentEvent } from "@bambamboole/lattice/events/event-names";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getColumns, getPagination, getRowMetadata, getRows, getState } from "./payload";
 import { buildEndpoint, nextSort } from "./query";

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -1,6 +1,6 @@
-import { withRefHeader } from "@bambamboole/lattice/core/component-ref";
-import type { Node } from "@bambamboole/lattice/core/types";
-import { LATTICE_EVENT, type ReloadComponentEvent } from "@bambamboole/lattice/events/event-names";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import type { Node } from "@lattice/lattice/core/types";
+import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice/lattice/events/event-names";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getColumns, getPagination, getRowMetadata, getRows, getState } from "./payload";
 import { buildEndpoint, nextSort } from "./query";

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -8,5 +8,5 @@ export type {
   PageBreadcrumb,
   PagePayload,
   RendererComponent,
-} from "@bambamboole/lattice";
+} from "@lattice/lattice";
 export type { Method } from "@inertiajs/core";

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -8,5 +8,5 @@ export type {
   PageBreadcrumb,
   PagePayload,
   RendererComponent,
-} from "@lattice";
+} from "@bambamboole/lattice";
 export type { Method } from "@inertiajs/core";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "noEmit": true,
     "noImplicitAny": true,
     "paths": {
-      "@bambamboole/lattice": ["./resources/js/index.ts"],
-      "@bambamboole/lattice/*": ["./resources/js/*"]
+      "@lattice/lattice": ["./resources/js/index.ts"],
+      "@lattice/lattice/*": ["./resources/js/*"]
     },
     "skipLibCheck": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "noEmit": true,
     "noImplicitAny": true,
     "paths": {
-      "@lattice": ["./resources/js/index.ts"],
-      "@lattice/*": ["./resources/js/*"]
+      "@bambamboole/lattice": ["./resources/js/index.ts"],
+      "@bambamboole/lattice/*": ["./resources/js/*"]
     },
     "skipLibCheck": true,
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@bambamboole/lattice": path.resolve(__dirname, "resources/js"),
+      "@lattice/lattice": path.resolve(__dirname, "resources/js"),
     },
   },
   test: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@lattice": path.resolve(__dirname, "resources/js"),
+      "@bambamboole/lattice": path.resolve(__dirname, "resources/js"),
     },
   },
   test: {


### PR DESCRIPTION
Makes the React renderer actually installable as documented. Previously Frontend Setup told users to `import @bambamboole/lattice/page`, but that alias only existed in this repo and the dependency list was incomplete, so a clean app could not build.

## Package
- Rename the internal `@lattice` import alias to `@bambamboole/lattice` so a consumer resolves the entry point and all internal imports with one alias pointing at `vendor/bambamboole/lattice/resources/js`.
- Add `@source` to `lattice.css` so importing the stylesheet auto-registers the component classes with Tailwind — no manual `@source` line for consumers.
- Exclude frontend tests from the Composer distribution via `.gitattributes`.

## Docs
- Installation: correct the PHP requirement (8.4+), add Tailwind 4, and explain the one-package delivery model (PHP + JS ship together, wired via a Vite alias — no npm package).
- Frontend Setup: rewrite with the real steps — complete `npm install`, the Vite alias + matching `tsconfig` paths, the stylesheet import, and the renderer registration.

## Verification
`npm test` (132), `composer test` (200), `tsc`, oxlint, oxfmt, and `astro check` all pass.