### PR TITLE
feat: text/presence filter & condition operators (+ exhaustive evaluateOp)

### DIFF
--- a/resources/js/form/components/conditions.test.ts
+++ b/resources/js/form/components/conditions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { evaluateConditions } from "./conditions";
+import { evaluateConditions, type Condition } from "./conditions";
 
 describe("evaluateConditions", () => {
   it("hides when a visible condition fails", () => {
@@ -43,5 +43,15 @@ describe("evaluateConditions", () => {
 
   it("honors static flags", () => {
     expect(evaluateConditions(undefined, {}, { hidden: true }).hidden).toBe(true);
+  });
+
+  it("treats an unknown operator as matching so malformed payloads fail open", () => {
+    const operator = "unsupported" as unknown as Condition["operator"];
+    const result = evaluateConditions(
+      { visible: [{ field: "type", operator, value: "x" }] },
+      { type: "anything" },
+      {},
+    );
+    expect(result.hidden).toBe(false);
   });
 });

--- a/resources/js/form/components/conditions.test.ts
+++ b/resources/js/form/components/conditions.test.ts
@@ -41,6 +41,23 @@ describe("evaluateConditions", () => {
     ).toBe(true);
   });
 
+  it("supports text and presence operators", () => {
+    const shows = (operator: Condition["operator"], value: unknown, fieldValue: unknown) =>
+      !evaluateConditions(
+        { visible: [{ field: "name", operator, value }] },
+        { name: fieldValue },
+        {},
+      ).hidden;
+
+    expect(shows("contains", "ell", "hello")).toBe(true);
+    expect(shows("starts_with", "he", "hello")).toBe(true);
+    expect(shows("ends_with", "lo", "hello")).toBe(true);
+    expect(shows("empty", null, "")).toBe(true);
+    expect(shows("empty", null, "x")).toBe(false);
+    expect(shows("filled", null, "x")).toBe(true);
+    expect(shows("filled", null, "")).toBe(false);
+  });
+
   it("honors static flags", () => {
     expect(evaluateConditions(undefined, {}, { hidden: true }).hidden).toBe(true);
   });

--- a/resources/js/form/components/conditions.ts
+++ b/resources/js/form/components/conditions.ts
@@ -46,9 +46,13 @@ function equals(actual: unknown, expected: unknown): boolean {
   return String(actual ?? "") === String(expected ?? "");
 }
 
-function contains(actual: unknown, expected: unknown): boolean {
+function isIn(actual: unknown, expected: unknown): boolean {
   const needles = (Array.isArray(expected) ? expected : [expected]).map((value) => String(value));
   return needles.includes(String(actual ?? ""));
+}
+
+function isBlank(value: unknown): boolean {
+  return value == null || String(value) === "";
 }
 
 // Unknown operators from untrusted payloads fail open (the condition matches).
@@ -72,10 +76,20 @@ function evaluateOp(operator: ConditionOperator, actual: unknown, expected: unkn
       return Number(actual) >= Number(expected);
     case "lte":
       return Number(actual) <= Number(expected);
+    case "contains":
+      return String(actual ?? "").includes(String(expected ?? ""));
+    case "starts_with":
+      return String(actual ?? "").startsWith(String(expected ?? ""));
+    case "ends_with":
+      return String(actual ?? "").endsWith(String(expected ?? ""));
     case "in":
-      return contains(actual, expected);
+      return isIn(actual, expected);
     case "not_in":
-      return !contains(actual, expected);
+      return !isIn(actual, expected);
+    case "empty":
+      return isBlank(actual);
+    case "filled":
+      return !isBlank(actual);
     default:
       return evaluateUnknownOperator(operator);
   }

--- a/resources/js/form/components/conditions.ts
+++ b/resources/js/form/components/conditions.ts
@@ -1,4 +1,6 @@
-export type Condition = { field: string; operator: string; value: unknown };
+import type { ConditionOperator } from "@lattice/lattice/generated/types";
+
+export type Condition = { field: string; operator: ConditionOperator; value: unknown };
 
 export type FieldConditions = {
   visible?: Condition[];
@@ -49,7 +51,14 @@ function contains(actual: unknown, expected: unknown): boolean {
   return needles.includes(String(actual ?? ""));
 }
 
-function evaluateOp(operator: string, actual: unknown, expected: unknown): boolean {
+// Unknown operators from untrusted payloads fail open (the condition matches).
+// The `never` parameter makes a ConditionOperator added without a case above a
+// compile error rather than a silent fall-through.
+function evaluateUnknownOperator(_operator: never): boolean {
+  return true;
+}
+
+function evaluateOp(operator: ConditionOperator, actual: unknown, expected: unknown): boolean {
   switch (operator) {
     case "eq":
       return equals(actual, expected);
@@ -68,7 +77,7 @@ function evaluateOp(operator: string, actual: unknown, expected: unknown): boole
     case "not_in":
       return !contains(actual, expected);
     default:
-      return true;
+      return evaluateUnknownOperator(operator);
   }
 }
 

--- a/resources/js/generated/types.ts
+++ b/resources/js/generated/types.ts
@@ -1,8 +1,8 @@
 export type Align = 'center' | 'left' | 'start' | 'stretch';
-export type ConditionOperator = 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'not_in';
+export type ConditionOperator = 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains' | 'starts_with' | 'ends_with' | 'in' | 'not_in' | 'empty' | 'filled';
 export type ControlType = 'text' | 'number' | 'date' | 'boolean';
 export type EffectType = 'toast' | 'reloadComponent' | 'reloadPage' | 'redirect' | 'download' | 'openModal' | 'closeModal' | 'resetForm';
-export type FilterOperator = 'contains' | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'before' | 'after';
+export type FilterOperator = 'contains' | 'starts_with' | 'ends_with' | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'before' | 'after' | 'empty' | 'filled';
 export type Gap = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 export type PageContainer = 'centered' | 'default';

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -2,7 +2,7 @@ import { Filter, Plus, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { ControlType, FilterOperator } from "@lattice/lattice/generated/types";
-import { operatorLabel } from "../query";
+import { operatorLabel, VALUELESS_FILTER_OPERATORS } from "../query";
 import type { FilterClause, TableColumn } from "../types";
 import { FilterValueInput } from "./filter-value-input";
 
@@ -210,7 +210,15 @@ function FilterClauseList({
           operators={operators}
           clause={{ field: column.key, operator: draftOperator, value: "" }}
           processing={processing}
-          onOperator={setDraftOperator}
+          onOperator={(operator) => {
+            if (VALUELESS_FILTER_OPERATORS.has(operator)) {
+              onAdd({ field: column.key, operator, value: "" });
+              setDraftOperator(defaultOperator);
+              setAdding(false);
+              return;
+            }
+            setDraftOperator(operator);
+          }}
           onValue={(value) => {
             if (value !== "") {
               onAdd({ field: column.key, operator: draftOperator, value });
@@ -256,6 +264,8 @@ function FilterClauseRow({
   onValue: (value: string) => void;
   onRemove: () => void;
 }) {
+  const valueless = VALUELESS_FILTER_OPERATORS.has(clause.operator);
+
   return (
     <div className="grid gap-2">
       <div className="flex items-center gap-2">
@@ -286,15 +296,17 @@ function FilterClauseRow({
           <Trash2 aria-hidden="true" className="size-4" />
         </button>
       </div>
-      <FilterValueInput
-        type={type}
-        label={column.label}
-        ariaLabel={`${column.label} filter value`}
-        value={clause.value}
-        processing={processing}
-        onCommit={onValue}
-        onClear={() => onValue("")}
-      />
+      {!valueless && (
+        <FilterValueInput
+          type={type}
+          label={column.label}
+          ariaLabel={`${column.label} filter value`}
+          value={clause.value}
+          processing={processing}
+          onCommit={onValue}
+          onClear={() => onValue("")}
+        />
+      )}
     </div>
   );
 }

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -68,6 +68,8 @@ function serializeSorts(state: TableState): string {
 
 const operatorLabels: Record<string, string> = {
   contains: "contains",
+  starts_with: "starts with",
+  ends_with: "ends with",
   eq: "equals",
   neq: "not equals",
   gt: ">",
@@ -76,7 +78,12 @@ const operatorLabels: Record<string, string> = {
   lte: "≤",
   before: "before",
   after: "after",
+  empty: "is empty",
+  filled: "is not empty",
 };
+
+// Operators that filter on presence alone and carry no value input.
+export const VALUELESS_FILTER_OPERATORS = new Set<string>(["empty", "filled"]);
 
 export function operatorLabel(operator: string): string {
   return operatorLabels[operator] ?? operator;

--- a/src/Forms/Enums/ConditionOperator.php
+++ b/src/Forms/Enums/ConditionOperator.php
@@ -12,8 +12,13 @@ enum ConditionOperator: string
     case GreaterThanOrEqual = 'gte';
     case LessThan = 'lt';
     case LessThanOrEqual = 'lte';
+    case Contains = 'contains';
+    case StartsWith = 'starts_with';
+    case EndsWith = 'ends_with';
     case In = 'in';
     case NotIn = 'not_in';
+    case Empty = 'empty';
+    case Filled = 'filled';
 
     public function evaluate(mixed $actual, mixed $expected): bool
     {
@@ -24,8 +29,13 @@ enum ConditionOperator: string
             self::LessThan => $this->compareNumeric($actual, $expected) < 0,
             self::GreaterThanOrEqual => $this->compareNumeric($actual, $expected) >= 0,
             self::LessThanOrEqual => $this->compareNumeric($actual, $expected) <= 0,
-            self::In => $this->contains($actual, $expected),
-            self::NotIn => ! $this->contains($actual, $expected),
+            self::Contains => str_contains((string) $actual, (string) $expected),
+            self::StartsWith => str_starts_with((string) $actual, (string) $expected),
+            self::EndsWith => str_ends_with((string) $actual, (string) $expected),
+            self::In => $this->isIn($actual, $expected),
+            self::NotIn => ! $this->isIn($actual, $expected),
+            self::Empty => $this->isBlank($actual),
+            self::Filled => ! $this->isBlank($actual),
         };
     }
 
@@ -43,10 +53,15 @@ enum ConditionOperator: string
         return (string) $actual === (string) $expected;
     }
 
-    private function contains(mixed $actual, mixed $expected): bool
+    private function isIn(mixed $actual, mixed $expected): bool
     {
         $needles = array_map(static fn (mixed $v): string => (string) $v, (array) $expected);
 
         return in_array((string) $actual, $needles, true);
+    }
+
+    private function isBlank(mixed $value): bool
+    {
+        return $value === null || (string) $value === '';
     }
 }

--- a/src/Tables/Enums/FilterOperator.php
+++ b/src/Tables/Enums/FilterOperator.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Model;
 enum FilterOperator: string
 {
     case Contains = 'contains';
+    case StartsWith = 'starts_with';
+    case EndsWith = 'ends_with';
     case Equals = 'eq';
     case NotEquals = 'neq';
     case GreaterThan = 'gt';
@@ -18,6 +20,8 @@ enum FilterOperator: string
     case LessThanOrEqual = 'lte';
     case Before = 'before';
     case After = 'after';
+    case Empty = 'empty';
+    case Filled = 'filled';
 
     /**
      * @return array<int, ControlType>
@@ -25,12 +29,17 @@ enum FilterOperator: string
     public function appliesTo(): array
     {
         return match ($this) {
-            self::Contains => [ControlType::Text],
-            self::Equals => [ControlType::Text, ControlType::Number, ControlType::Date, ControlType::Boolean],
+            self::Contains, self::StartsWith, self::EndsWith => [ControlType::Text],
+            self::Equals, self::Empty, self::Filled => [ControlType::Text, ControlType::Number, ControlType::Date, ControlType::Boolean],
             self::NotEquals => [ControlType::Text, ControlType::Number],
             self::GreaterThan, self::GreaterThanOrEqual, self::LessThan, self::LessThanOrEqual => [ControlType::Number],
             self::Before, self::After => [ControlType::Date],
         };
+    }
+
+    public function requiresValue(): bool
+    {
+        return ! in_array($this, [self::Empty, self::Filled], true);
     }
 
     /**
@@ -41,7 +50,9 @@ enum FilterOperator: string
     public function apply(Builder $builder, ControlType $controlType, string $field, string $value): void
     {
         match ($this) {
-            self::Contains => $builder->where($field, 'like', '%'.str_replace(['%', '_'], ['\\%', '\\_'], $value).'%'),
+            self::Contains => $builder->where($field, 'like', '%'.$this->escapeLike($value).'%'),
+            self::StartsWith => $builder->where($field, 'like', $this->escapeLike($value).'%'),
+            self::EndsWith => $builder->where($field, 'like', '%'.$this->escapeLike($value)),
             self::Equals => $controlType->applyEquals($builder, $field, $value),
             self::NotEquals => $this->compare($builder, $controlType, $field, '!=', $value),
             self::GreaterThan => $this->compare($builder, $controlType, $field, '>', $value),
@@ -50,7 +61,16 @@ enum FilterOperator: string
             self::LessThanOrEqual => $this->compare($builder, $controlType, $field, '<=', $value),
             self::Before => $builder->whereDate($field, '<', $value),
             self::After => $builder->whereDate($field, '>', $value),
+            self::Empty => $builder->where(function (Builder $query) use ($field): void {
+                $query->whereNull($field)->orWhere($field, '');
+            }),
+            self::Filled => $builder->whereNotNull($field)->where($field, '!=', ''),
         };
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['%', '_'], ['\\%', '\\_'], $value);
     }
 
     /**

--- a/src/Tables/FilterClause.php
+++ b/src/Tables/FilterClause.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables;
 
+use Lattice\Lattice\Tables\Enums\FilterOperator;
+
 final readonly class FilterClause
 {
     public function __construct(
@@ -25,7 +27,15 @@ final readonly class FilterClause
 
     public function isComplete(): bool
     {
-        return $this->field !== '' && $this->operator !== '' && $this->value !== '';
+        if ($this->field === '' || $this->operator === '') {
+            return false;
+        }
+
+        if (FilterOperator::tryFrom($this->operator)?->requiresValue() === false) {
+            return true;
+        }
+
+        return $this->value !== '';
     }
 
     /**

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -545,7 +545,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         'filter' => [
                             'enabled' => true,
                             'type' => 'text',
-                            'operators' => ['contains', 'eq', 'neq'],
+                            'operators' => ['contains', 'starts_with', 'ends_with', 'eq', 'neq', 'empty', 'filled'],
                             'defaultOperator' => 'contains',
                         ],
                     ],
@@ -556,7 +556,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         'filter' => [
                             'enabled' => true,
                             'type' => 'text',
-                            'operators' => ['contains', 'eq', 'neq'],
+                            'operators' => ['contains', 'starts_with', 'ends_with', 'eq', 'neq', 'empty', 'filled'],
                             'defaultOperator' => 'eq',
                         ],
                     ],

--- a/tests/Feature/ProductsTest.php
+++ b/tests/Feature/ProductsTest.php
@@ -512,6 +512,24 @@ test('the products table applies date, boolean, and number clause filters', func
         ->and($resolve('price:gte:100')->pluck('id')->all())->toBe([$featured->getKey()]);
 });
 
+test('the products table applies text, starts/ends-with, and presence filters', function () {
+    $widget = Product::factory()->create(['name' => 'Widget']);
+    $gizmo = Product::factory()->create(['name' => 'Gizmo']);
+    $blank = Product::factory()->create(['name' => '']);
+
+    $table = new ProductsTable;
+    $columns = $table->columns();
+
+    $resolve = fn (string $filter) => $table->resolveMatching(
+        TableQuery::fromRequest(Request::create('/', 'GET', ['filter' => $filter]), $columns, 'workbench.products'),
+    );
+
+    expect($resolve('name:starts_with:Wid')->pluck('id')->all())->toBe([$widget->getKey()])
+        ->and($resolve('name:ends_with:zmo')->pluck('id')->all())->toBe([$gizmo->getKey()])
+        ->and($resolve('name:empty:')->pluck('id')->all())->toBe([$blank->getKey()])
+        ->and($resolve('name:filled:')->pluck('id')->sort()->values()->all())->toBe([$widget->getKey(), $gizmo->getKey()]);
+});
+
 test('the products table rejects a filter operator not allowed for the column', function () {
     $columns = (new ProductsTable)->columns();
 

--- a/tests/Unit/ConditionOperatorTest.php
+++ b/tests/Unit/ConditionOperatorTest.php
@@ -16,4 +16,13 @@ it('evaluates operators', function (mixed $actual, ConditionOperator $op, mixed 
     'lt numeric' => ['17', ConditionOperator::LessThan, 18, true],
     'in' => ['free', ConditionOperator::In, ['free', 'trial'], true],
     'not in' => ['pro', ConditionOperator::NotIn, ['free', 'trial'], true],
+    'contains' => ['hello world', ConditionOperator::Contains, 'world', true],
+    'contains miss' => ['hello', ConditionOperator::Contains, 'world', false],
+    'starts with' => ['business', ConditionOperator::StartsWith, 'bus', true],
+    'ends with' => ['business', ConditionOperator::EndsWith, 'ness', true],
+    'empty on null' => [null, ConditionOperator::Empty, null, true],
+    'empty on blank string' => ['', ConditionOperator::Empty, null, true],
+    'empty on value' => ['x', ConditionOperator::Empty, null, false],
+    'filled on value' => ['x', ConditionOperator::Filled, null, true],
+    'filled on blank string' => ['', ConditionOperator::Filled, null, false],
 ]);


### PR DESCRIPTION
Combines the `evaluateOp` hardening (#126) with the new operators it unblocks (#124, #125), per request to keep them on one PR.

## 1. Harden `evaluateOp` (#126)
`evaluateOp` (the client mirror of `ConditionOperator::evaluate()`) had a silent `default: return true`. Now `Condition.operator` and the param are typed as the generated `ConditionOperator`, and the default routes through an exhaustiveness guard — a `ConditionOperator` added without a JS case is a **compile error** (proven: injecting a value yields `TS2345 ... not assignable to 'never'`). Unknown operators from untrusted payloads still fail open.

## 2. New operators on both enums (#124 / #125)
- **`ConditionOperator`** (forms): + `contains`, `starts_with`, `ends_with`, `empty`, `filled`
- **`FilterOperator`** (tables): + `starts_with`, `ends_with`, `empty`, `filled` (already had `contains`)
- `empty`/`filled` treat **null or empty string** as empty.

Value-less plumbing for `empty`/`filled`: `FilterOperator::requiresValue` drives `FilterClause::isComplete` so value-less clauses survive parsing/validation; the filter UI hides the value input and commits the clause on operator selection. The array-membership helper behind `in`/`not_in` was renamed `contains` → `isIn` (both PHP & TS) to free `contains` for the new string operator. Server-side `apply()`/`appliesTo()` stay PHPStan-exhaustive; columns surface the new operators automatically via `ControlType::operators()`.

## Verification
PHPStan clean · `tsc` clean · pest 210 (Unit+Feature) + browser table filter/sort · vitest 134 · oxlint + oxfmt clean. New coverage: ConditionOperator dataset rows, server-side text/presence filter test, client conditions test, and the fail-open regression test.