### PR TITLE
refactor: single serialization path via json_encode

### DIFF
--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -1,6 +1,20 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Node } from "@lattice/lattice/core/types";
+import type { ColumnData } from "@lattice/lattice/generated/types";
+
+function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): ColumnData {
+  return {
+    type: "text",
+    sortable: null,
+    filter: null,
+    date: null,
+    copyable: null,
+    link: null,
+    columns: null,
+    ...partial,
+  };
+}
 
 const http = vi.hoisted(() => ({
   processing: false,
@@ -21,7 +35,7 @@ const { default: TableComponent } = await import("./table");
 const node = {
   id: "workbench.products",
   props: {
-    columns: [{ key: "name", label: "Name" }],
+    columns: [col({ key: "name", label: "Name" })],
     data: [
       { id: 1, name: "Lamp" },
       { id: 2, name: "Shelf" },

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -1,7 +1,21 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Node } from "@lattice/lattice/core/types";
+import type { ColumnData } from "@lattice/lattice/generated/types";
 import TableComponent from "./table";
+
+function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): ColumnData {
+  return {
+    type: "text",
+    sortable: null,
+    filter: null,
+    date: null,
+    copyable: null,
+    link: null,
+    columns: null,
+    ...partial,
+  };
+}
 
 describe("Lattice table component", () => {
   afterEach(() => {
@@ -13,7 +27,7 @@ describe("Lattice table component", () => {
       id: "workbench.users",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
             sortable: true,
@@ -23,19 +37,19 @@ describe("Lattice table component", () => {
               operators: ["contains", "eq", "neq"],
               defaultOperator: "contains",
             },
-          },
-          {
+          }),
+          col({
             key: "status",
             label: "Status",
-          },
-          {
+          }),
+          col({
             key: "created_at",
             label: "Created",
             date: {
               format: "Y-m-d H:i",
             },
-          },
-          {
+          }),
+          col({
             key: "email",
             label: "Email",
             sortable: true,
@@ -44,7 +58,7 @@ describe("Lattice table component", () => {
               href: "mailto:{value}",
               external: false,
             },
-          },
+          }),
         ],
         data: [
           {
@@ -100,29 +114,29 @@ describe("Lattice table component", () => {
       id: "workbench.stacked-users",
       props: {
         columns: [
-          {
+          col({
             key: "identity",
             label: "Identity",
             type: "stack",
             columns: [
-              {
+              col({
                 key: "name",
                 label: "Name",
                 type: "text",
                 sortable: true,
-              },
-              {
+              }),
+              col({
                 key: "email",
                 label: "Email",
                 type: "text",
-              },
+              }),
             ],
-          },
-          {
+          }),
+          col({
             key: "status",
             label: "Status",
             type: "text",
-          },
+          }),
         ],
         data: [
           {
@@ -215,16 +229,16 @@ describe("Lattice table component", () => {
       id: "workbench.users",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
             sortable: true,
-          },
-          {
+          }),
+          col({
             key: "email",
             label: "Email",
             sortable: true,
-          },
+          }),
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.users",
@@ -289,11 +303,11 @@ describe("Lattice table component", () => {
       id: "teams.members",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
             sortable: true,
-          },
+          }),
         ],
         data: [],
         endpoint: "/lattice/tables/teams.members",
@@ -347,10 +361,10 @@ describe("Lattice table component", () => {
       id: "settings.passkeys",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
-          },
+          }),
         ],
         data: [{ id: 1, name: "Taylor" }],
         endpoint: "/lattice/tables/settings.passkeys",
@@ -434,11 +448,11 @@ describe("Lattice table component", () => {
       id: "workbench.users",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
             sortable: true,
-          },
+          }),
         ],
         data: [{ id: 1, name: "Taylor" }],
         endpoint: "/lattice/tables/workbench.users",
@@ -494,10 +508,10 @@ describe("Lattice table component", () => {
       id: "workbench.small-users",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
-          },
+          }),
         ],
         data: [{ id: 1, name: "Taylor" }],
         pagination: {
@@ -552,10 +566,10 @@ describe("Lattice table component", () => {
       id: "workbench.users",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
-          },
+          }),
         ],
         data: [{ id: 2, name: "Ada" }],
         endpoint: "/lattice/tables/workbench.users",
@@ -623,10 +637,10 @@ describe("Lattice table component", () => {
       id: "workbench.users.none",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
-          },
+          }),
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.users.none",
@@ -674,7 +688,7 @@ describe("Lattice table component", () => {
       id: "workbench.products",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
             filter: {
@@ -683,8 +697,8 @@ describe("Lattice table component", () => {
               operators: ["contains", "eq", "neq"],
               defaultOperator: "contains",
             },
-          },
-          {
+          }),
+          col({
             key: "featured",
             label: "Featured",
             filter: {
@@ -693,8 +707,8 @@ describe("Lattice table component", () => {
               operators: ["eq"],
               defaultOperator: "eq",
             },
-          },
-          {
+          }),
+          col({
             key: "updated_at",
             label: "Updated",
             filter: {
@@ -703,7 +717,7 @@ describe("Lattice table component", () => {
               operators: ["eq", "before", "after"],
               defaultOperator: "eq",
             },
-          },
+          }),
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.products",
@@ -749,7 +763,7 @@ describe("Lattice table component", () => {
     const node = {
       id: "workbench.products",
       props: {
-        columns: [{ key: "name", label: "Name" }],
+        columns: [col({ key: "name", label: "Name" })],
         data: [{ name: "Taylor" }],
         striped: true,
         state: { filters: [], page: 1, perPage: 25, sorts: [] },
@@ -779,7 +793,7 @@ describe("Lattice table component", () => {
       id: "workbench.products",
       props: {
         columns: [
-          {
+          col({
             key: "name",
             label: "Name",
             filter: {
@@ -788,7 +802,7 @@ describe("Lattice table component", () => {
               operators: ["contains", "eq", "neq"],
               defaultOperator: "contains",
             },
-          },
+          }),
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.products",

--- a/resources/js/table/types.ts
+++ b/resources/js/table/types.ts
@@ -9,10 +9,7 @@ import type {
 
 export type { ColumnData, ColumnFilter, ColumnType, TableSort };
 
-export type TableColumn = Pick<ColumnData, "key" | "label"> &
-  Partial<Omit<ColumnData, "key" | "label" | "columns">> & {
-    columns?: TableColumn[];
-  };
+export type TableColumn = ColumnData;
 
 export type TableRow = Record<string, unknown>;
 

--- a/src/Actions/ActionResult.php
+++ b/src/Actions/ActionResult.php
@@ -86,25 +86,14 @@ final readonly class ActionResult implements JsonSerializable
     }
 
     /**
-     * @return array{ok: bool, data: array<string, mixed>, effects: array<int, array<string, mixed>>}
+     * @return array{ok: bool, data: array<string, mixed>, effects: array<int, EffectContract>}
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
             'ok' => $this->ok,
             'data' => $this->data,
-            'effects' => array_map(
-                fn (EffectContract $effect): array => $effect->toArray(),
-                $this->effects,
-            ),
+            'effects' => $this->effects,
         ];
-    }
-
-    /**
-     * @return array{ok: bool, data: array<string, mixed>, effects: array<int, array<string, mixed>>}
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 }

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -71,10 +71,7 @@ class Action extends Component
      */
     public function effects(array $effects): static
     {
-        return $this->prop('effects', array_map(
-            fn (Effect $effect): array => $effect->toArray(),
-            $effects,
-        ));
+        return $this->prop('effects', $effects);
     }
 
     protected function type(): string

--- a/src/Actions/Contracts/Effect.php
+++ b/src/Actions/Contracts/Effect.php
@@ -6,10 +6,4 @@ namespace Lattice\Lattice\Actions\Contracts;
 
 use JsonSerializable;
 
-interface Effect extends JsonSerializable
-{
-    /**
-     * @return array<string, mixed>
-     */
-    public function toArray(): array;
-}
+interface Effect extends JsonSerializable {}

--- a/src/Actions/Effect.php
+++ b/src/Actions/Effect.php
@@ -29,7 +29,7 @@ final readonly class Effect implements EffectContract
             default => throw new \InvalidArgumentException('A toast message string is required.'),
         };
 
-        return new self(EffectType::Toast, $toast->toArray());
+        return new self(EffectType::Toast, $toast->jsonSerialize());
     }
 
     public static function reloadComponent(string $component): self
@@ -74,19 +74,11 @@ final readonly class Effect implements EffectContract
     /**
      * @return array<string, mixed>
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
             'type' => $this->type->value,
             ...$this->payload,
         ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 }

--- a/src/Core/Components/Component.php
+++ b/src/Core/Components/Component.php
@@ -77,21 +77,13 @@ abstract class Component implements JsonSerializable
     /**
      * @return array<string, mixed>
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return array_reduce(
             $this->serializationHooks(),
             fn (array $data, string $hook): array => $this->{$hook}($data),
             [],
         );
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 
     /**

--- a/src/Core/Components/ContainerComponent.php
+++ b/src/Core/Components/ContainerComponent.php
@@ -59,10 +59,7 @@ abstract class ContainerComponent extends Component
     {
         return [
             ...$data,
-            'schema' => array_map(
-                fn (Component $child): array => $child->toArray(),
-                $this->renderableChildren(),
-            ),
+            'schema' => $this->renderableChildren(),
         ];
     }
 }

--- a/src/Core/Components/Tab.php
+++ b/src/Core/Components/Tab.php
@@ -49,18 +49,13 @@ class Tab extends ContainerComponent
         return is_int($timeout) ? $timeout : null;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function toArrayForTabs(string $activeValue): array
+    public function withoutHiddenChildren(string $activeValue): static
     {
-        $data = $this->toArray();
-
         if ($this->requiresConfirmation() && $this->value() !== $activeValue) {
-            unset($data['schema']);
+            return (clone $this)->schema([]);
         }
 
-        return $data;
+        return $this;
     }
 
     protected function type(): string

--- a/src/Core/Components/Tabs.php
+++ b/src/Core/Components/Tabs.php
@@ -63,9 +63,9 @@ class Tabs extends ContainerComponent
         return [
             ...$data,
             'schema' => array_map(
-                fn (Component $child): array => $child instanceof Tab
-                    ? $child->toArrayForTabs($activeValue)
-                    : $child->toArray(),
+                fn (Component $child): Component => $child instanceof Tab
+                    ? $child->withoutHiddenChildren($activeValue)
+                    : $child,
                 $this->renderableChildren(),
             ),
         ];

--- a/src/Core/PageSchema.php
+++ b/src/Core/PageSchema.php
@@ -34,16 +34,13 @@ final class PageSchema
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<int, Component>
      */
-    public function toArray(): array
+    public function renderable(): array
     {
-        return array_map(
-            fn (Component $component): array => $component->toArray(),
-            array_values(array_filter(
-                $this->components,
-                fn (Component $component): bool => $component->shouldRender(),
-            )),
-        );
+        return array_values(array_filter(
+            $this->components,
+            fn (Component $component): bool => $component->shouldRender(),
+        ));
     }
 }

--- a/src/Core/Values/ToastMessage.php
+++ b/src/Core/Values/ToastMessage.php
@@ -22,19 +22,11 @@ final readonly class ToastMessage implements JsonSerializable
     /**
      * @return array{variant: string, message: string}
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
             'variant' => $this->variant->value,
             'message' => $this->message,
         ];
-    }
-
-    /**
-     * @return array{variant: string, message: string}
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 }

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -148,7 +148,7 @@ abstract class FormDefinition extends Definition implements ProvidesForm
             }
 
             $field->applyResolution($data, $request);
-            $fields[$field->name()] = $field->toArray();
+            $fields[$field->name()] = $field;
 
             if ($field->hasResolvedValue()) {
                 $values[$field->name()] = $field->resolvedValue();

--- a/src/Fragments/FragmentRegistry.php
+++ b/src/Fragments/FragmentRegistry.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Fragments;
 
 use Lattice\Lattice\Attributes\ComponentAttribute;
 use Lattice\Lattice\Attributes\Fragment;
+use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\DefinitionRegistry;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Fragments\Components\Fragment as FragmentComponent;
@@ -28,7 +29,7 @@ final class FragmentRegistry extends DefinitionRegistry
     }
 
     /**
-     * @return array{schema: array<int, array<string, mixed>>}
+     * @return array{schema: array<int, Component>}
      */
     public function response(string $key, ?FragmentDefinition $definition = null): array
     {
@@ -37,7 +38,7 @@ final class FragmentRegistry extends DefinitionRegistry
         return [
             'schema' => $definition
                 ->schema(PageSchema::make())
-                ->toArray(),
+                ->renderable(),
         ];
     }
 

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -24,7 +24,7 @@ final class ActionController
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->actions, 'action', $action);
 
         return response()->json(
-            $definition->handle($request)->toArray(),
+            $definition->handle($request),
         );
     }
 }

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -36,7 +36,7 @@ final class BulkActionController
 
         $records = $this->resolveRecords($request, $table, $tableKey);
 
-        return response()->json($definition->handle($records, $request)->toArray());
+        return response()->json($definition->handle($records, $request));
     }
 
     /**

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -90,8 +90,21 @@ abstract class Page implements PageContract
             'menus' => $request instanceof Request
                 ? Lattice::menus()->toArray($request)
                 : [],
-            'schema' => $schema->toArray(),
+            'schema' => $this->serializeSchema($schema),
         ];
+    }
+
+    /**
+     * Realize the component tree to its wire array eagerly, inside the request
+     * lifecycle, so serialization side effects (such as a Tabs confirmation
+     * redirect) fire before the response view is rendered rather than during
+     * the final json_encode.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function serializeSchema(PageSchema $schema): array
+    {
+        return json_decode(json_encode($schema->renderable(), JSON_THROW_ON_ERROR), true);
     }
 
     private function response(PageSchema $schema): Response

--- a/src/Tables/Columns/Column.php
+++ b/src/Tables/Columns/Column.php
@@ -32,14 +32,6 @@ abstract class Column implements JsonSerializable
 
     abstract public function toData(): ColumnData;
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function toArray(): array
-    {
-        return $this->toData()->toArray();
-    }
-
     protected function sortableValue(): ?bool
     {
         return $this instanceof Sortable && $this->isSortable() ? true : null;
@@ -59,11 +51,8 @@ abstract class Column implements JsonSerializable
         );
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): ColumnData
     {
-        return $this->toArray();
+        return $this->toData();
     }
 }

--- a/src/Tables/Columns/ColumnData.php
+++ b/src/Tables/Columns/ColumnData.php
@@ -9,8 +9,9 @@ use Lattice\Lattice\Tables\Enums\ColumnType;
 
 /**
  * The wire shape of a table column. Built by each Column's toData() and
- * generated to TypeScript. Fields not applicable to a column type stay null
- * and are stripped from the payload.
+ * generated to TypeScript. Every field is always present; fields not
+ * applicable to a column type are null, so the generated type matches the
+ * payload exactly.
  */
 final readonly class ColumnData implements JsonSerializable
 {
@@ -34,28 +35,18 @@ final readonly class ColumnData implements JsonSerializable
     /**
      * @return array<string, mixed>
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
-        return array_filter([
+        return [
             'key' => $this->key,
             'label' => $this->label,
-            'sortable' => $this->sortable,
-            'filter' => $this->filter?->toArray(),
             'type' => $this->type->value,
+            'sortable' => $this->sortable,
+            'filter' => $this->filter,
             'date' => $this->date,
             'copyable' => $this->copyable,
             'link' => $this->link,
-            'columns' => $this->columns === null
-                ? null
-                : array_map(fn (self $column): array => $column->toArray(), $this->columns),
-        ], fn (mixed $value): bool => $value !== null && $value !== []);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
+            'columns' => $this->columns,
+        ];
     }
 }

--- a/src/Tables/Columns/ColumnFilter.php
+++ b/src/Tables/Columns/ColumnFilter.php
@@ -9,8 +9,8 @@ use Lattice\Lattice\Tables\Enums\FilterOperator;
 use Lattice\Lattice\Tables\Enums\FilterType;
 
 /**
- * The wire shape of a column's filter capability. Built by Column::toArray()
- * from a Filterable column and generated to TypeScript.
+ * The wire shape of a column's filter capability. Built by a Filterable column
+ * and generated to TypeScript.
  */
 final readonly class ColumnFilter implements JsonSerializable
 {
@@ -27,7 +27,7 @@ final readonly class ColumnFilter implements JsonSerializable
     /**
      * @return array<string, mixed>
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
             'enabled' => $this->enabled,
@@ -35,13 +35,5 @@ final readonly class ColumnFilter implements JsonSerializable
             'operators' => array_map(fn (FilterOperator $operator): string => $operator->value, $this->operators),
             'defaultOperator' => $this->defaultOperator->value,
         ];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 }

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -2,6 +2,7 @@
 
 namespace Lattice\Lattice\Tables\Components;
 
+use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\IsInteractive;
 use Lattice\Lattice\Tables\Columns\Column;
@@ -53,10 +54,7 @@ class Table extends Component
      */
     public function columns(array $columns): static
     {
-        return $this->prop('columns', array_map(
-            fn (Column $column): array => $column->toArray(),
-            $columns,
-        ));
+        return $this->prop('columns', $columns);
     }
 
     public function layout(string $layout): static
@@ -69,7 +67,7 @@ class Table extends Component
     }
 
     /**
-     * @param  array<int, array<string, mixed>>  $actions
+     * @param  array<int, Action>  $actions
      */
     public function bulkActions(array $actions): static
     {
@@ -91,7 +89,7 @@ class Table extends Component
 
     public function result(TableResult $result, TableQuery $query): static
     {
-        return $this->props($result->toArray($query));
+        return $this->props($result->forQuery($query)->jsonSerialize());
     }
 
     protected function type(): string

--- a/src/Tables/FilterClause.php
+++ b/src/Tables/FilterClause.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables;
 
+use JsonSerializable;
 use Lattice\Lattice\Tables\Enums\FilterOperator;
 
-final readonly class FilterClause
+final readonly class FilterClause implements JsonSerializable
 {
     public function __construct(
         public string $field,
@@ -41,7 +42,7 @@ final readonly class FilterClause
     /**
      * @return array{field: string, operator: string, value: string}
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
             'field' => $this->field,

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -7,12 +7,13 @@ namespace Lattice\Lattice\Tables;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use JsonSerializable;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\Filterable;
 use Lattice\Lattice\Tables\Columns\Sortable;
 use Lattice\Lattice\Tables\Enums\FilterOperator;
 
-final readonly class TableQuery
+final readonly class TableQuery implements JsonSerializable
 {
     /**
      * @param  array<int, FilterClause>  $filters
@@ -77,19 +78,13 @@ final readonly class TableQuery
     }
 
     /**
-     * @return array{filters: array<int, array{field: string, operator: string, value: string}>, sorts: array<int, array{key: string, direction: string}>, page: int, perPage: int}
+     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int}
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
-            'filters' => array_map(
-                fn (FilterClause $clause): array => $clause->toArray(),
-                $this->filters,
-            ),
-            'sorts' => array_map(
-                fn (TableSort $sort): array => $sort->toArray(),
-                $this->sorts,
-            ),
+            'filters' => $this->filters,
+            'sorts' => $this->sorts,
             'page' => $this->page,
             'perPage' => $this->perPage,
         ];

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -62,25 +62,22 @@ final class TableRegistry extends DefinitionRegistry
         return $lazy ? $component->prop('lazy', true) : $component;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function response(string $key, Request $request, ?TableDefinition $definition = null): array
+    public function response(string $key, Request $request, ?TableDefinition $definition = null): TableResult
     {
         $definition ??= $this->resolve($key);
         $columns = $definition->columns();
         $query = TableQuery::fromRequest($request, $columns, $key, $definition->perPage());
 
-        return $this->decorateResult($definition, $definition->source()->query($query))->toArray($query);
+        return $this->decorateResult($definition, $definition->source()->query($query))->forQuery($query);
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<int, ActionComponent>
      */
     private function bulkActions(TableDefinition $definition, string $key): array
     {
         return array_map(
-            fn (ActionComponent $action): array => $action->context(['table' => $key])->toArray(),
+            fn (ActionComponent $action): ActionComponent => $action->context(['table' => $key]),
             $definition->bulkActions(),
         );
     }
@@ -114,10 +111,7 @@ final class TableRegistry extends DefinitionRegistry
     private function decorateResult(TableDefinition $definition, TableResult $result): TableResult
     {
         return $result->decorateRows(function (array $row) use ($definition): array {
-            $actions = array_map(
-                fn ($action): array => $action->toArray(),
-                $definition->actions($row),
-            );
+            $actions = $definition->actions($row);
 
             if ($actions === []) {
                 return $row;

--- a/src/Tables/TableResult.php
+++ b/src/Tables/TableResult.php
@@ -20,6 +20,7 @@ final readonly class TableResult implements JsonSerializable
     private function __construct(
         private array $data,
         private array $pagination = [],
+        private ?TableQuery $query = null,
     ) {}
 
     /**
@@ -98,7 +99,12 @@ final readonly class TableResult implements JsonSerializable
      */
     public function pagination(array $pagination): self
     {
-        return new self($this->data, $pagination);
+        return new self($this->data, $pagination, $this->query);
+    }
+
+    public function forQuery(TableQuery $query): self
+    {
+        return new self($this->data, $this->pagination, $query);
     }
 
     /**
@@ -112,27 +118,20 @@ final readonly class TableResult implements JsonSerializable
         return new self(
             array_map($callback, $this->data, array_keys($this->data)),
             $this->pagination,
+            $this->query,
         );
     }
 
     /**
-     * @return array{data: array<int, array<string, mixed>>, pagination: array<string, mixed>, state: array<string, mixed>}
+     * @return array{data: array<int, array<string, mixed>>, pagination: array<string, mixed>, state: TableQuery}
      */
-    public function toArray(?TableQuery $query = null): array
+    public function jsonSerialize(): array
     {
         return [
             'data' => $this->data,
             'pagination' => $this->pagination,
-            'state' => ($query ?? TableQuery::empty())->toArray(),
+            'state' => $this->query ?? TableQuery::empty(),
         ];
-    }
-
-    /**
-     * @return array{data: array<int, array<string, mixed>>, pagination: array<string, mixed>, state: array<string, mixed>}
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 
     /**

--- a/src/Tables/TableSort.php
+++ b/src/Tables/TableSort.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables;
 
+use JsonSerializable;
 use Lattice\Lattice\Tables\Enums\SortDirection;
 
-final readonly class TableSort
+final readonly class TableSort implements JsonSerializable
 {
     public function __construct(public string $key, public SortDirection $direction) {}
 
@@ -22,7 +23,7 @@ final readonly class TableSort
     /**
      * @return array{key: string, direction: string}
      */
-    public function toArray(): array
+    public function jsonSerialize(): array
     {
         return [
             'key' => $this->key,

--- a/tests/Feature/ActionIconTest.php
+++ b/tests/Feature/ActionIconTest.php
@@ -6,10 +6,9 @@ use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Core\Enums\LucideIcon;
 
 test('actions serialize lucide icon enum values', function () {
-    expect(Action::make('send-message')
+    expect(wire(Action::make('send-message')
         ->label('Send')
-        ->icon(LucideIcon::Send)
-        ->toArray())
+        ->icon(LucideIcon::Send)))
         ->toMatchArray([
             'type' => 'action',
             'id' => 'send-message',
@@ -21,10 +20,9 @@ test('actions serialize lucide icon enum values', function () {
 });
 
 test('actions serialize arbitrary backed enum icon values', function () {
-    expect(Action::make('custom-action')
+    expect(wire(Action::make('custom-action')
         ->label('Custom')
-        ->icon(WorkbenchCustomActionIcon::Spark)
-        ->toArray()['props']['icon'])
+        ->icon(WorkbenchCustomActionIcon::Spark))['props']['icon'])
         ->toBe('custom.spark');
 });
 

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -146,10 +146,10 @@ test('lattice facade resolves the registry and exposes the menu registry', funct
 test('lattice can discover attributed definitions from a path and namespace', function () {
     Lattice::discover(__DIR__.'/../Fixtures/Discovery', 'Lattice\\Lattice\\Tests\\Fixtures\\Discovery');
 
-    $form = Form::use(DiscoveredProfileForm::class)->toArray();
-    $table = Table::use(DiscoveredUsersTable::class)->toArray();
-    $action = ActionComponent::use(DiscoveredPingAction::class)->toArray();
-    $fragment = FragmentComponent::lazy(DiscoveredPanelFragment::class)->toArray();
+    $form = wire(Form::use(DiscoveredProfileForm::class));
+    $table = wire(Table::use(DiscoveredUsersTable::class));
+    $action = wire(ActionComponent::use(DiscoveredPingAction::class));
+    $fragment = wire(FragmentComponent::lazy(DiscoveredPanelFragment::class));
 
     expect($form)
         ->toMatchArray([
@@ -200,12 +200,12 @@ test('lattice discovers attributed bulk action definitions', function () {
 });
 
 test('interactive components keep their serialized ids', function () {
-    expect(Form::make('demo-form')->toArray())
+    expect(wire(Form::make('demo-form')))
         ->toMatchArray([
             'type' => 'form',
             'id' => 'demo-form',
         ])
-        ->and(Table::make('demo-table')->toArray())
+        ->and(wire(Table::make('demo-table')))
         ->toMatchArray([
             'type' => 'table',
             'id' => 'demo-table',
@@ -213,14 +213,12 @@ test('interactive components keep their serialized ids', function () {
 });
 
 test('interactive components seal request context for endpoints', function () {
-    $form = Form::make('demo-form')
+    $form = wire(Form::make('demo-form')
         ->action('/lattice/forms/demo-form')
-        ->context(['team' => 'lattice-core'])
-        ->toArray();
-    $table = Table::make('demo-table')
+        ->context(['team' => 'lattice-core']));
+    $table = wire(Table::make('demo-table')
         ->endpoint('/lattice/tables/demo-table')
-        ->context(['team' => 'lattice-core'])
-        ->toArray();
+        ->context(['team' => 'lattice-core']));
 
     expect($form)
         ->toMatchArray([
@@ -239,9 +237,9 @@ test('interactive components seal request context for endpoints', function () {
 });
 
 test('forms serialize schema children like pages', function () {
-    expect(Form::make('profile-form')->schema([
+    expect(wire(Form::make('profile-form')->schema([
         Text::make('Profile details'),
-    ])->toArray())
+    ])))
         ->toMatchArray([
             'type' => 'form',
             'id' => 'profile-form',
@@ -312,7 +310,7 @@ test('components serialize through prioritized hook attributes without child-spe
         }
     };
 
-    expect($component->toArray())
+    expect(wire($component))
         ->toBe([
             'type' => 'hooked',
             'custom' => 'value',
@@ -354,7 +352,7 @@ test('private serialization hooks are ignored', function () {
         }
     };
 
-    expect($component->toArray())->toBe([
+    expect(wire($component))->toBe([
         'type' => 'private-hooked',
     ])->and($component->privateDataForTest([]))->toBe([
         'private' => 'value',
@@ -362,7 +360,7 @@ test('private serialization hooks are ignored', function () {
 });
 
 test('forms can disable their default submit button', function () {
-    expect(Form::make('profile-form')->withoutSubmitButton()->toArray())
+    expect(wire(Form::make('profile-form')->withoutSubmitButton()))
         ->toMatchArray([
             'type' => 'form',
             'id' => 'profile-form',
@@ -373,11 +371,10 @@ test('forms can disable their default submit button', function () {
 });
 
 test('password inputs can request automatic confirmation fields', function () {
-    expect(PasswordInput::make('password', 'Password')
+    expect(wire(PasswordInput::make('password', 'Password')
         ->required()
         ->passwordRules('minlength:8')
-        ->needsConfirmation()
-        ->toArray())
+        ->needsConfirmation()))
         ->toMatchArray([
             'type' => 'form.password-input',
             'props' => [
@@ -410,7 +407,7 @@ test('components can opt out of rendering with when', function () {
         }
     };
 
-    $pageData = $page->toArray($page->render(PageSchema::make()));
+    $pageData = wire($page->toArray($page->render(PageSchema::make())));
 
     expect($pageData['schema'])
         ->toHaveCount(2)
@@ -420,15 +417,14 @@ test('components can opt out of rendering with when', function () {
 });
 
 test('segmented control serializes options value and emit event', function () {
-    expect(SegmentedControl::make('appearance', 'Appearance')
+    expect(wire(SegmentedControl::make('appearance', 'Appearance')
         ->value('system')
         ->emits('lattice:appearance-change')
         ->options([
             SegmentedControl::option('Light', 'light'),
             SegmentedControl::option('Dark', 'dark'),
             SegmentedControl::option('System', 'system'),
-        ])
-        ->toArray())
+        ])))
         ->toMatchArray([
             'type' => 'segmented-control',
             'props' => [
@@ -459,7 +455,7 @@ test('registered forms serialize their configured endpoint and isolated error ba
 
     Lattice::forms([WorkbenchProfileForm::class]);
 
-    $form = Form::use(WorkbenchProfileForm::class)->toArray();
+    $form = wire(Form::use(WorkbenchProfileForm::class));
 
     expect($form)
         ->toMatchArray([
@@ -486,9 +482,8 @@ test('registered forms serialize their configured endpoint and isolated error ba
 test('registered forms can be submitted through the package endpoint', function () {
     Lattice::forms([WorkbenchProfileForm::class]);
 
-    $ref = componentRef(Form::use(WorkbenchProfileForm::class)
-        ->context(['team' => 'lattice-core'])
-        ->toArray());
+    $ref = componentRef(wire(Form::use(WorkbenchProfileForm::class)
+        ->context(['team' => 'lattice-core'])));
 
     patch('/lattice/forms/settings.profile', [
         'name' => 'Taylor',
@@ -517,7 +512,7 @@ test('registered form endpoints require a valid component reference', function (
 test('registered forms receive the current request while serializing definitions', function () {
     Lattice::forms([WorkbenchRequestAwareForm::class]);
 
-    Route::get('request-aware-form', fn () => response()->json(Form::use(WorkbenchRequestAwareForm::class)->toArray()))
+    Route::get('request-aware-form', fn () => response()->json(wire(Form::use(WorkbenchRequestAwareForm::class))))
         ->middleware('web');
 
     getJson('/request-aware-form?label=Request aware')
@@ -530,7 +525,7 @@ test('registered tables serialize their configured endpoint columns state and in
 
     Lattice::tables([WorkbenchUsersTable::class]);
 
-    $table = Table::use(WorkbenchUsersTable::class)->toArray();
+    $table = wire(Table::use(WorkbenchUsersTable::class));
 
     expect($table)
         ->toMatchArray([
@@ -551,23 +546,37 @@ test('registered tables serialize their configured endpoint columns state and in
                             'operators' => ['contains', 'starts_with', 'ends_with', 'eq', 'neq', 'empty', 'filled'],
                             'defaultOperator' => 'contains',
                         ],
+                        'date' => null,
+                        'copyable' => null,
+                        'link' => null,
+                        'columns' => null,
                     ],
                     [
                         'key' => 'status',
                         'label' => 'Status',
                         'type' => 'text',
+                        'sortable' => null,
                         'filter' => [
                             'enabled' => true,
                             'type' => 'text',
                             'operators' => ['contains', 'starts_with', 'ends_with', 'eq', 'neq', 'empty', 'filled'],
                             'defaultOperator' => 'eq',
                         ],
+                        'date' => null,
+                        'copyable' => null,
+                        'link' => null,
+                        'columns' => null,
                     ],
                     [
                         'key' => 'email',
                         'label' => 'Email',
                         'type' => 'text',
                         'sortable' => true,
+                        'filter' => null,
+                        'date' => null,
+                        'copyable' => null,
+                        'link' => null,
+                        'columns' => null,
                     ],
                 ],
                 'data' => [
@@ -593,7 +602,7 @@ test('registered tables can serialize lazily without running their query', funct
 
     Lattice::tables([WorkbenchLazyUsersTable::class]);
 
-    $table = Table::lazy(WorkbenchLazyUsersTable::class)->toArray();
+    $table = wire(Table::lazy(WorkbenchLazyUsersTable::class));
 
     expect($table)
         ->toMatchArray([
@@ -608,6 +617,12 @@ test('registered tables can serialize lazily without running their query', funct
                         'key' => 'name',
                         'label' => 'Name',
                         'type' => 'text',
+                        'sortable' => null,
+                        'filter' => null,
+                        'date' => null,
+                        'copyable' => null,
+                        'link' => null,
+                        'columns' => null,
                     ],
                 ],
                 'data' => [],
@@ -628,7 +643,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
     Lattice::actions([WorkbenchPingAction::class]);
     Lattice::tables([WorkbenchStackedUsersTable::class]);
 
-    $table = Table::use(WorkbenchStackedUsersTable::class)->toArray();
+    $table = wire(Table::use(WorkbenchStackedUsersTable::class));
 
     expect($table)
         ->toMatchArray([
@@ -641,17 +656,33 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                 'key' => 'identity',
                 'label' => 'Identity',
                 'type' => 'stack',
+                'sortable' => null,
+                'filter' => null,
+                'date' => null,
+                'copyable' => null,
+                'link' => null,
                 'columns' => [
                     [
                         'key' => 'name',
                         'label' => 'Name',
                         'type' => 'text',
                         'sortable' => true,
+                        'filter' => null,
+                        'date' => null,
+                        'copyable' => null,
+                        'link' => null,
+                        'columns' => null,
                     ],
                     [
                         'key' => 'email',
                         'label' => 'Email',
                         'type' => 'text',
+                        'sortable' => null,
+                        'filter' => null,
+                        'date' => null,
+                        'copyable' => null,
+                        'link' => null,
+                        'columns' => null,
                     ],
                 ],
             ],
@@ -659,6 +690,12 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                 'key' => 'status',
                 'label' => 'Status',
                 'type' => 'text',
+                'sortable' => null,
+                'filter' => null,
+                'date' => null,
+                'copyable' => null,
+                'link' => null,
+                'columns' => null,
             ],
         ])
         ->and($table['props']['data'][0]['actions'][0])->toMatchArray([
@@ -675,7 +712,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
 test('registered tables parse clause filters sorts and pagination through the endpoint', function () {
     Lattice::tables([WorkbenchUsersTable::class]);
 
-    $ref = componentRef(Table::use(WorkbenchUsersTable::class)->toArray());
+    $ref = componentRef(wire(Table::use(WorkbenchUsersTable::class)));
 
     latticeGet('/lattice/tables/workbench.users?filter=name:contains:tay,status:eq:active&sort=-name,email&page=2&per_page=50', $ref)
         ->assertOk()
@@ -695,7 +732,7 @@ test('registered tables parse clause filters sorts and pagination through the en
 test('registered tables reject filters and sorts that are not allowed by columns', function () {
     Lattice::tables([WorkbenchUsersTable::class]);
 
-    $ref = componentRef(Table::use(WorkbenchUsersTable::class)->toArray());
+    $ref = componentRef(wire(Table::use(WorkbenchUsersTable::class)));
 
     latticeGet('/lattice/tables/workbench.users?filter=password:contains:secret', $ref)
         ->assertUnprocessable()
@@ -711,9 +748,8 @@ test('registered tables reject filters and sorts that are not allowed by columns
 test('registered table endpoints require a valid component reference and use trusted context', function () {
     Lattice::discover(__DIR__.'/../Fixtures/Discovery', 'Lattice\\Lattice\\Tests\\Fixtures\\Discovery');
 
-    $ref = componentRef(Table::use(DiscoveredUsersTable::class)
-        ->context(['team' => 'trusted-team'])
-        ->toArray());
+    $ref = componentRef(wire(Table::use(DiscoveredUsersTable::class)
+        ->context(['team' => 'trusted-team'])));
 
     getJson('/lattice/tables/fixtures.users')
         ->assertForbidden();
@@ -727,12 +763,11 @@ test('registered table endpoints require a valid component reference and use tru
 });
 
 test('text columns serialize display modifiers', function () {
-    expect(TextColumn::make('published_at')
+    expect(wire(TextColumn::make('published_at')
         ->label('Published')
         ->date('Y-m-d')
         ->copyable()
-        ->link('/posts/{id}')
-        ->toArray())
+        ->link('/posts/{id}')))
         ->toMatchArray([
             'key' => 'published_at',
             'label' => 'Published',
@@ -751,7 +786,7 @@ test('text columns serialize display modifiers', function () {
 test('workbench users table exposes timestamp columns for each row', function () {
     Lattice::tables([WorkbenchAppUsersTable::class]);
 
-    $columns = Table::use(WorkbenchAppUsersTable::class)->toArray()['props']['columns'];
+    $columns = wire(Table::use(WorkbenchAppUsersTable::class))['props']['columns'];
 
     expect(array_column($columns, 'key'))->toBe(['name', 'email', 'created_at', 'updated_at'])
         ->and($columns[2])->toMatchArray([
@@ -784,7 +819,7 @@ test('eloquent tables can use infinite pagination metadata', function () {
 
     Lattice::tables([WorkbenchInfiniteUsersTable::class]);
 
-    $table = Table::use(WorkbenchInfiniteUsersTable::class)->toArray();
+    $table = wire(Table::use(WorkbenchInfiniteUsersTable::class));
     $ref = componentRef($table);
 
     expect($table['props']['pagination'])
@@ -829,7 +864,7 @@ test('eloquent tables use table pagination with totals by default', function () 
 
     Lattice::tables([WorkbenchDefaultUsersTable::class]);
 
-    $ref = componentRef(Table::use(WorkbenchDefaultUsersTable::class)->toArray());
+    $ref = componentRef(wire(Table::use(WorkbenchDefaultUsersTable::class)));
 
     latticeGet('/lattice/tables/workbench.default-users?per_page=2', $ref)
         ->assertOk()
@@ -853,7 +888,7 @@ test('eloquent tables can use simple pagination without totals', function () {
 
     Lattice::tables([WorkbenchSimpleUsersTable::class]);
 
-    $ref = componentRef(Table::use(WorkbenchSimpleUsersTable::class)->toArray());
+    $ref = componentRef(wire(Table::use(WorkbenchSimpleUsersTable::class)));
 
     latticeGet('/lattice/tables/workbench.simple-users?per_page=2', $ref)
         ->assertOk()
@@ -876,7 +911,7 @@ test('eloquent tables can disable pagination for small datasets', function () {
 
     Lattice::tables([WorkbenchSmallUsersTable::class]);
 
-    $ref = componentRef(Table::use(WorkbenchSmallUsersTable::class)->toArray());
+    $ref = componentRef(wire(Table::use(WorkbenchSmallUsersTable::class)));
 
     latticeGet('/lattice/tables/workbench.small-users?per_page=1', $ref)
         ->assertOk()
@@ -891,7 +926,7 @@ test('registered actions serialize their configured endpoint method label and ef
 
     Lattice::actions([WorkbenchPingAction::class]);
 
-    $action = ActionComponent::use(WorkbenchPingAction::class)->toArray();
+    $action = wire(ActionComponent::use(WorkbenchPingAction::class));
 
     expect($action)
         ->toMatchArray([
@@ -919,7 +954,7 @@ test('registered actions serialize their configured endpoint method label and ef
 });
 
 test('action groups serialize grouped child actions', function () {
-    $group = ActionGroup::make('workbench.user-actions')
+    $group = wire(ActionGroup::make('workbench.user-actions')
         ->label('Manage user')
         ->actions([
             ActionComponent::make('workbench.users.promote')
@@ -931,8 +966,7 @@ test('action groups serialize grouped child actions', function () {
                 ->label('Remove')
                 ->method('delete')
                 ->variant('destructive'),
-        ])
-        ->toArray();
+        ]));
 
     expect($group)
         ->toMatchArray([
@@ -970,9 +1004,8 @@ test('action groups serialize grouped child actions', function () {
 test('registered actions can be handled through the package endpoint', function () {
     Lattice::actions([WorkbenchPingAction::class]);
 
-    $ref = componentRef(ActionComponent::use(WorkbenchPingAction::class)
-        ->context(['team' => 'trusted-team'])
-        ->toArray());
+    $ref = componentRef(wire(ActionComponent::use(WorkbenchPingAction::class)
+        ->context(['team' => 'trusted-team'])));
 
     postJson('/lattice/actions/workbench.ping', [
         'name' => 'Taylor',
@@ -1005,18 +1038,18 @@ test('toast messages serialize for flash data and action effects', function () {
 
     assert($flashedToast instanceof ToastMessage);
 
-    expect($flashedToast->toArray())
+    expect(wire($flashedToast))
         ->toBe([
             'variant' => 'warning',
             'message' => 'Review the settings.',
         ])
-        ->and(Effect::toast(ToastVariant::Warning, 'Review the settings.')->toArray())
+        ->and(wire(Effect::toast(ToastVariant::Warning, 'Review the settings.')))
         ->toBe([
             'type' => 'toast',
             'variant' => 'warning',
             'message' => 'Review the settings.',
         ])
-        ->and(ActionResult::success()->toast('Saved.')->toArray())
+        ->and(wire(ActionResult::success()->toast('Saved.')))
         ->toMatchArray([
             'effects' => [
                 [
@@ -1026,7 +1059,7 @@ test('toast messages serialize for flash data and action effects', function () {
                 ],
             ],
         ])
-        ->and(ActionResult::success()->toast(ToastVariant::Warning, 'Review the settings.')->toArray())
+        ->and(wire(ActionResult::success()->toast(ToastVariant::Warning, 'Review the settings.')))
         ->toMatchArray([
             'effects' => [
                 [
@@ -1057,14 +1090,14 @@ test('action results expose the full effect vocabulary', function () {
         ->download('/exports/report.csv')
         ->resetForm('teams.create');
 
-    expect($result->toArray()['effects'])->toBe([
+    expect(wire($result)['effects'])->toBe([
         ['type' => 'reloadPage'],
         ['type' => 'redirect', 'url' => '/dashboard'],
         ['type' => 'download', 'url' => '/exports/report.csv'],
         ['type' => 'resetForm', 'form' => 'teams.create'],
     ])
-        ->and(Effect::resetForm()->toArray())->toBe(['type' => 'resetForm'])
-        ->and(Effect::reloadPage()->toArray())->toBe(['type' => 'reloadPage']);
+        ->and(wire(Effect::resetForm()))->toBe(['type' => 'resetForm'])
+        ->and(wire(Effect::reloadPage()))->toBe(['type' => 'reloadPage']);
 });
 
 test('interaction endpoints return 404 for unknown component ids', function () {
@@ -1111,7 +1144,7 @@ test('interaction endpoints re-run authorization for every interaction', functio
 });
 
 test('actions can serialize confirmation modal configuration', function () {
-    expect(ActionComponent::make('delete-account')
+    expect(wire(ActionComponent::make('delete-account')
         ->label('Delete account')
         ->method('delete')
         ->variant('destructive')
@@ -1120,8 +1153,7 @@ test('actions can serialize confirmation modal configuration', function () {
             description: 'This cannot be undone.',
             confirmLabel: 'Delete account',
             cancelLabel: 'Keep account',
-        )
-        ->toArray())
+        )))
         ->toMatchArray([
             'type' => 'action',
             'id' => 'delete-account',
@@ -1140,13 +1172,12 @@ test('actions can serialize confirmation modal configuration', function () {
 });
 
 test('modals serialize composable children for action driven dialogs', function () {
-    expect(Modal::make('settings.two-factor-setup')
+    expect(wire(Modal::make('settings.two-factor-setup')
         ->title('Set up two-factor authentication')
         ->description('Scan the QR code with your authenticator app.')
         ->schema([
             Text::make('Recovery codes will appear here.'),
-        ])
-        ->toArray())
+        ])))
         ->toMatchArray([
             'type' => 'modal',
             'id' => 'settings.two-factor-setup',
@@ -1168,7 +1199,7 @@ test('modals serialize composable children for action driven dialogs', function 
 test('registered fragments serialize lazy endpoints and return component schemas', function () {
     Lattice::fragments([WorkbenchTwoFactorSetupFragment::class]);
 
-    $fragment = FragmentComponent::lazy(WorkbenchTwoFactorSetupFragment::class)->toArray();
+    $fragment = wire(FragmentComponent::lazy(WorkbenchTwoFactorSetupFragment::class));
     $ref = componentRef($fragment);
 
     expect($fragment)
@@ -1195,10 +1226,10 @@ test('registered fragments serialize lazy endpoints and return component schemas
 });
 
 test('links and horizontal stacks serialize as separate composable primitives', function () {
-    expect(Stack::make('prompt')->direction('row')->gap(Gap::ExtraSmall)->schema([
+    expect(wire(Stack::make('prompt')->direction('row')->gap(Gap::ExtraSmall)->schema([
         Text::make('Need access?'),
         Link::make('Register')->href('/register'),
-    ])->toArray())
+    ])))
         ->toMatchArray([
             'type' => 'stack',
             'key' => 'prompt',
@@ -1225,11 +1256,10 @@ test('links and horizontal stacks serialize as separate composable primitives', 
 });
 
 test('layout enums serialize to their backed string values', function () {
-    expect(Stack::make('layout')
+    expect(wire(Stack::make('layout')
         ->align(Align::Center)
         ->gap(Gap::Large)
-        ->width(Width::Small)
-        ->toArray())
+        ->width(Width::Small)))
         ->toMatchArray([
             'props' => [
                 'align' => 'center',
@@ -1237,12 +1267,12 @@ test('layout enums serialize to their backed string values', function () {
                 'width' => 'sm',
             ],
         ])
-        ->and(Text::make('Centered')->align(Align::Center)->toArray()['props']['align'])
+        ->and(wire(Text::make('Centered')->align(Align::Center))['props']['align'])
         ->toBe('center');
 });
 
 test('tabs serialize tab panels as composable children', function () {
-    expect(Tabs::make('settings-tabs')
+    expect(wire(Tabs::make('settings-tabs')
         ->defaultValue('security')
         ->schema([
             Tab::make('profile', 'Profile')->schema([
@@ -1251,8 +1281,7 @@ test('tabs serialize tab panels as composable children', function () {
             Tab::make('security', 'Security')->schema([
                 Form::make('password-form'),
             ]),
-        ])
-        ->toArray())
+        ])))
         ->toMatchArray([
             'type' => 'tabs',
             'key' => 'settings-tabs',
@@ -1295,9 +1324,8 @@ test('tabs serialize tab panels as composable children', function () {
 });
 
 test('tabs can customize their query string key', function () {
-    expect(Tabs::make('settings-tabs')
-        ->queryKey('settings-tab')
-        ->toArray())
+    expect(wire(Tabs::make('settings-tabs')
+        ->queryKey('settings-tab')))
         ->toMatchArray([
             'type' => 'tabs',
             'key' => 'settings-tabs',
@@ -1309,13 +1337,12 @@ test('tabs can customize their query string key', function () {
 });
 
 test('tabs ignore hidden tab children when resolving their active value', function () {
-    $tabs = Tabs::make('settings-tabs')
+    $tabs = wire(Tabs::make('settings-tabs')
         ->defaultValue('security')
         ->schema([
             Tab::make('profile', 'Profile'),
             Tab::make('security', 'Security')->when(false),
-        ])
-        ->toArray();
+        ]));
 
     expect($tabs['props']['activeValue'])->toBe('profile')
         ->and($tabs['schema'])->toHaveCount(1)
@@ -1337,7 +1364,7 @@ test('tabs hydrate their active value from the request query string', function (
 });
 
 test('confirmed inactive tabs serialize only their tab metadata', function () {
-    $tabs = Tabs::make('settings-tabs')
+    $tabs = wire(Tabs::make('settings-tabs')
         ->defaultValue('profile')
         ->schema([
             Tab::make('profile', 'Profile')->schema([
@@ -1348,8 +1375,7 @@ test('confirmed inactive tabs serialize only their tab metadata', function () {
                 ->schema([
                     Text::make('Security form'),
                 ]),
-        ])
-        ->toArray();
+        ]));
 
     expect($tabs['props']['activeValue'])->toBe('profile')
         ->and($tabs['props']['defaultValue'])->toBe('profile')
@@ -1695,7 +1721,7 @@ class WorkbenchUsersTable extends TableDefinition
             [
                 'name' => 'Taylor',
                 'filters' => array_map(
-                    fn ($filter): array => $filter->toArray(),
+                    fn ($filter): array => wire($filter),
                     $query->filters(),
                 ),
                 'sorts' => array_map(

--- a/tests/Feature/ProductRelatedProductsTest.php
+++ b/tests/Feature/ProductRelatedProductsTest.php
@@ -19,7 +19,7 @@ test('the product form syncs related products on create', function () {
     $alpha = Product::factory()->create(['name' => 'Alpha']);
     $beta = Product::factory()->create(['name' => 'Beta']);
 
-    $form = Form::use(ProductForm::class)->toArray();
+    $form = wire(Form::use(ProductForm::class));
 
     post('/lattice/forms/workbench.products.form', [
         'name' => 'Gadget',
@@ -51,9 +51,8 @@ test('the product form replaces related products on update', function () {
 
     $product->relatedProducts()->sync([$alpha->getKey(), $beta->getKey()]);
 
-    $form = Form::use(ProductForm::class)
-        ->context(['product_id' => $product->getKey()])
-        ->toArray();
+    $form = wire(Form::use(ProductForm::class)
+        ->context(['product_id' => $product->getKey()]));
 
     patch('/lattice/forms/workbench.products.form', [
         'name' => 'Desk Lamp',
@@ -73,7 +72,7 @@ test('the product form ignores related ids that do not exist', function () {
 
     $alpha = Product::factory()->create(['name' => 'Alpha']);
 
-    $form = Form::use(ProductForm::class)->toArray();
+    $form = wire(Form::use(ProductForm::class));
 
     post('/lattice/forms/workbench.products.form', [
         'name' => 'Gadget',
@@ -114,9 +113,8 @@ test('the product form resolves related product labels for prefilled ids', funct
 
     $related = Product::factory()->create(['name' => 'Walnut Desk']);
 
-    $form = Form::use(ProductForm::class)
-        ->fill(['related_products' => [$related->getKey()]])
-        ->toArray();
+    $form = wire(Form::use(ProductForm::class)
+        ->fill(['related_products' => [$related->getKey()]]));
 
     expect(json_encode($form))
         ->toContain('{"label":"Walnut Desk","value":"'.$related->getKey().'"}');

--- a/tests/Feature/ProductsTest.php
+++ b/tests/Feature/ProductsTest.php
@@ -52,15 +52,14 @@ function productHeaders(array $component, array $extra = []): array
 }
 
 test('forms serialize initial state for bound edit values', function () {
-    $form = Form::make('product-form')
+    $form = wire(Form::make('product-form')
         ->fill([
             'name' => 'Desk Lamp',
             'sku' => 'LAMP-001',
         ])
         ->schema([
             TextInput::make('name', 'Name'),
-        ])
-        ->toArray();
+        ]));
 
     expect($form)
         ->toMatchArray([
@@ -76,9 +75,8 @@ test('forms serialize initial state for bound edit values', function () {
 });
 
 test('forms can enable precognitive validation with a delay', function () {
-    $form = Form::make('product-form')
-        ->precognitive(650)
-        ->toArray();
+    $form = wire(Form::make('product-form')
+        ->precognitive(650));
 
     expect($form)
         ->toMatchArray([
@@ -112,7 +110,7 @@ test('the product index page lists products and links to creation', function () 
 test('the product form creates products', function () {
     Lattice::forms([ProductForm::class]);
 
-    $form = Form::use(ProductForm::class)->toArray();
+    $form = wire(Form::use(ProductForm::class));
 
     post('/lattice/forms/workbench.products.form', [
         'name' => 'Desk Lamp',
@@ -170,9 +168,8 @@ test('the product form updates the trusted product from sealed context', functio
         'status' => 'active',
     ]);
 
-    $form = Form::use(ProductForm::class)
-        ->context(['product_id' => $trustedProduct->getKey()])
-        ->toArray();
+    $form = wire(Form::use(ProductForm::class)
+        ->context(['product_id' => $trustedProduct->getKey()]));
 
     patch('/lattice/forms/workbench.products.form', [
         'product_id' => $tamperedProduct->getKey(),
@@ -197,7 +194,7 @@ test('the product form updates the trusted product from sealed context', functio
 test('the product form validates required fields', function () {
     Lattice::forms([ProductForm::class]);
 
-    $form = Form::use(ProductForm::class)->toArray();
+    $form = wire(Form::use(ProductForm::class));
 
     post('/lattice/forms/workbench.products.form', [
         'name' => '',
@@ -217,7 +214,7 @@ test('the product form validates required fields', function () {
 test('the product form returns precognitive validation errors without creating products', function () {
     Lattice::forms([ProductForm::class]);
 
-    $form = Form::use(ProductForm::class)->toArray();
+    $form = wire(Form::use(ProductForm::class));
 
     post('/lattice/forms/workbench.products.form', [
         'name' => '',
@@ -239,7 +236,7 @@ test('the product form returns precognitive validation errors without creating p
 test('the product form accepts valid precognitive validation without creating products', function () {
     Lattice::forms([ProductForm::class]);
 
-    $form = Form::use(ProductForm::class)->toArray();
+    $form = wire(Form::use(ProductForm::class));
 
     post('/lattice/forms/workbench.products.form', [
         'name' => 'Desk Lamp',
@@ -273,9 +270,8 @@ test('the product form validates edit uniqueness from sealed context during prec
         'status' => 'active',
     ]);
 
-    $form = Form::use(ProductForm::class)
-        ->context(['product_id' => $trustedProduct->getKey()])
-        ->toArray();
+    $form = wire(Form::use(ProductForm::class)
+        ->context(['product_id' => $trustedProduct->getKey()]));
 
     patch('/lattice/forms/workbench.products.form', [
         'name' => 'Desk Lamp',
@@ -328,9 +324,8 @@ test('the product archive row action is pinned to its sealed product', function 
     $other = Product::factory()->create(['status' => 'active']);
 
     $ref = productComponentRef(
-        Action::use(ArchiveProductAction::class)
-            ->context(['product_id' => $target->getKey()])
-            ->toArray(),
+        wire(Action::use(ArchiveProductAction::class)
+            ->context(['product_id' => $target->getKey()])),
     );
 
     patch('/lattice/actions/workbench.products.archive', [
@@ -350,9 +345,8 @@ test('the product archive row action authorizes per row', function () {
     $archived = Product::factory()->create(['status' => 'archived']);
 
     $ref = productComponentRef(
-        Action::use(ArchiveProductAction::class)
-            ->context(['product_id' => $archived->getKey()])
-            ->toArray(),
+        wire(Action::use(ArchiveProductAction::class)
+            ->context(['product_id' => $archived->getKey()])),
     );
 
     patch('/lattice/actions/workbench.products.archive', [], ['X-Lattice-Ref' => $ref])
@@ -420,9 +414,8 @@ test('bulk actions execute through their serialized component reference', functi
     $product = Product::factory()->create(['status' => 'active']);
 
     $ref = data_get(
-        BulkAction::use(ArchiveSelectedProductsAction::class)
-            ->context(['table' => 'workbench.products'])
-            ->toArray(),
+        wire(BulkAction::use(ArchiveSelectedProductsAction::class)
+            ->context(['table' => 'workbench.products'])),
         'props.ref',
     );
 
@@ -438,14 +431,14 @@ test('bulk actions execute through their serialized component reference', functi
 test('the products table is serialized as striped', function () {
     Lattice::tables([ProductsTable::class]);
 
-    expect(data_get(Table::use(ProductsTable::class)->toArray(), 'props.striped'))->toBeTrue();
+    expect(data_get(wire(Table::use(ProductsTable::class)), 'props.striped'))->toBeTrue();
 });
 
 test('the products table serializes bulk actions bound to the table', function () {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
-    $bulkActions = data_get(Table::use(ProductsTable::class)->toArray(), 'props.bulkActions');
+    $bulkActions = data_get(wire(Table::use(ProductsTable::class)), 'props.bulkActions');
 
     expect($bulkActions)->toBeArray()->toHaveCount(1)
         ->and($bulkActions[0]['id'])->toBe('workbench.products.archive-selected')

--- a/tests/Feature/SelectPrefillTest.php
+++ b/tests/Feature/SelectPrefillTest.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Forms\Components\Select;
  */
 function prefilledOptions(Form $form): array
 {
-    return $form->toArray()['schema'][0]['props']['options'] ?? [];
+    return wire($form)['schema'][0]['props']['options'] ?? [];
 }
 
 it('resolves the label for a single filled id', function (): void {
@@ -61,7 +61,7 @@ it('passes a single value to the resolver as a one-element array', function (): 
                 }),
         ]);
 
-    $form->toArray();
+    wire($form);
 
     expect($received)->toBe(['7']);
 });
@@ -91,7 +91,7 @@ it('does not resolve when there is no filled value', function (): void {
                 }),
         ]);
 
-    $form->toArray();
+    wire($form);
 
     expect($resolved)->toBeFalse();
 });

--- a/tests/Feature/SelectSearchTest.php
+++ b/tests/Feature/SelectSearchTest.php
@@ -71,7 +71,7 @@ it('searches options through the form endpoint with a signed reference', functio
     Product::factory()->create(['name' => 'Walnut Desk']);
     Product::factory()->create(['name' => 'Steel Lamp']);
 
-    $ref = Form::use(ShowcaseForm::class)->toArray()['props']['ref'];
+    $ref = wire(Form::use(ShowcaseForm::class))['props']['ref'];
 
     post('/lattice/forms/workbench.showcase.form', [
         '_search' => 'related_products',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,3 +7,14 @@ use Lattice\Lattice\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
 uses(RefreshDatabase::class)->in(__DIR__);
+
+/**
+ * Serialize a wire object (or array of them) the way the HTTP response does,
+ * so tests can assert against the JSON payload without a toArray() shortcut.
+ *
+ * @return array<array-key, mixed>
+ */
+function wire(mixed $value): array
+{
+    return json_decode(json_encode($value, JSON_THROW_ON_ERROR), true);
+}

--- a/tests/Unit/ActionResultTest.php
+++ b/tests/Unit/ActionResultTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 use Lattice\Lattice\Actions\ActionResult;
 
 it('marks a successful result as ok', function (): void {
-    expect(ActionResult::success(['id' => 1])->toArray())
+    expect(wire(ActionResult::success(['id' => 1])))
         ->toMatchArray(['ok' => true, 'data' => ['id' => 1]]);
 });
 
 it('marks a failed result as not ok', function (): void {
-    expect(ActionResult::failure(['reason' => 'denied'])->toArray())
+    expect(wire(ActionResult::failure(['reason' => 'denied'])))
         ->toMatchArray(['ok' => false, 'data' => ['reason' => 'denied']]);
 });

--- a/tests/Unit/DateInputTest.php
+++ b/tests/Unit/DateInputTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Lattice\Lattice\Forms\Components\DateInput;
 
 it('serializes a date input', function (): void {
-    $node = DateInput::make('due', 'Due date')->min('2026-01-01')->max('2026-12-31')->toArray();
+    $node = wire(DateInput::make('due', 'Due date')->min('2026-01-01')->max('2026-12-31'));
 
     expect($node['type'])->toBe('form.date-input')
         ->and($node['props'])->toMatchArray([

--- a/tests/Unit/EnumOptionsTest.php
+++ b/tests/Unit/EnumOptionsTest.php
@@ -23,7 +23,7 @@ enum LabelledStatus: string implements HasLabel
 }
 
 it('builds options from an enum class using humanised names by default', function (): void {
-    $options = Choice::make('status', 'Status')->enum(PlainStatus::class)->toArray()['props']['options'];
+    $options = wire(Choice::make('status', 'Status')->enum(PlainStatus::class))['props']['options'];
 
     expect($options)->toBe([
         ['label' => 'Draft', 'value' => 'draft'],
@@ -38,7 +38,7 @@ it('uses the HasLabel contract for labels and supports translations', function (
     ], 'de');
     app()->setLocale('de');
 
-    $options = Choice::make('status', 'Status')->enum(LabelledStatus::class)->toArray()['props']['options'];
+    $options = wire(Choice::make('status', 'Status')->enum(LabelledStatus::class))['props']['options'];
 
     expect($options)->toBe([
         ['label' => 'Aktiv', 'value' => 'active'],
@@ -47,9 +47,8 @@ it('uses the HasLabel contract for labels and supports translations', function (
 });
 
 it('builds options from a subset of enum cases', function (): void {
-    $options = Choice::make('status', 'Status')
-        ->enum([PlainStatus::Draft])
-        ->toArray()['props']['options'];
+    $options = wire(Choice::make('status', 'Status')
+        ->enum([PlainStatus::Draft]))['props']['options'];
 
     expect($options)->toBe([
         ['label' => 'Draft', 'value' => 'draft'],

--- a/tests/Unit/FieldConditionsTest.php
+++ b/tests/Unit/FieldConditionsTest.php
@@ -6,10 +6,9 @@ use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormData;
 
 it('serializes declarative conditions into props', function (): void {
-    $props = TextInput::make('company', 'Company')
+    $props = wire(TextInput::make('company', 'Company')
         ->dependsOn('type', 'business')
-        ->requiredWhen('type', 'business')
-        ->toArray()['props'];
+        ->requiredWhen('type', 'business'))['props'];
 
     expect($props['conditions']['visible'])->toBe([
         ['field' => 'type', 'operator' => 'eq', 'value' => 'business'],
@@ -19,10 +18,9 @@ it('serializes declarative conditions into props', function (): void {
 });
 
 it('supports the operator form and array in', function (): void {
-    $props = TextInput::make('x', 'X')
+    $props = wire(TextInput::make('x', 'X')
         ->dependsOn('age', 'gte', 18)
-        ->disabledWhen('plan', 'in', ['free', 'trial'])
-        ->toArray()['props'];
+        ->disabledWhen('plan', 'in', ['free', 'trial']))['props'];
 
     expect($props['conditions']['visible'][0])->toBe(['field' => 'age', 'operator' => 'gte', 'value' => 18])
         ->and($props['conditions']['disabled'][0])->toBe(['field' => 'plan', 'operator' => 'in', 'value' => ['free', 'trial']]);
@@ -42,5 +40,5 @@ it('evaluates visibility and required against data', function (): void {
 it('treats array value as an in condition', function (): void {
     $field = TextInput::make('x', 'X')->dependsOn('plan', ['free', 'trial']);
 
-    expect($field->toArray()['props']['conditions']['visible'][0]['operator'])->toBe('in');
+    expect(wire($field)['props']['conditions']['visible'][0]['operator'])->toBe('in');
 });

--- a/tests/Unit/FieldResolutionTest.php
+++ b/tests/Unit/FieldResolutionTest.php
@@ -8,13 +8,11 @@ use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormData;
 
 it('serializes dependsOn keys and the any-change marker', function (): void {
-    $optionsProps = Choice::make('state', 'State')
-        ->dependsOn('country', fn (Choice $f, FormData $d) => $f)
-        ->toArray()['props'];
+    $optionsProps = wire(Choice::make('state', 'State')
+        ->dependsOn('country', fn (Choice $f, FormData $d) => $f))['props'];
 
-    $valueProps = TextInput::make('total', 'Total')
-        ->value(fn (FormData $d) => $d->float('qty'))
-        ->toArray()['props'];
+    $valueProps = wire(TextInput::make('total', 'Total')
+        ->value(fn (FormData $d) => $d->float('qty')))['props'];
 
     expect($optionsProps['dependsOnKeys'])->toBe(['country'])
         ->and($valueProps['dependsOnAny'])->toBeTrue();
@@ -28,7 +26,7 @@ it('resolves a value closure during resolution', function (): void {
 
     expect($field->hasResolvedValue())->toBeTrue()
         ->and($field->resolvedValue())->toBe(12.0)
-        ->and($field->toArray()['props']['value'])->toBe(12.0);
+        ->and(wire($field)['props']['value'])->toEqual(12.0);
 });
 
 it('marks a value set inside a dependsOn closure as resolved', function (): void {
@@ -52,5 +50,5 @@ it('runs dependsOn closures during resolution', function (): void {
 
     $field->applyResolution(FormData::make(['country' => 'germany']), Request::create('/'));
 
-    expect($field->toArray()['props']['options'])->toBe([['label' => 'Germany', 'value' => 'germany']]);
+    expect(wire($field)['props']['options'])->toBe([['label' => 'Germany', 'value' => 'germany']]);
 });

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -21,7 +21,7 @@ it('exposes its name and serializes name/label', function (): void {
     $field = makeField();
 
     expect($field->name())->toBe('price')
-        ->and($field->toArray()['props'])->toMatchArray(['name' => 'price', 'label' => 'Price']);
+        ->and(wire($field)['props'])->toMatchArray(['name' => 'price', 'label' => 'Price']);
 });
 
 it('resolves array rules', function (): void {

--- a/tests/Unit/InteractiveComponentTest.php
+++ b/tests/Unit/InteractiveComponentTest.php
@@ -19,12 +19,12 @@ function makeInteractiveComponent(): Component
 }
 
 it('serialises an interactive component without an id instead of crashing', function (): void {
-    expect(makeInteractiveComponent()->toArray())->not->toHaveKey('id');
+    expect(wire(makeInteractiveComponent()))->not->toHaveKey('id');
 });
 
 it('throws a clear error when an interactive component with an endpoint has no id', function (): void {
     $component = makeInteractiveComponent()->prop('endpoint', '/run');
 
-    expect(fn (): array => $component->toArray())
+    expect(fn (): array => wire($component))
         ->toThrow(LogicException::class, 'must be given an id()');
 });

--- a/tests/Unit/NumberInputTest.php
+++ b/tests/Unit/NumberInputTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 use Lattice\Lattice\Forms\Components\NumberInput;
 
 it('serializes a number input', function (): void {
-    $node = NumberInput::make('qty', 'Qty')->min(0)->max(100)->step(1)->toArray();
+    $node = wire(NumberInput::make('qty', 'Qty')->min(0)->max(100)->step(1));
 
     expect($node['type'])->toBe('form.number-input')
         ->and($node['props'])->toMatchArray(['name' => 'qty', 'min' => 0, 'max' => 100, 'step' => 1]);
 });
 
 it('serializes a number input with a slider flag', function (): void {
-    $node = NumberInput::make('level', 'Level')->slider()->min(0)->max(10)->toArray();
+    $node = wire(NumberInput::make('level', 'Level')->slider()->min(0)->max(10));
 
     expect($node['props'])->toMatchArray(['slider' => true, 'min' => 0, 'max' => 10]);
 });

--- a/tests/Unit/SelectTest.php
+++ b/tests/Unit/SelectTest.php
@@ -12,9 +12,9 @@ it('serializes static options without search flags', function (): void {
         Select::option('Pro', 'pro'),
     ]);
 
-    $props = $field->toArray()['props'];
+    $props = wire($field)['props'];
 
-    expect($field->toArray()['type'])->toBe('form.select')
+    expect(wire($field)['type'])->toBe('form.select')
         ->and($props['options'])->toBe([
             ['label' => 'Free', 'value' => 'free'],
             ['label' => 'Pro', 'value' => 'pro'],
@@ -29,7 +29,7 @@ it('serializes the multiple and searchable flags but never the resolver', functi
         ->multiple()
         ->searchable(fn (string $query) => []);
 
-    $props = $field->toArray()['props'];
+    $props = wire($field)['props'];
 
     expect($props['multiple'])->toBeTrue()
         ->and($props['searchable'])->toBeTrue()

--- a/tests/Unit/TextareaTest.php
+++ b/tests/Unit/TextareaTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Lattice\Lattice\Forms\Components\Textarea;
 
 it('serializes a textarea', function (): void {
-    $node = Textarea::make('bio', 'Bio')->rows(4)->placeholder('Tell us about yourself')->toArray();
+    $node = wire(Textarea::make('bio', 'Bio')->rows(4)->placeholder('Tell us about yourself'));
 
     expect($node['type'])->toBe('form.textarea')
         ->and($node['props'])->toMatchArray([


### PR DESCRIPTION
Drops the hand-written `toArray()` flatten convention across components and value objects. Each wire object now implements only `jsonSerialize()` and holds its children/nested VOs as objects; serialization happens once at the response boundary via `json_encode`. This removes the per-child `->toArray()` boilerplate and the dual `toArray()`/`jsonSerialize()` pairs. Alpha — no backward-compat shims.

## Single serialization path
- `Component`/`ContainerComponent`/`Tabs` serialize children as objects (under the `schema` key); the `json_encode` boundary recurses via `JsonSerializable`.
- Value objects (`ColumnData`, `ColumnFilter`, `TableSort`, `FilterClause`, `TableQuery`, `TableResult`, `ActionResult`, `Effect`, `ToastMessage`, `Column`) drop `toArray()` and keep a single `jsonSerialize()` that holds nested VOs as objects.
- `TableResult` carries the query (`forQuery()`) so `state` serializes without a parametrized `toArray($query)`. Controllers/registries hand objects straight to `response()->json(...)` / Inertia.

## No-strip in generated VOs
- `ColumnData` no longer strips null/empty fields, so the generated TypeScript matches the wire exactly: **`TableColumn = ColumnData`** directly, replacing the `Pick`/`Partial` adapter.
- `Component::filterEmptyValues` stays — its TS type is hand-written, so stripping there gives no inference benefit while keeping the wire lean and the absence/security (`context`) assertions intact.

## Tests
- Assert the wire through a `json_encode` round-trip (`wire()` helper) or typed value-object accessors instead of a `toArray()` shortcut.
- Exact column-list assertions spell out the full no-strip shape; one whole-float case (`12.0` → JSON `12`) uses loose wire equality while the typed accessor still checks `12.0`.

## Left intentionally (not the flatten convention)
`Page::toArray` (response assembler), `MenuRegistry`/`MenuItem` `toArray` (request aggregator + route-action persistence), `RichContent::toArray` (TipTap document render).

## Verification
Pint · PHPStan · `tsc` · oxlint · oxfmt clean · Pest 233 passed (incl. browser) · Vitest 134 passed.

Follow-up parked: Phase 3 (TablePagination/TableState generation + flat-VO-vs-discriminator revisit).