### PR TITLE
Vertical tabs + keyboard roving focus

### DIFF
--- a/resources/js/core/components/tabs.test.tsx
+++ b/resources/js/core/components/tabs.test.tsx
@@ -14,6 +14,40 @@ vi.mock("@inertiajs/react", () => ({
 
 const TextProbe: RendererComponent<"text"> = ({ node }) => <span>{String(node.props?.text)}</span>;
 
+function renderTabs(tabsProps: Record<string, unknown>) {
+  const registry = createRegistry({
+    components: {
+      tab: eagerComponent(TabComponent),
+      tabs: eagerComponent(TabsComponent),
+      text: eagerComponent(TextProbe),
+    },
+    name: "test/tabs",
+  });
+
+  const tab = (label: string, value: string) => ({
+    schema: [{ props: { text: `${label} panel` }, type: "text" }],
+    props: { label, value },
+    type: "tab",
+  });
+
+  return render(
+    <Renderer
+      nodes={[
+        {
+          schema: [
+            tab("Overview", "overview"),
+            tab("Details", "details"),
+            tab("History", "history"),
+          ],
+          props: { defaultValue: "overview", queryKey: "tabs", ...tabsProps },
+          type: "tabs",
+        },
+      ]}
+      registry={registry}
+    />,
+  );
+}
+
 describe("Lattice tabs component", () => {
   beforeEach(() => {
     vi.mocked(router.visit).mockClear();
@@ -279,5 +313,55 @@ describe("Lattice tabs component", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Later" }));
 
     expect(screen.getByText("Loaded after opening")).toBeVisible();
+  });
+
+  it("roves focus across tabs with arrow, home and end keys", () => {
+    renderTabs({});
+    const tablist = screen.getByRole("tablist");
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    const details = screen.getByRole("tab", { name: "Details" });
+    const history = screen.getByRole("tab", { name: "History" });
+
+    expect(tablist).toHaveAttribute("aria-orientation", "horizontal");
+    expect(overview).toHaveAttribute("tabindex", "0");
+    expect(details).toHaveAttribute("tabindex", "-1");
+
+    overview.focus();
+    fireEvent.keyDown(overview, { key: "ArrowRight" });
+    expect(details).toHaveFocus();
+
+    fireEvent.keyDown(details, { key: "ArrowRight" });
+    expect(history).toHaveFocus();
+
+    fireEvent.keyDown(history, { key: "ArrowRight" });
+    expect(overview).toHaveFocus();
+
+    fireEvent.keyDown(overview, { key: "End" });
+    expect(history).toHaveFocus();
+
+    fireEvent.keyDown(history, { key: "Home" });
+    expect(overview).toHaveFocus();
+
+    fireEvent.keyDown(overview, { key: "ArrowLeft" });
+    expect(history).toHaveFocus();
+  });
+
+  it("lays out vertical tabs and roves focus with up and down arrows", () => {
+    renderTabs({ orientation: "vertical" });
+    const tablist = screen.getByRole("tablist");
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    const details = screen.getByRole("tab", { name: "Details" });
+
+    expect(tablist).toHaveAttribute("aria-orientation", "vertical");
+
+    overview.focus();
+    fireEvent.keyDown(overview, { key: "ArrowDown" });
+    expect(details).toHaveFocus();
+
+    fireEvent.keyDown(details, { key: "ArrowUp" });
+    expect(overview).toHaveFocus();
+
+    fireEvent.keyDown(overview, { key: "ArrowRight" });
+    expect(overview).toHaveFocus();
   });
 });

--- a/resources/js/core/components/tabs.test.tsx
+++ b/resources/js/core/components/tabs.test.tsx
@@ -39,7 +39,12 @@ function renderTabs(tabsProps: Record<string, unknown>) {
             tab("Details", "details"),
             tab("History", "history"),
           ],
-          props: { defaultValue: "overview", queryKey: "tabs", ...tabsProps },
+          props: {
+            defaultValue: "overview",
+            orientation: "horizontal",
+            queryKey: "tabs",
+            ...tabsProps,
+          },
           type: "tabs",
         },
       ]}

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -1,6 +1,6 @@
 import { router } from "@inertiajs/react";
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
-import type { ReactNode } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import type { Tab } from "@lattice/lattice/types/generated";
 import { cn } from "@lattice/lattice/lib/utils";
@@ -87,8 +87,11 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
   const tabs = useMemo(() => getTabs(node), [node]);
   const firstValue = tabs[0]?.value ?? "";
   const queryKey = node.props.queryKey;
+  const orientation = node.props.orientation ?? "horizontal";
+  const isVertical = orientation === "vertical";
   const serverActiveValue = node.props.activeValue;
   const defaultValue = node.props.defaultValue ?? firstValue;
+  const tablistRef = useRef<HTMLDivElement>(null);
   const [activeValue, setActiveTabValue] = useState(
     () => serverActiveValue || (queryValue(queryKey, tabs) ?? defaultValue) || firstValue,
   );
@@ -114,12 +117,58 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
     }
   }
 
+  function onTablistKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
+    const nextKey = isVertical ? "ArrowDown" : "ArrowRight";
+    const prevKey = isVertical ? "ArrowUp" : "ArrowLeft";
+
+    if (
+      event.key !== nextKey &&
+      event.key !== prevKey &&
+      event.key !== "Home" &&
+      event.key !== "End"
+    ) {
+      return;
+    }
+
+    const buttons = Array.from(
+      tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? [],
+    );
+
+    if (buttons.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    const current = buttons.indexOf(document.activeElement as HTMLButtonElement);
+
+    let index: number;
+    if (event.key === "Home") {
+      index = 0;
+    } else if (event.key === "End") {
+      index = buttons.length - 1;
+    } else {
+      const delta = event.key === nextKey ? 1 : -1;
+      const base = current < 0 ? 0 : current;
+      index = (base + delta + buttons.length) % buttons.length;
+    }
+
+    buttons[index]?.focus();
+  }
+
   return (
     <TabsContext.Provider value={{ activeValue, setActiveValue: selectTabValue }}>
-      <div className="grid gap-6" data-lattice-tabs={node.key ?? node.id}>
+      <div
+        className={cn("gap-6", isVertical ? "flex" : "grid")}
+        data-lattice-tabs={node.key ?? node.id}
+      >
         <div
           aria-label="Tabs"
-          className="inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-lt bg-lt-muted p-1"
+          aria-orientation={orientation}
+          className={cn(
+            "gap-1 rounded-lt bg-lt-muted p-1",
+            isVertical ? "flex flex-col" : "inline-flex w-fit max-w-full overflow-x-auto",
+          )}
+          ref={tablistRef}
           role="tablist"
         >
           {tabs.map((tab) => {
@@ -134,11 +183,14 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
                   isActive
                     ? "bg-lt-bg text-lt-fg shadow-xs"
                     : "text-lt-muted-fg hover:bg-lt-bg/60 hover:text-lt-fg",
+                  isVertical && "text-left",
                 )}
                 id={`${tab.value}-tab`}
                 key={tab.value}
                 onClick={() => selectTab(tab)}
+                onKeyDown={onTablistKeyDown}
                 role="tab"
+                tabIndex={isActive ? 0 : -1}
                 type="button"
               >
                 {tab.label}
@@ -147,7 +199,7 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
           })}
         </div>
 
-        <div className="min-w-0">{children}</div>
+        <div className={cn("min-w-0", isVertical && "flex-1")}>{children}</div>
       </div>
     </TabsContext.Provider>
   );

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -87,7 +87,7 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
   const tabs = useMemo(() => getTabs(node), [node]);
   const firstValue = tabs[0]?.value ?? "";
   const queryKey = node.props.queryKey;
-  const orientation = node.props.orientation ?? "horizontal";
+  const orientation = node.props.orientation;
   const isVertical = orientation === "vertical";
   const serverActiveValue = node.props.activeValue;
   const defaultValue = node.props.defaultValue ?? firstValue;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -473,6 +473,7 @@ export type Op =
   | "after"
   | "empty"
   | "filled";
+export type Orientation = "horizontal" | "vertical";
 export type Outlet = object;
 export type PageContainer = "centered" | "default";
 export type PageLayout = "app" | "auth" | "none";
@@ -609,6 +610,7 @@ export type TableSort = {
 export type Tabs = {
   activeValue: string;
   defaultValue: string | null;
+  orientation: Orientation;
   queryKey: string;
 };
 export type Text = {

--- a/src/Core/Components/Tabs.php
+++ b/src/Core/Components/Tabs.php
@@ -5,12 +5,15 @@ namespace Lattice\Lattice\Core\Components;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Support\Facades\Date;
 use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Enums\Orientation;
 
 class Tabs extends ContainerComponent
 {
     public ?string $defaultValue = null;
 
     public string $queryKey = 'tabs';
+
+    public Orientation $orientation = Orientation::Horizontal;
 
     public string $activeValue;
 
@@ -29,6 +32,13 @@ class Tabs extends ContainerComponent
     public function queryKey(string $key): static
     {
         $this->queryKey = $key;
+
+        return $this;
+    }
+
+    public function orientation(Orientation $orientation): static
+    {
+        $this->orientation = $orientation;
 
         return $this;
     }

--- a/src/Core/Enums/Orientation.php
+++ b/src/Core/Enums/Orientation.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Enums;
+
+enum Orientation: string
+{
+    case Horizontal = 'horizontal';
+    case Vertical = 'vertical';
+}

--- a/tests/Browser/TabsTest.php
+++ b/tests/Browser/TabsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+it('switches horizontal and vertical tabs end to end', function (): void {
+    visit('/tabs')
+        ->assertSee('Horizontal tabs')
+        ->assertSee('Vertical tabs')
+        ->assertPresent('[role="tablist"][aria-orientation="horizontal"]')
+        ->assertPresent('[role="tablist"][aria-orientation="vertical"]')
+        ->assertSee('Overview panel')
+        ->assertSee('Account panel')
+        ->assertDontSee('Details panel')
+        ->assertDontSee('Security panel')
+        ->click('Details')
+        ->assertSee('Details panel')
+        ->click('Security')
+        ->assertSee('Security panel')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/CoreTypedPropsGoldenTest.php
+++ b/tests/Feature/CoreTypedPropsGoldenTest.php
@@ -10,6 +10,7 @@ use Lattice\Lattice\Core\Components\Tabs;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Align;
 use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\Orientation;
 use Lattice\Lattice\Core\Enums\Width;
 
 test('GOLDEN stack serializes enums direction and key wire-identically', function () {
@@ -107,6 +108,7 @@ test('GOLDEN tabs serialize defaultValue queryKey and computed activeValue', fun
             'key' => 'settings-tabs',
             'props' => [
                 'queryKey' => 'tabs',
+                'orientation' => 'horizontal',
                 'defaultValue' => 'security',
                 'activeValue' => 'security',
             ],
@@ -132,10 +134,16 @@ test('GOLDEN tabs with custom queryKey and no defaultValue keep empty activeValu
             'key' => 'settings-tabs',
             'props' => [
                 'queryKey' => 'settings-tab',
+                'orientation' => 'horizontal',
                 'activeValue' => '',
                 'defaultValue' => null,
             ],
         ]);
+});
+
+test('GOLDEN tabs serialize a vertical orientation', function () {
+    expect(wire(Tabs::make('settings-tabs')->orientation(Orientation::Vertical))['props']['orientation'])
+        ->toBe('vertical');
 });
 
 test('GOLDEN confirmed inactive tab serializes confirm metadata and drops its children', function () {

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -1357,6 +1357,7 @@ test('tabs serialize tab panels as composable children', function () {
                 'activeValue' => 'security',
                 'defaultValue' => 'security',
                 'queryKey' => 'tabs',
+                'orientation' => 'horizontal',
             ],
             'schema' => [
                 [
@@ -1417,6 +1418,7 @@ test('tabs can customize their query string key', function () {
             'props' => [
                 'activeValue' => '',
                 'queryKey' => 'settings-tab',
+                'orientation' => 'horizontal',
                 'defaultValue' => null,
             ],
         ]);

--- a/workbench/app/Pages/TabsPage.php
+++ b/workbench/app/Pages/TabsPage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Components\Tab;
+use Lattice\Lattice\Core\Components\Tabs;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\Orientation;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page;
+
+final class TabsPage extends Page
+{
+    public function title(): string
+    {
+        return 'Lattice Tabs';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('tabs-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make('Horizontal tabs'),
+                    Tabs::make('horizontal-tabs')
+                        ->queryKey('h')
+                        ->defaultValue('overview')
+                        ->schema([
+                            Tab::make('overview', 'Overview')->schema([Text::make('Overview panel')]),
+                            Tab::make('details', 'Details')->schema([Text::make('Details panel')]),
+                            Tab::make('history', 'History')->schema([Text::make('History panel')]),
+                        ]),
+                    Heading::make('Vertical tabs'),
+                    Tabs::make('vertical-tabs')
+                        ->queryKey('v')
+                        ->orientation(Orientation::Vertical)
+                        ->defaultValue('account')
+                        ->schema([
+                            Tab::make('account', 'Account')->schema([Text::make('Account panel')]),
+                            Tab::make('security', 'Security')->schema([Text::make('Security panel')]),
+                            Tab::make('billing', 'Billing')->schema([Text::make('Billing panel')]),
+                        ]),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
+++ b/workbench/app/Providers/TypeScriptTransformerServiceProvider.php
@@ -25,6 +25,7 @@ use Lattice\Lattice\Core\Enums\Align;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Core\Enums\Orientation;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\Enums\ToastVariant;
@@ -129,6 +130,7 @@ final class TypeScriptTransformerServiceProvider extends TypeScriptTransformerAp
                 Width::class,
                 PageLayout::class,
                 PageContainer::class,
+                Orientation::class,
                 ToastVariant::class,
                 PaginationType::class,
                 ColumnType::class,

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -10,12 +10,16 @@ use Workbench\App\Pages\ProductEditPage;
 use Workbench\App\Pages\ProductsPage;
 use Workbench\App\Pages\ShowcasePage;
 use Workbench\App\Pages\TablesPage;
+use Workbench\App\Pages\TabsPage;
 
 Route::latticePage('/', HomePage::class)
     ->name('home');
 
 Route::latticePage('/tables', TablesPage::class)
     ->name('tables');
+
+Route::latticePage('/tabs', TabsPage::class)
+    ->name('tabs');
 
 Route::latticePage('/products', ProductsPage::class)
     ->name('products.index');


### PR DESCRIPTION
Adds vertical tab orientation and arrow-key navigation to the Tabs component, wired end to end.

## What changed
- **`Core\Enums\Orientation`** (`horizontal` | `vertical`) + **`Tabs::orientation()`** setter, generated to TypeScript and consumed by the React renderer.
- **Vertical layout** — the tablist sits beside the panels (flex row) instead of above them, with `aria-orientation` set accordingly.
- **Roving focus** — arrow keys move focus across tabs (Left/Right horizontally, Up/Down vertically), plus Home/End, using roving `tabindex`. The handler lives on each tab button (natively focusable). **Activation stays manual** (Enter/Space/click) so arrowing doesn't fire the query-string sync or confirm-required `router.visit` — the WAI-ARIA pattern for tabs with side effects.

## Tests
- **Vitest** — roving focus across arrow/Home/End keys, and the vertical layout + Up/Down nav.
- **Browser** (`TabsTest`) — a workbench `/tabs` page with horizontal + vertical tabs; asserts both render, expose `aria-orientation`, and switch panels end to end.
- Updated the Tabs wire-shape goldens for the new `orientation` prop.

Green: PHP 262, vitest 142, browser 23, format / lint / typecheck / build.