### PR TITLE
feat: migrate Table to typed properties and retire the legacy prop bag

### DIFF
--- a/resources/js/generated/types.ts
+++ b/resources/js/generated/types.ts
@@ -426,7 +426,7 @@ export type Modal = {
   ref?: string | null;
   title?: string | null;
 };
-export type Node = FormNode | CoreNode | ActionNode | FragmentNode;
+export type Node = FormNode | CoreNode | ActionNode | FragmentNode | TableNode;
 export type NodeType = Node["type"];
 export type NumberInput = {
   autoFocus?: boolean | null;
@@ -566,6 +566,21 @@ export type Tab = {
   } | null;
   label: string;
   value: string;
+};
+export type Table = {
+  bulkActions?: Action[];
+  columns?: ColumnData[];
+  endpoint?: string | null;
+  layout?: string | null;
+  lazy?: boolean | null;
+  ref?: string | null;
+  striped?: boolean | null;
+};
+export type TableNode = {
+  type: "table";
+  key?: string;
+  id?: string;
+  props: Table;
 };
 export type TableSort = {
   readonly key: string;

--- a/resources/js/table/types.ts
+++ b/resources/js/table/types.ts
@@ -1,9 +1,11 @@
 import type {
+  ActionNode,
   ColumnData,
   ColumnFilter,
   ColumnType,
   FilterOperator,
   PaginationType,
+  Table,
   TableSort,
 } from "@lattice/lattice/generated/types";
 
@@ -46,17 +48,11 @@ export type TableResponse = {
 
 declare module "@lattice/lattice/core/types" {
   interface ComponentProps {
-    table: {
-      bulkActions?: Array<Record<string, unknown>>;
-      columns?: TableColumn[];
+    table: Omit<Table, "bulkActions"> & {
+      bulkActions?: ActionNode[];
       data?: TableRow[];
-      endpoint?: string;
-      ref?: string;
-      lazy?: boolean;
-      layout?: string;
-      striped?: boolean;
-      pagination?: Record<string, unknown>;
-      state?: Record<string, unknown>;
+      pagination?: TablePagination;
+      state?: Partial<TableState>;
     };
   }
 }

--- a/src/Core/Components/Component.php
+++ b/src/Core/Components/Component.php
@@ -5,8 +5,8 @@ namespace Lattice\Lattice\Core\Components;
 use BackedEnum;
 use JsonSerializable;
 use Lattice\Lattice\Attributes\SerializationHook;
+use ReflectionClass;
 use ReflectionMethod;
-use ReflectionObject;
 use ReflectionProperty;
 use Spatie\Attributes\Attributes;
 use Spatie\Attributes\AttributeTarget;
@@ -22,9 +22,9 @@ abstract class Component implements JsonSerializable
     private static array $serializationHookCache = [];
 
     /**
-     * @var array<string, mixed>
+     * @var array<class-string, list<ReflectionProperty>>
      */
-    protected array $props = [];
+    private static array $wirePropertyCache = [];
 
     protected bool $shouldRender = true;
 
@@ -35,26 +35,6 @@ abstract class Component implements JsonSerializable
     public function key(string $key): static
     {
         $this->key = $key;
-
-        return $this;
-    }
-
-    /**
-     * @param  array<string, mixed>  $props
-     */
-    public function props(array $props): static
-    {
-        $this->props = [
-            ...$this->props,
-            ...$props,
-        ];
-
-        return $this;
-    }
-
-    public function prop(string $name, mixed $value): static
-    {
-        $this->props[$name] = $value;
 
         return $this;
     }
@@ -116,21 +96,17 @@ abstract class Component implements JsonSerializable
     }
 
     /**
-     * Merge the legacy props bag with the public typed properties (including
-     * inherited and trait properties), omitting null and empty-array values so
-     * unset props stay absent from the wire. Backed enums serialize to their value.
+     * Reflects the public typed properties (including inherited and trait
+     * properties), omitting null and empty-array values so unset props stay
+     * absent from the wire. Backed enums serialize to their value.
      *
      * @return array<string, mixed>
      */
     protected function wireProps(): array
     {
-        $props = $this->props;
+        $props = [];
 
-        foreach ((new ReflectionObject($this))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
-            if ($property->isStatic()) {
-                continue;
-            }
-
+        foreach (self::wireProperties(static::class) as $property) {
             if (! $property->isInitialized($this)) {
                 continue;
             }
@@ -145,6 +121,18 @@ abstract class Component implements JsonSerializable
         }
 
         return $props;
+    }
+
+    /**
+     * @param  class-string  $class
+     * @return list<ReflectionProperty>
+     */
+    private static function wireProperties(string $class): array
+    {
+        return self::$wirePropertyCache[$class] ??= array_values(array_filter(
+            (new ReflectionClass($class))->getProperties(ReflectionProperty::IS_PUBLIC),
+            static fn (ReflectionProperty $property): bool => ! $property->isStatic(),
+        ));
     }
 
     /**

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lattice\Lattice\Tables\Components;
 
 use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\IsInteractive;
 use Lattice\Lattice\Tables\Columns\Column;
+use Lattice\Lattice\Tables\Columns\ColumnData;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableRegistry;
@@ -14,6 +18,33 @@ use Lattice\Lattice\Tables\TableResult;
 class Table extends Component
 {
     use IsInteractive;
+
+    public ?string $endpoint = null;
+
+    /**
+     * @var array<int, ColumnData>
+     */
+    public array $columns = [];
+
+    public ?string $layout = null;
+
+    /**
+     * @var array<int, Action>
+     */
+    public array $bulkActions = [];
+
+    public ?bool $striped = null;
+
+    public ?bool $lazy = null;
+
+    /**
+     * The serialized {data, pagination, state} result, projected into props
+     * verbatim so empty data/pagination stay on the wire — typed reflection
+     * would otherwise skip them.
+     *
+     * @var array<string, mixed>|null
+     */
+    protected ?array $result = null;
 
     public static function make(string $id): static
     {
@@ -25,11 +56,10 @@ class Table extends Component
      */
     public static function use(string $table): static
     {
+        /** @var static $registered */
         $registered = app(TableRegistry::class)->component($table);
 
-        return (new static)
-            ->id($registered->id)
-            ->props($registered->props);
+        return clone $registered;
     }
 
     /**
@@ -37,16 +67,17 @@ class Table extends Component
      */
     public static function lazy(string $table): static
     {
+        /** @var static $registered */
         $registered = app(TableRegistry::class)->lazyComponent($table);
 
-        return (new static)
-            ->id($registered->id)
-            ->props($registered->props);
+        return clone $registered;
     }
 
     public function endpoint(string $endpoint): static
     {
-        return $this->prop('endpoint', $endpoint);
+        $this->endpoint = $endpoint;
+
+        return $this;
     }
 
     /**
@@ -54,7 +85,9 @@ class Table extends Component
      */
     public function columns(array $columns): static
     {
-        return $this->prop('columns', $columns);
+        $this->columns = array_map(fn (Column $column): ColumnData => $column->toData(), $columns);
+
+        return $this;
     }
 
     public function layout(string $layout): static
@@ -63,7 +96,9 @@ class Table extends Component
             return $this;
         }
 
-        return $this->prop('layout', $layout);
+        $this->layout = $layout;
+
+        return $this;
     }
 
     /**
@@ -75,7 +110,9 @@ class Table extends Component
             return $this;
         }
 
-        return $this->prop('bulkActions', $actions);
+        $this->bulkActions = $actions;
+
+        return $this;
     }
 
     public function striped(bool $striped): static
@@ -84,16 +121,38 @@ class Table extends Component
             return $this;
         }
 
-        return $this->prop('striped', true);
+        $this->striped = true;
+
+        return $this;
     }
 
     public function result(TableResult $result, TableQuery $query): static
     {
-        return $this->props($result->forQuery($query)->jsonSerialize());
+        $this->result = $result->forQuery($query)->jsonSerialize();
+
+        return $this;
     }
 
     protected function type(): string
     {
         return 'table';
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 250)]
+    protected function projectResult(array $data): array
+    {
+        if ($this->result === null) {
+            return $data;
+        }
+
+        $props = is_array($data['props'] ?? null) ? $data['props'] : [];
+
+        $data['props'] = [...$props, ...$this->result];
+
+        return $data;
     }
 }

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -59,7 +59,11 @@ final class TableRegistry extends DefinitionRegistry
             ->bulkActions($this->bulkActions($definition, $key))
             ->result($result($definition, $query), $query);
 
-        return $lazy ? $component->prop('lazy', true) : $component;
+        if ($lazy) {
+            $component->lazy = true;
+        }
+
+        return $component;
     }
 
     public function response(string $key, Request $request, ?TableDefinition $definition = null): TableResult

--- a/tests/Feature/NodeUnionTest.php
+++ b/tests/Feature/NodeUnionTest.php
@@ -18,6 +18,7 @@ use Lattice\Lattice\Core\Components\Tab;
 use Lattice\Lattice\Core\Components\Tabs;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Fragments\Components\Fragment;
+use Lattice\Lattice\Tables\Components\Table;
 
 function nodeWireType(string $class): string
 {
@@ -68,6 +69,10 @@ it('keeps the Fragment wire type present in the generated FragmentNode union', f
     expect(unionBlock('FragmentNode'))->toContain('"'.nodeWireType(Fragment::class).'"');
 });
 
+it('keeps the Table wire type present in the generated TableNode union', function (): void {
+    expect(unionBlock('TableNode'))->toContain('"'.nodeWireType(Table::class).'"');
+});
+
 it('exposes the shared Node union composed of every domain union', function (): void {
     $node = unionBlock('Node');
 
@@ -75,5 +80,6 @@ it('exposes the shared Node union composed of every domain union', function (): 
         ->toContain('FormNode')
         ->toContain('CoreNode')
         ->toContain('ActionNode')
-        ->toContain('FragmentNode');
+        ->toContain('FragmentNode')
+        ->toContain('TableNode');
 });

--- a/tests/Feature/TableWireShapeTest.php
+++ b/tests/Feature/TableWireShapeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Components\Table;
+use Lattice\Lattice\Tables\TableQuery;
+use Lattice\Lattice\Tables\TableRegistry;
+use Lattice\Lattice\Tables\TableResult;
+use Workbench\App\Tables\ProductsTable;
+
+it('serializes the table component wire shape', function (): void {
+    $table = Table::make('demo')
+        ->endpoint('/tables/demo')
+        ->columns([
+            TextColumn::make('name')->label('Name')->sortable()->filterable(),
+            TextColumn::make('price')->label('Price')->numeric(),
+        ])
+        ->layout('table')
+        ->striped(true)
+        ->result(TableResult::make([['name' => 'A'], ['name' => 'B']]), TableQuery::empty());
+
+    $payload = json_decode(json_encode($table), true);
+
+    expect($payload['type'])->toBe('table');
+    expect($payload['props']['endpoint'])->toBe('/tables/demo');
+    expect($payload['props']['striped'])->toBeTrue();
+    expect($payload['props'])->not->toHaveKey('layout');
+    expect($payload['props']['columns'][0])->toMatchArray([
+        'key' => 'name',
+        'label' => 'Name',
+        'type' => 'text',
+        'sortable' => true,
+    ]);
+    expect($payload['props']['columns'][0])->toHaveKey('filter');
+    expect($payload['props']['data'])->toBe([['name' => 'A'], ['name' => 'B']]);
+    expect($payload['props']['state'])->toBe([
+        'filters' => [],
+        'sorts' => [],
+        'page' => 1,
+        'perPage' => 25,
+    ]);
+    expect($payload['props'])->not->toHaveKey('bulkActions');
+});
+
+it('keeps empty data present on a lazy table (wire trap)', function (): void {
+    Lattice::tables([ProductsTable::class]);
+
+    $table = app(TableRegistry::class)->lazyComponent(ProductsTable::class);
+
+    $payload = json_decode(json_encode($table), true);
+
+    expect($payload['type'])->toBe('table');
+    expect($payload['props']['lazy'])->toBeTrue();
+    expect($payload['props']['striped'])->toBeTrue();
+    expect($payload['props'])->toHaveKey('data');
+    expect($payload['props']['data'])->toBe([]);
+    expect($payload['props']['pagination']['mode'])->toBe('table');
+    expect($payload['props']['columns'])->toHaveCount(6);
+    expect($payload['props']['bulkActions'][0]['type'])->toBe('bulkAction');
+});

--- a/tests/Unit/InteractiveComponentTest.php
+++ b/tests/Unit/InteractiveComponentTest.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\IsInteractive;
 
-function makeInteractiveComponent(): Component
+function makeInteractiveComponent(?string $endpoint = null): Component
 {
-    return new class extends Component
+    $component = new class extends Component
     {
         use IsInteractive;
+
+        public ?string $endpoint = null;
 
         protected function type(): string
         {
             return 'test.interactive';
         }
     };
+
+    $component->endpoint = $endpoint;
+
+    return $component;
 }
 
 it('serialises an interactive component without an id instead of crashing', function (): void {
@@ -23,7 +29,7 @@ it('serialises an interactive component without an id instead of crashing', func
 });
 
 it('throws a clear error when an interactive component with an endpoint has no id', function (): void {
-    $component = makeInteractiveComponent()->prop('endpoint', '/run');
+    $component = makeInteractiveComponent('/run');
 
     expect(fn (): array => wire($component))
         ->toThrow(LogicException::class, 'must be given an id()');

--- a/tests/Unit/WirePropsTest.php
+++ b/tests/Unit/WirePropsTest.php
@@ -9,7 +9,7 @@ enum WirePropsProbeStatus: string
     case Active = 'active';
 }
 
-it('collects public typed properties over the legacy props bag, skipping nulls', function (): void {
+it('collects public typed properties, skipping nulls and builder-only state', function (): void {
     $component = new class extends Component
     {
         public string $label = 'Hi';
@@ -28,14 +28,11 @@ it('collects public typed properties over the legacy props bag, skipping nulls',
         /** @return array<string, mixed> */
         public function exposeWireProps(): array
         {
-            $this->prop('legacy', true);
-
             return $this->wireProps();
         }
     };
 
     expect($component->exposeWireProps())->toBe([
-        'legacy' => true,
         'label' => 'Hi',
         'status' => 'active',
     ]);

--- a/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
+++ b/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
@@ -44,6 +44,7 @@ use Lattice\Lattice\Forms\Enums\ConditionOperator;
 use Lattice\Lattice\Fragments\Components\Fragment;
 use Lattice\Lattice\Tables\Columns\ColumnData;
 use Lattice\Lattice\Tables\Columns\ColumnFilter;
+use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 use Lattice\Lattice\Tables\Enums\FilterOperator;
 use Lattice\Lattice\Tables\Enums\FilterType;
@@ -111,6 +112,10 @@ final class TypeScriptTransformerServiceProvider extends TypeScriptTransformerAp
             Fragment::class => ['type' => 'fragment', 'container' => true, 'interactive' => true],
         ];
 
+        $tableComponents = [
+            Table::class => ['type' => 'table', 'interactive' => true],
+        ];
+
         $optional = fn (string $name): TypeScriptProperty => new TypeScriptProperty($name, new TypeScriptString, isOptional: true);
         $effect = fn (string $type, array $payload = []): TypeScriptObject => new TypeScriptObject([
             new TypeScriptProperty('type', new TypeScriptLiteral($type)),
@@ -159,6 +164,7 @@ final class TypeScriptTransformerServiceProvider extends TypeScriptTransformerAp
                 ...array_keys($coreComponents),
                 ...array_keys($actionComponents),
                 ...array_keys($fragmentComponents),
+                ...array_keys($tableComponents),
             ]))
             ->provider(new LatticeNodesProvider(
                 $formFields,
@@ -166,6 +172,7 @@ final class TypeScriptTransformerServiceProvider extends TypeScriptTransformerAp
                 $coreComponents,
                 $actionComponents,
                 $fragmentComponents,
+                $tableComponents,
                 'form',
                 Effect::class,
                 $effectType,

--- a/workbench/app/Support/LatticeNodesProvider.php
+++ b/workbench/app/Support/LatticeNodesProvider.php
@@ -38,6 +38,7 @@ final class LatticeNodesProvider implements TransformedProvider
      * @param  array<class-string, ComponentSpec>  $coreComponents
      * @param  array<class-string, ComponentSpec>  $actionComponents
      * @param  array<class-string, ComponentSpec>  $fragmentComponents
+     * @param  array<class-string, ComponentSpec>  $tableComponents
      * @param  class-string|null  $effectContract
      */
     public function __construct(
@@ -46,6 +47,7 @@ final class LatticeNodesProvider implements TransformedProvider
         private readonly array $coreComponents,
         private readonly array $actionComponents,
         private readonly array $fragmentComponents,
+        private readonly array $tableComponents,
         private readonly string $formType = 'form',
         private readonly ?string $effectContract = null,
         private readonly ?TypeScriptNode $effectType = null,
@@ -63,6 +65,7 @@ final class LatticeNodesProvider implements TransformedProvider
             $this->alias('CoreNode', $this->componentsUnion($this->coreComponents)),
             $this->alias('ActionNode', $this->componentsUnion($this->actionComponents)),
             $this->alias('FragmentNode', $this->componentsUnion($this->fragmentComponents)),
+            $this->alias('TableNode', $this->componentsUnion($this->tableComponents)),
             $this->alias('Node', $this->nodeUnion()),
             $this->alias('NodeType', $this->typeAccess('Node')),
         ];
@@ -120,7 +123,7 @@ final class LatticeNodesProvider implements TransformedProvider
     {
         return new TypeScriptUnion(array_map(
             fn (string $name): TypeScriptReference => new TypeScriptReference($this->selfReference($name)),
-            ['FormNode', 'CoreNode', 'ActionNode', 'FragmentNode'],
+            ['FormNode', 'CoreNode', 'ActionNode', 'FragmentNode', 'TableNode'],
         ));
     }
 


### PR DESCRIPTION
Completes the typed-components migration: moves the `Table` component off the legacy prop bag, then retires the bag entirely.

## Tables (#135)
- `Table` config (`endpoint`, `columns`, `layout`, `bulkActions`, `striped`, `lazy`) → typed public properties. `columns` are stored as `ColumnData` and `bulkActions` as `Action` components.
- The dynamic `{data, pagination, state}` result is projected into props via a serialization hook, so an empty `data: []` (lazy tables) stays on the wire — typed reflection would otherwise skip it.
- `use()`/`lazy()` now `clone` the registered component; `TableRegistry` sets the typed `lazy` flag.
- Generates a `Table` prop type and a `TableNode` in the shared `Node` union. The frontend adopts the generated `Table`, correcting `bulkActions` to `ActionNode[]` (the wire carries action nodes, not props) and composing the typed `data`/`pagination`/`state` response.

## Retire the legacy bag (#136)
With every component on typed properties, remove the public `prop()`/`props()` methods and the `$props` array from `Component`, and drop the bag-merge line from `wireProps()` (now pure reflection). The reflected public-property list is cached per class, mirroring the serialization-hook cache. **Breaking change** (pre-1.0).

## Wire-identical
Guarded by new table golden/wire-shape tests plus the existing suite. The bag was already empty for every migrated component, so retiring it changes no output.

## Verification
`composer test` (275), phpstan, pint, `composer types` no-op, `npm` typecheck/test/lint/format:check/build, and `composer test:browser` (22) all green.
