### PR TITLE
Form-hook reuse + table render memoization

### DIFF
--- a/resources/js/form/components/field-props.ts
+++ b/resources/js/form/components/field-props.ts
@@ -23,3 +23,18 @@ export type FieldProps = {
 export function fieldProps(node: Node): FieldProps {
   return node.props as FieldProps;
 }
+
+/**
+ * Pre-order walk over every node in a form schema, read through the FieldProps
+ * lens. The single traversal shared by the label/value collector and the
+ * dependency-watch collector.
+ */
+export function walkFields(
+  nodes: Node[] | undefined,
+  visit: (props: FieldProps, node: Node) => void,
+): void {
+  for (const child of nodes ?? []) {
+    visit(fieldProps(child), child);
+    walkFields(child.schema, visit);
+  }
+}

--- a/resources/js/form/components/fields/checkbox.tsx
+++ b/resources/js/form/components/fields/checkbox.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from "react";
 import type { RendererComponent } from "@lattice/lattice/core/types";
 import { Checkbox } from "../base/checkbox";
 import { Label } from "../base/label";
 import { toBoolean } from "../conditions";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
+import { useSeedDefault } from "../use-seed-default";
 import { useFormValue, useSetFormValue } from "../values";
 
 export const CheckboxComponent: RendererComponent<"form.checkbox"> = ({ node }) => {
@@ -16,11 +16,7 @@ export const CheckboxComponent: RendererComponent<"form.checkbox"> = ({ node }) 
   const defaultChecked = toBoolean(node.props.value);
   const checked = storedValue !== undefined ? toBoolean(storedValue) : defaultChecked;
 
-  useEffect(() => {
-    if (storedValue === undefined) {
-      setValue(name, defaultChecked);
-    }
-  }, [name, defaultChecked, setValue, storedValue]);
+  useSeedDefault(name, defaultChecked);
 
   if (hidden) {
     return null;

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import type { Option, RendererComponent } from "@lattice/lattice/core/types";
 import { SegmentedPills } from "@lattice/lattice/core/components/segmented-pills";
 import { FormFieldFrame } from "../base/field";
 import { useControlledField } from "../use-controlled-field";
 import { useResolvedNode } from "../resolved-nodes";
-import { useFormValue, useSetFormValue } from "../values";
+import { useSeedDefault } from "../use-seed-default";
 
 export const ChoiceComponent: RendererComponent<"form.choice"> = ({ node }) => {
   const resolvedNode = useResolvedNode(node);
   const { name, value, error, hidden, required, readonly, disabled, commit } =
     useControlledField(node);
-  const storedValue = useFormValue(name);
-  const setValue = useSetFormValue();
   const options = useMemo(
     () => (resolvedNode.props as { options?: Option[] }).options ?? [],
     [resolvedNode.props],
@@ -19,13 +17,7 @@ export const ChoiceComponent: RendererComponent<"form.choice"> = ({ node }) => {
   const fallbackValue = options[0]?.value ?? "";
   const selected = value || fallbackValue;
 
-  // Seed the store with the default selection so dependent fields and the
-  // submitted payload reflect it before the user interacts.
-  useEffect(() => {
-    if (storedValue === undefined && selected) {
-      setValue(name, selected);
-    }
-  }, [name, storedValue, selected, setValue]);
+  useSeedDefault(name, selected || undefined);
 
   if (hidden || options.length === 0) {
     return null;

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -5,7 +5,7 @@ import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { useEffect, useMemo } from "react";
 import { FormSubmitButton } from "./base/submit-button";
 import { FormProvider } from "./context";
-import { fieldProps } from "./field-props";
+import { walkFields } from "./field-props";
 import { ResolvedNodesProvider } from "./resolved-nodes";
 import { useFormResolver } from "./use-form-resolver";
 import { FormValuesProvider } from "./values";
@@ -15,24 +15,20 @@ type CollectedFields = {
   values: Record<string, unknown>;
 };
 
-function collectFields(
-  nodes: Node[] | undefined,
-  collected: CollectedFields = { labels: {}, values: {} },
-): CollectedFields {
-  for (const child of nodes ?? []) {
-    const props = fieldProps(child);
+function collectFields(nodes: Node[] | undefined): CollectedFields {
+  const collected: CollectedFields = { labels: {}, values: {} };
 
-    if (props.name) {
-      if (props.label) {
-        collected.labels[props.name] = props.label;
-      }
-      if (props.value !== undefined) {
-        collected.values[props.name] = props.value;
-      }
+  walkFields(nodes, (props) => {
+    if (!props.name) {
+      return;
     }
-
-    collectFields(child.schema, collected);
-  }
+    if (props.label) {
+      collected.labels[props.name] = props.label;
+    }
+    if (props.value !== undefined) {
+      collected.values[props.name] = props.value;
+    }
+  });
 
   return collected;
 }

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Node } from "@lattice/lattice/core/types";
-import { fieldProps } from "./field-props";
+import { walkFields } from "./field-props";
 import { FORM_DEBOUNCE_MS, postFormAction } from "./form-transport";
 import { useFormValues, useSetFormValue } from "./values";
 
@@ -8,21 +8,6 @@ type ResolveResponse = {
   fields?: Record<string, Node>;
   values?: Record<string, unknown>;
 };
-
-function collectWatch(nodes: Node[] | undefined, keys: Set<string>, state: { any: boolean }): void {
-  for (const child of nodes ?? []) {
-    const props = fieldProps(child);
-    if (Array.isArray(props.dependsOnKeys)) {
-      for (const key of props.dependsOnKeys) {
-        keys.add(String(key));
-      }
-    }
-    if (props.dependsOnAny) {
-      state.any = true;
-    }
-    collectWatch(child.schema, keys, state);
-  }
-}
 
 export function useFormResolver(
   action: string,
@@ -35,9 +20,18 @@ export function useFormResolver(
 
   const watch = useMemo(() => {
     const keys = new Set<string>();
-    const state = { any: false };
-    collectWatch(nodes, keys, state);
-    return { keys: [...keys], any: state.any };
+    let any = false;
+    walkFields(nodes, (props) => {
+      if (Array.isArray(props.dependsOnKeys)) {
+        for (const key of props.dependsOnKeys) {
+          keys.add(String(key));
+        }
+      }
+      if (props.dependsOnAny) {
+        any = true;
+      }
+    });
+    return { keys: [...keys], any };
   }, [nodes]);
 
   const watched = watch.any

--- a/resources/js/form/components/use-seed-default.ts
+++ b/resources/js/form/components/use-seed-default.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useFormValue, useSetFormValue } from "./values";
+
+/**
+ * Seed the form store with a field's default value when nothing is stored yet,
+ * so dependent fields and the submitted payload reflect it before the user
+ * interacts. Pass undefined as the value to skip seeding.
+ */
+export function useSeedDefault(name: string, value: unknown): void {
+  const stored = useFormValue(name);
+  const setValue = useSetFormValue();
+
+  useEffect(() => {
+    if (stored === undefined && value !== undefined) {
+      setValue(name, value);
+    }
+  }, [name, value, stored, setValue]);
+}

--- a/resources/js/table/components/filter-stack-bar.tsx
+++ b/resources/js/table/components/filter-stack-bar.tsx
@@ -1,25 +1,22 @@
 import { X } from "lucide-react";
-import { flattenColumns } from "../payload";
 import { operatorLabel } from "../query";
 import type { FilterClause, TableColumn } from "../types";
 
 export function FilterStackBar({
   filters,
-  columns,
+  columnsByKey,
   processing,
   onRemove,
 }: {
   filters: FilterClause[];
-  columns: TableColumn[];
+  columnsByKey: Map<string, TableColumn>;
   processing: boolean;
   onRemove: (index: number) => void;
 }) {
-  const labels = new Map(flattenColumns(columns).map((column) => [column.key, column.label]));
-
   return (
     <div className="flex flex-wrap items-center gap-4 border-b border-lt-border px-4 py-2.5 text-sm">
       {filters.map((clause, index) => {
-        const label = labels.get(clause.field) ?? clause.field;
+        const label = columnsByKey.get(clause.field)?.label ?? clause.field;
 
         return (
           <span

--- a/resources/js/table/components/sort-bar.tsx
+++ b/resources/js/table/components/sort-bar.tsx
@@ -1,14 +1,14 @@
 import { ArrowDown, ArrowUp, X } from "lucide-react";
-import { getSortColumn, getSortDirectionLabel } from "../query";
+import { getSortDirectionLabel } from "../query";
 import type { TableColumn, TableSort, TableState } from "../types";
 
 export function SortBar({
-  columns,
+  columnsByKey,
   state,
   processing,
   onClear,
 }: {
-  columns: TableColumn[];
+  columnsByKey: Map<string, TableColumn>;
   state: TableState;
   processing: boolean;
   onClear: (sort: TableSort) => void;
@@ -16,7 +16,7 @@ export function SortBar({
   return (
     <div className="flex flex-wrap items-center gap-4 border-b border-lt-border px-4 py-2.5 text-sm">
       {state.sorts.map((sort, index) => {
-        const column = getSortColumn(columns, sort);
+        const column = columnsByKey.get(sort.key);
         const label = column?.label ?? sort.key;
         const Chevron = sort.direction === "desc" ? ArrowDown : ArrowUp;
 

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -1,7 +1,7 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 import type { TableNode } from "../types";
 import { getBulkActions } from "../bulk";
-import { getRowActions, getRowKey } from "../payload";
+import { flattenColumns, getRowActions, getRowKey } from "../payload";
 import { getColumnGridTemplate, getQueryParams, getVisiblePages } from "../query";
 import { useTable } from "../use-table";
 import { useTableSelection } from "../use-table-selection";
@@ -33,15 +33,22 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
     loadMore,
   } = useTable(node);
 
-  const bulkActions = getBulkActions(node.props?.bulkActions);
+  const bulkActions = useMemo(
+    () => getBulkActions(node.props?.bulkActions),
+    [node.props?.bulkActions],
+  );
   const hasBulkActions = bulkActions.length > 0;
-  const rowEntries = rows.map((row, index) => ({
-    row,
-    actions: getRowActions(row),
-    key: getRowKey(row, index),
-  }));
+  const rowEntries = useMemo(
+    () =>
+      rows.map((row, index) => ({ row, actions: getRowActions(row), key: getRowKey(row, index) })),
+    [rows],
+  );
   const selection = useTableSelection(rowEntries.map((entry) => entry.key));
 
+  const columnsByKey = useMemo(
+    () => new Map(flattenColumns(columns).map((column) => [column.key, column])),
+    [columns],
+  );
   const currentPage = pagination.currentPage ?? state.page;
   const lastPage = pagination.lastPage ?? currentPage;
   const mode = pagination.mode ?? "table";
@@ -51,7 +58,10 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   const striped = node.props?.striped === true;
   const hasFilters = columns.some((column) => column.filter?.enabled);
   const filterEntries = filters.map((clause, index) => ({ clause, index }));
-  const gridTemplateColumns = getColumnGridTemplate(columns, hasActions, hasBulkActions);
+  const gridTemplateColumns = useMemo(
+    () => getColumnGridTemplate(columns, hasActions, hasBulkActions),
+    [columns, hasActions, hasBulkActions],
+  );
 
   return (
     <div
@@ -78,13 +88,18 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
       {filters.length > 0 && (
         <FilterStackBar
           filters={filters}
-          columns={columns}
+          columnsByKey={columnsByKey}
           processing={processing}
           onRemove={removeFilter}
         />
       )}
       {state.sorts.length > 0 && (
-        <SortBar columns={columns} state={state} processing={processing} onClear={clearSort} />
+        <SortBar
+          columnsByKey={columnsByKey}
+          state={state}
+          processing={processing}
+          onClear={clearSort}
+        />
       )}
       <div className="w-max min-w-full text-sm" role="table">
         <div className="border-b border-lt-border bg-lt-muted/50" role="rowgroup">

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -1,12 +1,7 @@
-import { flattenColumns } from "./payload";
 import type { TableColumn, TableSort, TableState } from "./types";
 
 export function getColumnSort(state: TableState, column: TableColumn): TableSort | undefined {
   return state.sorts.find((currentSort) => currentSort.key === column.key);
-}
-
-export function getSortColumn(columns: TableColumn[], sort: TableSort): TableColumn | undefined {
-  return flattenColumns(columns).find((column) => column.key === sort.key);
 }
 
 export function getColumnAriaSort(

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -13,7 +13,7 @@ import type {
 } from "./types";
 
 export function useTable(node: TableNode) {
-  const columns = getColumns(node.props?.columns);
+  const columns = useMemo(() => getColumns(node.props?.columns), [node.props?.columns]);
   const endpoint = typeof node.props?.endpoint === "string" ? node.props.endpoint : null;
   const componentRef = typeof node.props?.ref === "string" ? node.props.ref : "";
   const isLazy = node.props?.lazy === true;

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -21,7 +21,6 @@ export function useTable(node: TableNode) {
   const [rows, setRows] = useState(() => getRows(node.props?.data));
   const [pagination, setPagination] = useState(() => getPagination(node.props?.pagination));
   const [state, setState] = useState(initialState);
-  const [filters, setFilters] = useState(initialState.filters);
   const [processing, setProcessing] = useState(isLazy);
   const [hasLoaded, setHasLoaded] = useState(!isLazy);
   const infiniteLoaderRef = useRef<HTMLDivElement | null>(null);
@@ -50,7 +49,6 @@ export function useTable(node: TableNode) {
         setRows((currentRows) => (append ? [...currentRows, ...resultRows] : resultRows));
         setPagination(getPagination(result.pagination));
         setState(resultState);
-        setFilters(resultState.filters);
         setHasLoaded(true);
       } finally {
         setProcessing(false);
@@ -75,37 +73,23 @@ export function useTable(node: TableNode) {
     });
   }
 
-  function addFilter(clause: FilterClause): void {
-    const next = [...filters, clause];
+  function applyFilters(next: FilterClause[]): void {
+    const nextState = { ...state, filters: next, page: 1 };
 
-    setFilters(next);
-    void load({
-      ...state,
-      filters: next,
-      page: 1,
-    });
+    setState(nextState);
+    void load(nextState);
+  }
+
+  function addFilter(clause: FilterClause): void {
+    applyFilters([...state.filters, clause]);
   }
 
   function updateFilter(index: number, clause: FilterClause): void {
-    const next = filters.map((current, position) => (position === index ? clause : current));
-
-    setFilters(next);
-    void load({
-      ...state,
-      filters: next,
-      page: 1,
-    });
+    applyFilters(state.filters.map((current, position) => (position === index ? clause : current)));
   }
 
   function removeFilter(index: number): void {
-    const next = filters.filter((_, current) => current !== index);
-
-    setFilters(next);
-    void load({
-      ...state,
-      filters: next,
-      page: 1,
-    });
+    applyFilters(state.filters.filter((_, current) => current !== index));
   }
 
   function goToPage(page: number): void {
@@ -185,7 +169,7 @@ export function useTable(node: TableNode) {
     rows,
     pagination,
     state,
-    filters,
+    filters: state.filters,
     addFilter,
     updateFilter,
     removeFilter,


### PR DESCRIPTION
Frontend cleanup pass — reuse in the form hooks and memoization on the table render path.

## Form hooks
- **`walkFields`** — `collectFields` (labels/values) and `collectWatch` (dependency keys) were the same recursive schema walk; one `walkFields(nodes, visit)` helper now backs both (each keeps its own memo).
- **`useSeedDefault`** — `checkbox` and `choice` ran the same "seed the store with the default when nothing is stored yet" effect; extracted into one hook. (`select` reads with a fallback rather than seeding, so it's untouched.)

## Table
- **`useTable`** — drop the redundant `filters` state; `state.filters` is the source of truth, updated optimistically via an `applyFilters` helper (was hand-synced across `load` + three mutators).
- **Memoize render derivations** — `columns` (was a fresh `getColumns` array every render), `rowEntries`, `bulkActions`, the grid template, and a single `columnsByKey` Map threaded into `SortBar`/`FilterStackBar` (replacing two separate per-render/per-sort `flattenColumns` calls; the now-dead `getSortColumn` is removed).

**Not done — P-ts3** (`useCallback` the `commit` closure): looked into it; there's no `React.memo` boundary in `form/` and `commit` is never a dependency, so stabilizing it reduces zero renders. Recommend closing as won't-fix.

No behavior change. Green: vitest 140, browser 22, format / lint / typecheck.