### PR TITLE
chore: release the first version as 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "bump-minor-pre-major": true,
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "changelog-sections": [


### PR DESCRIPTION
## What

Makes the initial release **0.1.0** instead of release-please's `1.0.0` first-release default, and keeps the project in the 0.x line going forward.

- **`Release-As: 0.1.0`** (in the commit footer) — a one-time override that tells release-please to cut the first release as 0.1.0. It's consumed by that release, so nothing to clean up afterward.
- **`bump-minor-pre-major: true`** in `release-please-config.json` — while < 1.0.0, breaking changes bump the **minor** (0.1.0 → 0.2.0) instead of forcing 1.0.0. Relevant for the in-flight namespace rename and any future breaking change.

There are no tags yet and the manifest is at `0.0.0`, so this is the first release — `1.0.0` was just release-please's default, not a breaking-change bump.

## After merging

Merge this with a **merge commit** (the repo default) so the `Release-As: 0.1.0` footer reaches `main`. The release-please workflow then re-runs and updates the open release PR (#4) from `1.0.0` to **0.1.0**. Merge that PR to tag `0.1.0`.

> Note: `feat:` still bumps the minor in 0.x (0.1.0 → 0.2.0). If you'd rather features only bump the patch and reserve minor bumps for breaking changes, add `"bump-patch-for-minor-pre-major": true` too.