### PR TITLE
ci: fix the docs Pages deploy (build the Astro site, not the package bundle)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/configure-pages@v6
-      - uses: withastro/action@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Build the docs site
+        run: npm run docs:build
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
 
   deploy:
     needs: build


### PR DESCRIPTION
## Problem

The **Deploy docs to GitHub Pages** workflow has failed on every run since it was added. `withastro/action` runs `npm run build`, but in this repo that script is the **package's Vite bundle** (`vite build`) — the docs site is built by `docs:build` (`astro build`). So no `dist/` was produced and the artifact step failed:

```
##[group]Run $PACKAGE_MANAGER run build   →   npm run build (= vite build)
tar: dist/: Cannot open: No such file or directory
##[error]Process completed with exit code 2.
```

## Fix

Replace `withastro/action` with explicit steps that build the docs the same way as local (`npm run docs:build`, verified to emit `dist/` with 6 pages) and upload that directory:

- `setup-node` (node 24, npm cache) → `npm ci` → `npm run docs:build`
- `configure-pages` → `upload-pages-artifact` with `path: dist/`

Deploy job unchanged.

> Re-homed from PR #13, which was merged before this commit could be added there.