### PR TITLE
Forms cleanup + live-example docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,7 @@
+import path from "node:path";
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
 
 const site = process.env.SITE_URL || "https://latticephp.com";
@@ -13,6 +15,7 @@ export default defineConfig({
     enabled: false,
   },
   integrations: [
+    react(),
     starlight({
       title: "Lattice",
       description: "Server-driven React components for Laravel and Inertia.",
@@ -53,7 +56,13 @@ export default defineConfig({
         },
         {
           label: "Forms",
-          items: [{ label: "Overview", link: "/forms/overview/" }],
+          items: [
+            { label: "Overview", link: "/forms/overview/" },
+            {
+              label: "Fields",
+              items: [{ label: "Text input", link: "/forms/fields/text-input/" }],
+            },
+          ],
         },
         {
           label: "Tables",
@@ -75,5 +84,12 @@ export default defineConfig({
   vite: {
     cacheDir: `node_modules/.vite-${viteCacheSuffix}`,
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        "@lattice/lattice": path.resolve("./resources/js"),
+        "@components": path.resolve("./docs/components"),
+      },
+      dedupe: ["react", "react-dom"],
+    },
   },
 });

--- a/docs/components/ComponentExample.astro
+++ b/docs/components/ComponentExample.astro
@@ -1,0 +1,32 @@
+---
+import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
+import LatticePreview from "@components/LatticePreview.tsx";
+
+interface Props {
+  php: string;
+  nodes: unknown[];
+  values?: Record<string, unknown>;
+}
+
+const { php, nodes, values = {} } = Astro.props;
+---
+
+<Tabs>
+  <TabItem label="PHP">
+    <Code code={php} lang="php" />
+  </TabItem>
+  <TabItem label="Preview">
+    <div class="lattice-preview not-content">
+      <LatticePreview client:only="react" nodes={nodes} values={values} />
+    </div>
+  </TabItem>
+</Tabs>
+
+<style>
+  .lattice-preview {
+    padding: 1.5rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    background: var(--sl-color-bg);
+  }
+</style>

--- a/docs/components/LatticePreview.tsx
+++ b/docs/components/LatticePreview.tsx
@@ -1,0 +1,16 @@
+import { Renderer, registry } from "@lattice/lattice";
+import { FormValuesProvider } from "@lattice/lattice/form/components/values";
+import type { Node } from "@lattice/lattice/core/types";
+
+type Props = {
+  nodes: Node[];
+  values?: Record<string, unknown>;
+};
+
+export default function LatticePreview({ nodes, values = {} }: Props) {
+  return (
+    <FormValuesProvider initial={values}>
+      <Renderer nodes={nodes} registry={registry} />
+    </FormValuesProvider>
+  );
+}

--- a/docs/content/docs/forms/fields/text-input.mdx
+++ b/docs/content/docs/forms/fields/text-input.mdx
@@ -1,0 +1,48 @@
+---
+title: Text input
+description: A single-line text field, with email and other HTML input types.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+The text input collects a single line of text. Create one with `TextInput::make()`, passing the field name and its label.
+
+<ComponentExample
+  php={`TextInput::make('name', 'Team name')
+    ->placeholder('My team')
+    ->required()`}
+  nodes={[
+    {
+      type: "form.text-input",
+      props: {
+        name: "name",
+        label: "Team name",
+        placeholder: "My team",
+        required: true,
+      },
+    },
+  ]}
+  values={{ name: "" }}
+/>
+
+## Email
+
+Call `->email()` to set the HTML input type to `email` and apply email validation:
+
+<ComponentExample
+  php={`TextInput::make('email', 'Email address')
+    ->email()
+    ->placeholder('you@example.com')`}
+  nodes={[
+    {
+      type: "form.text-input",
+      props: {
+        name: "email",
+        label: "Email address",
+        type: "email",
+        placeholder: "you@example.com",
+      },
+    },
+  ]}
+  values={{ email: "" }}
+/>

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -4,6 +4,10 @@
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 
+/* Lattice component preview: design tokens + scan the renderer source for utilities. */
+@import "../../resources/css/lattice.css";
+@source "../../resources/js";
+
 @theme {
   --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lattice-php/lattice",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lattice-php/lattice",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.1.4",
@@ -26,6 +26,7 @@
         "tailwind-merge": "^3.0.1"
       },
       "devDependencies": {
+        "@astrojs/react": "^5.0.7",
         "@astrojs/starlight": "^0.40.0",
         "@astrojs/starlight-tailwind": "^5.0.0",
         "@inertiajs/react": "^3.0.0",
@@ -404,6 +405,631 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@astrojs/react": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/react/-/react-5.0.7.tgz",
+      "integrity": "sha512-N9cCoxvnLWaP+AK1Fv4e5Mc7ktnVTpSo2nWLwvD9Ohr1dJKygwrTSm9yatqoahgb1A5Kwjg/rT2shRiIVdn3aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.0",
+        "@vitejs/plugin-react": "^5.2.0",
+        "devalue": "^5.8.1",
+        "ultrahtml": "^1.6.0",
+        "vite": "^7.3.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@astrojs/react/node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@astrojs/react/node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@astrojs/sitemap": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
@@ -505,6 +1131,153 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -525,6 +1298,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
@@ -541,12 +1338,78 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3485,6 +4348,395 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.23.1",
       "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
@@ -4562,6 +5814,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -5339,6 +6636,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bcp-47": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
@@ -5395,6 +6705,61 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -5944,6 +7309,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.23.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
@@ -6073,6 +7445,16 @@
         "@esbuild/win32-arm64": "0.28.0",
         "@esbuild/win32-ia32": "0.28.0",
         "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -6379,6 +7761,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-tsconfig": {
@@ -7263,12 +8655,38 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
@@ -7658,6 +9076,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lucide-react": {
@@ -8984,6 +10412,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9720,6 +11158,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -10195,6 +11643,51 @@
         "@rolldown/binding-wasm32-wasi": "1.0.3",
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rope-sequence": {
@@ -11134,6 +12627,37 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -11571,6 +13095,13 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@astrojs/react": "^5.0.7",
     "@astrojs/starlight": "^0.40.0",
     "@astrojs/starlight-tailwind": "^5.0.0",
     "@inertiajs/react": "^3.0.0",

--- a/resources/js/core/components/fragment.tsx
+++ b/resources/js/core/components/fragment.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import { withRefHeader } from "@lattice/lattice/core/component-ref";
 import { getStringProp } from "@lattice/lattice/core/props";
 import { Renderer, useRendererContext } from "@lattice/lattice/core/renderer";
-import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import type { Node, RendererComponent, Schema } from "@lattice/lattice/core/types";
 import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice/lattice/events/event-names";
 
 type FragmentResponse = {
-  components?: Node[];
+  schema?: Schema;
 };
 
 declare module "@lattice/lattice/core/types" {
@@ -34,7 +34,7 @@ const FragmentComponent: RendererComponent<"fragment"> = ({ node }) => {
   const endpoint = getStringProp(node.props, "endpoint");
   const isLazy = node.props?.lazy === true;
   const componentRef = getStringProp(node.props, "ref");
-  const [components, setComponents] = useState(() => node.children ?? []);
+  const [components, setComponents] = useState(() => node.schema ?? []);
   const [hasLoaded, setHasLoaded] = useState(!isLazy);
   const [processing, setProcessing] = useState(isLazy && endpoint !== "");
   const { fallback, missingComponent, registry } = useRendererContext();
@@ -55,7 +55,7 @@ const FragmentComponent: RendererComponent<"fragment"> = ({ node }) => {
       });
       const result = (await response.json()) as FragmentResponse;
 
-      setComponents(getComponents(result.components));
+      setComponents(getComponents(result.schema));
       setHasLoaded(true);
     } finally {
       setProcessing(false);

--- a/resources/js/core/components/modal-fragment.test.tsx
+++ b/resources/js/core/components/modal-fragment.test.tsx
@@ -27,7 +27,7 @@ describe("Lattice modal and fragment components", () => {
       <Renderer
         nodes={[
           {
-            children: [
+            schema: [
               {
                 props: {
                   text: "Authenticator setup",
@@ -72,7 +72,7 @@ describe("Lattice modal and fragment components", () => {
     fetch.mockResolvedValue(
       new Response(
         JSON.stringify({
-          components: [
+          schema: [
             {
               props: {
                 text: "Loaded fragment body",
@@ -135,7 +135,7 @@ describe("Lattice modal and fragment components", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            components: [
+            schema: [
               {
                 props: {
                   text: "Initial fragment body",
@@ -149,7 +149,7 @@ describe("Lattice modal and fragment components", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
-            components: [
+            schema: [
               {
                 props: {
                   text: "Reloaded fragment body",

--- a/resources/js/core/components/tabs.test.tsx
+++ b/resources/js/core/components/tabs.test.tsx
@@ -34,9 +34,9 @@ describe("Lattice tabs component", () => {
       <Renderer
         nodes={[
           {
-            children: [
+            schema: [
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Profile form",
@@ -51,7 +51,7 @@ describe("Lattice tabs component", () => {
                 type: "tab",
               },
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Security form",
@@ -104,9 +104,9 @@ describe("Lattice tabs component", () => {
       <Renderer
         nodes={[
           {
-            children: [
+            schema: [
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Profile form",
@@ -121,7 +121,7 @@ describe("Lattice tabs component", () => {
                 type: "tab",
               },
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Security form",
@@ -169,9 +169,9 @@ describe("Lattice tabs component", () => {
       <Renderer
         nodes={[
           {
-            children: [
+            schema: [
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Profile form",
@@ -230,9 +230,9 @@ describe("Lattice tabs component", () => {
       <Renderer
         nodes={[
           {
-            children: [
+            schema: [
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Loaded immediately",
@@ -247,7 +247,7 @@ describe("Lattice tabs component", () => {
                 type: "tab",
               },
               {
-                children: [
+                schema: [
                   {
                     props: {
                       text: "Loaded after opening",

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -34,7 +34,7 @@ type TabItem = {
 };
 
 function getTabs(node: Node): TabItem[] {
-  return (node.children ?? [])
+  return (node.schema ?? [])
     .filter((child) => child.type === "tab")
     .map((child) => ({
       confirm: getConfirmationProp(child.props),

--- a/resources/js/core/components/theming.test.tsx
+++ b/resources/js/core/components/theming.test.tsx
@@ -28,7 +28,7 @@ describe("Lattice component theming", () => {
   it("renders package controls with lt token utilities", () => {
     const tabs = {
       id: "settings.tabs",
-      children: [
+      schema: [
         {
           id: "settings.profile",
           props: {

--- a/resources/js/core/renderer.test.tsx
+++ b/resources/js/core/renderer.test.tsx
@@ -21,7 +21,7 @@ describe("Renderer", () => {
       <Renderer
         nodes={[
           {
-            children: [
+            schema: [
               {
                 id: "child",
                 type: "test.component",

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -82,11 +82,11 @@ function NodeRenderer({
   }
 
   const Component = registration.component;
-  const children = node.children?.length ? (
+  const children = node.schema?.length ? (
     <Renderer
       fallback={fallback}
       missingComponent={UnknownComponent}
-      nodes={node.children}
+      nodes={node.schema}
       registry={registry}
     />
   ) : null;

--- a/resources/js/core/types.ts
+++ b/resources/js/core/types.ts
@@ -14,19 +14,22 @@ export type PropsFor<TType extends string> = TType extends ComponentType
   : NodeProps;
 
 export type Node<TType extends string = string> = {
-  children?: Node[];
   id?: string;
   key?: string;
   props?: PropsFor<TType>;
+  schema?: Schema;
   type: TType;
 };
 
+/** An ordered list of component nodes — the content of a page, form, or container. */
+export type Schema = Node[];
+
 export type PagePayload = {
   breadcrumbs: PageBreadcrumb[];
-  components: Node[];
   container: PageContainer;
   layout: string;
   menus: Record<string, MenuPayload | undefined>;
+  schema: Schema;
   title: string | null;
 };
 

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -62,7 +62,7 @@ function collectFields(
       }
     }
 
-    collectFields(child.children, collected);
+    collectFields(child.schema, collected);
   }
 
   return collected;
@@ -135,8 +135,8 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
   const resetOnSuccess = props.resetOnSuccess ?? [];
   const state = getFormState(node.props);
   const { labels: fieldLabels, values: fieldValues } = useMemo(
-    () => collectFields(node.children),
-    [node.children],
+    () => collectFields(node.schema),
+    [node.schema],
   );
   const initialValues = { ...fieldValues, ...state };
   const shouldRenderSubmitButton = getBooleanProp(props, "submitButton", true);
@@ -194,7 +194,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
             <FormBody
               action={action}
               componentRef={componentRef}
-              nodes={node.children}
+              nodes={node.schema}
               shouldRenderSubmitButton={shouldRenderSubmitButton}
               submitLabel={submitLabel}
             >

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -20,7 +20,7 @@ function collectWatch(nodes: Node[] | undefined, keys: Set<string>, state: { any
     if (getBooleanProp(child.props, "dependsOnAny")) {
       state.any = true;
     }
-    collectWatch(child.children, keys, state);
+    collectWatch(child.schema, keys, state);
   }
 }
 

--- a/resources/js/form/skeleton.tsx
+++ b/resources/js/form/skeleton.tsx
@@ -5,9 +5,9 @@ export const FormSkeletonComponent: RendererComponent<"form"> = ({ node }) => {
     1,
     Math.min(
       4,
-      node.children
+      node.schema
         ?.find((child) => child.type === "grid")
-        ?.children?.filter((child) => child.type !== "form.hidden-input").length ?? 2,
+        ?.schema?.filter((child) => child.type !== "form.hidden-input").length ?? 2,
     ),
   );
 

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -39,6 +39,7 @@ export type {
   RendererComponent,
   RendererComponentModule,
   RendererComponentProps,
+  Schema,
   UnknownComponent,
 } from "./core/types";
 export type { Method } from "@inertiajs/core";

--- a/resources/js/inertia.test.tsx
+++ b/resources/js/inertia.test.tsx
@@ -23,7 +23,7 @@ function pageWithLattice(lattice: PagePayload): InertiaPage {
 function payload(lattice: Partial<PagePayload> = {}): PagePayload {
   return {
     breadcrumbs: [],
-    components: [],
+    schema: [],
     container: "default",
     layout: "none",
     menus: {},

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -11,7 +11,7 @@ vi.mock("@inertiajs/react", () => ({
 function payload(lattice: Partial<PagePayload> = {}): PagePayload {
   return {
     breadcrumbs: [],
-    components: [],
+    schema: [],
     container: "default",
     layout: "none",
     menus: {},
@@ -25,7 +25,7 @@ describe("Page", () => {
     render(
       <Page
         lattice={payload({
-          components: [
+          schema: [
             {
               props: { text: "Package rendered" },
               type: "text",
@@ -44,7 +44,7 @@ describe("Page", () => {
     render(
       <Page
         lattice={payload({
-          components: [
+          schema: [
             {
               props: { text: "Inside the app shell" },
               type: "text",
@@ -77,7 +77,7 @@ describe("Page", () => {
       <Provider registry={registry}>
         <Page
           lattice={payload({
-            components: [
+            schema: [
               {
                 props: { message: "Custom registry component" },
                 type: "custom.message",

--- a/resources/js/page.tsx
+++ b/resources/js/page.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export default function Page({ lattice }: Props) {
   const registry = useRegistry();
-  const content = <Renderer fallback={null} nodes={lattice.components} registry={registry} />;
+  const content = <Renderer fallback={null} nodes={lattice.schema} registry={registry} />;
 
   return (
     <>

--- a/resources/js/table/components/table-action-node.tsx
+++ b/resources/js/table/components/table-action-node.tsx
@@ -11,7 +11,7 @@ export function TableActionNode({ node }: { node: Node }) {
   if (node.type === "action.group") {
     return (
       <ActionGroupComponent node={node as Node<"action.group">}>
-        {node.children?.map((childNode, index) => (
+        {node.schema?.map((childNode, index) => (
           <TableActionNode
             key={childNode.key ?? childNode.id ?? `${childNode.type}-${index}`}
             node={childNode}

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -138,7 +138,7 @@ describe("Lattice table component", () => {
             status: "Active",
             actions: [
               {
-                children: [
+                schema: [
                   {
                     id: "workbench.ping",
                     props: {

--- a/src/Actions/Components/ActionGroup.php
+++ b/src/Actions/Components/ActionGroup.php
@@ -25,7 +25,7 @@ class ActionGroup extends ContainerComponent
      */
     public function actions(array $actions): static
     {
-        return $this->children($actions);
+        return $this->schema($actions);
     }
 
     protected function type(): string

--- a/src/Core/Components/ContainerComponent.php
+++ b/src/Core/Components/ContainerComponent.php
@@ -12,18 +12,11 @@ abstract class ContainerComponent extends Component
     protected array $children = [];
 
     /**
-     * @param  array<int, Component>  $children
+     * @param  array<int, Component>  $components
      */
-    public function children(array $children): static
+    public function schema(array $components): static
     {
-        $this->children = $children;
-
-        return $this;
-    }
-
-    public function child(Component $child): static
-    {
-        $this->children[] = $child;
+        $this->children = $components;
 
         return $this;
     }

--- a/src/Core/Components/ContainerComponent.php
+++ b/src/Core/Components/ContainerComponent.php
@@ -55,11 +55,11 @@ abstract class ContainerComponent extends Component
      * @return array<string, mixed>
      */
     #[SerializationHook(priority: 300)]
-    protected function serialiseChildren(array $data): array
+    protected function serialiseSchema(array $data): array
     {
         return [
             ...$data,
-            'children' => array_map(
+            'schema' => array_map(
                 fn (Component $child): array => $child->toArray(),
                 $this->renderableChildren(),
             ),

--- a/src/Core/Components/Tab.php
+++ b/src/Core/Components/Tab.php
@@ -57,7 +57,7 @@ class Tab extends ContainerComponent
         $data = $this->toArray();
 
         if ($this->requiresConfirmation() && $this->value() !== $activeValue) {
-            unset($data['children']);
+            unset($data['schema']);
         }
 
         return $data;

--- a/src/Core/Components/Tabs.php
+++ b/src/Core/Components/Tabs.php
@@ -53,7 +53,7 @@ class Tabs extends ContainerComponent
      * @return array<string, mixed>
      */
     #[SerializationHook(priority: 300)]
-    protected function serialiseChildren(array $data): array
+    protected function serialiseSchema(array $data): array
     {
         $props = $data['props'] ?? [];
         $activeValue = is_array($props) && is_string($props['activeValue'] ?? null)
@@ -62,7 +62,7 @@ class Tabs extends ContainerComponent
 
         return [
             ...$data,
-            'children' => array_map(
+            'schema' => array_map(
                 fn (Component $child): array => $child instanceof Tab
                     ? $child->toArrayForTabs($activeValue)
                     : $child->toArray(),

--- a/src/Core/PageSchema.php
+++ b/src/Core/PageSchema.php
@@ -19,7 +19,7 @@ final class PageSchema
     /**
      * @param  array<int, Component>  $components
      */
-    public function components(array $components): static
+    public function schema(array $components): static
     {
         $this->components = $components;
 

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -45,12 +45,15 @@ abstract class Field extends Component
      */
     protected array $messages = [];
 
-    public static function make(string $name, string $label): static
+    public static function make(string $name, ?string $label = null): static
     {
-        return (new static)->props([
-            'label' => $label,
-            'name' => $name,
-        ]);
+        $props = ['name' => $name];
+
+        if ($label !== null) {
+            $props['label'] = $label;
+        }
+
+        return (new static)->props($props);
     }
 
     public function name(): string
@@ -58,7 +61,15 @@ abstract class Field extends Component
         return (string) ($this->props['name'] ?? '');
     }
 
-    public function label(): ?string
+    public function label(string $label): static
+    {
+        return $this->prop('label', $label);
+    }
+
+    /**
+     * @internal
+     */
+    public function getLabel(): ?string
     {
         $label = $this->props['label'] ?? null;
 
@@ -73,6 +84,8 @@ abstract class Field extends Component
     }
 
     /**
+     * @internal
+     *
      * @return array<string, string>
      */
     public function messages(): array
@@ -97,6 +110,8 @@ abstract class Field extends Component
     }
 
     /**
+     * @internal
+     *
      * @return array<int, mixed>
      */
     public function resolveRules(FormData $data, Request $request): array
@@ -130,12 +145,17 @@ abstract class Field extends Component
         return $this->addCondition('visible', (string) $attributes, $operatorOrValue, $value, func_num_args());
     }
 
+    public function visibleWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
+    {
+        return $this->addCondition('visible', $field, $operatorOrValue, $value, func_num_args());
+    }
+
     public function requiredWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
         return $this->addCondition('required', $field, $operatorOrValue, $value, func_num_args());
     }
 
-    public function readonlyWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
+    public function readOnlyWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
         return $this->addCondition('readonly', $field, $operatorOrValue, $value, func_num_args());
     }
@@ -173,9 +193,9 @@ abstract class Field extends Component
         return $this->prop('required', $required);
     }
 
-    public function readonly(bool $readonly = true): static
+    public function readOnly(bool $readOnly = true): static
     {
-        return $this->prop('readonly', $readonly);
+        return $this->prop('readonly', $readOnly);
     }
 
     public function disabled(bool $disabled = true): static
@@ -200,11 +220,17 @@ abstract class Field extends Component
         return $this;
     }
 
+    /**
+     * @internal
+     */
     public function isComputed(): bool
     {
         return $this->dependencies !== [] || $this->valueResolver !== null;
     }
 
+    /**
+     * @internal
+     */
     public function applyResolution(FormData $data, Request $request): void
     {
         $this->resolving = true;
@@ -220,16 +246,25 @@ abstract class Field extends Component
         $this->resolving = false;
     }
 
+    /**
+     * @internal
+     */
     public function hasResolvedValue(): bool
     {
         return $this->hasResolvedValue;
     }
 
+    /**
+     * @internal
+     */
     public function resolvedValue(): mixed
     {
         return $this->props['value'] ?? null;
     }
 
+    /**
+     * @internal
+     */
     public function isVisible(FormData $data): bool
     {
         if ($this->props['hidden'] ?? false) {
@@ -239,21 +274,33 @@ abstract class Field extends Component
         return ($this->conditions['visible'] ?? null)?->allMatch($data) ?? true;
     }
 
+    /**
+     * @internal
+     */
     public function isRequired(FormData $data): bool
     {
         return ($this->props['required'] ?? false) || (($this->conditions['required'] ?? null)?->anyMatches($data) ?? false);
     }
 
-    public function isReadonly(FormData $data): bool
+    /**
+     * @internal
+     */
+    public function isReadOnly(FormData $data): bool
     {
         return ($this->props['readonly'] ?? false) || (($this->conditions['readonly'] ?? null)?->anyMatches($data) ?? false);
     }
 
+    /**
+     * @internal
+     */
     public function isDisabled(FormData $data): bool
     {
         return ($this->props['disabled'] ?? false) || (($this->conditions['disabled'] ?? null)?->anyMatches($data) ?? false);
     }
 
+    /**
+     * @internal
+     */
     public function hasValue(): bool
     {
         return array_key_exists('value', $this->props);

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -36,8 +36,6 @@ abstract class Field extends Component
 
     protected ?Closure $valueResolver = null;
 
-    protected bool $resolving = false;
-
     protected bool $hasResolvedValue = false;
 
     /**
@@ -142,33 +140,33 @@ abstract class Field extends Component
             return $this;
         }
 
-        return $this->addCondition('visible', (string) $attributes, $operatorOrValue, $value, func_num_args());
+        return $this->addCondition('visible', (string) $attributes, $operatorOrValue, $value);
     }
 
     public function visibleWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
-        return $this->addCondition('visible', $field, $operatorOrValue, $value, func_num_args());
+        return $this->addCondition('visible', $field, $operatorOrValue, $value);
     }
 
     public function requiredWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
-        return $this->addCondition('required', $field, $operatorOrValue, $value, func_num_args());
+        return $this->addCondition('required', $field, $operatorOrValue, $value);
     }
 
     public function readOnlyWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
-        return $this->addCondition('readonly', $field, $operatorOrValue, $value, func_num_args());
+        return $this->addCondition('readonly', $field, $operatorOrValue, $value);
     }
 
     public function disabledWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
-        return $this->addCondition('disabled', $field, $operatorOrValue, $value, func_num_args());
+        return $this->addCondition('disabled', $field, $operatorOrValue, $value);
     }
 
-    private function addCondition(string $group, string $field, mixed $operatorOrValue, mixed $value, int $argCount): static
+    private function addCondition(string $group, string $field, mixed $operatorOrValue, mixed $value): static
     {
         ($this->conditions[$group] ??= new ConditionSet)
-            ->add($this->makeCondition($field, $operatorOrValue, $value, $argCount));
+            ->add($this->makeCondition($field, $operatorOrValue, $value));
 
         return $this;
     }
@@ -178,14 +176,9 @@ abstract class Field extends Component
         return $this->prop('hidden', $hidden);
     }
 
-    public function show(): static
+    public function visible(bool $visible = true): static
     {
-        return $this->hidden(false);
-    }
-
-    public function hide(): static
-    {
-        return $this->hidden(true);
+        return $this->prop('hidden', ! $visible);
     }
 
     public function required(bool $required = true): static
@@ -211,13 +204,7 @@ abstract class Field extends Component
             return $this;
         }
 
-        $this->prop('value', $value);
-
-        if ($this->resolving) {
-            $this->hasResolvedValue = true;
-        }
-
-        return $this;
+        return $this->prop('value', $value);
     }
 
     /**
@@ -233,17 +220,14 @@ abstract class Field extends Component
      */
     public function applyResolution(FormData $data, Request $request): void
     {
-        $this->resolving = true;
-
         foreach ($this->dependencies as $dependency) {
             ($dependency['callback'])($this, $data, $request);
         }
 
         if ($this->valueResolver !== null) {
-            $this->value(($this->valueResolver)($data, $request));
+            $this->prop('value', ($this->valueResolver)($data, $request));
+            $this->hasResolvedValue = true;
         }
-
-        $this->resolving = false;
     }
 
     /**
@@ -279,7 +263,7 @@ abstract class Field extends Component
      */
     public function isRequired(FormData $data): bool
     {
-        return ($this->props['required'] ?? false) || (($this->conditions['required'] ?? null)?->anyMatches($data) ?? false);
+        return $this->conditionState('required', $data);
     }
 
     /**
@@ -287,7 +271,7 @@ abstract class Field extends Component
      */
     public function isReadOnly(FormData $data): bool
     {
-        return ($this->props['readonly'] ?? false) || (($this->conditions['readonly'] ?? null)?->anyMatches($data) ?? false);
+        return $this->conditionState('readonly', $data);
     }
 
     /**
@@ -295,7 +279,12 @@ abstract class Field extends Component
      */
     public function isDisabled(FormData $data): bool
     {
-        return ($this->props['disabled'] ?? false) || (($this->conditions['disabled'] ?? null)?->anyMatches($data) ?? false);
+        return $this->conditionState('disabled', $data);
+    }
+
+    private function conditionState(string $group, FormData $data): bool
+    {
+        return ($this->props[$group] ?? false) || (($this->conditions[$group] ?? null)?->anyMatches($data) ?? false);
     }
 
     /**
@@ -321,15 +310,17 @@ abstract class Field extends Component
      */
     public function prefill(mixed $value): void {}
 
-    private function makeCondition(string $field, mixed $operatorOrValue, mixed $value, int $argCount): Condition
+    private function makeCondition(string $field, mixed $operatorOrValue, mixed $value): Condition
     {
-        if ($argCount >= 3) {
-            $operator = $operatorOrValue instanceof ConditionOperator ? $operatorOrValue : ConditionOperator::from((string) $operatorOrValue);
-
-            return new Condition($field, $operator, $value);
+        if ($value === null && ! $operatorOrValue instanceof ConditionOperator) {
+            return new Condition($field, is_array($operatorOrValue) ? ConditionOperator::In : ConditionOperator::Equals, $operatorOrValue);
         }
 
-        return new Condition($field, is_array($operatorOrValue) ? ConditionOperator::In : ConditionOperator::Equals, $operatorOrValue);
+        $operator = $operatorOrValue instanceof ConditionOperator
+            ? $operatorOrValue
+            : ConditionOperator::fromHuman((string) $operatorOrValue);
+
+        return new Condition($field, $operator, $value);
     }
 
     /**
@@ -341,8 +332,8 @@ abstract class Field extends Component
     {
         $conditions = [];
 
-        foreach (['visible', 'required', 'readonly', 'disabled'] as $group) {
-            $serialised = ($this->conditions[$group] ?? null)?->jsonSerialize() ?? [];
+        foreach ($this->conditions as $group => $set) {
+            $serialised = $set->jsonSerialize();
 
             if ($serialised !== []) {
                 $conditions[$group] = $serialised;

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -36,6 +36,8 @@ abstract class Field extends Component
 
     protected ?Closure $valueResolver = null;
 
+    protected bool $resolving = false;
+
     protected bool $hasResolvedValue = false;
 
     /**
@@ -204,7 +206,13 @@ abstract class Field extends Component
             return $this;
         }
 
-        return $this->prop('value', $value);
+        $this->prop('value', $value);
+
+        if ($this->resolving) {
+            $this->hasResolvedValue = true;
+        }
+
+        return $this;
     }
 
     /**
@@ -220,14 +228,17 @@ abstract class Field extends Component
      */
     public function applyResolution(FormData $data, Request $request): void
     {
+        $this->resolving = true;
+
         foreach ($this->dependencies as $dependency) {
             ($dependency['callback'])($this, $data, $request);
         }
 
         if ($this->valueResolver !== null) {
-            $this->prop('value', ($this->valueResolver)($data, $request));
-            $this->hasResolvedValue = true;
+            $this->value(($this->valueResolver)($data, $request));
         }
+
+        $this->resolving = false;
     }
 
     /**

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -16,6 +16,8 @@ class Form extends ContainerComponent
 {
     use IsInteractive;
 
+    public const DEFAULT_VALIDATION_DEBOUNCE_MS = 1500;
+
     public static function make(string $id): static
     {
         return (new static)->id($id);
@@ -57,11 +59,11 @@ class Form extends ContainerComponent
         return $this->prop('state', $state instanceof Arrayable ? $state->toArray() : $state);
     }
 
-    public function precognitive(int $delay = 1500): static
+    public function precognitive(int $debounceMs = self::DEFAULT_VALIDATION_DEBOUNCE_MS): static
     {
         return $this
             ->prop('precognitive', true)
-            ->prop('validationTimeout', $delay);
+            ->prop('validationTimeout', $debounceMs);
     }
 
     public function withoutSubmitButton(): static

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -33,7 +33,7 @@ class Form extends ContainerComponent
         return (new static)
             ->id($registered->id)
             ->props($registered->props)
-            ->children($registered->children);
+            ->schema($registered->children);
     }
 
     public function action(string $action): static
@@ -69,14 +69,6 @@ class Form extends ContainerComponent
     public function withoutSubmitButton(): static
     {
         return $this->prop('submitButton', false);
-    }
-
-    /**
-     * @param  array<int, Component>  $components
-     */
-    public function schema(array $components): static
-    {
-        return $this->children($components);
     }
 
     /**

--- a/src/Forms/Components/HiddenInput.php
+++ b/src/Forms/Components/HiddenInput.php
@@ -4,14 +4,6 @@ namespace Lattice\Lattice\Forms\Components;
 
 class HiddenInput extends Field
 {
-    public static function make(string $name, string $value): static
-    {
-        return (new static)->props([
-            'name' => $name,
-            'value' => $value,
-        ]);
-    }
-
     protected function type(): string
     {
         return 'form.hidden-input';

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -37,6 +37,9 @@ class Select extends Field
         return $this->prop('searchable', true);
     }
 
+    /**
+     * @internal
+     */
     public function isSearchable(): bool
     {
         return $this->searchResolver !== null;
@@ -57,6 +60,8 @@ class Select extends Field
     }
 
     /**
+     * @internal
+     *
      * @return array<int, array{label: string, value: string}>
      */
     public function resolveSearch(string $query, FormData $data, Request $request): array

--- a/src/Forms/Enums/ConditionOperator.php
+++ b/src/Forms/Enums/ConditionOperator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Forms\Enums;
 
+use InvalidArgumentException;
+
 enum ConditionOperator: string
 {
     case Equals = 'eq';
@@ -20,6 +22,26 @@ enum ConditionOperator: string
     case Empty = 'empty';
     case Filled = 'filled';
 
+    /**
+     * Resolve an operator from an enum value (`gt`) or a human comparison (`>`).
+     */
+    public static function fromHuman(string $operator): self
+    {
+        return match ($operator) {
+            '=', '==' => self::Equals,
+            '!=', '<>' => self::NotEquals,
+            '>' => self::GreaterThan,
+            '>=' => self::GreaterThanOrEqual,
+            '<' => self::LessThan,
+            '<=' => self::LessThanOrEqual,
+            default => self::tryFrom($operator) ?? throw new InvalidArgumentException(sprintf(
+                'Unknown condition operator [%s]. Use a comparison such as ">", ">=", "!=", or one of: %s.',
+                $operator,
+                implode(', ', array_map(static fn (self $case): string => $case->value, self::cases())),
+            )),
+        };
+    }
+
     public function evaluate(mixed $actual, mixed $expected): bool
     {
         return match ($this) {
@@ -34,8 +56,8 @@ enum ConditionOperator: string
             self::EndsWith => str_ends_with((string) $actual, (string) $expected),
             self::In => $this->isIn($actual, $expected),
             self::NotIn => ! $this->isIn($actual, $expected),
-            self::Empty => $this->isBlank($actual),
-            self::Filled => ! $this->isBlank($actual),
+            self::Empty => blank($actual),
+            self::Filled => filled($actual),
         };
     }
 
@@ -58,10 +80,5 @@ enum ConditionOperator: string
         $needles = array_map(static fn (mixed $v): string => (string) $v, (array) $expected);
 
         return in_array((string) $actual, $needles, true);
-    }
-
-    private function isBlank(mixed $value): bool
-    {
-        return $value === null || (string) $value === '';
     }
 }

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -66,7 +66,7 @@ abstract class FormDefinition extends Definition implements ProvidesForm
                 continue;
             }
 
-            if ($field->isReadonly($data) || $field->isDisabled($data)) {
+            if ($field->isReadOnly($data) || $field->isDisabled($data)) {
                 unset($validated[$name]);
 
                 continue;
@@ -193,8 +193,8 @@ abstract class FormDefinition extends Definition implements ProvidesForm
     private function attributeSet(Collection $fields, FormData $data): array
     {
         return $fields
-            ->filter(fn (Field $field): bool => $field->isVisible($data) && $field->label() !== null)
-            ->mapWithKeys(fn (Field $field): array => [$field->name() => (string) $field->label()])
+            ->filter(fn (Field $field): bool => $field->isVisible($data) && $field->getLabel() !== null)
+            ->mapWithKeys(fn (Field $field): array => [$field->name() => (string) $field->getLabel()])
             ->all();
     }
 
@@ -208,7 +208,7 @@ abstract class FormDefinition extends Definition implements ProvidesForm
             return true;
         }
 
-        return ($field->isReadonly($data) || $field->isDisabled($data)) && $field->hasValue();
+        return ($field->isReadOnly($data) || $field->isDisabled($data)) && $field->hasValue();
     }
 
     /**

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -34,39 +34,70 @@ abstract class FormDefinition extends Definition implements ProvidesForm
         $fields = $this->resolvedFields($request, $data);
 
         $input = $request->all();
+        $rules = [];
+        $messages = [];
+        $attributes = [];
 
-        foreach ($fields as $field) {
-            if ($this->usesServerValue($field, $data)) {
-                $input[$field->name()] = $field->resolvedValue();
-            }
-        }
-
-        $validator = $this->validator(
-            $input,
-            $this->ruleSet($fields, $data, $request),
-            $this->messageSet($fields, $data),
-            $this->attributeSet($fields, $data),
-            $request,
-        );
-
-        $validated = $validator->validate();
+        /** @var array<int, array{field: Field, name: string, visible: bool, serverValue: bool, locked: bool}> $plan */
+        $plan = [];
 
         foreach ($fields as $field) {
             $name = $field->name();
+            $visible = $field->isVisible($data);
+            $locked = $field->isReadOnly($data) || $field->isDisabled($data);
+            $serverValue = $field->hasResolvedValue() || ($locked && $field->hasValue());
 
-            if (! $field->isVisible($data)) {
+            $plan[] = [
+                'field' => $field,
+                'name' => $name,
+                'visible' => $visible,
+                'serverValue' => $serverValue,
+                'locked' => $locked,
+            ];
+
+            if ($serverValue) {
+                $input[$name] = $field->resolvedValue();
+            }
+
+            if (! $visible) {
+                continue;
+            }
+
+            $fieldRules = $field->resolveRules($data, $request);
+
+            if ($field->isRequired($data) && ! in_array('required', $fieldRules, true)) {
+                array_unshift($fieldRules, 'required');
+            }
+
+            if ($fieldRules !== []) {
+                $rules[$name] = $fieldRules;
+            }
+
+            foreach ($field->messages() as $rule => $message) {
+                $messages["{$name}.{$rule}"] = $message;
+            }
+
+            if (($label = $field->getLabel()) !== null) {
+                $attributes[$name] = $label;
+            }
+        }
+
+        $validated = $this->validator($input, $rules, $messages, $attributes, $request)->validate();
+
+        foreach ($plan as ['field' => $field, 'name' => $name, 'visible' => $visible, 'serverValue' => $serverValue, 'locked' => $locked]) {
+            if (! $visible) {
                 unset($validated[$name]);
 
                 continue;
             }
 
-            if ($this->usesServerValue($field, $data)) {
+            if ($serverValue) {
                 $validated[$name] = $field->resolvedValue();
 
                 continue;
             }
 
-            if ($field->isReadOnly($data) || $field->isDisabled($data)) {
+            if ($locked) {
                 unset($validated[$name]);
 
                 continue;
@@ -146,77 +177,6 @@ abstract class FormDefinition extends Definition implements ProvidesForm
     protected function buildForm(Request $request): Form
     {
         return $this->definition(Form::make('form'), $request);
-    }
-
-    /**
-     * @param  Collection<int, Field>  $fields
-     * @return array<string, array<int, mixed>>
-     */
-    private function ruleSet(Collection $fields, FormData $data, Request $request): array
-    {
-        return $fields
-            ->filter(fn (Field $field): bool => $field->isVisible($data))
-            ->mapWithKeys(function (Field $field) use ($data, $request): array {
-                $rules = $field->resolveRules($data, $request);
-
-                if ($field->isRequired($data) && ! in_array('required', $rules, true)) {
-                    array_unshift($rules, 'required');
-                }
-
-                return [$field->name() => $rules];
-            })
-            ->filter(fn (array $rules): bool => $rules !== [])
-            ->all();
-    }
-
-    /**
-     * Custom validation messages keyed as "{field}.{rule}", collected from visible fields.
-     *
-     * @param  Collection<int, Field>  $fields
-     * @return array<string, string>
-     */
-    private function messageSet(Collection $fields, FormData $data): array
-    {
-        $messages = [];
-
-        foreach ($fields as $field) {
-            if (! $field->isVisible($data)) {
-                continue;
-            }
-
-            foreach ($field->messages() as $rule => $message) {
-                $messages["{$field->name()}.{$rule}"] = $message;
-            }
-        }
-
-        return $messages;
-    }
-
-    /**
-     * Field labels used as human-friendly validation attribute names.
-     *
-     * @param  Collection<int, Field>  $fields
-     * @return array<string, string>
-     */
-    private function attributeSet(Collection $fields, FormData $data): array
-    {
-        return $fields
-            ->filter(fn (Field $field): bool => $field->isVisible($data) && $field->getLabel() !== null)
-            ->mapWithKeys(fn (Field $field): array => [$field->name() => (string) $field->getLabel()])
-            ->all();
-    }
-
-    /**
-     * A field's value is authoritative server-side when it is computed (imperative value
-     * closure) or when it is locked (readonly/disabled) and carries a declarative value.
-     */
-    private function usesServerValue(Field $field, FormData $data): bool
-    {
-        if ($field->hasResolvedValue()) {
-            return true;
-        }
-
-        return ($field->isReadOnly($data) || $field->isDisabled($data)) && $field->hasValue();
     }
 
     /**

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -92,7 +92,7 @@ abstract class FormDefinition extends Definition implements ProvidesForm
         $query = $request->string('q')->toString();
         $data = FormData::fromRequest($request);
 
-        $field = $this->definition(Form::make('form'), $request)
+        $field = $this->buildForm($request)
             ->fields()
             ->first(fn (Field $field): bool => $field->name() === $name);
 
@@ -111,7 +111,7 @@ abstract class FormDefinition extends Definition implements ProvidesForm
         $fields = [];
         $values = [];
 
-        foreach ($this->definition(Form::make('form'), $request)->fields() as $field) {
+        foreach ($this->buildForm($request)->fields() as $field) {
             if (! $field->isComputed()) {
                 continue;
             }
@@ -135,9 +135,17 @@ abstract class FormDefinition extends Definition implements ProvidesForm
      */
     protected function resolvedFields(Request $request, FormData $data): Collection
     {
-        return $this->definition(Form::make('form'), $request)
+        return $this->buildForm($request)
             ->fields()
             ->each(fn (Field $field) => $field->applyResolution($data, $request));
+    }
+
+    /**
+     * Build this form's component tree for the current request.
+     */
+    protected function buildForm(Request $request): Form
+    {
+        return $this->definition(Form::make('form'), $request);
     }
 
     /**

--- a/src/Fragments/FragmentRegistry.php
+++ b/src/Fragments/FragmentRegistry.php
@@ -28,14 +28,14 @@ final class FragmentRegistry extends DefinitionRegistry
     }
 
     /**
-     * @return array{components: array<int, array<string, mixed>>}
+     * @return array{schema: array<int, array<string, mixed>>}
      */
     public function response(string $key, ?FragmentDefinition $definition = null): array
     {
         $definition ??= $this->resolve($key);
 
         return [
-            'components' => $definition
+            'schema' => $definition
                 ->schema(PageSchema::make())
                 ->toArray(),
         ];

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -78,7 +78,7 @@ abstract class Page implements PageContract
     }
 
     /**
-     * @return array{title: string|null, layout: string, container: string, breadcrumbs: array<int, array{title: string, href: string}>, menus: array<string, array{groups: array<int, array{label: string|null, items: array<int, array{active: bool, href: string, icon: string|null, key: string, label: string, method: string}>}>}>, components: array<int, array<string, mixed>>}
+     * @return array{title: string|null, layout: string, container: string, breadcrumbs: array<int, array{title: string, href: string}>, menus: array<string, array{groups: array<int, array{label: string|null, items: array<int, array{active: bool, href: string, icon: string|null, key: string, label: string, method: string}>}>}>, schema: array<int, array<string, mixed>>}
      */
     public function toArray(PageSchema $schema, ?Request $request = null): array
     {
@@ -90,7 +90,7 @@ abstract class Page implements PageContract
             'menus' => $request instanceof Request
                 ? Lattice::menus()->toArray($request)
                 : [],
-            'components' => $schema->toArray(),
+            'schema' => $schema->toArray(),
         ];
     }
 

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -245,7 +245,7 @@ test('forms serialize schema children like pages', function () {
         ->toMatchArray([
             'type' => 'form',
             'id' => 'profile-form',
-            'children' => [
+            'schema' => [
                 [
                     'type' => 'text',
                     'props' => [
@@ -412,11 +412,11 @@ test('components can opt out of rendering with when', function () {
 
     $pageData = $page->toArray($page->render(PageSchema::make()));
 
-    expect($pageData['components'])
+    expect($pageData['schema'])
         ->toHaveCount(2)
-        ->and($pageData['components'][0]['props']['text'])->toBe('Visible root')
-        ->and($pageData['components'][1]['children'])->toHaveCount(1)
-        ->and($pageData['components'][1]['children'][0]['props']['text'])->toBe('Visible child');
+        ->and($pageData['schema'][0]['props']['text'])->toBe('Visible root')
+        ->and($pageData['schema'][1]['schema'])->toHaveCount(1)
+        ->and($pageData['schema'][1]['schema'][0]['props']['text'])->toBe('Visible child');
 });
 
 test('segmented control serializes options value and emit event', function () {
@@ -472,7 +472,7 @@ test('registered forms serialize their configured endpoint and isolated error ba
                 'ref' => componentRef($form),
                 'submitButton' => false,
             ],
-            'children' => [
+            'schema' => [
                 [
                     'type' => 'text',
                     'props' => [
@@ -522,7 +522,7 @@ test('registered forms receive the current request while serializing definitions
 
     getJson('/request-aware-form?label=Request aware')
         ->assertOk()
-        ->assertJsonPath('children.0.props.text', 'Request aware');
+        ->assertJsonPath('schema.0.props.text', 'Request aware');
 });
 
 test('registered tables serialize their configured endpoint columns state and initial data', function () {
@@ -941,7 +941,7 @@ test('action groups serialize grouped child actions', function () {
             'props' => [
                 'label' => 'Manage user',
             ],
-            'children' => [
+            'schema' => [
                 [
                     'type' => 'action',
                     'id' => 'workbench.users.promote',
@@ -949,7 +949,7 @@ test('action groups serialize grouped child actions', function () {
                         'endpoint' => '/lattice/actions/workbench.users.promote',
                         'label' => 'Promote',
                         'method' => 'patch',
-                        'ref' => componentRef($group['children'][0]),
+                        'ref' => componentRef($group['schema'][0]),
                     ],
                 ],
                 [
@@ -959,7 +959,7 @@ test('action groups serialize grouped child actions', function () {
                         'endpoint' => '/lattice/actions/workbench.users.remove',
                         'label' => 'Remove',
                         'method' => 'delete',
-                        'ref' => componentRef($group['children'][1]),
+                        'ref' => componentRef($group['schema'][1]),
                         'variant' => 'destructive',
                     ],
                 ],
@@ -1154,7 +1154,7 @@ test('modals serialize composable children for action driven dialogs', function 
                 'title' => 'Set up two-factor authentication',
                 'description' => 'Scan the QR code with your authenticator app.',
             ],
-            'children' => [
+            'schema' => [
                 [
                     'type' => 'text',
                     'props' => [
@@ -1190,8 +1190,8 @@ test('registered fragments serialize lazy endpoints and return component schemas
 
     latticeGet('/lattice/fragments/workbench.two-factor-setup', $ref)
         ->assertOk()
-        ->assertJsonPath('components.0.type', 'text')
-        ->assertJsonPath('components.0.props.text', 'Authenticator setup loaded.');
+        ->assertJsonPath('schema.0.type', 'text')
+        ->assertJsonPath('schema.0.props.text', 'Authenticator setup loaded.');
 });
 
 test('links and horizontal stacks serialize as separate composable primitives', function () {
@@ -1206,7 +1206,7 @@ test('links and horizontal stacks serialize as separate composable primitives', 
                 'direction' => 'row',
                 'gap' => 'xs',
             ],
-            'children' => [
+            'schema' => [
                 [
                     'type' => 'text',
                     'props' => [
@@ -1261,14 +1261,14 @@ test('tabs serialize tab panels as composable children', function () {
                 'defaultValue' => 'security',
                 'queryKey' => 'tabs',
             ],
-            'children' => [
+            'schema' => [
                 [
                     'type' => 'tab',
                     'props' => [
                         'label' => 'Profile',
                         'value' => 'profile',
                     ],
-                    'children' => [
+                    'schema' => [
                         [
                             'type' => 'text',
                             'props' => [
@@ -1283,7 +1283,7 @@ test('tabs serialize tab panels as composable children', function () {
                         'label' => 'Security',
                         'value' => 'security',
                     ],
-                    'children' => [
+                    'schema' => [
                         [
                             'type' => 'form',
                             'id' => 'password-form',
@@ -1318,8 +1318,8 @@ test('tabs ignore hidden tab children when resolving their active value', functi
         ->toArray();
 
     expect($tabs['props']['activeValue'])->toBe('profile')
-        ->and($tabs['children'])->toHaveCount(1)
-        ->and($tabs['children'][0]['props']['value'])->toBe('profile');
+        ->and($tabs['schema'])->toHaveCount(1)
+        ->and($tabs['schema'][0]['props']['value'])->toBe('profile');
 });
 
 test('tabs hydrate their active value from the request query string', function () {
@@ -1331,8 +1331,8 @@ test('tabs hydrate their active value from the request query string', function (
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page')
-            ->where('lattice.components.0.props.defaultValue', 'profile')
-            ->where('lattice.components.0.props.activeValue', 'security')
+            ->where('lattice.schema.0.props.defaultValue', 'profile')
+            ->where('lattice.schema.0.props.activeValue', 'security')
         );
 });
 
@@ -1354,13 +1354,13 @@ test('confirmed inactive tabs serialize only their tab metadata', function () {
     expect($tabs['props']['activeValue'])->toBe('profile')
         ->and($tabs['props']['defaultValue'])->toBe('profile')
         ->and($tabs['props']['queryKey'])->toBe('tabs')
-        ->and($tabs['children'][0]['props']['value'])->toBe('profile')
-        ->and($tabs['children'][1]['props']['value'])->toBe('security')
-        ->and($tabs['children'][1]['props']['confirm'])->toMatchArray([
+        ->and($tabs['schema'][0]['props']['value'])->toBe('profile')
+        ->and($tabs['schema'][1]['props']['value'])->toBe('security')
+        ->and($tabs['schema'][1]['props']['confirm'])->toMatchArray([
             'required' => true,
             'redirectUrl' => '/user/confirm-password',
         ])
-        ->and($tabs['children'][1])->not->toHaveKey('children');
+        ->and($tabs['schema'][1])->not->toHaveKey('schema');
 });
 
 test('confirmed active tabs redirect to password confirmation when the password is not confirmed', function () {
@@ -1385,8 +1385,8 @@ test('confirmed active tabs serialize their children after password confirmation
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page')
-            ->where('lattice.components.0.props.activeValue', 'security')
-            ->where('lattice.components.0.children.1.children.0.props.text', 'Security form')
+            ->where('lattice.schema.0.props.activeValue', 'security')
+            ->where('lattice.schema.0.schema.1.schema.0.props.text', 'Security form')
         );
 });
 
@@ -1413,7 +1413,7 @@ test('pages use laravel controller resolution for constructor dependencies rende
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page')
-            ->where('lattice.components.0.props.text', 'Injected Route Bound User details details')
+            ->where('lattice.schema.0.props.text', 'Injected Route Bound User details details')
         );
 });
 
@@ -1431,7 +1431,7 @@ test('pages can authorize requests before rendering', function () {
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page')
-            ->where('lattice.components.0.props.text', 'Authorized page')
+            ->where('lattice.schema.0.props.text', 'Authorized page')
         );
 });
 
@@ -1579,17 +1579,17 @@ test('workbench pages serialize package component trees for inertia', function (
             ->where('lattice.title', 'Lattice Workbench')
             ->where('lattice.layout', 'none')
             ->where('lattice.container', 'centered')
-            ->where('lattice.components.0.type', 'stack')
-            ->where('lattice.components.0.key', 'workbench-page')
-            ->where('lattice.components.0.children.0.type', 'stack')
-            ->where('lattice.components.0.children.0.key', 'workbench-hero')
-            ->where('lattice.components.0.children.0.children.0.type', 'badge')
-            ->where('lattice.components.0.children.0.children.0.props.label', 'Lattice Package')
-            ->where('lattice.components.0.children.0.children.1.type', 'heading')
-            ->where('lattice.components.0.children.0.children.1.props.text', 'Workbench page')
-            ->where('lattice.components.0.children.1.type', 'grid')
-            ->where('lattice.components.0.children.1.children.0.type', 'card')
-            ->where('lattice.components.0.children.1.children.0.props.title', 'Components'));
+            ->where('lattice.schema.0.type', 'stack')
+            ->where('lattice.schema.0.key', 'workbench-page')
+            ->where('lattice.schema.0.schema.0.type', 'stack')
+            ->where('lattice.schema.0.schema.0.key', 'workbench-hero')
+            ->where('lattice.schema.0.schema.0.schema.0.type', 'badge')
+            ->where('lattice.schema.0.schema.0.schema.0.props.label', 'Lattice Package')
+            ->where('lattice.schema.0.schema.0.schema.1.type', 'heading')
+            ->where('lattice.schema.0.schema.0.schema.1.props.text', 'Workbench page')
+            ->where('lattice.schema.0.schema.1.type', 'grid')
+            ->where('lattice.schema.0.schema.1.schema.0.type', 'card')
+            ->where('lattice.schema.0.schema.1.schema.0.props.title', 'Components'));
 });
 
 test('workbench tables page serializes lazy tables for each pagination type', function () {
@@ -1600,24 +1600,24 @@ test('workbench tables page serializes lazy tables for each pagination type', fu
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page')
             ->where('lattice.title', 'Lattice Tables')
-            ->where('lattice.components.0.type', 'stack')
-            ->where('lattice.components.0.key', 'tables-page')
-            ->where('lattice.components.0.children.1.type', 'tabs')
-            ->where('lattice.components.0.children.1.props.defaultValue', 'none')
-            ->where('lattice.components.0.children.1.children.0.props.value', 'none')
-            ->where('lattice.components.0.children.1.children.0.children.1.id', 'workbench.users.none')
-            ->where('lattice.components.0.children.1.children.0.children.1.props.lazy', true)
-            ->where('lattice.components.0.children.1.children.0.children.1.props.data', [])
-            ->where('lattice.components.0.children.1.children.0.children.1.props.pagination.mode', 'none')
-            ->where('lattice.components.0.children.1.children.1.props.value', 'simple')
-            ->where('lattice.components.0.children.1.children.1.children.1.id', 'workbench.users.simple')
-            ->where('lattice.components.0.children.1.children.1.children.1.props.pagination.mode', 'simple')
-            ->where('lattice.components.0.children.1.children.2.props.value', 'table')
-            ->where('lattice.components.0.children.1.children.2.children.1.id', 'workbench.users.table')
-            ->where('lattice.components.0.children.1.children.2.children.1.props.pagination.mode', 'table')
-            ->where('lattice.components.0.children.1.children.3.props.value', 'infinite')
-            ->where('lattice.components.0.children.1.children.3.children.1.id', 'workbench.users.infinite')
-            ->where('lattice.components.0.children.1.children.3.children.1.props.pagination.mode', 'infinite'));
+            ->where('lattice.schema.0.type', 'stack')
+            ->where('lattice.schema.0.key', 'tables-page')
+            ->where('lattice.schema.0.schema.1.type', 'tabs')
+            ->where('lattice.schema.0.schema.1.props.defaultValue', 'none')
+            ->where('lattice.schema.0.schema.1.schema.0.props.value', 'none')
+            ->where('lattice.schema.0.schema.1.schema.0.schema.1.id', 'workbench.users.none')
+            ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.lazy', true)
+            ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.data', [])
+            ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.pagination.mode', 'none')
+            ->where('lattice.schema.0.schema.1.schema.1.props.value', 'simple')
+            ->where('lattice.schema.0.schema.1.schema.1.schema.1.id', 'workbench.users.simple')
+            ->where('lattice.schema.0.schema.1.schema.1.schema.1.props.pagination.mode', 'simple')
+            ->where('lattice.schema.0.schema.1.schema.2.props.value', 'table')
+            ->where('lattice.schema.0.schema.1.schema.2.schema.1.id', 'workbench.users.table')
+            ->where('lattice.schema.0.schema.1.schema.2.schema.1.props.pagination.mode', 'table')
+            ->where('lattice.schema.0.schema.1.schema.3.props.value', 'infinite')
+            ->where('lattice.schema.0.schema.1.schema.3.schema.1.id', 'workbench.users.infinite')
+            ->where('lattice.schema.0.schema.1.schema.3.schema.1.props.pagination.mode', 'infinite'));
 });
 
 test('workbench user seeder creates sample table data idempotently', function () {

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -125,9 +125,9 @@ function latticeGet(string $url, string $ref): TestResponse
     return getJson($url, latticeHeaders($ref));
 }
 
-function exposesChildrenApi(object $component): bool
+function exposesSchemaApi(object $component): bool
 {
-    return method_exists($component, 'children');
+    return method_exists($component, 'schema');
 }
 
 test('lattice component factories stay open for extension', function () {
@@ -256,7 +256,7 @@ test('forms serialize schema children like pages', function () {
         ]);
 });
 
-test('only container components expose children', function () {
+test('only container components expose a schema', function () {
     $containerComponents = [
         Card::make('Card', 'Description'),
         Grid::make(),
@@ -281,11 +281,11 @@ test('only container components expose children', function () {
     ];
 
     foreach ($containerComponents as $component) {
-        expect(exposesChildrenApi($component))->toBeTrue();
+        expect(exposesSchemaApi($component))->toBeTrue();
     }
 
     foreach ($leafComponents as $component) {
-        expect(exposesChildrenApi($component))->toBeFalse();
+        expect(exposesSchemaApi($component))->toBeFalse();
     }
 });
 
@@ -399,10 +399,10 @@ test('components can opt out of rendering with when', function () {
     {
         public function render(PageSchema $schema): PageSchema
         {
-            return $schema->components([
+            return $schema->schema([
                 Text::make('Visible root'),
                 Text::make('Hidden root')->when(false),
-                Stack::make('nested')->children([
+                Stack::make('nested')->schema([
                     Text::make('Visible child'),
                     Text::make('Hidden child')->when(false),
                 ]),
@@ -1143,7 +1143,7 @@ test('modals serialize composable children for action driven dialogs', function 
     expect(Modal::make('settings.two-factor-setup')
         ->title('Set up two-factor authentication')
         ->description('Scan the QR code with your authenticator app.')
-        ->children([
+        ->schema([
             Text::make('Recovery codes will appear here.'),
         ])
         ->toArray())
@@ -1195,7 +1195,7 @@ test('registered fragments serialize lazy endpoints and return component schemas
 });
 
 test('links and horizontal stacks serialize as separate composable primitives', function () {
-    expect(Stack::make('prompt')->direction('row')->gap(Gap::ExtraSmall)->children([
+    expect(Stack::make('prompt')->direction('row')->gap(Gap::ExtraSmall)->schema([
         Text::make('Need access?'),
         Link::make('Register')->href('/register'),
     ])->toArray())
@@ -1244,11 +1244,11 @@ test('layout enums serialize to their backed string values', function () {
 test('tabs serialize tab panels as composable children', function () {
     expect(Tabs::make('settings-tabs')
         ->defaultValue('security')
-        ->children([
-            Tab::make('profile', 'Profile')->children([
+        ->schema([
+            Tab::make('profile', 'Profile')->schema([
                 Text::make('Profile form'),
             ]),
-            Tab::make('security', 'Security')->children([
+            Tab::make('security', 'Security')->schema([
                 Form::make('password-form'),
             ]),
         ])
@@ -1311,7 +1311,7 @@ test('tabs can customize their query string key', function () {
 test('tabs ignore hidden tab children when resolving their active value', function () {
     $tabs = Tabs::make('settings-tabs')
         ->defaultValue('security')
-        ->children([
+        ->schema([
             Tab::make('profile', 'Profile'),
             Tab::make('security', 'Security')->when(false),
         ])
@@ -1339,13 +1339,13 @@ test('tabs hydrate their active value from the request query string', function (
 test('confirmed inactive tabs serialize only their tab metadata', function () {
     $tabs = Tabs::make('settings-tabs')
         ->defaultValue('profile')
-        ->children([
-            Tab::make('profile', 'Profile')->children([
+        ->schema([
+            Tab::make('profile', 'Profile')->schema([
                 Text::make('Profile form'),
             ]),
             Tab::make('security', 'Security')
                 ->confirm()
-                ->children([
+                ->schema([
                     Text::make('Security form'),
                 ]),
         ])
@@ -1908,11 +1908,11 @@ final class WorkbenchTabsPage extends Page
         return $schema->component(
             Tabs::make('settings-tabs')
                 ->defaultValue('profile')
-                ->children([
-                    Tab::make('profile', 'Profile')->children([
+                ->schema([
+                    Tab::make('profile', 'Profile')->schema([
                         Text::make('Profile form'),
                     ]),
-                    Tab::make('security', 'Security')->children([
+                    Tab::make('security', 'Security')->schema([
                         Text::make('Security form'),
                     ]),
                 ]),
@@ -1927,13 +1927,13 @@ final class WorkbenchConfirmedTabsPage extends Page
         return $schema->component(
             Tabs::make('settings-tabs')
                 ->defaultValue('profile')
-                ->children([
-                    Tab::make('profile', 'Profile')->children([
+                ->schema([
+                    Tab::make('profile', 'Profile')->schema([
                         Text::make('Profile form'),
                     ]),
                     Tab::make('security', 'Security')
                         ->confirm()
-                        ->children([
+                        ->schema([
                             Text::make('Security form'),
                         ]),
                 ]),

--- a/tests/Feature/ProductRelatedProductsTest.php
+++ b/tests/Feature/ProductRelatedProductsTest.php
@@ -105,7 +105,7 @@ test('the product edit page binds related product ids into form state', function
         ->assertOk()
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page', false)
-            ->where('lattice.components.0.children.1.props.state.related_products', [$related->getKey()])
+            ->where('lattice.schema.0.schema.1.props.state.related_products', [$related->getKey()])
         );
 });
 

--- a/tests/Feature/ProductsTest.php
+++ b/tests/Feature/ProductsTest.php
@@ -103,9 +103,9 @@ test('the product index page lists products and links to creation', function () 
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page', false)
             ->where('lattice.title', 'Products')
-            ->where('lattice.components.0.children.0.children.1.props.href', '/products/create')
-            ->where('lattice.components.0.children.1.id', 'workbench.products')
-            ->where('lattice.components.0.children.1.props.data.0.name', 'Desk Lamp')
+            ->where('lattice.schema.0.schema.0.schema.1.props.href', '/products/create')
+            ->where('lattice.schema.0.schema.1.id', 'workbench.products')
+            ->where('lattice.schema.0.schema.1.props.data.0.name', 'Desk Lamp')
         );
 });
 
@@ -145,12 +145,12 @@ test('the product edit page binds existing product state', function () {
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page', false)
             ->where('lattice.title', 'Edit Product')
-            ->where('lattice.components.0.children.1.props.method', 'patch')
-            ->where('lattice.components.0.children.1.props.submitLabel', 'Save product')
-            ->where('lattice.components.0.children.1.props.state.name', 'Desk Lamp')
-            ->where('lattice.components.0.children.1.props.state.sku', 'LAMP-001')
-            ->where('lattice.components.0.children.1.props.state.price', '49.99')
-            ->where('lattice.components.0.children.1.props.state.status', 'draft')
+            ->where('lattice.schema.0.schema.1.props.method', 'patch')
+            ->where('lattice.schema.0.schema.1.props.submitLabel', 'Save product')
+            ->where('lattice.schema.0.schema.1.props.state.name', 'Desk Lamp')
+            ->where('lattice.schema.0.schema.1.props.state.sku', 'LAMP-001')
+            ->where('lattice.schema.0.schema.1.props.state.price', '49.99')
+            ->where('lattice.schema.0.schema.1.props.state.status', 'draft')
         );
 });
 

--- a/tests/Feature/ResolvedValidationTest.php
+++ b/tests/Feature/ResolvedValidationTest.php
@@ -20,8 +20,8 @@ function resolvedDefinition(): FormDefinition
                 TextInput::make('mode', 'Mode'),
                 TextInput::make('secret', 'Secret')
                     ->dependsOn('mode', fn (TextInput $f, FormData $d) => $d->get('mode') === 'reveal'
-                        ? $f->show()->rules(['required', 'string'])
-                        : $f->hide()),
+                        ? $f->visible()->rules(['required', 'string'])
+                        : $f->hidden()),
                 TextInput::make('qty', 'Qty'),
                 TextInput::make('price', 'Price'),
                 TextInput::make('total', 'Total')

--- a/tests/Feature/ResolvedValidationTest.php
+++ b/tests/Feature/ResolvedValidationTest.php
@@ -65,8 +65,8 @@ function lockedDefinition(): FormDefinition
         public function definition(Form $form, Request $request): Form
         {
             return $form->schema([
-                TextInput::make('display', 'Display')->readonly()->rules(['string']),
-                TextInput::make('locked', 'Locked')->readonly()->value('server')->rules(['string']),
+                TextInput::make('display', 'Display')->readOnly()->rules(['string']),
+                TextInput::make('locked', 'Locked')->readOnly()->value('server')->rules(['string']),
                 TextInput::make('off', 'Off')->disabled()->rules(['string']),
                 TextInput::make('name', 'Name')->rules(['required', 'string']),
             ]);

--- a/tests/Feature/SelectPrefillTest.php
+++ b/tests/Feature/SelectPrefillTest.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Forms\Components\Select;
  */
 function prefilledOptions(Form $form): array
 {
-    return $form->toArray()['children'][0]['props']['options'] ?? [];
+    return $form->toArray()['schema'][0]['props']['options'] ?? [];
 }
 
 it('resolves the label for a single filled id', function (): void {

--- a/tests/Unit/FieldResolutionTest.php
+++ b/tests/Unit/FieldResolutionTest.php
@@ -31,6 +31,19 @@ it('resolves a value closure during resolution', function (): void {
         ->and($field->toArray()['props']['value'])->toBe(12.0);
 });
 
+it('marks a value set inside a dependsOn closure as resolved', function (): void {
+    $field = TextInput::make('total', 'Total')
+        ->dependsOn(
+            ['qty', 'price'],
+            fn (TextInput $f, FormData $d) => $f->value($d->float('qty') * $d->float('price')),
+        );
+
+    $field->applyResolution(FormData::make(['qty' => '4', 'price' => '5']), Request::create('/'));
+
+    expect($field->hasResolvedValue())->toBeTrue()
+        ->and($field->resolvedValue())->toBe(20.0);
+});
+
 it('runs dependsOn closures during resolution', function (): void {
     $field = Choice::make('state', 'State')
         ->dependsOn('country', fn (Choice $f, FormData $d) => $f->options([

--- a/tests/Unit/FormFieldsTest.php
+++ b/tests/Unit/FormFieldsTest.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Forms\Components\TextInput;
 it('flattens fields including nested containers', function (): void {
     $form = Form::make('demo')->schema([
         TextInput::make('name', 'Name'),
-        Stack::make('group')->children([
+        Stack::make('group')->schema([
             TextInput::make('sku', 'SKU'),
             Choice::make('status', 'Status'),
         ]),

--- a/workbench/app/Forms/DependentDemoForm.php
+++ b/workbench/app/Forms/DependentDemoForm.php
@@ -27,7 +27,7 @@ class DependentDemoForm extends FormDefinition
         return $form
             ->precognitive(300)
             ->schema([
-                Card::make('Account')->children([
+                Card::make('Account')->schema([
                     Choice::make('type', 'Type')->options([
                         Choice::option('Personal', 'personal'),
                         Choice::option('Business', 'business'),
@@ -37,8 +37,8 @@ class DependentDemoForm extends FormDefinition
                         ->requiredWhen('type', 'business')
                         ->rules(['string', 'max:255']),
                 ]),
-                Card::make('Order')->children([
-                    Grid::make()->columns(2)->children([
+                Card::make('Order')->schema([
+                    Grid::make()->columns(2)->schema([
                         NumberInput::make('qty', 'Qty')->min(0),
                         NumberInput::make('unit_price', 'Unit price')->min(0)->step(0.01),
                     ]),
@@ -48,7 +48,7 @@ class DependentDemoForm extends FormDefinition
                     NumberInput::make('level', 'Level')->slider()->min(0)->max(10),
                     DateInput::make('due', 'Due date'),
                 ]),
-                Card::make('Content')->children([
+                Card::make('Content')->schema([
                     Textarea::make('bio', 'Bio')->rows(4)->rules(['nullable', 'string', 'max:500']),
                     RichEditor::make('article', 'Article'),
                 ]),

--- a/workbench/app/Forms/DependentDemoForm.php
+++ b/workbench/app/Forms/DependentDemoForm.php
@@ -43,7 +43,7 @@ class DependentDemoForm extends FormDefinition
                         NumberInput::make('unit_price', 'Unit price')->min(0)->step(0.01),
                     ]),
                     TextInput::make('total', 'Total')
-                        ->readonly()
+                        ->readOnly()
                         ->value(fn (FormData $data) => $data->float('qty') * $data->float('unit_price')),
                     NumberInput::make('level', 'Level')->slider()->min(0)->max(10),
                     DateInput::make('due', 'Due date'),

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -27,10 +27,10 @@ class ProductForm extends FormDefinition
         return $form
             ->precognitive(2650)
             ->schema([
-                Card::make('Product details')->children([
+                Card::make('Product details')->schema([
                     TextInput::make('name', 'Name')
                         ->rules(['required', 'string', 'max:255']),
-                    Grid::make()->columns(2)->children([
+                    Grid::make()->columns(2)->schema([
                         TextInput::make('sku', 'SKU')
                             ->rules(['required', 'string', 'max:255', Rule::unique(Product::class, 'sku')->ignore($product)]),
                         TextInput::make('price', 'Price')

--- a/workbench/app/Forms/ShowcaseForm.php
+++ b/workbench/app/Forms/ShowcaseForm.php
@@ -94,7 +94,7 @@ class ShowcaseForm extends FormDefinition
                         NumberInput::make('unit_price', 'Unit price')->min(0)->step(0.01),
                     ]),
                     TextInput::make('total', 'Total')
-                        ->readonly()
+                        ->readOnly()
                         ->dependsOn(
                             ['quantity', 'unit_price'],
                             fn (TextInput $field, FormData $data) => $field->value(
@@ -141,7 +141,7 @@ class ShowcaseForm extends FormDefinition
                         ->rules(['accepted']),
                 ]),
 
-                HiddenInput::make('source', 'workbench-showcase'),
+                HiddenInput::make('source')->value('workbench-showcase'),
             ]);
     }
 

--- a/workbench/app/Forms/ShowcaseForm.php
+++ b/workbench/app/Forms/ShowcaseForm.php
@@ -34,8 +34,8 @@ class ShowcaseForm extends FormDefinition
             ->precognitive(500)
             ->submitLabel('Submit showcase')
             ->schema([
-                Card::make('Profile', 'Your basic account information.')->children([
-                    Grid::make()->columns(2)->children([
+                Card::make('Profile', 'Your basic account information.')->schema([
+                    Grid::make()->columns(2)->schema([
                         TextInput::make('name', 'Full name')
                             ->placeholder('Ada Lovelace')
                             ->rules(['required', 'string', 'max:255']),
@@ -53,8 +53,8 @@ class ShowcaseForm extends FormDefinition
                         ->rules(['nullable', 'string', 'max:1000']),
                 ]),
 
-                Card::make('Details')->children([
-                    Grid::make()->columns(2)->children([
+                Card::make('Details')->schema([
+                    Grid::make()->columns(2)->schema([
                         NumberInput::make('age', 'Age')
                             ->min(0)
                             ->max(120)
@@ -76,7 +76,7 @@ class ShowcaseForm extends FormDefinition
                         ->rules(['required', Rule::in(['free', 'pro', 'enterprise'])]),
                 ]),
 
-                Card::make('Conditional fields', 'The company field appears for business accounts.')->children([
+                Card::make('Conditional fields', 'The company field appears for business accounts.')->schema([
                     Choice::make('account_type', 'Account type')
                         ->options([
                             Choice::option('Personal', 'personal'),
@@ -88,8 +88,8 @@ class ShowcaseForm extends FormDefinition
                         ->rules(['string', 'max:255']),
                 ]),
 
-                Card::make('Order total', 'The total is computed on the server.')->children([
-                    Grid::make()->columns(2)->children([
+                Card::make('Order total', 'The total is computed on the server.')->schema([
+                    Grid::make()->columns(2)->schema([
                         NumberInput::make('quantity', 'Quantity')->min(1),
                         NumberInput::make('unit_price', 'Unit price')->min(0)->step(0.01),
                     ]),
@@ -103,7 +103,7 @@ class ShowcaseForm extends FormDefinition
                         ),
                 ]),
 
-                Card::make('Selection', 'Static and searchable selects.')->children([
+                Card::make('Selection', 'Static and searchable selects.')->schema([
                     Select::make('country', 'Country')
                         ->placeholder('Pick a country')
                         ->options([
@@ -131,11 +131,11 @@ class ShowcaseForm extends FormDefinition
                         ->rules(['nullable', 'array']),
                 ]),
 
-                Card::make('Article')->children([
+                Card::make('Article')->schema([
                     RichEditor::make('article', 'Article'),
                 ]),
 
-                Card::make('Consent')->children([
+                Card::make('Consent')->schema([
                     Checkbox::make('newsletter', 'Subscribe to the newsletter'),
                     Checkbox::make('terms', 'I accept the terms and conditions')
                         ->rules(['accepted']),

--- a/workbench/app/Pages/DependentDemoPage.php
+++ b/workbench/app/Pages/DependentDemoPage.php
@@ -22,10 +22,10 @@ class DependentDemoPage extends Page
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('dependent-demo-page')
                 ->gap(Gap::Large)
-                ->children([
+                ->schema([
                     Heading::make('Dependent Demo'),
                     Form::use(DependentDemoForm::class)
                         ->method(HttpMethod::Post)

--- a/workbench/app/Pages/HomePage.php
+++ b/workbench/app/Pages/HomePage.php
@@ -25,20 +25,20 @@ final class HomePage extends Page
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('workbench-page')
                 ->gap(Gap::ExtraLarge)
-                ->children([
+                ->schema([
                     Stack::make('workbench-hero')
                         ->gap(Gap::Large)
-                        ->children([
+                        ->schema([
                             Badge::make('Lattice Package'),
                             Heading::make('Workbench page'),
                             Text::make('Package primitives render through a host application page.'),
                         ]),
                     Grid::make('workbench-capabilities')
                         ->columns(2)
-                        ->children([
+                        ->schema([
                             Card::make('Components', 'Server-side component trees serialize to typed React nodes.'),
                             Card::make('Renderer', 'The package renderer resolves registered component types.'),
                         ]),

--- a/workbench/app/Pages/ProductCreatePage.php
+++ b/workbench/app/Pages/ProductCreatePage.php
@@ -22,10 +22,10 @@ class ProductCreatePage extends Page
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('product-create-page')
                 ->gap(Gap::Large)
-                ->children([
+                ->schema([
                     Heading::make('Create Product'),
                     Form::use(ProductForm::class)
                         ->method(HttpMethod::Post)

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -23,10 +23,10 @@ class ProductEditPage extends Page
 
     public function render(PageSchema $schema, Product $product): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('product-edit-page')
                 ->gap(Gap::Large)
-                ->children([
+                ->schema([
                     Heading::make('Edit Product'),
                     Form::use(ProductForm::class)
                         ->method(HttpMethod::Patch)

--- a/workbench/app/Pages/ProductsPage.php
+++ b/workbench/app/Pages/ProductsPage.php
@@ -22,14 +22,14 @@ class ProductsPage extends Page
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('products-page')
                 ->gap(Gap::Large)
-                ->children([
+                ->schema([
                     Stack::make('products-header')
                         ->direction('row')
                         ->align('center')
-                        ->children([
+                        ->schema([
                             Heading::make('Products'),
                             Button::make('Create product')
                                 ->href('/products/create'),

--- a/workbench/app/Pages/ShowcasePage.php
+++ b/workbench/app/Pages/ShowcasePage.php
@@ -22,10 +22,10 @@ class ShowcasePage extends Page
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('showcase-page')
                 ->gap(Gap::Large)
-                ->children([
+                ->schema([
                     Heading::make('Form Showcase'),
                     Form::use(ShowcaseForm::class)
                         ->method(HttpMethod::Post),

--- a/workbench/app/Pages/TablesPage.php
+++ b/workbench/app/Pages/TablesPage.php
@@ -28,33 +28,33 @@ final class TablesPage extends Page
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('tables-page')
                 ->gap(Gap::ExtraLarge)
-                ->children([
+                ->schema([
                     Stack::make('tables-hero')
                         ->gap(Gap::Large)
-                        ->children([
+                        ->schema([
                             Badge::make('Tables'),
                             Heading::make('Pagination modes'),
                             Text::make('Each tab mounts its table on first open.'),
                         ]),
                     Tabs::make('pagination-mode-tabs')
                         ->defaultValue('none')
-                        ->children([
-                            Tab::make('none', 'None')->children([
+                        ->schema([
+                            Tab::make('none', 'None')->schema([
                                 Heading::make('No pagination', 2),
                                 Table::lazy(UsersNoneTable::class),
                             ]),
-                            Tab::make('simple', 'Simple')->children([
+                            Tab::make('simple', 'Simple')->schema([
                                 Heading::make('Simple pagination', 2),
                                 Table::lazy(UsersSimpleTable::class),
                             ]),
-                            Tab::make('table', 'Table')->children([
+                            Tab::make('table', 'Table')->schema([
                                 Heading::make('Table pagination', 2),
                                 Table::lazy(UsersTablePaginationTable::class),
                             ]),
-                            Tab::make('infinite', 'Infinite')->children([
+                            Tab::make('infinite', 'Infinite')->schema([
                                 Heading::make('Infinite pagination', 2),
                                 Table::lazy(UsersInfiniteTable::class),
                             ]),


### PR DESCRIPTION
Tidies the forms PHP API and the container/schema model, and adds an interactive docs component for fields. Rebased on the table refactor (#20).

## Forms API
- `HiddenInput::make($name)->value($v)` (label is the consistent 2nd `make()` arg, or omitted); `label()` is now a fluent setter (`getLabel()` is the `@internal` reader).
- camelCase `readOnly()`/`readOnlyWhen()`; added `visibleWhen()` to mirror `requiredWhen()/readOnlyWhen()/disabledWhen()`.
- Conditional operators accept human comparisons — `requiredWhen('plan', '>', 5)` — via `ConditionOperator::fromHuman()` with a helpful error.
- Orchestration methods marked `@internal` so the fluent surface stays clean.

## Internal cleanups
- Dropped the `func_num_args()`/`$argCount` plumbing and the derivable `resolving` flag.
- `validate()` resolves each field's visible/required/readonly/disabled + server-value decision in a **single pass** (was two loops + three Collection passes).
- Collapsed the condition predicates; `Empty`/`Filled` use Laravel `blank()`/`filled()`; one `buildForm()` helper.

## One `schema()` everywhere
- Every container component, the page builder, and forms declare content with `schema([...])` (`children()`/`components()` removed/renamed; unused `child()` dropped).
- The **serialized key** matches: container nodes ship `schema` (was `children`), page/fragment payloads ship `schema` (was `components`).
- New `Schema` TypeScript type (`Node[]`), used by `Node.schema`/`PagePayload.schema`; all renderer consumers updated. Note: this is a wire-format change.

## Docs
- A `ComponentExample` component (Starlight tabs) showing a field's PHP definition next to a **live preview** rendered from a JSON node through the in-repo renderer, plus the first field page (text input). More field pages to follow.

Verified: PHP 210 tests, vitest 134, tsc, pint, phpstan, oxlint/oxfmt all green; docs preview confirmed in-browser.