### PR TITLE
feat: alias the generated HttpMethod type to Inertia's Method

### DIFF
--- a/resources/js/core/components/link.tsx
+++ b/resources/js/core/components/link.tsx
@@ -1,4 +1,3 @@
-import type { Method } from "@inertiajs/core";
 import { Link } from "@inertiajs/react";
 import type { ComponentProps } from "react";
 import { cn } from "@lattice/lattice/lib/utils";
@@ -18,18 +17,10 @@ function TextLink({ className = "", children, ...props }: ComponentProps<typeof 
   );
 }
 
-function getLinkMethod(method: string): Method {
-  if (method === "delete" || method === "patch" || method === "post" || method === "put") {
-    return method;
-  }
-
-  return "get";
-}
-
 const LinkComponent: RendererComponent<"link"> = ({ node }) => (
   <TextLink
     href={node.props.href ?? "#"}
-    method={getLinkMethod(node.props.method ?? "get")}
+    method={node.props.method ?? "get"}
     tabIndex={node.props.tabIndex ?? undefined}
   >
     {node.props.label}

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -1,22 +1,13 @@
-import type { Method } from "@inertiajs/core";
 import { Link, usePage } from "@inertiajs/react";
 import type { RendererComponent } from "@lattice/lattice/core/types";
 import { IconRenderer } from "@lattice/lattice/icons";
 import { cn } from "@lattice/lattice/lib/utils";
 
-function getLinkMethod(method: string): Method {
-  if (method === "delete" || method === "patch" || method === "post" || method === "put") {
-    return method;
-  }
-
-  return "get";
-}
-
 const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) => {
   const label = node.props.label;
   const href = node.props.href ?? "";
   const icon = node.props.icon;
-  const method = getLinkMethod(node.props.method ?? "get");
+  const method = node.props.method ?? "get";
   const currentPath = usePage().url.split("?")[0];
   const active = href !== "" && currentPath === href;
 

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -413,7 +413,7 @@ export type HiddenInput = {
   required: boolean | null;
   value: any;
 };
-export type HttpMethod = "get" | "post" | "put" | "patch" | "delete";
+export type HttpMethod = import("@inertiajs/core").Method;
 export type LayoutNode =
   | {
       type: "outlet";

--- a/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
+++ b/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
@@ -24,7 +24,6 @@ use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Align;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
-use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\Enums\ToastVariant;
@@ -61,6 +60,7 @@ use Spatie\TypeScriptTransformer\Writers\FlatModuleWriter;
 use Workbench\App\Support\LatticeComponentTransformer;
 use Workbench\App\Support\LatticeEffectType;
 use Workbench\App\Support\LatticeEnumTransformer;
+use Workbench\App\Support\LatticeHttpMethodTransformer;
 use Workbench\App\Support\LatticeNodesProvider;
 use Workbench\App\Support\LatticeValueObjectTransformer;
 use Workbench\App\Support\OxfmtFormatter;
@@ -121,6 +121,7 @@ final class TypeScriptTransformerServiceProvider extends TypeScriptTransformerAp
         ];
 
         $config
+            ->transformer(new LatticeHttpMethodTransformer)
             ->transformer(new LatticeEnumTransformer([
                 Align::class,
                 ButtonVariant::class,
@@ -129,7 +130,6 @@ final class TypeScriptTransformerServiceProvider extends TypeScriptTransformerAp
                 PageLayout::class,
                 PageContainer::class,
                 ToastVariant::class,
-                HttpMethod::class,
                 PaginationType::class,
                 ColumnType::class,
                 FilterType::class,

--- a/workbench/app/Support/LatticeHttpMethodTransformer.php
+++ b/workbench/app/Support/LatticeHttpMethodTransformer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Support;
+
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Spatie\TypeScriptTransformer\Data\TransformationContext;
+use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
+use Spatie\TypeScriptTransformer\References\PhpClassReference;
+use Spatie\TypeScriptTransformer\Transformed\Transformed;
+use Spatie\TypeScriptTransformer\Transformed\Untransformable;
+use Spatie\TypeScriptTransformer\Transformers\Transformer;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptAlias;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIdentifier;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptRaw;
+
+/**
+ * Aliases the PHP HttpMethod enum onto Inertia's own `Method` type, so the wire
+ * `method` props share a single source of truth with @inertiajs/core instead of
+ * generating a parallel string union the frontend then has to bridge. Emitted as
+ * an inline `import(...)` type so the generated module stays self-contained and
+ * the reference is type-only by construction.
+ */
+final class LatticeHttpMethodTransformer implements Transformer
+{
+    public function transform(PhpClassNode $phpClassNode, TransformationContext $context): Transformed|Untransformable
+    {
+        if ($phpClassNode->getName() !== HttpMethod::class) {
+            return Untransformable::create();
+        }
+
+        return new Transformed(
+            new TypeScriptAlias(
+                new TypeScriptIdentifier($context->name),
+                new TypeScriptRaw('import("@inertiajs/core").Method'),
+            ),
+            new PhpClassReference($phpClassNode),
+            $context->nameSpaceSegments,
+            true,
+        );
+    }
+}


### PR DESCRIPTION
## What & why

Inertia's `Method` is defined as exactly `'get' | 'post' | 'put' | 'patch' | 'delete'` — byte-for-byte our `HttpMethod`. Generating a separate `HttpMethod` union meant the frontend kept bridging the two (`getLinkMethod`). This makes the generated type *be* Inertia's `Method`, so there's a single source of truth.

## Changes
- **New transformer** `LatticeHttpMethodTransformer` (workbench TS-gen layer): maps the PHP `HttpMethod` enum to `export type HttpMethod = import("@inertiajs/core").Method;`, and it's dropped from the union-enum allow-list.
- Uses an **inline `import(...)` type** rather than a top-level import: spatie's `AdditionalImport` mangles npm specifiers (`./@inertiajs/core`) and emits a value import; the inline form is type-only by construction and keeps `generated.ts` self-contained.
- **Cleanup**: removed the redundant `getLinkMethod` bridges in `link.tsx` and `menu-item.tsx` — `node.props.method` is now `Method | null` and flows straight into `<Link>`. `bulk.ts` keeps its local `asMethod` (untrusted `unknown` parse).

## Verification
`tsc` 0 errors · oxlint clean · vitest 139 ✓ · Pest 252 ✓ · Pint clean · `npm run build` ✓ (confirms the inline import type emits fine under `isolatedModules`) · `composer types` idempotent.

The PHP wire is unchanged — only the TS type — so backend tests are unaffected.

> Stacked on #29 (`feat/menu-components`); rebase onto `main` once that merges.