### PR TITLE
Drop dead TypeScript code and redundant aliases

### DIFF
--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -16,15 +16,13 @@ type ActionResponse = {
   ok?: boolean;
 };
 
-type ActionData = Record<string, never>;
-
 const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const endpoint = node.props.endpoint ?? "";
   const icon = node.props.icon;
   const label = node.props.label ?? "Run action";
   const componentRef = node.props.ref ?? "";
   const method: Method = node.props.method ?? "post";
-  const http = useHttp<ActionData, ActionResponse>({});
+  const http = useHttp<Record<string, never>, ActionResponse>({});
   const [isConfirming, setIsConfirming] = useState(false);
   const confirmation = node.props.confirmation;
   const variant = node.props.variant ?? "default";

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -8,13 +8,7 @@ import { Spinner } from "@lattice/lattice/core/components/spinner";
 import type { RendererComponent } from "@lattice/lattice/core/types";
 import { IconRenderer } from "@lattice/lattice/icons";
 import { dispatchActionEffects, dispatchActionError, getActionEffects } from "../effects";
-import type { ActionEffect } from "../effects";
-
-type ActionResponse = {
-  data?: Record<string, unknown>;
-  effects?: ActionEffect[];
-  ok?: boolean;
-};
+import type { ActionResponse } from "../effects";
 
 const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const endpoint = node.props.endpoint ?? "";

--- a/resources/js/action/effects.ts
+++ b/resources/js/action/effects.ts
@@ -4,6 +4,13 @@ import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 
 export type ActionEffect = Effect;
 
+/** The JSON shape returned by an action / bulk-action endpoint. */
+export type ActionResponse = {
+  data?: Record<string, unknown>;
+  effects?: ActionEffect[];
+  ok?: boolean;
+};
+
 const eventNames = {
   toast: LATTICE_EVENT.toast,
   reloadComponent: LATTICE_EVENT.reloadComponent,

--- a/resources/js/action/effects.ts
+++ b/resources/js/action/effects.ts
@@ -4,7 +4,6 @@ import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 
 export type ActionEffect = Effect;
 
-/** The JSON shape returned by an action / bulk-action endpoint. */
 export type ActionResponse = {
   data?: Record<string, unknown>;
   effects?: ActionEffect[];

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -29,6 +29,10 @@ export function useRendererContext(): RendererContextValue {
   return context;
 }
 
+function nodeKey(node: Node, index: number): string {
+  return node.key ?? node.id ?? `${node.type}-${index}`;
+}
+
 export function Renderer({
   fallback = null,
   missingComponent: UnknownComponent = MissingComponent,
@@ -52,29 +56,14 @@ export function Renderer({
   return (
     <RendererContext.Provider value={context}>
       {nodes.map((node, index) => (
-        <NodeRenderer
-          fallback={fallback}
-          key={node.key ?? node.id ?? `${node.type}-${index}`}
-          missingComponent={UnknownComponent}
-          node={node}
-          registry={registry}
-        />
+        <NodeRenderer key={nodeKey(node, index)} node={node} />
       ))}
     </RendererContext.Provider>
   );
 }
 
-function NodeRenderer({
-  fallback,
-  missingComponent: UnknownComponent,
-  node,
-  registry,
-}: {
-  fallback: ReactNode;
-  missingComponent: UnknownComponent;
-  node: Node;
-  registry: ComponentRegistry;
-}) {
+function NodeRenderer({ node }: { node: Node }) {
+  const { fallback, missingComponent: UnknownComponent, registry } = useRendererContext();
   const registration = registry[node.type];
 
   if (!registration) {
@@ -82,14 +71,9 @@ function NodeRenderer({
   }
 
   const Component = registration.component;
-  const children = node.schema?.length ? (
-    <Renderer
-      fallback={fallback}
-      missingComponent={UnknownComponent}
-      nodes={node.schema}
-      registry={registry}
-    />
-  ) : null;
+  const children = node.schema?.length
+    ? node.schema.map((child, index) => <NodeRenderer key={nodeKey(child, index)} node={child} />)
+    : null;
 
   const renderedComponent = <Component node={node}>{children}</Component>;
 

--- a/resources/js/form/components/conditions.ts
+++ b/resources/js/form/components/conditions.ts
@@ -55,8 +55,7 @@ function isBlank(value: unknown): boolean {
   return value == null || String(value) === "";
 }
 
-// Compare two date-ish values, or null when either cannot be parsed (so a
-// before/after against an unparseable value never matches). Mirrors PHP strtotime.
+// Null when either value can't be parsed, so before/after never matches a bad date. Mirrors PHP strtotime.
 function compareDates(actual: unknown, expected: unknown): number | null {
   const left = Date.parse(String(actual));
   const right = Date.parse(String(expected));

--- a/resources/js/form/components/context.tsx
+++ b/resources/js/form/components/context.tsx
@@ -6,13 +6,9 @@ type FormContextValue = {
   componentRef: string;
   errors: Record<string, string | undefined>;
   fieldLabels: Record<string, string>;
-  invalid: (field: string) => boolean;
   precognitive: boolean;
   processing: boolean;
-  touch: (field: string) => void;
   validate: (field: string) => void;
-  validating: boolean;
-  valid: (field: string) => boolean;
 };
 
 const FormContext = createContext<FormContextValue>({
@@ -21,13 +17,9 @@ const FormContext = createContext<FormContextValue>({
   componentRef: "",
   errors: {},
   fieldLabels: {},
-  invalid: () => false,
   precognitive: false,
   processing: false,
-  touch: () => {},
   validate: () => {},
-  validating: false,
-  valid: () => false,
 });
 
 export function FormProvider({

--- a/resources/js/form/components/field-props.ts
+++ b/resources/js/form/components/field-props.ts
@@ -24,11 +24,7 @@ export function fieldProps(node: Node): FieldProps {
   return node.props as FieldProps;
 }
 
-/**
- * Pre-order walk over every node in a form schema, read through the FieldProps
- * lens. The single traversal shared by the label/value collector and the
- * dependency-watch collector.
- */
+/** The single schema traversal shared by the label/value and dependency-watch collectors. */
 export function walkFields(
   nodes: Node[] | undefined,
   visit: (props: FieldProps, node: Node) => void,

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -11,8 +11,6 @@ import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFormValue } from "../values";
 
-type SelectOption = Option;
-
 function toValues(stored: unknown, fallback: string | string[] | undefined): string[] {
   const source = stored ?? fallback;
 
@@ -47,7 +45,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
 
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SelectOption[]>([]);
+  const [results, setResults] = useState<Option[]>([]);
   const [loading, setLoading] = useState(false);
 
   const labels = useMemo(() => {
@@ -77,7 +75,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
     setLoading(true);
 
     const timer = window.setTimeout(() => {
-      void postFormAction<{ options?: SelectOption[] }>(
+      void postFormAction<{ options?: Option[] }>(
         action,
         componentRef,
         { _search: name, q: query },
@@ -106,7 +104,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
     blur(name);
   }
 
-  function pick(option: SelectOption): void {
+  function pick(option: Option): void {
     if (multiple) {
       const next = selected.includes(option.value)
         ? selected.filter((value) => value !== option.value)

--- a/resources/js/form/components/fields/simple-field.tsx
+++ b/resources/js/form/components/fields/simple-field.tsx
@@ -3,12 +3,7 @@ import type { Node } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { type ControlledField, useControlledField } from "../use-controlled-field";
 
-/**
- * The shared shell for store-controlled single-input fields: wires the field
- * through useControlledField, renders nothing while conditions hide it, and
- * wraps the control in the standard labelled frame. The control is supplied as
- * a render prop, receiving the resolved field state.
- */
+/** The shared shell for single-input fields; the control is a render prop receiving the resolved field state. */
 export function SimpleField({
   node,
   label,

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -120,17 +120,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
       headers={withRefHeader(componentRef)}
       className="mx-auto flex w-full max-w-2xl flex-col gap-6"
     >
-      {({
-        clearErrors,
-        errors,
-        invalid,
-        processing,
-        reset,
-        touch,
-        validate,
-        validating,
-        valid,
-      }) => (
+      {({ clearErrors, errors, processing, reset, validate }) => (
         <FormProvider
           value={{
             action,
@@ -138,13 +128,9 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
             componentRef,
             errors: errors as Record<string, string | undefined>,
             fieldLabels,
-            invalid: (field) => invalid(field),
             precognitive,
             processing,
-            touch: (field) => touch(field),
             validate: (field) => validate(field),
-            validating,
-            valid: (field) => valid(field),
           }}
         >
           <FormResetListener componentId={node.id} reset={reset} />

--- a/resources/js/form/components/use-controlled-field.ts
+++ b/resources/js/form/components/use-controlled-field.ts
@@ -13,12 +13,7 @@ export type ControlledField = FieldState & {
   commit: (value: unknown) => void;
 };
 
-/**
- * Shared wiring for store-controlled, condition-aware fields: derives the current
- * string value (store, falling back to the node's value prop), the field state
- * (hidden/required/readonly/disabled), the current error, and a `commit` callback
- * that writes to the store and triggers precognition validation / error clearing.
- */
+/** Shared wiring read by every store-controlled, condition-aware field. */
 export function useControlledField(node: Node): ControlledField {
   const { errors } = useFormContext();
   const state = useDependentField(node);

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -34,9 +34,11 @@ export function useFormResolver(
     return { keys: [...keys], any };
   }, [nodes]);
 
-  const watched = watch.any
-    ? JSON.stringify(values)
-    : JSON.stringify(watch.keys.map((key) => values[key]));
+  // In "any" mode the resolve fires on any value change, and the values store
+  // keeps a stable reference until something actually changes (Object.is short-
+  // circuit in setValue), so the object identity is the change signal — no need
+  // to serialize every value each keystroke. Otherwise hash only the watched keys.
+  const watchSignature = watch.any ? values : JSON.stringify(watch.keys.map((key) => values[key]));
 
   useEffect(() => {
     if (watch.keys.length === 0 && !watch.any) {
@@ -71,7 +73,7 @@ export function useFormResolver(
       controller.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [watched, action, componentRef, watch.keys.length, watch.any, setValue]);
+  }, [watchSignature, action, componentRef, watch.keys.length, watch.any, setValue]);
 
   return resolved;
 }

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -34,10 +34,9 @@ export function useFormResolver(
     return { keys: [...keys], any };
   }, [nodes]);
 
-  // In "any" mode the resolve fires on any value change, and the values store
-  // keeps a stable reference until something actually changes (Object.is short-
-  // circuit in setValue), so the object identity is the change signal — no need
-  // to serialize every value each keystroke. Otherwise hash only the watched keys.
+  // In "any" mode the values store keeps a stable reference until something
+  // actually changes (Object.is in setValue), so its identity is the change
+  // signal — no need to serialize every value. Otherwise hash the watched keys.
   const watchSignature = watch.any ? values : JSON.stringify(watch.keys.map((key) => values[key]));
 
   useEffect(() => {

--- a/resources/js/form/components/use-seed-default.ts
+++ b/resources/js/form/components/use-seed-default.ts
@@ -2,9 +2,8 @@ import { useEffect } from "react";
 import { useFormValue, useSetFormValue } from "./values";
 
 /**
- * Seed the form store with a field's default value when nothing is stored yet,
- * so dependent fields and the submitted payload reflect it before the user
- * interacts. Pass undefined as the value to skip seeding.
+ * Seed a field's default into the store so dependent fields and the submitted
+ * payload reflect it before the user interacts. Pass undefined to skip.
  */
 export function useSeedDefault(name: string, value: unknown): void {
   const stored = useFormValue(name);

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -1,12 +1,7 @@
-import type { InertiaLinkProps } from "@inertiajs/react";
 import { clsx } from "clsx";
 import type { ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
-}
-
-export function toUrl(url: NonNullable<InertiaLinkProps["href"]>): string {
-  return typeof url === "string" ? url : url.url;
 }

--- a/resources/js/table/bulk.ts
+++ b/resources/js/table/bulk.ts
@@ -1,12 +1,5 @@
 import type { Method } from "@inertiajs/core";
-import type { ActionNode, ButtonVariant } from "@lattice/lattice/types/generated";
-
-export type BulkActionConfirmation = {
-  cancelLabel?: string;
-  confirmLabel?: string;
-  description?: string;
-  title?: string;
-};
+import type { Action, ActionNode, ButtonVariant } from "@lattice/lattice/types/generated";
 
 export type BulkAction = {
   id: string;
@@ -15,7 +8,7 @@ export type BulkAction = {
   endpoint: string;
   ref: string;
   variant: ButtonVariant;
-  confirmation: BulkActionConfirmation | null;
+  confirmation: Action["confirmation"];
 };
 
 export function getBulkActions(actions: ActionNode[] | undefined): BulkAction[] {

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -5,18 +5,12 @@ import {
   dispatchActionError,
   getActionEffects,
 } from "@lattice/lattice/action/effects";
-import type { ActionEffect } from "@lattice/lattice/action/effects";
+import type { ActionResponse } from "@lattice/lattice/action/effects";
 import { withRefHeader } from "@lattice/lattice/core/component-ref";
 import { Button } from "@lattice/lattice/core/components/button";
 import { ConfirmDialog } from "@lattice/lattice/core/components/confirm-dialog";
 import { Spinner } from "@lattice/lattice/core/components/spinner";
 import type { BulkAction } from "../bulk";
-
-type BulkResponse = {
-  data?: Record<string, unknown>;
-  effects?: ActionEffect[];
-  ok?: boolean;
-};
 
 type BulkData = {
   allMatching?: boolean;
@@ -42,7 +36,7 @@ export function BulkBar({
   onSelectAllMatching: () => void;
   onCompleted: () => void;
 }) {
-  const http = useHttp<BulkData, BulkResponse>({});
+  const http = useHttp<BulkData, ActionResponse>({});
   const [confirming, setConfirming] = useState<BulkAction | null>(null);
 
   async function submit(action: BulkAction): Promise<void> {

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -79,7 +79,6 @@ const operatorLabels: Record<string, string> = {
   filled: "is not empty",
 };
 
-// Operators that filter on presence alone and carry no value input.
 export const VALUELESS_FILTER_OPERATORS = new Set<string>(["empty", "filled"]);
 
 export function operatorLabel(operator: string): string {


### PR DESCRIPTION
Small dead-code / alias cleanup found in a fresh TS review.

- **`utils.ts toUrl`** — exported helper called nowhere and not re-exported from `index.ts`. Removed (with its `InertiaLinkProps` import).
- **Four dead `FormContext` members** — `invalid`, `valid`, `touch`, `validating` were wired through the provider but never read by any consumer. Dropped from the type, the default context, and the provider value (and the InertiaForm render-prop destructure).
- **`SelectOption`** — a pure re-alias of the already-imported `Option`. Removed; use `Option` directly.
- **`ActionData`** — `Record<string, never>` used once as a `useHttp` generic arg, conveying nothing. Inlined.

No behavior change. Green: vitest 142, format / lint / typecheck / build:lib.