### PR TITLE
docs: fixture-backed examples, node tree tab, and field docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Pest
         run: composer test
 
+      - name: Docs fixtures are up to date
+        run: |
+          git add --intent-to-add docs/fixtures
+          git diff --exit-code docs/fixtures
+
   browser:
     name: Browser (Pest)
     runs-on: ubuntu-latest

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,8 +60,13 @@ export default defineConfig({
             { label: "Overview", link: "/forms/overview/" },
             {
               label: "Fields",
-              items: [{ label: "Text input", link: "/forms/fields/text-input/" }],
+              items: [
+                { label: "Overview", link: "/forms/fields/overview/" },
+                { label: "Text input", link: "/forms/fields/text-input/" },
+              ],
             },
+            { label: "Validation", link: "/forms/validation/" },
+            { label: "Conditional fields", link: "/forms/conditional-fields/" },
           ],
         },
         {

--- a/docs/components/ComponentExample.astro
+++ b/docs/components/ComponentExample.astro
@@ -1,14 +1,27 @@
 ---
 import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 import LatticePreview from "@components/LatticePreview.tsx";
+import NodeTree from "@components/NodeTree.tsx";
 
 interface Props {
   php: string;
-  nodes: unknown[];
+  fixture: string;
   values?: Record<string, unknown>;
 }
 
-const { php, nodes, values = {} } = Astro.props;
+const { php, fixture, values = {} } = Astro.props;
+
+const fixtures = import.meta.glob<{ default: unknown[] }>("../fixtures/*.json", {
+  eager: true,
+});
+
+const entry = fixtures[`../fixtures/${fixture}.json`];
+
+if (!entry) {
+  throw new Error(`Unknown fixture "${fixture}". Did a test dump it to docs/fixtures/?`);
+}
+
+const nodes = entry.default;
 ---
 
 <Tabs>
@@ -18,6 +31,11 @@ const { php, nodes, values = {} } = Astro.props;
   <TabItem label="Preview">
     <div class="lattice-preview not-content">
       <LatticePreview client:only="react" nodes={nodes} values={values} />
+    </div>
+  </TabItem>
+  <TabItem label="Tree">
+    <div class="lattice-preview not-content">
+      <NodeTree client:load nodes={nodes} />
     </div>
   </TabItem>
 </Tabs>

--- a/docs/components/NodeTree.tsx
+++ b/docs/components/NodeTree.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import type { Node } from "@lattice/lattice/core/types";
+
+type Props = {
+  nodes: Node[];
+};
+
+function isNode(value: unknown): value is Node {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === "string"
+  );
+}
+
+function childNodes(node: Node): Node[] {
+  const children: Node[] = [...(node.schema ?? [])];
+
+  for (const value of Object.values(node.props ?? {})) {
+    if (isNode(value)) {
+      children.push(value);
+    } else if (Array.isArray(value)) {
+      children.push(...value.filter(isNode));
+    }
+  }
+
+  return children;
+}
+
+function scalarProps(node: Node): [string, unknown][] {
+  return Object.entries(node.props ?? {}).filter(([, value]) => {
+    if (isNode(value)) {
+      return false;
+    }
+
+    return !(Array.isArray(value) && value.some(isNode));
+  });
+}
+
+function TreeNode({ node }: { node: Node }) {
+  const props = scalarProps(node);
+  const children = childNodes(node);
+  const expandable = props.length > 0 || children.length > 0;
+  const [open, setOpen] = useState(true);
+
+  return (
+    <li className="lattice-tree__item">
+      <button
+        type="button"
+        className="lattice-tree__row"
+        aria-expanded={expandable ? open : undefined}
+        disabled={!expandable}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="lattice-tree__caret">{expandable ? (open ? "▾" : "▸") : "·"}</span>
+        <span className="lattice-tree__type">{node.type}</span>
+      </button>
+
+      {open && expandable ? (
+        <div className="lattice-tree__body">
+          {props.length > 0 ? (
+            <ul className="lattice-tree__props">
+              {props.map(([key, value]) => (
+                <li key={key} className="lattice-tree__prop">
+                  <span className="lattice-tree__key">{key}</span>
+                  <span className="lattice-tree__sep">:</span>
+                  <span className="lattice-tree__value">{JSON.stringify(value)}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {children.length > 0 ? (
+            <ul className="lattice-tree__children">
+              {children.map((child, index) => (
+                <TreeNode key={child.key ?? child.id ?? index} node={child} />
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+export default function NodeTree({ nodes }: Props) {
+  return (
+    <ul className="lattice-tree">
+      {nodes.map((node, index) => (
+        <TreeNode key={node.key ?? node.id ?? index} node={node} />
+      ))}
+    </ul>
+  );
+}

--- a/docs/content/docs/forms/conditional-fields.mdx
+++ b/docs/content/docs/forms/conditional-fields.mdx
@@ -1,0 +1,93 @@
+---
+title: Conditional fields
+description: Show, require, or disable fields based on other fields, and compute values from the form data.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+Fields can react to the rest of the form. A condition compares another field's value and toggles this
+field's visibility, required, read-only, or disabled state. Conditions are evaluated on the client as
+the user types, and the same rules are re-checked on the server, so they cannot be bypassed.
+
+Each method names the field to watch, an optional operator, and the value to compare against. Open the
+**Tree** tab on the examples below to see the `conditions` that are serialized to the client.
+
+## Visible when
+
+`->visibleWhen()` hides the field until the condition matches.
+
+<ComponentExample
+  php={`TextInput::make('vat', 'VAT ID')
+    ->visibleWhen('type', 'business')`}
+  fixture="field.visible-when"
+  values={{ vat: "" }}
+/>
+
+## Required when
+
+`->requiredWhen()` makes the field required only while the condition matches.
+
+<ComponentExample
+  php={`TextInput::make('vat', 'VAT ID')
+    ->requiredWhen('country', 'DE')`}
+  fixture="field.required-when"
+  values={{ vat: "" }}
+/>
+
+## Read-only and disabled when
+
+`->readOnlyWhen()` and `->disabledWhen()` toggle the read-only and disabled states the same way.
+
+```php
+TextInput::make('coupon', 'Coupon')
+    ->readOnlyWhen('plan', 'enterprise');
+
+TextInput::make('coupon', 'Coupon')
+    ->disabledWhen('billing', 'invoice');
+```
+
+## Operators
+
+With two arguments, the condition checks equality. Pass an array to match any of several values, or
+pass an operator as the middle argument for other comparisons.
+
+```php
+TextInput::make('vat', 'VAT ID')
+    ->visibleWhen('country', ['DE', 'AT', 'CH']);
+
+NumberInput::make('guardian', 'Guardian name')
+    ->requiredWhen('age', '<', 18);
+```
+
+The operator accepts a comparison string or a `ConditionOperator` case:
+
+| Comparison        | Operator                            |
+| ----------------- | ----------------------------------- |
+| `=`, `==`         | `ConditionOperator::Equals`         |
+| `!=`, `<>`        | `ConditionOperator::NotEquals`      |
+| `>`, `>=`         | `GreaterThan`, `GreaterThanOrEqual` |
+| `<`, `<=`         | `LessThan`, `LessThanOrEqual`       |
+| `contains`        | `ConditionOperator::Contains`       |
+| `in`, `not_in`    | `In`, `NotIn`                       |
+| `empty`, `filled` | `Empty`, `Filled`                   |
+
+## Computed values
+
+A field's value can be derived from the form data instead of typed. Pass a closure to `->value()` to
+compute it from the current `FormData`. The closure runs on the server whenever the inputs change.
+
+```php
+TextInput::make('total', 'Total')
+    ->value(fn (FormData $data) => $data->float('qty') * $data->float('price'));
+```
+
+When the computation also needs to change other parts of the field, use `->dependsOn()` to name the
+fields to watch and receive the field itself in the closure.
+
+```php
+TextInput::make('total', 'Total')
+    ->dependsOn(
+        ['qty', 'price'],
+        fn (TextInput $field, FormData $data) => $field->value($data->float('qty') * $data->float('price')),
+    );
+```

--- a/docs/content/docs/forms/conditional-fields.mdx
+++ b/docs/content/docs/forms/conditional-fields.mdx
@@ -14,24 +14,37 @@ Each method names the field to watch, an optional operator, and the value to com
 
 ## Visible when
 
-`->visibleWhen()` hides the field until the condition matches.
+`->visibleWhen()` hides the field until the condition matches. Switch the account type below to
+**Individual** and the VAT ID field disappears.
 
 <ComponentExample
-  php={`TextInput::make('vat', 'VAT ID')
+  php={`Choice::make('type', 'Account type')->options([
+    Choice::option('Business', 'business'),
+    Choice::option('Individual', 'individual'),
+]);
+
+TextInput::make('vat', 'VAT ID')
     ->visibleWhen('type', 'business')`}
   fixture="field.visible-when"
-  values={{ vat: "" }}
+  values={{ type: "business", vat: "" }}
 />
 
 ## Required when
 
-`->requiredWhen()` makes the field required only while the condition matches.
+`->requiredWhen()` makes the field required only while the condition matches. With **Germany**
+selected the VAT ID is required; pick another country and it becomes optional.
 
 <ComponentExample
-  php={`TextInput::make('vat', 'VAT ID')
+  php={`Choice::make('country', 'Country')->options([
+    Choice::option('Germany', 'DE'),
+    Choice::option('Austria', 'AT'),
+    Choice::option('United States', 'US'),
+]);
+
+TextInput::make('vat', 'VAT ID')
     ->requiredWhen('country', 'DE')`}
   fixture="field.required-when"
-  values={{ vat: "" }}
+  values={{ country: "DE", vat: "" }}
 />
 
 ## Read-only and disabled when

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -1,0 +1,90 @@
+---
+title: Fields
+description: The common options shared by every form field — label, default value, required, disabled, read-only, and visibility.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+Fields are the building blocks of a form. Lattice ships `TextInput`, `Textarea`, `Select`,
+`Choice`, `Checkbox`, `DateInput`, `NumberInput`, `PasswordInput`, and `RichEditor`, and you can
+add your own. Each field type has its own page for the options unique to it; this page covers the
+options every field shares.
+
+For validation and conditional behavior — which also apply to every field — see
+[Validation](/forms/validation/) and [Conditional fields](/forms/conditional-fields/).
+
+The options below extend the base `Field` class, so they work the same on every field. The examples
+use `TextInput`, but the methods are identical everywhere.
+
+## Label
+
+`make()` takes the field name and an optional label. Pass the label as the second argument, or
+set it later with `->label()`. Omit it and the field renders without a visible label.
+
+```php
+TextInput::make('name', 'Team name');
+
+TextInput::make('name')->label('Team name');
+```
+
+## Default value
+
+`->value()` seeds the field with a starting value. On a form bound to a record, the record's
+value wins; otherwise this default is used.
+
+<ComponentExample
+  php={`TextInput::make('name', 'Team name')
+    ->value('Acme Inc')`}
+  fixture="field.default-value"
+  values={{ name: "Acme Inc" }}
+/>
+
+## Required
+
+`->required()` marks the field as required, adding the indicator and a `required` validation rule.
+
+<ComponentExample
+  php={`TextInput::make('name', 'Team name')
+    ->required()`}
+  fixture="field.required"
+  values={{ name: "" }}
+/>
+
+## Disabled
+
+`->disabled()` renders the field non-interactive. A disabled field is not submitted with the form.
+
+<ComponentExample
+  php={`TextInput::make('name', 'Team name')
+    ->value('Acme Inc')
+    ->disabled()`}
+  fixture="field.disabled"
+  values={{ name: "Acme Inc" }}
+/>
+
+## Read-only
+
+`->readOnly()` shows the value but prevents editing. Unlike `disabled`, a read-only field is still
+submitted.
+
+<ComponentExample
+  php={`TextInput::make('slug', 'Slug')
+    ->value('acme-inc')
+    ->readOnly()`}
+  fixture="field.read-only"
+  values={{ slug: "acme-inc" }}
+/>
+
+## Hidden and visible
+
+`->hidden()` removes the field from the rendered form; `->visible()` is the inverse and reads more
+naturally when toggling on a condition. Both accept a boolean.
+
+```php
+TextInput::make('internal_note', 'Internal note')->hidden();
+
+TextInput::make('internal_note', 'Internal note')->visible($user->isAdmin());
+```
+
+To show or hide a field based on another field's value, see
+[Conditional fields](/forms/conditional-fields/).

--- a/docs/content/docs/forms/fields/text-input.mdx
+++ b/docs/content/docs/forms/fields/text-input.mdx
@@ -11,17 +11,7 @@ The text input collects a single line of text. Create one with `TextInput::make(
   php={`TextInput::make('name', 'Team name')
     ->placeholder('My team')
     ->required()`}
-  nodes={[
-    {
-      type: "form.text-input",
-      props: {
-        name: "name",
-        label: "Team name",
-        placeholder: "My team",
-        required: true,
-      },
-    },
-  ]}
+  fixture="text-input.required"
   values={{ name: "" }}
 />
 
@@ -33,16 +23,6 @@ Call `->email()` to set the HTML input type to `email` and apply email validatio
   php={`TextInput::make('email', 'Email address')
     ->email()
     ->placeholder('you@example.com')`}
-  nodes={[
-    {
-      type: "form.text-input",
-      props: {
-        name: "email",
-        label: "Email address",
-        type: "email",
-        placeholder: "you@example.com",
-      },
-    },
-  ]}
+  fixture="text-input.email"
   values={{ email: "" }}
 />

--- a/docs/content/docs/forms/fields/text-input.mdx
+++ b/docs/content/docs/forms/fields/text-input.mdx
@@ -15,6 +15,11 @@ The text input collects a single line of text. Create one with `TextInput::make(
   values={{ name: "" }}
 />
 
+## Placeholder
+
+`->placeholder()` sets the muted hint shown while the field is empty. It is not a value — an empty
+field still submits as empty.
+
 ## Email
 
 Call `->email()` to set the HTML input type to `email` and apply email validation:
@@ -26,3 +31,35 @@ Call `->email()` to set the HTML input type to `email` and apply email validatio
   fixture="text-input.email"
   values={{ email: "" }}
 />
+
+## Autocomplete
+
+`->autoComplete()` sets the HTML `autocomplete` attribute so the browser can offer saved values.
+Pass any valid token, such as `organization`, `username`, or `off`.
+
+```php
+TextInput::make('company', 'Company')->autoComplete('organization');
+```
+
+## Autofocus
+
+`->autoFocus()` focuses the field when the form mounts. Use it on the first field only.
+
+```php
+TextInput::make('name', 'Team name')->autoFocus();
+```
+
+## Tab index
+
+`->tabIndex()` overrides the keyboard tab order. Most forms should rely on the natural document
+order instead.
+
+```php
+TextInput::make('name', 'Team name')->tabIndex(1);
+```
+
+## Common options
+
+`TextInput` shares label, default value, required, disabled, read-only, and visibility options with
+every field — see [Fields](/forms/fields/overview/). For validation and conditional behavior, see
+[Validation](/forms/validation/) and [Conditional fields](/forms/conditional-fields/).

--- a/docs/content/docs/forms/validation.md
+++ b/docs/content/docs/forms/validation.md
@@ -1,0 +1,70 @@
+---
+title: Validation
+description: Server-side validation with Laravel rules, custom messages, and live feedback through Precognition.
+---
+
+Validation always runs on the server using Laravel's validator, so the rules you write are the rules
+that protect your data. With Precognition enabled, the same rules also run live as the user fills the
+form, without you writing any client-side validation.
+
+## Adding rules
+
+`->rules()` accepts an array of Laravel validation rules. Calls accumulate, so you can add rules
+across several calls or alongside the helpers below.
+
+```php
+TextInput::make('name', 'Team name')
+    ->rules(['min:2', 'max:50']);
+```
+
+Rules may be rule objects, not just strings:
+
+```php
+use Illuminate\Validation\Rules\Password;
+
+PasswordInput::make('password', 'Password')
+    ->rules([Password::min(8)->mixedCase()->numbers()]);
+```
+
+## Rule helpers
+
+Some rules have dedicated methods that read better and may adjust the field at the same time.
+`->required()` adds the `required` rule and the required indicator; `->email()` sets the input type
+to `email` and adds email validation.
+
+```php
+TextInput::make('email', 'Email address')
+    ->required()
+    ->email();
+```
+
+## Custom messages
+
+`->message()` overrides the message for a single rule on this field. The first argument is the rule
+name, the second is the message.
+
+```php
+TextInput::make('name', 'Team name')
+    ->rules(['min:2'])
+    ->message('min', 'Your team name needs at least two characters.');
+```
+
+## Dynamic rules
+
+Pass a closure to `->rules()` to build rules from the current form data. The closure receives the
+`FormData` and the `Request`, and returns additional rules. It runs at validation time, so it always
+sees the latest input.
+
+```php
+TextInput::make('discount_code', 'Discount code')
+    ->rules(fn (FormData $data, Request $request) => $data->boolean('has_discount')
+        ? ['required', 'exists:discounts,code']
+        : []);
+```
+
+## Live validation
+
+Validation runs live through [Laravel Precognition](https://laravel.com/docs/precognition): as the
+user edits a field, the form sends a precognitive request that runs your rules and returns messages
+without executing the submission. Because it is the exact same server-side ruleset, there is nothing
+to keep in sync — what passes live is what passes on submit.

--- a/docs/fixtures/field.default-value.json
+++ b/docs/fixtures/field.default-value.json
@@ -1,0 +1,10 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "name",
+            "label": "Team name",
+            "value": "Acme Inc"
+        }
+    }
+]

--- a/docs/fixtures/field.default-value.json
+++ b/docs/fixtures/field.default-value.json
@@ -1,10 +1,10 @@
 [
     {
-        "type": "form.text-input",
         "props": {
-            "name": "name",
             "label": "Team name",
+            "name": "name",
             "value": "Acme Inc"
-        }
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/field.disabled.json
+++ b/docs/fixtures/field.disabled.json
@@ -1,0 +1,11 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "name",
+            "label": "Team name",
+            "value": "Acme Inc",
+            "disabled": true
+        }
+    }
+]

--- a/docs/fixtures/field.disabled.json
+++ b/docs/fixtures/field.disabled.json
@@ -1,11 +1,11 @@
 [
     {
-        "type": "form.text-input",
         "props": {
-            "name": "name",
+            "disabled": true,
             "label": "Team name",
-            "value": "Acme Inc",
-            "disabled": true
-        }
+            "name": "name",
+            "value": "Acme Inc"
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/field.read-only.json
+++ b/docs/fixtures/field.read-only.json
@@ -1,11 +1,11 @@
 [
     {
-        "type": "form.text-input",
         "props": {
-            "name": "slug",
             "label": "Slug",
-            "value": "acme-inc",
-            "readonly": true
-        }
+            "name": "slug",
+            "readonly": true,
+            "value": "acme-inc"
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/field.read-only.json
+++ b/docs/fixtures/field.read-only.json
@@ -1,0 +1,11 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "slug",
+            "label": "Slug",
+            "value": "acme-inc",
+            "readonly": true
+        }
+    }
+]

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -1,9 +1,8 @@
 [
     {
-        "type": "form.choice",
         "props": {
-            "name": "country",
             "label": "Country",
+            "name": "country",
             "options": [
                 {
                     "label": "Germany",
@@ -18,13 +17,11 @@
                     "value": "US"
                 }
             ]
-        }
+        },
+        "type": "form.choice"
     },
     {
-        "type": "form.text-input",
         "props": {
-            "name": "vat",
-            "label": "VAT ID",
             "conditions": {
                 "required": [
                     {
@@ -33,7 +30,10 @@
                         "value": "DE"
                     }
                 ]
-            }
-        }
+            },
+            "label": "VAT ID",
+            "name": "vat"
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -1,0 +1,18 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "vat",
+            "label": "VAT ID",
+            "conditions": {
+                "required": [
+                    {
+                        "field": "country",
+                        "operator": "eq",
+                        "value": "DE"
+                    }
+                ]
+            }
+        }
+    }
+]

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -1,5 +1,26 @@
 [
     {
+        "type": "form.choice",
+        "props": {
+            "name": "country",
+            "label": "Country",
+            "options": [
+                {
+                    "label": "Germany",
+                    "value": "DE"
+                },
+                {
+                    "label": "Austria",
+                    "value": "AT"
+                },
+                {
+                    "label": "United States",
+                    "value": "US"
+                }
+            ]
+        }
+    },
+    {
         "type": "form.text-input",
         "props": {
             "name": "vat",

--- a/docs/fixtures/field.required.json
+++ b/docs/fixtures/field.required.json
@@ -1,0 +1,10 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "name",
+            "label": "Team name",
+            "required": true
+        }
+    }
+]

--- a/docs/fixtures/field.required.json
+++ b/docs/fixtures/field.required.json
@@ -1,10 +1,10 @@
 [
     {
-        "type": "form.text-input",
         "props": {
-            "name": "name",
             "label": "Team name",
+            "name": "name",
             "required": true
-        }
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -1,5 +1,22 @@
 [
     {
+        "type": "form.choice",
+        "props": {
+            "name": "type",
+            "label": "Account type",
+            "options": [
+                {
+                    "label": "Business",
+                    "value": "business"
+                },
+                {
+                    "label": "Individual",
+                    "value": "individual"
+                }
+            ]
+        }
+    },
+    {
         "type": "form.text-input",
         "props": {
             "name": "vat",

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -1,9 +1,8 @@
 [
     {
-        "type": "form.choice",
         "props": {
-            "name": "type",
             "label": "Account type",
+            "name": "type",
             "options": [
                 {
                     "label": "Business",
@@ -14,13 +13,11 @@
                     "value": "individual"
                 }
             ]
-        }
+        },
+        "type": "form.choice"
     },
     {
-        "type": "form.text-input",
         "props": {
-            "name": "vat",
-            "label": "VAT ID",
             "conditions": {
                 "visible": [
                     {
@@ -29,7 +26,10 @@
                         "value": "business"
                     }
                 ]
-            }
-        }
+            },
+            "label": "VAT ID",
+            "name": "vat"
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -1,0 +1,18 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "vat",
+            "label": "VAT ID",
+            "conditions": {
+                "visible": [
+                    {
+                        "field": "type",
+                        "operator": "eq",
+                        "value": "business"
+                    }
+                ]
+            }
+        }
+    }
+]

--- a/docs/fixtures/text-input.email.json
+++ b/docs/fixtures/text-input.email.json
@@ -1,0 +1,11 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "type": "email",
+            "name": "email",
+            "label": "Email address",
+            "placeholder": "you@example.com"
+        }
+    }
+]

--- a/docs/fixtures/text-input.email.json
+++ b/docs/fixtures/text-input.email.json
@@ -1,11 +1,11 @@
 [
     {
-        "type": "form.text-input",
         "props": {
-            "type": "email",
-            "name": "email",
             "label": "Email address",
-            "placeholder": "you@example.com"
-        }
+            "name": "email",
+            "placeholder": "you@example.com",
+            "type": "email"
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/text-input.required.json
+++ b/docs/fixtures/text-input.required.json
@@ -1,11 +1,11 @@
 [
     {
-        "type": "form.text-input",
         "props": {
-            "name": "name",
             "label": "Team name",
-            "required": true,
-            "placeholder": "My team"
-        }
+            "name": "name",
+            "placeholder": "My team",
+            "required": true
+        },
+        "type": "form.text-input"
     }
 ]

--- a/docs/fixtures/text-input.required.json
+++ b/docs/fixtures/text-input.required.json
@@ -1,0 +1,11 @@
+[
+    {
+        "type": "form.text-input",
+        "props": {
+            "name": "name",
+            "label": "Team name",
+            "required": true,
+            "placeholder": "My team"
+        }
+    }
+]

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -62,3 +62,73 @@
 .sl-markdown-content :is(th, td):not(:where(.not-content *)) {
   overflow-wrap: anywhere;
 }
+
+.lattice-tree {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: var(--sl-font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.7;
+}
+
+.lattice-tree__item {
+  list-style: none;
+}
+
+.lattice-tree__row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.lattice-tree__row:disabled {
+  cursor: default;
+}
+
+.lattice-tree__caret {
+  width: 1ch;
+  color: var(--sl-color-gray-3);
+}
+
+.lattice-tree__type {
+  color: var(--sl-color-accent-high);
+  font-weight: 600;
+}
+
+.lattice-tree__body {
+  margin-left: 1.4ch;
+  border-left: 1px solid var(--sl-color-gray-5);
+  padding-left: 1ch;
+}
+
+.lattice-tree__props,
+.lattice-tree__children {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lattice-tree__prop {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.lattice-tree__key {
+  color: var(--sl-color-text-accent);
+}
+
+.lattice-tree__sep {
+  color: var(--sl-color-gray-3);
+}
+
+.lattice-tree__value {
+  color: var(--sl-color-text);
+  overflow-wrap: anywhere;
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,3 +18,19 @@ function wire(mixed $value): array
 {
     return json_decode(json_encode($value, JSON_THROW_ON_ERROR), true);
 }
+
+/**
+ * Dump an array of nodes to docs/fixtures/<key>.json so the docs site can render
+ * a real, test-generated example instead of hand-maintained JSON.
+ *
+ * @param  array<int, mixed>  $nodes
+ */
+function dumpFixture(string $key, array $nodes): void
+{
+    $path = dirname(__DIR__).'/docs/fixtures/'.$key.'.json';
+
+    file_put_contents(
+        $path,
+        json_encode($nodes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n",
+    );
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -23,14 +23,31 @@ function wire(mixed $value): array
  * Dump an array of nodes to docs/fixtures/<key>.json so the docs site can render
  * a real, test-generated example instead of hand-maintained JSON.
  *
+ * Object keys are sorted so the output is identical across PHP versions, keeping
+ * the committed fixtures stable for the CI guard. List order (nodes, options,
+ * conditions) is preserved.
+ *
  * @param  array<int, mixed>  $nodes
  */
 function dumpFixture(string $key, array $nodes): void
 {
-    $path = dirname(__DIR__).'/docs/fixtures/'.$key.'.json';
+    $normalized = json_decode(json_encode($nodes, JSON_THROW_ON_ERROR), true);
 
     file_put_contents(
-        $path,
-        json_encode($nodes, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n",
+        dirname(__DIR__).'/docs/fixtures/'.$key.'.json',
+        json_encode(sortFixtureKeys($normalized), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n",
     );
+}
+
+function sortFixtureKeys(mixed $value): mixed
+{
+    if (! is_array($value)) {
+        return $value;
+    }
+
+    if (! array_is_list($value)) {
+        ksort($value);
+    }
+
+    return array_map('sortFixtureKeys', $value);
 }

--- a/tests/Unit/TextInputTest.php
+++ b/tests/Unit/TextInputTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Lattice\Lattice\Forms\Components\Choice;
 use Lattice\Lattice\Forms\Components\TextInput;
 
 it('serializes a text input', function (): void {
@@ -67,10 +68,19 @@ describe('docs fixtures', function (): void {
 
     it('dumps the conditional field examples', function (): void {
         dumpFixture('field.visible-when', [
+            Choice::make('type', 'Account type')->options([
+                Choice::option('Business', 'business'),
+                Choice::option('Individual', 'individual'),
+            ]),
             TextInput::make('vat', 'VAT ID')->visibleWhen('type', 'business'),
         ]);
 
         dumpFixture('field.required-when', [
+            Choice::make('country', 'Country')->options([
+                Choice::option('Germany', 'DE'),
+                Choice::option('Austria', 'AT'),
+                Choice::option('United States', 'US'),
+            ]),
             TextInput::make('vat', 'VAT ID')->requiredWhen('country', 'DE'),
         ]);
 

--- a/tests/Unit/TextInputTest.php
+++ b/tests/Unit/TextInputTest.php
@@ -44,4 +44,36 @@ describe('docs fixtures', function (): void {
 
         expect('docs/fixtures/text-input.email.json')->toBeReadableFile();
     });
+
+    it('dumps the common field option examples', function (): void {
+        dumpFixture('field.required', [
+            TextInput::make('name', 'Team name')->required(),
+        ]);
+
+        dumpFixture('field.default-value', [
+            TextInput::make('name', 'Team name')->value('Acme Inc'),
+        ]);
+
+        dumpFixture('field.disabled', [
+            TextInput::make('name', 'Team name')->value('Acme Inc')->disabled(),
+        ]);
+
+        dumpFixture('field.read-only', [
+            TextInput::make('slug', 'Slug')->value('acme-inc')->readOnly(),
+        ]);
+
+        expect('docs/fixtures/field.required.json')->toBeReadableFile();
+    });
+
+    it('dumps the conditional field examples', function (): void {
+        dumpFixture('field.visible-when', [
+            TextInput::make('vat', 'VAT ID')->visibleWhen('type', 'business'),
+        ]);
+
+        dumpFixture('field.required-when', [
+            TextInput::make('vat', 'VAT ID')->requiredWhen('country', 'DE'),
+        ]);
+
+        expect('docs/fixtures/field.required-when.json')->toBeReadableFile();
+    });
 });

--- a/tests/Unit/TextInputTest.php
+++ b/tests/Unit/TextInputTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\TextInput;
+
+it('serializes a text input', function (): void {
+    $node = wire(TextInput::make('name', 'Team name')->placeholder('My team')->required());
+
+    expect($node['type'])->toBe('form.text-input')
+        ->and($node['props'])->toMatchArray([
+            'name' => 'name',
+            'label' => 'Team name',
+            'placeholder' => 'My team',
+            'required' => true,
+        ]);
+});
+
+it('serializes an email text input', function (): void {
+    $node = wire(TextInput::make('email', 'Email address')->email()->placeholder('you@example.com'));
+
+    expect($node['type'])->toBe('form.text-input')
+        ->and($node['props'])->toMatchArray([
+            'name' => 'email',
+            'label' => 'Email address',
+            'type' => 'email',
+            'placeholder' => 'you@example.com',
+        ]);
+});
+
+describe('docs fixtures', function (): void {
+    it('dumps the required text input example', function (): void {
+        dumpFixture('text-input.required', [
+            TextInput::make('name', 'Team name')->placeholder('My team')->required(),
+        ]);
+
+        expect('docs/fixtures/text-input.required.json')->toBeReadableFile();
+    });
+
+    it('dumps the email text input example', function (): void {
+        dumpFixture('text-input.email', [
+            TextInput::make('email', 'Email address')->email()->placeholder('you@example.com'),
+        ]);
+
+        expect('docs/fixtures/text-input.email.json')->toBeReadableFile();
+    });
+});


### PR DESCRIPTION
## What

Make docs examples render from real test-generated fixtures, and flesh out the Forms field docs.

**Fixture-backed examples**
- `dumpFixture($key, array $nodes)` test helper writes one JSON file per key to `docs/fixtures/`. Tests build real components and dump their serialized nodes, so example JSON can't drift from what the code produces.
- `ComponentExample` loads node JSON by `fixture="<key>"` at build time (was inline `nodes`), and gains a **Tree** tab (`NodeTree`) — a collapsible, dev-tools-style view of each node's type and props.
- CI guard (`git add -N && git diff --exit-code docs/fixtures`) fails if committed fixtures go stale.

**Forms docs** (structure follows Filament/Nova: shared-options page + separate validation/conditions)
- **Fields / Overview** — options every field shares (label, default value, required, disabled, read-only, hidden/visible).
- **Validation** — rules, rule helpers, custom messages, dynamic rules, Precognition.
- **Conditional fields** — visible/required/read-only/disabled-when, operators, computed values. Examples render the controlling `Choice` field too, so the Preview demonstrates the toggle live.
- **Text input** rewritten to its specifics (placeholder, email/type, autocomplete, autofocus, tab index) and links to the shared reference.

## Verification
- 237 PHP tests pass; fixtures deterministic and guard clean.
- `docs:build` green; all new pages render with populated TOCs and working live previews.
- pint / typecheck / lint clean.