### PR TITLE
Adopt Radix overlays (Dialog + Popover)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.1.4",
+        "@radix-ui/react-dialog": "^1.1.16",
         "@radix-ui/react-label": "^2.1.2",
+        "@radix-ui/react-popover": "^1.1.16",
         "@radix-ui/react-slot": "^1.2.3",
         "@tiptap/extension-details": "^3.26.0",
         "@tiptap/extension-highlight": "^3.26.0",
@@ -2182,7 +2184,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
       }
@@ -2192,18 +2193,29 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
@@ -3804,6 +3816,29 @@
       "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.9.tgz",
+      "integrity": "sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.4.tgz",
@@ -3864,6 +3899,127 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
+      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-label": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.9.tgz",
@@ -3871,6 +4027,99 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.16.tgz",
+      "integrity": "sha512-8brVpAU5Uq7Bh0c8EFc4ZTf2JJTYn0o+1L+CUJB3UYIOkTjKGMgoHvduylrahdmNlr3DfH0rFq2DrbNZXgaspw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.0.tgz",
+      "integrity": "sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3951,6 +4200,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
@@ -3977,6 +4241,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4018,6 +4300,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
@@ -4035,6 +4335,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -6448,6 +6754,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -7175,6 +7493,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/devalue": {
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
@@ -7771,6 +8095,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-tsconfig": {
@@ -11168,6 +11501,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -12236,9 +12638,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -12656,6 +13056,49 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,9 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-dialog": "^1.1.16",
     "@radix-ui/react-label": "^2.1.2",
+    "@radix-ui/react-popover": "^1.1.16",
     "@radix-ui/react-slot": "^1.2.3",
     "@tiptap/extension-details": "^3.26.0",
     "@tiptap/extension-highlight": "^3.26.0",

--- a/resources/js/action/components/action-group.test.tsx
+++ b/resources/js/action/components/action-group.test.tsx
@@ -4,7 +4,7 @@ import { fakeNode } from "@lattice/lattice/test-support";
 import ActionGroupComponent from "./action-group";
 
 describe("Lattice action group component", () => {
-  it("opens a menu of grouped actions", () => {
+  it("opens a panel of grouped actions", () => {
     const node = fakeNode({
       id: "teams.members.2.actions",
       props: {
@@ -20,17 +20,16 @@ describe("Lattice action group component", () => {
       </ActionGroupComponent>,
     );
 
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Make admin" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Manage member" }));
 
-    expect(screen.getByRole("menu", { name: "Manage member" })).toBeVisible();
-    expect(screen.getByRole("menu", { name: "Manage member" })).toHaveClass("fixed");
+    expect(screen.getByRole("dialog", { name: "Manage member" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Make admin" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Remove" })).toBeVisible();
 
     fireEvent.click(screen.getByRole("button", { name: "Manage member" }));
 
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Make admin" })).not.toBeInTheDocument();
   });
 });

--- a/resources/js/action/components/action-group.tsx
+++ b/resources/js/action/components/action-group.tsx
@@ -1,106 +1,37 @@
+import * as Popover from "@radix-ui/react-popover";
 import { MoreHorizontal } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Button } from "@lattice/lattice/core/components/button";
 import type { RendererComponent } from "@lattice/lattice/core/types";
 
 const ActionGroupComponent: RendererComponent<"action.group"> = ({ children, node }) => {
   const label = node.props.label ?? "Actions";
-  const [open, setOpen] = useState(false);
-  const [position, setPosition] = useState<{ right: number; top: number } | null>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const updatePosition = useCallback(() => {
-    const rect = buttonRef.current?.getBoundingClientRect();
-
-    if (!rect) {
-      return;
-    }
-
-    setPosition({
-      right: Math.max(8, window.innerWidth - rect.right),
-      top: rect.bottom + 8,
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    updatePosition();
-
-    const closeWhenOutside = (event: MouseEvent): void => {
-      const target = event.target;
-
-      if (
-        target instanceof Node &&
-        (buttonRef.current?.contains(target) || menuRef.current?.contains(target))
-      ) {
-        return;
-      }
-
-      setOpen(false);
-    };
-
-    const closeOnEscape = (event: KeyboardEvent): void => {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    };
-
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    document.addEventListener("mousedown", closeWhenOutside);
-    document.addEventListener("keydown", closeOnEscape);
-
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-      document.removeEventListener("mousedown", closeWhenOutside);
-      document.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [open, updatePosition]);
-
-  const toggle = (): void => {
-    updatePosition();
-    setOpen((current) => !current);
-  };
-
-  const menu =
-    open && position && typeof document !== "undefined"
-      ? createPortal(
-          <div
-            ref={menuRef}
-            aria-label={label}
-            className="fixed z-50 grid min-w-40 gap-1 rounded-lt-sm border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-md [&>button]:w-full [&>button]:justify-start"
-            role="menu"
-            style={position}
-          >
-            {children}
-          </div>,
-          document.body,
-        )
-      : null;
 
   return (
     <div className="inline-flex" data-lattice-component={node.id}>
-      <Button
-        ref={buttonRef}
-        aria-label={label}
-        aria-expanded={open}
-        aria-haspopup="menu"
-        className="size-8 text-lt-muted-fg shadow-none hover:text-lt-fg"
-        onClick={toggle}
-        size="icon"
-        type="button"
-        variant="ghost"
-      >
-        <MoreHorizontal aria-hidden="true" className="size-4" />
-      </Button>
+      <Popover.Root>
+        <Popover.Trigger asChild>
+          <Button
+            aria-label={label}
+            className="size-8 text-lt-muted-fg shadow-none hover:text-lt-fg"
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <MoreHorizontal aria-hidden="true" className="size-4" />
+          </Button>
+        </Popover.Trigger>
 
-      {menu}
+        <Popover.Portal>
+          <Popover.Content
+            align="end"
+            aria-label={label}
+            className="z-50 grid min-w-40 gap-1 rounded-lt-sm border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-md [&>button]:w-full [&>button]:justify-start"
+            sideOffset={8}
+          >
+            {children}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </div>
   );
 };

--- a/resources/js/core/components/confirm-dialog.tsx
+++ b/resources/js/core/components/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
 import type { ButtonVariant } from "@lattice/lattice/types/generated";
 import { Button } from "./button";
 import { Spinner } from "./spinner";
@@ -24,37 +24,55 @@ export function ConfirmDialog({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
-  const titleId = useId();
+  const blockWhileProcessing = (event: Event): void => {
+    if (processing) {
+      event.preventDefault();
+    }
+  };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div
-        aria-labelledby={titleId}
-        aria-modal="true"
-        className="w-full max-w-md rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"
-        role="dialog"
-      >
-        <div className="grid gap-2">
-          <h2 className="text-lg font-semibold leading-none tracking-tight" id={titleId}>
-            {title}
-          </h2>
-          {description && <p className="text-sm text-lt-muted-fg">{description}</p>}
-        </div>
-        <div className="mt-6 flex justify-end gap-2">
-          <Button type="button" variant="outline" disabled={processing} onClick={onCancel}>
-            {cancelLabel}
-          </Button>
-          <Button
-            type="button"
-            variant={confirmVariant}
-            disabled={processing || confirmDisabled}
-            onClick={onConfirm}
-          >
-            {processing && <Spinner />}
-            {confirmLabel}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onCancel();
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content
+          {...(description ? {} : { "aria-describedby": undefined })}
+          className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"
+          onEscapeKeyDown={blockWhileProcessing}
+          onInteractOutside={blockWhileProcessing}
+        >
+          <div className="grid gap-2">
+            <Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
+              {title}
+            </Dialog.Title>
+            {description && (
+              <Dialog.Description className="text-sm text-lt-muted-fg">
+                {description}
+              </Dialog.Description>
+            )}
+          </div>
+          <div className="mt-6 flex justify-end gap-2">
+            <Button type="button" variant="outline" disabled={processing} onClick={onCancel}>
+              {cancelLabel}
+            </Button>
+            <Button
+              type="button"
+              variant={confirmVariant}
+              disabled={processing || confirmDisabled}
+              onClick={onConfirm}
+            >
+              {processing && <Spinner />}
+              {confirmLabel}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -1,3 +1,4 @@
+import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@lattice/lattice/core/components/button";
@@ -19,8 +20,6 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
   const description = node.props.description;
   const closeLabel = node.props.closeLabel ?? "Close";
   const [isOpen, setIsOpen] = useState(node.props.open === true);
-  const titleId = `${node.id ?? node.key ?? "lattice-modal"}-title`;
-  const descriptionId = `${node.id ?? node.key ?? "lattice-modal"}-description`;
 
   useEffect(() => {
     function open(event: Event): void {
@@ -44,45 +43,38 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
     };
   }, [node.id]);
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div
-        aria-describedby={description ? descriptionId : undefined}
-        aria-labelledby={titleId}
-        aria-modal="true"
-        className="max-h-[min(680px,calc(100vh-2rem))] w-full max-w-lg overflow-y-auto rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"
-        role="dialog"
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div className="grid gap-2">
-            <h2 className="text-lg font-semibold leading-none tracking-tight" id={titleId}>
-              {title}
-            </h2>
+    <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content
+          {...(description ? {} : { "aria-describedby": undefined })}
+          className="fixed left-1/2 top-1/2 z-50 max-h-[min(680px,calc(100vh-2rem))] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="grid gap-2">
+              <Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
+                {title}
+              </Dialog.Title>
 
-            {description && (
-              <p className="text-sm text-lt-muted-fg" id={descriptionId}>
-                {description}
-              </p>
-            )}
+              {description && (
+                <Dialog.Description className="text-sm text-lt-muted-fg">
+                  {description}
+                </Dialog.Description>
+              )}
+            </div>
+
+            <Dialog.Close asChild>
+              <Button aria-label={closeLabel} size="icon" variant="ghost">
+                <X aria-hidden="true" className="size-4" />
+              </Button>
+            </Dialog.Close>
           </div>
 
-          <Button
-            aria-label={closeLabel}
-            onClick={() => setIsOpen(false)}
-            size="icon"
-            variant="ghost"
-          >
-            <X aria-hidden="true" className="size-4" />
-          </Button>
-        </div>
-
-        <div className="mt-6 space-y-6">{children}</div>
-      </div>
-    </div>
+          <div className="mt-6 space-y-6">{children}</div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -1,5 +1,6 @@
+import * as Popover from "@radix-ui/react-popover";
 import { Check, ChevronsUpDown, Loader2, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@lattice/lattice/lib/utils";
 import type { Option, RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
@@ -48,7 +49,6 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SelectOption[]>([]);
   const [loading, setLoading] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const labels = useMemo(() => {
     const map = new Map<string, string>();
@@ -95,23 +95,6 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
       controller.abort();
     };
   }, [query, searchable, action, componentRef, name]);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    function onPointerDown(event: MouseEvent): void {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        close();
-      }
-    }
-
-    document.addEventListener("mousedown", onPointerDown);
-
-    return () => document.removeEventListener("mousedown", onPointerDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
 
   function commit(next: string[]): void {
     change(name, multiple ? next : (next[0] ?? ""));
@@ -161,7 +144,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
         <input name={name} type="hidden" value={selected[0] ?? ""} />
       )}
 
-      <div className="relative" ref={containerRef}>
+      <div>
         {multiple && selected.length > 0 && (
           <div className="mb-1.5 flex flex-wrap gap-1">
             {selected.map((value) => (
@@ -185,66 +168,80 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
           </div>
         )}
 
-        <button
-          aria-expanded={open}
-          aria-haspopup="listbox"
-          className={cn(
-            "flex min-h-9 w-full items-center justify-between gap-2 rounded-lt-sm border border-lt-input bg-transparent px-3 py-1.5 text-left text-sm shadow-xs transition-colors focus:border-lt-ring focus:outline-none focus:ring-[3px] focus:ring-lt-ring/50",
-            locked && "cursor-not-allowed opacity-60",
-          )}
-          disabled={locked}
-          onClick={() => setOpen((value) => !value)}
-          type="button"
+        <Popover.Root
+          open={open && !locked}
+          onOpenChange={(next) => {
+            if (next) {
+              setOpen(true);
+            } else {
+              close();
+            }
+          }}
         >
-          {!multiple && selected.length > 0 ? (
-            <span>{labelFor(selected[0])}</span>
-          ) : (
-            <span className="text-lt-muted-fg">{placeholder}</span>
-          )}
-          <ChevronsUpDown className="size-4 shrink-0 text-lt-muted-fg" />
-        </button>
-
-        {open && !locked && (
-          <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-lt-sm border border-lt-border bg-lt-bg shadow-md">
-            <div className="flex items-center gap-2 border-b border-lt-border px-3 py-2">
-              <input
-                aria-label="Search options"
-                autoFocus
-                className="w-full bg-transparent text-sm outline-none placeholder:text-lt-muted-fg"
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder={searchable ? "Search…" : "Filter…"}
-                value={query}
-              />
-              {loading && <Loader2 className="size-4 shrink-0 animate-spin text-lt-muted-fg" />}
-            </div>
-            <div className="max-h-60 overflow-y-auto p-1" role="listbox">
-              {visibleOptions.length === 0 ? (
-                <p className="px-3 py-2 text-sm text-lt-muted-fg">No options</p>
-              ) : (
-                visibleOptions.map((option) => {
-                  const isSelected = selected.includes(option.value);
-
-                  return (
-                    <button
-                      aria-selected={isSelected}
-                      className={cn(
-                        "flex w-full items-center justify-between gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-lt-accent hover:text-lt-accent-fg",
-                        isSelected && "bg-lt-accent/60",
-                      )}
-                      key={option.value}
-                      onClick={() => pick(option)}
-                      role="option"
-                      type="button"
-                    >
-                      {option.label}
-                      {isSelected && <Check className="size-4 shrink-0" />}
-                    </button>
-                  );
-                })
+          <Popover.Trigger asChild>
+            <button
+              aria-haspopup="listbox"
+              className={cn(
+                "flex min-h-9 w-full items-center justify-between gap-2 rounded-lt-sm border border-lt-input bg-transparent px-3 py-1.5 text-left text-sm shadow-xs transition-colors focus:border-lt-ring focus:outline-none focus:ring-[3px] focus:ring-lt-ring/50",
+                locked && "cursor-not-allowed opacity-60",
               )}
-            </div>
-          </div>
-        )}
+              disabled={locked}
+              type="button"
+            >
+              {!multiple && selected.length > 0 ? (
+                <span>{labelFor(selected[0])}</span>
+              ) : (
+                <span className="text-lt-muted-fg">{placeholder}</span>
+              )}
+              <ChevronsUpDown className="size-4 shrink-0 text-lt-muted-fg" />
+            </button>
+          </Popover.Trigger>
+
+          <Popover.Portal>
+            <Popover.Content
+              align="start"
+              className="z-50 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-lt-sm border border-lt-border bg-lt-bg shadow-md"
+              sideOffset={4}
+            >
+              <div className="flex items-center gap-2 border-b border-lt-border px-3 py-2">
+                <input
+                  aria-label="Search options"
+                  className="w-full bg-transparent text-sm outline-none placeholder:text-lt-muted-fg"
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder={searchable ? "Search…" : "Filter…"}
+                  value={query}
+                />
+                {loading && <Loader2 className="size-4 shrink-0 animate-spin text-lt-muted-fg" />}
+              </div>
+              <div className="max-h-60 overflow-y-auto p-1" role="listbox">
+                {visibleOptions.length === 0 ? (
+                  <p className="px-3 py-2 text-sm text-lt-muted-fg">No options</p>
+                ) : (
+                  visibleOptions.map((option) => {
+                    const isSelected = selected.includes(option.value);
+
+                    return (
+                      <button
+                        aria-selected={isSelected}
+                        className={cn(
+                          "flex w-full items-center justify-between gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-lt-accent hover:text-lt-accent-fg",
+                          isSelected && "bg-lt-accent/60",
+                        )}
+                        key={option.value}
+                        onClick={() => pick(option)}
+                        role="option"
+                        type="button"
+                      >
+                        {option.label}
+                        {isSelected && <Check className="size-4 shrink-0" />}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
       </div>
     </FormFieldFrame>
   );

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -1,6 +1,6 @@
+import * as Popover from "@radix-ui/react-popover";
 import { Filter, Plus, Trash2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useState } from "react";
 import type { FilterType, Op } from "@lattice/lattice/types/generated";
 import { operatorLabel, VALUELESS_FILTER_OPERATORS } from "../query";
 import type { FilterClause, TableColumn } from "../types";
@@ -24,48 +24,6 @@ export function ColumnFilterControl({
   onRemove: (index: number) => void;
 }) {
   const filter = column.filter;
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  const [open, setOpen] = useState(false);
-  const [position, setPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    function close(event: MouseEvent): void {
-      const target = event.target as Node;
-
-      if (buttonRef.current?.contains(target) || panelRef.current?.contains(target)) {
-        return;
-      }
-
-      setOpen(false);
-    }
-
-    function handleKey(event: KeyboardEvent): void {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-
-    function dismiss(): void {
-      setOpen(false);
-    }
-
-    document.addEventListener("mousedown", close);
-    document.addEventListener("keydown", handleKey);
-    window.addEventListener("scroll", dismiss, true);
-    window.addEventListener("resize", dismiss);
-
-    return () => {
-      document.removeEventListener("mousedown", close);
-      document.removeEventListener("keydown", handleKey);
-      window.removeEventListener("scroll", dismiss, true);
-      window.removeEventListener("resize", dismiss);
-    };
-  }, [open]);
 
   if (!filter) {
     return null;
@@ -92,22 +50,6 @@ export function ColumnFilterControl({
     }
   }
 
-  function toggle(): void {
-    if (open) {
-      setOpen(false);
-
-      return;
-    }
-
-    const rect = buttonRef.current?.getBoundingClientRect();
-
-    if (rect) {
-      setPosition({ top: rect.bottom + 4, left: rect.left });
-    }
-
-    setOpen(true);
-  }
-
   return (
     <div className="flex items-center gap-1">
       <div className="flex-1">
@@ -121,29 +63,28 @@ export function ColumnFilterControl({
           onClear={primary ? () => onRemove(primary.index) : undefined}
         />
       </div>
-      <button
-        ref={buttonRef}
-        type="button"
-        aria-label={`${column.label} filters`}
-        className="relative inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border disabled:opacity-50 data-[open=true]:border-lt-primary"
-        data-open={open}
-        disabled={processing}
-        onClick={toggle}
-      >
-        <Filter aria-hidden="true" className="size-4" />
-        {clauses.length > 0 && (
-          <span className="absolute -right-1.5 -top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-lt-primary text-[10px] font-medium text-lt-primary-fg">
-            {clauses.length}
-          </span>
-        )}
-      </button>
+      <Popover.Root>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            aria-label={`${column.label} filters`}
+            className="relative inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border disabled:opacity-50 data-[state=open]:border-lt-primary"
+            disabled={processing}
+          >
+            <Filter aria-hidden="true" className="size-4" />
+            {clauses.length > 0 && (
+              <span className="absolute -right-1.5 -top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-lt-primary text-[10px] font-medium text-lt-primary-fg">
+                {clauses.length}
+              </span>
+            )}
+          </button>
+        </Popover.Trigger>
 
-      {open &&
-        createPortal(
-          <div
-            ref={panelRef}
-            className="fixed z-50 w-80 rounded-lt border border-lt-border bg-lt-bg p-4 shadow-lg"
-            style={{ top: position.top, left: position.left }}
+        <Popover.Portal>
+          <Popover.Content
+            align="start"
+            className="z-50 w-80 rounded-lt border border-lt-border bg-lt-bg p-4 shadow-lg"
+            sideOffset={4}
           >
             <FilterClauseList
               column={column}
@@ -155,9 +96,9 @@ export function ColumnFilterControl({
               onUpdate={onUpdate}
               onRemove={onRemove}
             />
-          </div>,
-          document.body,
-        )}
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
     </div>
   );
 }


### PR DESCRIPTION
Replaces the five hand-rolled overlay surfaces with two Radix primitives, closing real a11y gaps and deleting ~800 LOC of bespoke interaction code. Foundation for #112 (form-in-action modals). Part of the rescoped #107.

## What changed
- **Modal + ConfirmDialog → Radix `Dialog`.** The hand-rolled centered cards had **no portal, no focus-trap, no Escape/backdrop dismiss** — now all of that plus auto-wired aria. ConfirmDialog blocks dismiss while processing. Styling unchanged.
- **action-group + column-filter-control + select dropdown → Radix `Popover`.** Each hand-rolled portal + `getBoundingClientRect` positioning + outside/Escape/scroll dismiss (3 copies). Now collision-aware positioning, focus management and light-dismiss from one primitive.
- `DropdownMenu` was evaluated for action-group and **rejected**: its children are rendered `Action` components (with their own confirm dialogs), not menu items, and it auto-closes on select — which would break confirm actions. Popover is the correct fit, so only `react-popover` + `react-dialog` are added.

## Bundle
- Spike measured the overlay packages at **28.3 KB gz** as a *conservative upper bound* (double-counts Radix internals already bundled via checkbox/label/slot; `@floating-ui/dom` already in the tree). Real consumer-side marginal ~20–25 KB.
- **lattice's own dist: 32 → 31.5 KB gz** — the deps are peer/external, and ~800 LOC of hand-rolled code is deleted, so the shipped library *shrinks*.

## Notes
- The action-group vitest test now asserts open/close behavior instead of the old `role=menu` / `fixed`-class internals (the old `role=menu` was inaccurate — plain buttons, no menu keyboard nav).

Green: vitest 140, browser 22 (filter popover, select dropdown, multi-select search, dialogs), format / lint / typecheck / build:lib.