### PR TITLE
ci: auto-update Packagist on release

### DIFF
--- a/.github/workflows/packagist.yml
+++ b/.github/workflows/packagist.yml
@@ -1,0 +1,29 @@
+name: packagist
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Notify Packagist
+    runs-on: ubuntu-latest
+    steps:
+      # Requires the PACKAGIST_USERNAME and PACKAGIST_TOKEN repository secrets.
+      # The package must already be submitted once at https://packagist.org/packages/submit.
+      - name: Trigger Packagist update
+        run: |
+          curl -sf -X POST \
+            -H 'content-type: application/json' \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -d '{"repository":{"url":"https://github.com/lattice-php/lattice"}}'
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}


### PR DESCRIPTION
Adds a workflow that notifies Packagist whenever a GitHub release is published, so new release-please tags get indexed automatically without manual intervention.

## How it works
- Triggers on `release: published` (the event release-please fires when a release PR is merged).
- Calls the Packagist update API for `https://github.com/lattice-php/lattice`.

## One-time manual setup required
This workflow keeps Packagist *updated*; it cannot register the package. Before it does anything useful:

1. Submit the repo once at https://packagist.org/packages/submit (registers `lattice/lattice`).
2. Add two repository secrets:
   - `PACKAGIST_USERNAME` — your Packagist username.
   - `PACKAGIST_TOKEN` — the API token from https://packagist.org/profile.

> Alternative: if you enable the Packagist GitHub integration (app/webhook) instead, Packagist auto-updates on push and this workflow is redundant — pick one.