### PR TITLE
feat: server-driven layouts with an outlet

### DIFF
--- a/config/lattice.php
+++ b/config/lattice.php
@@ -29,6 +29,10 @@ return [
         'registered' => [],
     ],
 
+    'layouts' => [
+        'registered' => [],
+    ],
+
     'actions' => [
         'endpoint' => 'lattice/actions/{action}',
         'middleware' => ['web'],

--- a/resources/js/core/types.ts
+++ b/resources/js/core/types.ts
@@ -24,10 +24,16 @@ export type Node<TType extends string = string> = {
 /** An ordered list of component nodes — the content of a page, form, or container. */
 export type Schema = Node[];
 
+/** A server-composed layout shell: its key plus a schema containing one Outlet. */
+export type LayoutPayload = {
+  key: string;
+  schema: Schema;
+};
+
 export type PagePayload = {
   breadcrumbs: PageBreadcrumb[];
   container: PageContainer;
-  layout: string;
+  layout: LayoutPayload | null;
   menus: Record<string, MenuPayload | undefined>;
   schema: Schema;
   title: string | null;

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -10,6 +10,7 @@ export { copyToClipboard, useClipboard } from "./clipboard";
 export { EventBridge } from "./events/event-bridge";
 export { IconRenderer, IconRendererProvider } from "./icons";
 export { createLayoutResolver, createPageResolver, pageComponentName } from "./inertia";
+export { layoutComponents, OutletContext, SchemaLayout } from "./layout";
 export { useMenu } from "./menu";
 export { Provider, useRegistry } from "./provider";
 export {
@@ -28,6 +29,7 @@ export type {
   ComponentProps,
   ComponentType,
   KnownPageContainer,
+  LayoutPayload,
   MenuGroup,
   MenuItem,
   MenuPayload,

--- a/resources/js/inertia.test.tsx
+++ b/resources/js/inertia.test.tsx
@@ -2,6 +2,7 @@ import type { Page as InertiaPage } from "@inertiajs/core";
 import type { ResolvedComponent } from "@inertiajs/react";
 import { describe, expect, it, vi } from "vitest";
 import { createLayoutResolver, createPageResolver } from "./inertia";
+import { SchemaLayout } from "./layout";
 import Page from "./page";
 import type { PagePayload } from "./core/types";
 
@@ -25,7 +26,7 @@ function payload(lattice: Partial<PagePayload> = {}): PagePayload {
     breadcrumbs: [],
     schema: [],
     container: "default",
-    layout: "none",
+    layout: null,
     menus: {},
     title: "Lattice",
     ...lattice,
@@ -57,56 +58,41 @@ describe("createPageResolver", () => {
 });
 
 describe("createLayoutResolver", () => {
-  it("maps app lattice pages to the configured app layout with breadcrumbs", () => {
-    const app = Symbol("app");
-    const auth = Symbol("auth");
-    const resolver = createLayoutResolver({ layouts: { app, auth } });
-    const breadcrumbs = [{ href: "/dashboard", title: "Dashboard" }];
+  it("renders lattice pages with a layout through the schema layout", () => {
+    const resolver = createLayoutResolver();
 
     expect(
       resolver(
         "lattice/page",
         pageWithLattice(
           payload({
-            breadcrumbs,
-            layout: "app",
+            layout: { key: "app", schema: [] },
           }),
         ),
       ),
-    ).toEqual([app, { breadcrumbs }]);
+    ).toBe(SchemaLayout);
   });
 
-  it("maps auth lattice pages to the configured auth layout", () => {
-    const app = Symbol("app");
-    const auth = Symbol("auth");
-    const resolver = createLayoutResolver({ layouts: { app, auth } });
+  it("renders layout-less lattice pages standalone", () => {
+    const resolver = createLayoutResolver();
 
-    expect(
-      resolver(
-        "lattice/page",
-        pageWithLattice(
-          payload({
-            layout: "auth",
-          }),
-        ),
-      ),
-    ).toBe(auth);
+    expect(resolver("lattice/page", pageWithLattice(payload()))).toBeNull();
   });
 
   it("delegates non-lattice pages to the default layout resolver", () => {
     const defaultLayout = vi.fn<(name: string, page: InertiaPage) => string>(
       () => "default-layout",
     );
-    const resolver = createLayoutResolver({
-      defaultLayout,
-      layouts: {
-        app: "app-layout",
-        auth: "auth-layout",
-      },
-    });
+    const resolver = createLayoutResolver({ defaultLayout });
     const page = pageWithLattice(payload());
 
     expect(resolver("auth/login", page)).toBe("default-layout");
     expect(defaultLayout).toHaveBeenCalledWith("auth/login", page);
+  });
+
+  it("returns null for non-lattice pages without a default resolver", () => {
+    const resolver = createLayoutResolver();
+
+    expect(resolver("auth/login", pageWithLattice(payload()))).toBeNull();
   });
 });

--- a/resources/js/inertia.ts
+++ b/resources/js/inertia.ts
@@ -1,5 +1,6 @@
 import type { Page as InertiaPage } from "@inertiajs/core";
 import type { ResolvedComponent } from "@inertiajs/react";
+import { SchemaLayout } from "./layout";
 import Page from "./page";
 import type { PagePayload } from "./core/types";
 
@@ -11,14 +12,8 @@ export type ResolvedPage =
   | { default: ResolvedComponent };
 export type PageModules = Record<string, () => Promise<ResolvedComponent>>;
 
-export type Layouts = {
-  app: unknown;
-  auth: unknown;
-};
-
 export type CreateLayoutResolverOptions = {
   defaultLayout?: (name: string, page: InertiaPage) => unknown;
-  layouts: Layouts;
 };
 
 export function createPageResolver(pages: PageModules) {
@@ -37,22 +32,14 @@ export function createPageResolver(pages: PageModules) {
   };
 }
 
-export function createLayoutResolver({ defaultLayout, layouts }: CreateLayoutResolverOptions) {
+export function createLayoutResolver({ defaultLayout }: CreateLayoutResolverOptions = {}) {
   return (name: string, page: InertiaPage): unknown => {
     if (name === pageComponentName) {
       const lattice = page.props.lattice as PagePayload | undefined;
 
-      if (lattice?.layout === "app") {
-        return [layouts.app, { breadcrumbs: lattice.breadcrumbs }];
-      }
-
-      if (lattice?.layout === "auth") {
-        return layouts.auth;
-      }
-
-      return null;
+      return lattice?.layout ? SchemaLayout : null;
     }
 
-    return defaultLayout?.(name, page) ?? layouts.app;
+    return defaultLayout?.(name, page) ?? null;
   };
 }

--- a/resources/js/layout/components.ts
+++ b/resources/js/layout/components.ts
@@ -1,0 +1,9 @@
+import { createPlugin, eagerComponent } from "@lattice/lattice/core/registry";
+import OutletComponent from "./outlet";
+
+export const layoutComponents = createPlugin({
+  components: {
+    outlet: eagerComponent(OutletComponent),
+  },
+  name: "lattice/layout",
+});

--- a/resources/js/layout/context.ts
+++ b/resources/js/layout/context.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * Carries the active page element down through a server-composed layout schema
+ * so the Outlet component can render it wherever the layout places it.
+ */
+export const OutletContext = createContext<ReactNode>(null);

--- a/resources/js/layout/index.ts
+++ b/resources/js/layout/index.ts
@@ -1,0 +1,3 @@
+export { layoutComponents } from "./components";
+export { OutletContext } from "./context";
+export { default as SchemaLayout } from "./schema-layout";

--- a/resources/js/layout/outlet.tsx
+++ b/resources/js/layout/outlet.tsx
@@ -1,0 +1,18 @@
+import { useContext } from "react";
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { OutletContext } from "./context";
+
+declare module "@lattice/lattice/core/types" {
+  interface ComponentProps {
+    outlet: Record<string, never>;
+  }
+}
+
+/**
+ * Renders the active page at the position the layout schema places it.
+ */
+const OutletComponent: RendererComponent<"outlet"> = () => {
+  return <>{useContext(OutletContext)}</>;
+};
+
+export default OutletComponent;

--- a/resources/js/layout/schema-layout.test.tsx
+++ b/resources/js/layout/schema-layout.test.tsx
@@ -1,0 +1,58 @@
+import { usePage } from "@inertiajs/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Provider } from "@lattice/lattice";
+import type { PagePayload } from "@lattice/lattice";
+import SchemaLayout from "./schema-layout";
+
+vi.mock("@inertiajs/react", () => ({
+  usePage: vi.fn<() => unknown>(),
+}));
+
+const mockedUsePage = vi.mocked(usePage);
+
+function payload(lattice: Partial<PagePayload> = {}): PagePayload {
+  return {
+    breadcrumbs: [],
+    schema: [],
+    container: "default",
+    layout: null,
+    menus: {},
+    title: "Lattice",
+    ...lattice,
+  };
+}
+
+function renderLayout(lattice: PagePayload) {
+  mockedUsePage.mockReturnValue({ props: { lattice } } as unknown as ReturnType<typeof usePage>);
+
+  return render(
+    <Provider>
+      <SchemaLayout>
+        <span>Page body</span>
+      </SchemaLayout>
+    </Provider>,
+  );
+}
+
+describe("SchemaLayout", () => {
+  it("renders the layout schema and the page at the outlet", () => {
+    renderLayout(
+      payload({
+        layout: {
+          key: "app",
+          schema: [{ props: { text: "Sidebar" }, type: "text" }, { type: "outlet" }],
+        },
+      }),
+    );
+
+    expect(screen.getByText("Sidebar")).toBeVisible();
+    expect(screen.getByText("Page body")).toBeVisible();
+  });
+
+  it("renders the page standalone when there is no layout", () => {
+    renderLayout(payload({ layout: null }));
+
+    expect(screen.getByText("Page body")).toBeVisible();
+  });
+});

--- a/resources/js/layout/schema-layout.tsx
+++ b/resources/js/layout/schema-layout.tsx
@@ -1,0 +1,28 @@
+import { usePage } from "@inertiajs/react";
+import type { ReactNode } from "react";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import type { PagePayload } from "@lattice/lattice/core/types";
+import { useRegistry } from "@lattice/lattice/provider";
+import { OutletContext } from "./context";
+
+/**
+ * Persistent Inertia layout that renders a server-composed layout schema and
+ * exposes the active page (`children`) to the Outlet via context. The same
+ * component instance is reused across navigations that share a layout, so
+ * shell state (open sidebar, scroll position) survives page visits.
+ */
+export default function SchemaLayout({ children }: { children: ReactNode }) {
+  const lattice = usePage().props.lattice as PagePayload;
+  const registry = useRegistry();
+  const layout = lattice.layout;
+
+  if (!layout) {
+    return <>{children}</>;
+  }
+
+  return (
+    <OutletContext.Provider value={children}>
+      <Renderer fallback={null} nodes={layout.schema} registry={registry} />
+    </OutletContext.Provider>
+  );
+}

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -13,7 +13,7 @@ function payload(lattice: Partial<PagePayload> = {}): PagePayload {
     breadcrumbs: [],
     schema: [],
     container: "default",
-    layout: "none",
+    layout: null,
     menus: {},
     title: "Lattice",
     ...lattice,
@@ -50,7 +50,7 @@ describe("Page", () => {
               type: "text",
             },
           ],
-          layout: "app",
+          layout: { key: "app", schema: [] },
         })}
       />,
     );

--- a/resources/js/page.tsx
+++ b/resources/js/page.tsx
@@ -29,7 +29,7 @@ export default function Page({ lattice }: Props) {
         <div
           data-testid="lattice-default-container"
           className={cn("w-full", {
-            "px-4 py-6": lattice.layout === "app",
+            "px-4 py-6": lattice.layout !== null,
           })}
         >
           {content}

--- a/resources/js/registry.ts
+++ b/resources/js/registry.ts
@@ -2,11 +2,13 @@ import { createRegistry } from "@lattice/lattice/core/registry";
 import { actionComponents } from "./action";
 import { coreComponents } from "./core/components";
 import { formComponents } from "./form";
+import { layoutComponents } from "./layout/components";
 import { tableComponents } from "./table";
 
 export const registry = createRegistry(
   coreComponents,
   actionComponents,
   formComponents,
+  layoutComponents,
   tableComponents,
 );

--- a/src/Attributes/Layout.php
+++ b/src/Attributes/Layout.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Layout extends ComponentAttribute {}

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -12,6 +12,8 @@ use Lattice\Lattice\Menu\MenuRegistry;
  * @method static void forms(class-string<\Lattice\Lattice\Forms\FormDefinition>|array<int, class-string<\Lattice\Lattice\Forms\FormDefinition>> $forms)
  * @method static void tables(class-string<\Lattice\Lattice\Tables\TableDefinition>|array<int, class-string<\Lattice\Lattice\Tables\TableDefinition>> $tables)
  * @method static void fragments(class-string<\Lattice\Lattice\Fragments\FragmentDefinition>|array<int, class-string<\Lattice\Lattice\Fragments\FragmentDefinition>> $fragments)
+ * @method static void layouts(class-string<\Lattice\Lattice\Layouts\LayoutDefinition>|array<int, class-string<\Lattice\Lattice\Layouts\LayoutDefinition>> $layouts)
+ * @method static \Lattice\Lattice\Layouts\LayoutRegistry layoutRegistry()
  * @method static void actions(class-string<\Lattice\Lattice\Actions\ActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\ActionDefinition>> $actions)
  * @method static void bulkActions(class-string<\Lattice\Lattice\Actions\BulkActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\BulkActionDefinition>> $bulkActions)
  * @method static void registerConfiguredDefinitions()

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -80,16 +80,14 @@ abstract class Page implements PageContract
     /**
      * @return array{title: string|null, layout: array{key: string, schema: array<int, array<string, mixed>>}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, menus: array<string, array{groups: array<int, array{label: string|null, items: array<int, array{active: bool, href: string, icon: string|null, key: string, label: string, method: string}>}>}>, schema: array<int, array<string, mixed>>}
      */
-    public function toArray(PageSchema $schema, ?Request $request = null): array
+    public function toArray(PageSchema $schema, Request $request): array
     {
         return [
             'title' => $this->title(),
             'layout' => $this->resolveLayout($request),
             'container' => $this->serializePageMetadata($this->container()),
             'breadcrumbs' => $this->breadcrumbs(),
-            'menus' => $request instanceof Request
-                ? Lattice::menus()->toArray($request)
-                : [],
+            'menus' => Lattice::menus()->toArray($request),
             'schema' => $this->serializeSchema($schema),
         ];
     }
@@ -102,7 +100,7 @@ abstract class Page implements PageContract
      *
      * @return array{key: string, schema: array<int, array<string, mixed>>}|null
      */
-    private function resolveLayout(?Request $request): ?array
+    private function resolveLayout(Request $request): ?array
     {
         $key = $this->serializePageMetadata($this->layout());
 
@@ -110,7 +108,7 @@ abstract class Page implements PageContract
             return null;
         }
 
-        $rendered = Lattice::layoutRegistry()->render($key, $request ?? app(Request::class));
+        $rendered = Lattice::layoutRegistry()->render($key, $request);
 
         return [
             'key' => $rendered['key'],

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -78,19 +78,43 @@ abstract class Page implements PageContract
     }
 
     /**
-     * @return array{title: string|null, layout: string, container: string, breadcrumbs: array<int, array{title: string, href: string}>, menus: array<string, array{groups: array<int, array{label: string|null, items: array<int, array{active: bool, href: string, icon: string|null, key: string, label: string, method: string}>}>}>, schema: array<int, array<string, mixed>>}
+     * @return array{title: string|null, layout: array{key: string, schema: array<int, array<string, mixed>>}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, menus: array<string, array{groups: array<int, array{label: string|null, items: array<int, array{active: bool, href: string, icon: string|null, key: string, label: string, method: string}>}>}>, schema: array<int, array<string, mixed>>}
      */
     public function toArray(PageSchema $schema, ?Request $request = null): array
     {
         return [
             'title' => $this->title(),
-            'layout' => $this->serializePageMetadata($this->layout()),
+            'layout' => $this->resolveLayout($request),
             'container' => $this->serializePageMetadata($this->container()),
             'breadcrumbs' => $this->breadcrumbs(),
             'menus' => $request instanceof Request
                 ? Lattice::menus()->toArray($request)
                 : [],
             'schema' => $this->serializeSchema($schema),
+        ];
+    }
+
+    /**
+     * Resolve the page's layout to its wire shape: the layout key plus its
+     * realized schema (a component tree containing an Outlet that marks where
+     * this page's content renders). Returns null when the page opts out of a
+     * layout (rendered standalone, e.g. centered auth screens).
+     *
+     * @return array{key: string, schema: array<int, array<string, mixed>>}|null
+     */
+    private function resolveLayout(?Request $request): ?array
+    {
+        $key = $this->serializePageMetadata($this->layout());
+
+        if ($key === '' || $key === PageLayout::None->value) {
+            return null;
+        }
+
+        $rendered = Lattice::layoutRegistry()->render($key, $request ?? app(Request::class));
+
+        return [
+            'key' => $rendered['key'],
+            'schema' => json_decode(json_encode($rendered['schema'], JSON_THROW_ON_ERROR), true),
         ];
     }
 

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -18,6 +18,8 @@ use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\FragmentDefinition;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Http\PageContract;
+use Lattice\Lattice\Layouts\LayoutDefinition;
+use Lattice\Lattice\Layouts\LayoutRegistry;
 use Lattice\Lattice\Menu\MenuRegistry;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableRegistry;
@@ -30,6 +32,7 @@ final class LatticeRegistry
         private readonly DiscoversDefinitions $discovery,
         private readonly FormRegistry $forms,
         private readonly FragmentRegistry $fragments,
+        private readonly LayoutRegistry $layouts,
         private readonly MenuRegistry $menus,
         private readonly Router $router,
         private readonly TableRegistry $tables,
@@ -75,6 +78,19 @@ final class LatticeRegistry
         $this->bulkActions->register($bulkActions);
     }
 
+    /**
+     * @param  class-string<LayoutDefinition>|array<int, class-string<LayoutDefinition>>  $layouts
+     */
+    public function layouts(string|array $layouts): void
+    {
+        $this->layouts->register($layouts);
+    }
+
+    public function layoutRegistry(): LayoutRegistry
+    {
+        return $this->layouts;
+    }
+
     public function menus(): MenuRegistry
     {
         return $this->menus;
@@ -108,7 +124,7 @@ final class LatticeRegistry
      */
     private function discoverableRegistries(): array
     {
-        $registries = [$this->forms, $this->tables, $this->actions, $this->fragments, $this->bulkActions];
+        $registries = [$this->forms, $this->tables, $this->actions, $this->fragments, $this->bulkActions, $this->layouts];
 
         return array_combine(
             array_map(static fn (DefinitionRegistry $registry): string => $registry->group(), $registries),

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -19,6 +19,7 @@ use Lattice\Lattice\Core\Services\DefinitionDiscovery;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\FragmentRegistry;
+use Lattice\Lattice\Layouts\LayoutRegistry;
 use Lattice\Lattice\Menu\MenuItem;
 use Lattice\Lattice\Menu\MenuRegistry;
 use Lattice\Lattice\Tables\TableRegistry;
@@ -42,6 +43,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->singleton(FormRegistry::class);
         $this->app->singleton(TableRegistry::class);
         $this->app->singleton(FragmentRegistry::class);
+        $this->app->singleton(LayoutRegistry::class);
         $this->app->singleton(ActionRegistry::class);
         $this->app->singleton(BulkActionRegistry::class);
         $this->app->singleton(MenuRegistry::class);

--- a/src/Layouts/Components/Outlet.php
+++ b/src/Layouts/Components/Outlet.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Layouts\Components;
+
+use Lattice\Lattice\Core\Components\Component;
+
+/**
+ * Marks where the active page's content is rendered inside a layout schema.
+ */
+class Outlet extends Component
+{
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+
+    protected function type(): string
+    {
+        return 'outlet';
+    }
+}

--- a/src/Layouts/Contracts/ProvidesLayout.php
+++ b/src/Layouts/Contracts/ProvidesLayout.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Layouts\Contracts;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\PageSchema;
+
+interface ProvidesLayout
+{
+    /**
+     * Build the layout shell. The returned schema must contain exactly one
+     * Outlet, marking where the active page's content is rendered.
+     */
+    public function schema(PageSchema $schema, Request $request): PageSchema;
+}

--- a/src/Layouts/LayoutDefinition.php
+++ b/src/Layouts/LayoutDefinition.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Layouts;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Definition;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Layouts\Contracts\ProvidesLayout;
+
+abstract class LayoutDefinition extends Definition implements ProvidesLayout
+{
+    abstract public function schema(PageSchema $schema, Request $request): PageSchema;
+}

--- a/src/Layouts/LayoutRegistry.php
+++ b/src/Layouts/LayoutRegistry.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Layouts;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\ComponentAttribute;
+use Lattice\Lattice\Attributes\Layout;
+use Lattice\Lattice\Core\Components\Component;
+use Lattice\Lattice\Core\DefinitionRegistry;
+use Lattice\Lattice\Core\PageSchema;
+
+/**
+ * @extends DefinitionRegistry<LayoutDefinition>
+ */
+final class LayoutRegistry extends DefinitionRegistry
+{
+    /**
+     * @return array{key: string, schema: array<int, Component>}
+     */
+    public function render(string $key, Request $request): array
+    {
+        $definition = $this->resolve($key);
+
+        return [
+            'key' => $key,
+            'schema' => $definition
+                ->schema(PageSchema::make(), $request)
+                ->renderable(),
+        ];
+    }
+
+    /**
+     * @return class-string<LayoutDefinition>
+     */
+    protected function definitionClass(): string
+    {
+        return LayoutDefinition::class;
+    }
+
+    /**
+     * @return class-string<ComponentAttribute>
+     */
+    public function attributeClass(): string
+    {
+        return Layout::class;
+    }
+
+    protected function name(): string
+    {
+        return 'layout';
+    }
+
+    public function group(): string
+    {
+        return 'layouts';
+    }
+}

--- a/tests/Feature/LatticeLayoutTest.php
+++ b/tests/Feature/LatticeLayoutTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Layout;
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Layouts\Components\Outlet;
+use Lattice\Lattice\Layouts\LayoutDefinition;
+use Lattice\Lattice\Layouts\LayoutRegistry;
+
+#[Layout('app')]
+final class WorkbenchAppLayout extends LayoutDefinition
+{
+    public function schema(PageSchema $schema, Request $request): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('app-shell')->schema([
+                Heading::make('Workbench'),
+                Outlet::make(),
+            ]),
+        ]);
+    }
+}
+
+final class WorkbenchLayoutPage extends Page
+{
+    public function layout(): string
+    {
+        return 'app';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Page body'));
+    }
+}
+
+final class WorkbenchStandalonePage extends Page
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Standalone body'));
+    }
+}
+
+test('the layout registry resolves a registered layout to its wire schema', function () {
+    Lattice::layouts([WorkbenchAppLayout::class]);
+
+    $rendered = app(LayoutRegistry::class)->render('app', new Request);
+    $schema = wire($rendered['schema']);
+
+    expect($rendered['key'])->toBe('app')
+        ->and($schema[0]['type'])->toBe('stack')
+        ->and($schema[0]['key'])->toBe('app-shell')
+        ->and($schema[0]['schema'][0]['type'])->toBe('heading')
+        ->and($schema[0]['schema'][1]['type'])->toBe('outlet');
+});
+
+test('the layout registry rejects an unregistered layout key', function () {
+    expect(fn () => app(LayoutRegistry::class)->render('missing', new Request))
+        ->toThrow(UnknownLatticeComponent::class);
+});
+
+test('a page serializes its layout as key and schema with an outlet', function () {
+    Lattice::layouts([WorkbenchAppLayout::class]);
+
+    $page = new WorkbenchLayoutPage;
+
+    $payload = $page->toArray($page->render(PageSchema::make()), new Request);
+
+    expect($payload['layout']['key'])->toBe('app')
+        ->and($payload['layout']['schema'][0]['type'])->toBe('stack')
+        ->and($payload['layout']['schema'][0]['schema'][1]['type'])->toBe('outlet')
+        ->and($payload['schema'][0])->toMatchArray([
+            'type' => 'text',
+            'props' => ['text' => 'Page body'],
+        ]);
+});
+
+test('a page without a layout serializes a null layout', function () {
+    $page = new WorkbenchStandalonePage;
+
+    $payload = $page->toArray($page->render(PageSchema::make()), new Request);
+
+    expect($payload['layout'])->toBeNull();
+});
+
+test('the none layout sentinel serializes a null layout', function () {
+    $page = new class extends Page
+    {
+        public function layout(): PageLayout
+        {
+            return PageLayout::None;
+        }
+
+        public function render(PageSchema $schema): PageSchema
+        {
+            return $schema->component(Text::make('body'));
+        }
+    };
+
+    expect($page->toArray($page->render(PageSchema::make()), new Request)['layout'])->toBeNull();
+});

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -1537,11 +1537,6 @@ test('pages serialize layout and container metadata', function () {
 
     $configuredPage = new class extends Page
     {
-        public function layout(): string
-        {
-            return 'custom';
-        }
-
         public function container(): string
         {
             return 'default';
@@ -1555,12 +1550,12 @@ test('pages serialize layout and container metadata', function () {
 
     expect($defaultPage->toArray($defaultPage->render(PageSchema::make())))
         ->toMatchArray([
-            'layout' => 'none',
+            'layout' => null,
             'container' => 'centered',
         ])
         ->and($configuredPage->toArray($configuredPage->render(PageSchema::make())))
         ->toMatchArray([
-            'layout' => 'custom',
+            'layout' => null,
             'container' => 'default',
         ]);
 });
@@ -1603,8 +1598,10 @@ test('workbench pages serialize package component trees for inertia', function (
         ->assertInertia(fn (AssertableInertia $page) => $page
             ->component('lattice/page')
             ->where('lattice.title', 'Lattice Workbench')
-            ->where('lattice.layout', 'none')
-            ->where('lattice.container', 'centered')
+            ->where('lattice.layout.key', 'app')
+            ->where('lattice.layout.schema.0.type', 'stack')
+            ->where('lattice.layout.schema.0.schema.1.schema.0.type', 'outlet')
+            ->where('lattice.container', 'default')
             ->where('lattice.schema.0.type', 'stack')
             ->where('lattice.schema.0.key', 'workbench-page')
             ->where('lattice.schema.0.schema.0.type', 'stack')

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -407,7 +407,7 @@ test('components can opt out of rendering with when', function () {
         }
     };
 
-    $pageData = wire($page->toArray($page->render(PageSchema::make())));
+    $pageData = wire($page->toArray($page->render(PageSchema::make()), new Request));
 
     expect($pageData['schema'])
         ->toHaveCount(2)
@@ -1548,12 +1548,12 @@ test('pages serialize layout and container metadata', function () {
         }
     };
 
-    expect($defaultPage->toArray($defaultPage->render(PageSchema::make())))
+    expect($defaultPage->toArray($defaultPage->render(PageSchema::make()), new Request))
         ->toMatchArray([
             'layout' => null,
             'container' => 'centered',
         ])
-        ->and($configuredPage->toArray($configuredPage->render(PageSchema::make())))
+        ->and($configuredPage->toArray($configuredPage->render(PageSchema::make()), new Request))
         ->toMatchArray([
             'layout' => null,
             'container' => 'default',
@@ -1579,7 +1579,7 @@ test('pages serialize breadcrumb metadata', function () {
         }
     };
 
-    expect($page->toArray($page->render(PageSchema::make())))
+    expect($page->toArray($page->render(PageSchema::make()), new Request))
         ->toMatchArray([
             'breadcrumbs' => [
                 [

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Layouts;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Layout;
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Link;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Layouts\Components\Outlet;
+use Lattice\Lattice\Layouts\LayoutDefinition;
+
+#[Layout('app')]
+final class AppLayout extends LayoutDefinition
+{
+    public function schema(PageSchema $schema, Request $request): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('app-shell')
+                ->direction('row')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Stack::make('app-sidebar')
+                        ->gap(Gap::Small)
+                        ->schema([
+                            Heading::make('Lattice', 2),
+                            Link::make('Home')->href('/'),
+                            Link::make('Tables')->href('/tables'),
+                            Link::make('Products')->href('/products'),
+                            Link::make('Form Showcase')->href('/showcase'),
+                        ]),
+                    Stack::make('app-main')
+                        ->schema([
+                            Outlet::make(),
+                        ]),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Pages/HomePage.php
+++ b/workbench/app/Pages/HomePage.php
@@ -11,6 +11,8 @@ use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Tables\Components\Table;
@@ -21,6 +23,16 @@ final class HomePage extends Page
     public function title(): string
     {
         return 'Lattice Workbench';
+    }
+
+    public function layout(): PageLayout
+    {
+        return PageLayout::App;
+    }
+
+    public function container(): PageContainer
+    {
+        return PageContainer::Default;
     }
 
     public function render(PageSchema $schema): PageSchema

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -18,6 +18,7 @@ use Workbench\App\Actions\ArchiveSelectedProductsAction;
 use Workbench\App\Forms\DependentDemoForm;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Forms\ShowcaseForm;
+use Workbench\App\Layouts\AppLayout;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
@@ -95,6 +96,10 @@ class WorkbenchServiceProvider extends ServiceProvider
             UsersSimpleTable::class,
             UsersTablePaginationTable::class,
             UsersInfiniteTable::class,
+        ]);
+
+        Lattice::layouts([
+            AppLayout::class,
         ]);
 
         $this->pointBoostAtPackageRoot();

--- a/workbench/resources/js/app.tsx
+++ b/workbench/resources/js/app.tsx
@@ -1,8 +1,9 @@
 import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
+import { createLayoutResolver, Provider, registry } from "@lattice/lattice";
 import type { ComponentType } from "react";
 import { createRoot } from "react-dom/client";
-import LatticePage from "../../../resources/js/page";
+import LatticePage from "@lattice/lattice/page";
 
 type PageModule = { default: ComponentType<any> };
 
@@ -19,11 +20,16 @@ createInertiaApp({
 
     return workbenchPages[`./Pages/${name}.tsx`];
   },
+  layout: createLayoutResolver(),
   setup({ el, App, props }) {
     if (!el) {
       return;
     }
 
-    createRoot(el).render(<App {...props} />);
+    createRoot(el).render(
+      <Provider registry={registry}>
+        <App {...props} />
+      </Provider>,
+    );
   },
 });


### PR DESCRIPTION
## What

Layouts become PHP classes that compose a **layout schema** containing an **`Outlet`** marking where the active page renders — replacing the hardcoded frontend shell and the route-macro menu workaround.

- `#[Layout('app')]` + `LayoutDefinition::schema(PageSchema, Request)` + `LayoutRegistry` (mirrors the existing `Fragment` definition/registry pattern)
- New `Outlet` component (the only new backend component this pass)
- `Page::toArray()` now emits `layout: { key, schema } | null` and resolves the layout via the registry
- Frontend `SchemaLayout` renders the layout schema and injects the page at the outlet via context, so Inertia persistent-layout behavior (sidebar/scroll state) survives navigation
- Navigation is expressed as ordinary schema components inside the layout — no menu macros needed
- Workbench `AppLayout` example wired into the served app (`HomePage` opts into it)

## Why

The shell (sidebar/header/nav) was hardcoded React in each consuming app, which forced a parallel menu data-channel (route `->menu()`/`->sidebar()` macros → `MenuRegistry` → `useMenu`). Making the layout server-composed lets navigation live in the layout schema and removes that workaround.

## Notes

- New components kept intentionally minimal (just `Outlet`); the richer layout primitives are left for the in-flight typed-component refactor, so this builds on the current `->prop()` bag.
- The existing `MenuRegistry`/route macros are left in place for now (unused by the new layout) rather than ripped out in the same pass.
- `createLayoutResolver` no longer takes `layouts: { app, auth }` (breaking, pre-1.0); the workbench wiring is updated.

## Verification

- `composer test` — 216 passed (+5 new) · `npm test` — 137 passed (+3)
- phpstan / tsc / oxlint / oxfmt clean · `npm run build` compiles · pint passes
- End-to-end on the served workbench: `/` returns `layout.key=app`, a sidebar with schema-driven links, the page content rendered at the `outlet`