### PR TITLE
feat: collapsible sidebar navigation + table layout fixes

### DIFF
--- a/resources/js/core/components/segmented-control.tsx
+++ b/resources/js/core/components/segmented-control.tsx
@@ -21,6 +21,7 @@ const SegmentedControlComponent: RendererComponent<"segmented-control"> = ({ nod
   return (
     <SegmentedPills
       ariaLabel={node.props.label ?? undefined}
+      name={name}
       onSelect={select}
       options={options}
       value={value}

--- a/resources/js/core/components/segmented-pills.tsx
+++ b/resources/js/core/components/segmented-pills.tsx
@@ -8,6 +8,7 @@ import { cn } from "@lattice/lattice/lib/utils";
 export function SegmentedPills({
   ariaLabel,
   disabled = false,
+  name,
   onSelect,
   options,
   tabIndex,
@@ -15,6 +16,7 @@ export function SegmentedPills({
 }: {
   ariaLabel?: string;
   disabled?: boolean;
+  name?: string;
   onSelect: (value: string) => void;
   options: Option[];
   tabIndex?: number;
@@ -32,6 +34,7 @@ export function SegmentedPills({
         return (
           <button
             aria-checked={isSelected}
+            data-test={`${name ?? "segment"}-${option.value}`}
             className={cn(
               "whitespace-nowrap rounded-lt-sm px-3 py-1.5 text-sm font-medium transition-colors",
               isSelected

--- a/resources/js/core/components/stack.tsx
+++ b/resources/js/core/components/stack.tsx
@@ -22,6 +22,7 @@ const stackGaps: Record<string, string> = {
 };
 
 const stackWidths: Record<string, string> = {
+  fill: "min-w-0 flex-1",
   full: "w-full",
   lg: "mx-auto w-full max-w-4xl",
   md: "mx-auto w-full max-w-2xl",

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -178,6 +178,7 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
               <button
                 aria-controls={`${tab.value}-panel`}
                 aria-selected={isActive}
+                data-test={`tab-${tab.value}`}
                 className={cn(
                   "whitespace-nowrap rounded-lt-sm px-3 py-1.5 text-sm font-medium transition-colors",
                   isActive

--- a/resources/js/form/components/base/password-input.tsx
+++ b/resources/js/form/components/base/password-input.tsx
@@ -22,6 +22,9 @@ export default function PasswordInput({ className, ref, ...props }: PasswordInpu
       />
       <button
         type="button"
+        data-test={
+          typeof props.name === "string" ? `${props.name}-visibility` : "password-visibility"
+        }
         onClick={() => setShowPassword((prev) => !prev)}
         className="absolute inset-y-0 right-0 flex items-center rounded-r-lt-sm px-3 text-lt-muted-fg hover:text-lt-fg focus-visible:ring-[3px] focus-visible:ring-lt-ring focus-visible:outline-none"
         aria-label={showPassword ? "Hide password" : "Show password"}

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -29,6 +29,7 @@ export const ChoiceComponent: RendererComponent<"form.choice"> = ({ node }) => {
       <SegmentedPills
         ariaLabel={node.props.label ?? undefined}
         disabled={readonly || disabled}
+        name={name}
         onSelect={commit}
         options={options}
         value={selected}

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -240,6 +240,7 @@ function EmojiPicker({ editor }: { editor: Editor }) {
     <div className="relative">
       <button
         aria-label="Insert emoji"
+        data-test="editor-emoji"
         className="inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg [&_svg]:size-4"
         onClick={() => setOpen((value) => !value)}
         onMouseDown={(event) => event.preventDefault()}
@@ -281,6 +282,7 @@ function Toolbar({ editor }: { editor: Editor }) {
           <button
             aria-label={item.label}
             aria-pressed={item.isActive(editor)}
+            data-test={`editor-${item.label.toLowerCase().replace(/\s+/g, "-")}`}
             className={cn(
               "inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg disabled:pointer-events-none disabled:opacity-40 [&_svg]:size-4",
               item.isActive(editor) && "bg-lt-accent text-lt-accent-fg",

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -154,6 +154,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
                 {!locked && (
                   <button
                     aria-label={`Remove ${labelFor(value)}`}
+                    data-test={`select-${name}-remove-${value}`}
                     className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-3"
                     onClick={() => remove(value)}
                     type="button"
@@ -179,6 +180,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
           <Popover.Trigger asChild>
             <button
               aria-haspopup="listbox"
+              data-test={`select-${name}`}
               className={cn(
                 "flex min-h-9 w-full items-center justify-between gap-2 rounded-lt-sm border border-lt-input bg-transparent px-3 py-1.5 text-left text-sm shadow-xs transition-colors focus:border-lt-ring focus:outline-none focus:ring-[3px] focus:ring-lt-ring/50",
                 locked && "cursor-not-allowed opacity-60",
@@ -204,6 +206,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
               <div className="flex items-center gap-2 border-b border-lt-border px-3 py-2">
                 <input
                   aria-label="Search options"
+                  data-test={`select-${name}-search`}
                   className="w-full bg-transparent text-sm outline-none placeholder:text-lt-muted-fg"
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder={searchable ? "Search…" : "Filter…"}
@@ -221,6 +224,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
                     return (
                       <button
                         aria-selected={isSelected}
+                        data-test={`select-${name}-option-${option.value}`}
                         className={cn(
                           "flex w-full items-center justify-between gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-lt-accent hover:text-lt-accent-fg",
                           isSelected && "bg-lt-accent/60",

--- a/resources/js/layout/components.ts
+++ b/resources/js/layout/components.ts
@@ -2,12 +2,14 @@ import { createPlugin, eagerComponent } from "@lattice/lattice/core/registry";
 import MenuComponent from "./menu";
 import MenuItemComponent from "./menu-item";
 import OutletComponent from "./outlet";
+import SidebarComponent from "./sidebar";
 
 export const layoutComponents = createPlugin({
   components: {
     menu: eagerComponent(MenuComponent),
     "menu-item": eagerComponent(MenuItemComponent),
     outlet: eagerComponent(OutletComponent),
+    sidebar: eagerComponent(SidebarComponent),
   },
   name: "lattice/layout",
 });

--- a/resources/js/layout/context.ts
+++ b/resources/js/layout/context.ts
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 import type { ReactNode } from "react";
 
 /**
@@ -6,3 +6,13 @@ import type { ReactNode } from "react";
  * so the Outlet component can render it wherever the layout places it.
  */
 export const OutletContext = createContext<ReactNode>(null);
+
+/**
+ * Whether the enclosing Sidebar is collapsed to its icon rail. Menu items read
+ * this to render icon-only and surface their submenu as a flyout instead.
+ */
+export const SidebarCollapsedContext = createContext(false);
+
+export function useSidebarCollapsed(): boolean {
+  return useContext(SidebarCollapsedContext);
+}

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -1,10 +1,12 @@
 import { Link, usePage } from "@inertiajs/react";
 import { ChevronRight } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 import type { RendererComponent, Schema } from "@lattice/lattice/core/types";
 import { IconRenderer } from "@lattice/lattice/icons";
 import { cn } from "@lattice/lattice/lib/utils";
+import { SidebarCollapsedContext, useSidebarCollapsed } from "./context";
 
 const rowClass =
   "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-lt-fg transition-colors hover:bg-lt-muted";
@@ -16,25 +18,35 @@ function schemaContainsPath(schema: Schema | undefined, path: string): boolean {
 }
 
 const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) => {
+  const collapsed = useSidebarCollapsed();
   const icon = node.props.icon;
+  const label = node.props.label;
   const href = node.props.href ?? "";
   const currentPath = usePage().url.split("?")[0];
 
   const content = (
     <>
       {icon ? <IconRenderer className="size-4 shrink-0" icon={icon} /> : null}
-      <span>{node.props.label}</span>
+      <span className={cn(collapsed && "sr-only")}>{label}</span>
     </>
   );
 
   if (href === "") {
     if (!children) {
-      return (
+      return collapsed ? null : (
         <li>
           <span className="flex items-center gap-2 px-3 py-2 text-xs font-semibold tracking-wide text-lt-muted-fg uppercase">
             {content}
           </span>
         </li>
+      );
+    }
+
+    if (collapsed) {
+      return (
+        <FlyoutGroup icon={icon} label={label}>
+          {children}
+        </FlyoutGroup>
       );
     }
 
@@ -51,9 +63,10 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
     <li>
       <Link
         aria-current={active ? "page" : undefined}
-        className={cn(rowClass, active && "bg-lt-muted font-medium")}
+        className={cn(rowClass, collapsed && "justify-center", active && "bg-lt-muted font-medium")}
         href={href}
         method={node.props.method ?? "get"}
+        title={collapsed ? label : undefined}
       >
         {content}
       </Link>
@@ -87,6 +100,73 @@ function CollapsibleItem({
         />
       </button>
       {open ? <ul className="mt-1 flex flex-col gap-1 pl-3">{children}</ul> : null}
+    </li>
+  );
+}
+
+function FlyoutGroup({
+  children,
+  icon,
+  label,
+}: {
+  children: ReactNode;
+  icon?: string | null;
+  label: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ left: 0, top: 0 });
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const url = usePage().url;
+
+  useEffect(() => setOpen(false), [url]);
+
+  function toggle(): void {
+    const rect = triggerRef.current?.getBoundingClientRect();
+
+    if (rect) {
+      setPosition({ left: rect.right + 4, top: rect.top });
+    }
+
+    setOpen((value) => !value);
+  }
+
+  return (
+    <li>
+      <button
+        aria-expanded={open}
+        aria-label={label}
+        className={cn(rowClass, "w-full justify-center")}
+        onClick={toggle}
+        ref={triggerRef}
+        title={label}
+        type="button"
+      >
+        {icon ? <IconRenderer className="size-4 shrink-0" icon={icon} /> : <span>{label}</span>}
+      </button>
+      {open
+        ? createPortal(
+            <>
+              <button
+                aria-label="Close menu"
+                className="fixed inset-0 z-40 cursor-default"
+                onClick={() => setOpen(false)}
+                type="button"
+              />
+              <SidebarCollapsedContext.Provider value={false}>
+                <ul
+                  className="fixed z-50 min-w-48 rounded-md border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-lg"
+                  style={{ left: position.left, top: position.top }}
+                >
+                  <li className="px-3 py-1.5 text-xs font-semibold tracking-wide text-lt-muted-fg uppercase">
+                    {label}
+                  </li>
+                  {children}
+                </ul>
+              </SidebarCollapsedContext.Provider>
+            </>,
+            document.body,
+          )
+        : null}
     </li>
   );
 }

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -23,6 +23,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
   const label = node.props.label;
   const href = node.props.href ?? "";
   const currentPath = usePage().url.split("?")[0];
+  const slug = label.toLowerCase().replace(/\s+/g, "-");
 
   const content = (
     <>
@@ -44,14 +45,18 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
 
     if (collapsed) {
       return (
-        <FlyoutGroup icon={icon} label={label}>
+        <FlyoutGroup icon={icon} label={label} testId={`menu-${slug}`}>
           {children}
         </FlyoutGroup>
       );
     }
 
     return (
-      <CollapsibleItem content={content} defaultOpen={schemaContainsPath(node.schema, currentPath)}>
+      <CollapsibleItem
+        content={content}
+        defaultOpen={schemaContainsPath(node.schema, currentPath)}
+        testId={`menu-${slug}`}
+      >
         {children}
       </CollapsibleItem>
     );
@@ -64,6 +69,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
       <Link
         aria-current={active ? "page" : undefined}
         className={cn(rowClass, collapsed && "justify-center", active && "bg-lt-muted font-medium")}
+        data-test={`menu-${slug}`}
         href={href}
         method={node.props.method ?? "get"}
         title={collapsed ? label : undefined}
@@ -78,10 +84,12 @@ function CollapsibleItem({
   children,
   content,
   defaultOpen,
+  testId,
 }: {
   children: ReactNode;
   content: ReactNode;
   defaultOpen: boolean;
+  testId: string;
 }) {
   const [open, setOpen] = useState(defaultOpen);
 
@@ -90,6 +98,7 @@ function CollapsibleItem({
       <button
         aria-expanded={open}
         className={cn(rowClass, "w-full")}
+        data-test={testId}
         onClick={() => setOpen((value) => !value)}
         type="button"
       >
@@ -108,10 +117,12 @@ function FlyoutGroup({
   children,
   icon,
   label,
+  testId,
 }: {
   children: ReactNode;
   icon?: string | null;
   label: string;
+  testId: string;
 }) {
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState({ left: 0, top: 0 });
@@ -136,6 +147,7 @@ function FlyoutGroup({
         aria-expanded={open}
         aria-label={label}
         className={cn(rowClass, "w-full justify-center")}
+        data-test={testId}
         onClick={toggle}
         ref={triggerRef}
         title={label}
@@ -149,6 +161,7 @@ function FlyoutGroup({
               <button
                 aria-label="Close menu"
                 className="fixed inset-0 z-40 cursor-default"
+                data-test={`${testId}-close`}
                 onClick={() => setOpen(false)}
                 type="button"
               />

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -1,45 +1,94 @@
 import { Link, usePage } from "@inertiajs/react";
-import type { RendererComponent } from "@lattice/lattice/core/types";
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { ReactNode } from "react";
+import type { RendererComponent, Schema } from "@lattice/lattice/core/types";
 import { IconRenderer } from "@lattice/lattice/icons";
 import { cn } from "@lattice/lattice/lib/utils";
 
+const rowClass =
+  "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-lt-fg transition-colors hover:bg-lt-muted";
+
+function schemaContainsPath(schema: Schema | undefined, path: string): boolean {
+  return (schema ?? []).some(
+    (child) => child.props?.href === path || schemaContainsPath(child.schema, path),
+  );
+}
+
 const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) => {
-  const label = node.props.label;
-  const href = node.props.href ?? "";
   const icon = node.props.icon;
-  const method = node.props.method ?? "get";
+  const href = node.props.href ?? "";
   const currentPath = usePage().url.split("?")[0];
-  const active = href !== "" && currentPath === href;
 
   const content = (
     <>
       {icon ? <IconRenderer className="size-4 shrink-0" icon={icon} /> : null}
-      <span>{label}</span>
+      <span>{node.props.label}</span>
     </>
   );
 
+  if (href === "") {
+    if (!children) {
+      return (
+        <li>
+          <span className="flex items-center gap-2 px-3 py-2 text-xs font-semibold tracking-wide text-lt-muted-fg uppercase">
+            {content}
+          </span>
+        </li>
+      );
+    }
+
+    return (
+      <CollapsibleItem content={content} defaultOpen={schemaContainsPath(node.schema, currentPath)}>
+        {children}
+      </CollapsibleItem>
+    );
+  }
+
+  const active = currentPath === href;
+
   return (
     <li>
-      {href ? (
-        <Link
-          aria-current={active ? "page" : undefined}
-          className={cn(
-            "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-lt-fg transition-colors hover:bg-lt-muted",
-            active && "bg-lt-muted font-medium",
-          )}
-          href={href}
-          method={method}
-        >
-          {content}
-        </Link>
-      ) : (
-        <span className="flex items-center gap-2 px-3 py-2 text-xs font-semibold tracking-wide text-lt-muted-fg uppercase">
-          {content}
-        </span>
-      )}
-      {children ? <ul className="flex flex-col gap-1 pl-3">{children}</ul> : null}
+      <Link
+        aria-current={active ? "page" : undefined}
+        className={cn(rowClass, active && "bg-lt-muted font-medium")}
+        href={href}
+        method={node.props.method ?? "get"}
+      >
+        {content}
+      </Link>
     </li>
   );
 };
+
+function CollapsibleItem({
+  children,
+  content,
+  defaultOpen,
+}: {
+  children: ReactNode;
+  content: ReactNode;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <li>
+      <button
+        aria-expanded={open}
+        className={cn(rowClass, "w-full")}
+        onClick={() => setOpen((value) => !value)}
+        type="button"
+      >
+        {content}
+        <ChevronRight
+          aria-hidden="true"
+          className={cn("ml-auto size-4 shrink-0 transition-transform", open && "rotate-90")}
+        />
+      </button>
+      {open ? <ul className="mt-1 flex flex-col gap-1 pl-3">{children}</ul> : null}
+    </li>
+  );
+}
 
 export default MenuItemComponent;

--- a/resources/js/layout/menu.test.tsx
+++ b/resources/js/layout/menu.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
 import { Renderer } from "@lattice/lattice/core/renderer";
 import type { Node } from "@lattice/lattice/core/types";
+import { SidebarCollapsedContext } from "./context";
 import MenuComponent from "./menu";
 import MenuItemComponent from "./menu-item";
 
@@ -88,7 +89,10 @@ describe("Menu", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Account" }));
 
-    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
     expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute("href", "/profile");
   });
 
@@ -101,14 +105,35 @@ describe("Menu", () => {
           id: "i-catalog",
           props: { label: "Catalog" },
           schema: [
-            { id: "i-products", props: { href: "/products", label: "Products" }, type: "menu-item" },
+            {
+              id: "i-products",
+              props: { href: "/products", label: "Products" },
+              type: "menu-item",
+            },
           ],
           type: "menu-item",
         },
       ],
     });
 
-    expect(screen.getByRole("button", { name: "Catalog" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "Catalog" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
     expect(screen.getByRole("link", { name: "Products" })).toHaveAttribute("href", "/products");
+  });
+
+  it("opens a group's submenu as a flyout when the sidebar is collapsed", () => {
+    render(
+      <SidebarCollapsedContext.Provider value={true}>
+        <Renderer nodes={[menu]} registry={registry} />
+      </SidebarCollapsedContext.Provider>,
+    );
+
+    expect(screen.queryByRole("link", { name: "Profile" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute("href", "/profile");
   });
 });

--- a/resources/js/layout/menu.test.tsx
+++ b/resources/js/layout/menu.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
 import { Renderer } from "@lattice/lattice/core/renderer";
@@ -73,16 +73,42 @@ describe("Menu", () => {
     expect(screen.getByRole("link", { name: "Home" })).not.toHaveAttribute("aria-current");
   });
 
-  it("renders an item without an href as a plain label", () => {
+  it("renders a non-link item with children as a collapsed toggle", () => {
     renderMenu(menu);
 
-    expect(screen.getByText("Account")).toBeVisible();
+    const toggle = screen.getByRole("button", { name: "Account" });
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryByRole("link", { name: "Account" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Profile" })).not.toBeInTheDocument();
   });
 
-  it("renders nested children of an item", () => {
+  it("expands the submenu when the toggle is clicked", () => {
     renderMenu(menu);
 
+    fireEvent.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute("href", "/profile");
+  });
+
+  it("opens a group that contains the active route by default", () => {
+    renderMenu({
+      id: "main",
+      type: "menu",
+      schema: [
+        {
+          id: "i-catalog",
+          props: { label: "Catalog" },
+          schema: [
+            { id: "i-products", props: { href: "/products", label: "Products" }, type: "menu-item" },
+          ],
+          type: "menu-item",
+        },
+      ],
+    });
+
+    expect(screen.getByRole("button", { name: "Catalog" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("link", { name: "Products" })).toHaveAttribute("href", "/products");
   });
 });

--- a/resources/js/layout/sidebar.test.tsx
+++ b/resources/js/layout/sidebar.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
 import { Renderer } from "@lattice/lattice/core/renderer";
 import type { Node } from "@lattice/lattice/core/types";
@@ -10,17 +10,50 @@ const registry = createRegistry({
   name: "test/sidebar",
 });
 
-const sidebar: Node = {
-  id: "app-sidebar",
-  type: "sidebar",
-};
+function renderSidebar(props: { collapsible: boolean; rememberState: boolean }) {
+  const node: Node = { id: "app-sidebar", props, type: "sidebar" };
+
+  return render(<Renderer nodes={[node]} registry={registry} />);
+}
 
 describe("Sidebar", () => {
-  it("renders a fixed-width aside that does not shrink", () => {
-    render(<Renderer nodes={[sidebar]} registry={registry} />);
+  afterEach(() => window.localStorage.clear());
 
-    const aside = screen.getByRole("complementary");
+  it("renders a fixed-width aside with no toggle when not collapsible", () => {
+    renderSidebar({ collapsible: false, rememberState: false });
 
-    expect(aside).toHaveClass("w-64", "shrink-0");
+    expect(screen.getByRole("complementary")).toHaveClass("w-64", "shrink-0");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("collapses to the icon rail when the toggle is clicked", () => {
+    renderSidebar({ collapsible: true, rememberState: false });
+
+    expect(screen.getByRole("complementary")).toHaveClass("w-64");
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+
+    expect(screen.getByRole("complementary")).toHaveClass("w-16");
+    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeVisible();
+  });
+
+  it("remembers the collapsed state when rememberState is on", () => {
+    const { unmount } = renderSidebar({ collapsible: true, rememberState: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+    expect(window.localStorage.getItem("lattice:sidebar:app-sidebar")).toBe("true");
+
+    unmount();
+    renderSidebar({ collapsible: true, rememberState: true });
+
+    expect(screen.getByRole("complementary")).toHaveClass("w-16");
+  });
+
+  it("does not persist the collapsed state when rememberState is off", () => {
+    renderSidebar({ collapsible: true, rememberState: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+
+    expect(window.localStorage.getItem("lattice:sidebar:app-sidebar")).toBeNull();
   });
 });

--- a/resources/js/layout/sidebar.test.tsx
+++ b/resources/js/layout/sidebar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import type { Node } from "@lattice/lattice/core/types";
+import SidebarComponent from "./sidebar";
+
+const registry = createRegistry({
+  components: { sidebar: eagerComponent(SidebarComponent) },
+  name: "test/sidebar",
+});
+
+const sidebar: Node = {
+  id: "app-sidebar",
+  type: "sidebar",
+};
+
+describe("Sidebar", () => {
+  it("renders a fixed-width aside that does not shrink", () => {
+    render(<Renderer nodes={[sidebar]} registry={registry} />);
+
+    const aside = screen.getByRole("complementary");
+
+    expect(aside).toHaveClass("w-64", "shrink-0");
+  });
+});

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -49,8 +49,8 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
             aria-expanded={!isCollapsed}
             aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
             className={cn(
-              "flex items-center rounded-md p-2 text-lt-fg transition-colors hover:bg-lt-muted",
-              isCollapsed ? "justify-center" : "justify-end",
+              "inline-flex items-center rounded-md p-2 text-lt-fg transition-colors hover:bg-lt-muted",
+              isCollapsed ? "self-center" : "self-end",
             )}
             onClick={toggle}
             type="button"

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -1,0 +1,12 @@
+import type { RendererComponent } from "@lattice/lattice/core/types";
+
+const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => (
+  <aside
+    className="flex w-64 shrink-0 flex-col gap-4 border-r border-lt-border p-4"
+    data-lattice-component={node.id}
+  >
+    {children}
+  </aside>
+);
+
+export default SidebarComponent;

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -1,12 +1,67 @@
+import { PanelLeft } from "lucide-react";
+import { useState } from "react";
 import type { RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+import { SidebarCollapsedContext } from "./context";
 
-const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => (
-  <aside
-    className="flex w-64 shrink-0 flex-col gap-4 border-r border-lt-border p-4"
-    data-lattice-component={node.id}
-  >
-    {children}
-  </aside>
-);
+function readStored(key: string, remember: boolean): boolean {
+  if (!remember || typeof window === "undefined") {
+    return false;
+  }
+
+  return window.localStorage.getItem(key) === "true";
+}
+
+const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
+  const collapsible = node.props.collapsible;
+  const rememberState = node.props.rememberState;
+  const storageKey = `lattice:sidebar:${node.id ?? "default"}`;
+
+  const [collapsed, setCollapsed] = useState(() =>
+    readStored(storageKey, collapsible && rememberState),
+  );
+
+  function toggle(): void {
+    setCollapsed((value) => {
+      const next = !value;
+
+      if (rememberState && typeof window !== "undefined") {
+        window.localStorage.setItem(storageKey, String(next));
+      }
+
+      return next;
+    });
+  }
+
+  const isCollapsed = collapsible && collapsed;
+
+  return (
+    <SidebarCollapsedContext.Provider value={isCollapsed}>
+      <aside
+        className={cn(
+          "flex shrink-0 flex-col gap-4 overflow-hidden border-r border-lt-border p-4 transition-[width]",
+          isCollapsed ? "w-16" : "w-64",
+        )}
+        data-lattice-component={node.id}
+      >
+        {collapsible ? (
+          <button
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            className={cn(
+              "flex items-center rounded-md p-2 text-lt-fg transition-colors hover:bg-lt-muted",
+              isCollapsed ? "justify-center" : "justify-end",
+            )}
+            onClick={toggle}
+            type="button"
+          >
+            <PanelLeft aria-hidden="true" className="size-4 shrink-0" />
+          </button>
+        ) : null}
+        {children}
+      </aside>
+    </SidebarCollapsedContext.Provider>
+  );
+};
 
 export default SidebarComponent;

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -48,6 +48,7 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
           <button
             aria-expanded={!isCollapsed}
             aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            data-test="sidebar-toggle"
             className={cn(
               "inline-flex items-center rounded-md p-2 text-lt-fg transition-colors hover:bg-lt-muted",
               isCollapsed ? "self-center" : "self-end",

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -78,6 +78,7 @@ export function BulkBar({
       {canSelectAllMatching && (
         <button
           type="button"
+          data-test="bulk-select-all-matching"
           className="font-medium text-lt-primary underline underline-offset-2"
           onClick={onSelectAllMatching}
         >
@@ -89,6 +90,7 @@ export function BulkBar({
           <Button
             key={action.id}
             type="button"
+            data-test={`bulk-action-${action.id}`}
             variant={action.variant}
             disabled={http.processing}
             onClick={() => run(action)}

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -60,6 +60,7 @@ export function ColumnFilterControl({
           processing={processing}
           withSearchIcon={type === "text" || type === "number"}
           grouped
+          testId={`filter-${column.key}-value`}
           onCommit={commitPrimary}
           onClear={primary ? () => onRemove(primary.index) : undefined}
         />
@@ -69,6 +70,7 @@ export function ColumnFilterControl({
           <button
             type="button"
             aria-label={`${column.label} filters`}
+            data-test={`filter-${column.key}`}
             className="relative -ml-px inline-flex size-9 shrink-0 items-center justify-center rounded-r-lt-sm border border-lt-input disabled:opacity-50 data-[state=open]:z-10 data-[state=open]:border-lt-primary"
             disabled={processing}
           >
@@ -175,6 +177,7 @@ function FilterClauseList({
       <div className="border-t border-lt-border pt-3">
         <button
           type="button"
+          data-test={`filter-${column.key}-add`}
           className="inline-flex w-full items-center justify-center gap-2 rounded-lt-sm bg-lt-muted px-3 py-2 text-sm font-medium hover:bg-lt-muted/70 disabled:opacity-50"
           disabled={processing}
           onClick={() => setAdding(true)}
@@ -214,6 +217,7 @@ function FilterClauseRow({
         {operators.length > 1 ? (
           <select
             aria-label={`${column.label} operator`}
+            data-test={`filter-${column.key}-operator`}
             className="h-9 flex-1 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal"
             disabled={processing}
             value={clause.operator}
@@ -231,6 +235,7 @@ function FilterClauseRow({
         <button
           type="button"
           aria-label={`Remove ${column.label} filter`}
+          data-test={`filter-${column.key}-remove`}
           className="inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border hover:bg-lt-muted disabled:opacity-50"
           disabled={processing}
           onClick={onRemove}

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -51,14 +51,15 @@ export function ColumnFilterControl({
   }
 
   return (
-    <div className="flex items-center gap-1">
-      <div className="flex-1">
+    <div className="flex min-w-0 max-w-44 items-stretch">
+      <div className="min-w-0 flex-1">
         <FilterValueInput
           type={type}
           label={column.label}
           value={primary?.clause.value ?? ""}
           processing={processing}
           withSearchIcon={type === "text" || type === "number"}
+          grouped
           onCommit={commitPrimary}
           onClear={primary ? () => onRemove(primary.index) : undefined}
         />
@@ -68,7 +69,7 @@ export function ColumnFilterControl({
           <button
             type="button"
             aria-label={`${column.label} filters`}
-            className="relative inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border disabled:opacity-50 data-[state=open]:border-lt-primary"
+            className="relative -ml-px inline-flex size-9 shrink-0 items-center justify-center rounded-r-lt-sm border border-lt-input disabled:opacity-50 data-[state=open]:z-10 data-[state=open]:border-lt-primary"
             disabled={processing}
           >
             <Filter aria-hidden="true" className="size-4" />

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -4,14 +4,14 @@ import type { TableColumn, TableSort, TableState } from "../types";
 
 function SortIndicator({ sort }: { sort: TableSort | undefined }) {
   if (sort?.direction === "asc") {
-    return <ArrowUp aria-hidden="true" className="size-3.5" />;
+    return <ArrowUp aria-hidden="true" className="size-3.5 shrink-0" />;
   }
 
   if (sort?.direction === "desc") {
-    return <ArrowDown aria-hidden="true" className="size-3.5" />;
+    return <ArrowDown aria-hidden="true" className="size-3.5 shrink-0" />;
   }
 
-  return <ChevronsUpDown aria-hidden="true" className="size-3.5 opacity-50" />;
+  return <ChevronsUpDown aria-hidden="true" className="size-3.5 shrink-0 opacity-50" />;
 }
 
 export function ColumnHeader({
@@ -30,21 +30,21 @@ export function ColumnHeader({
   return (
     <div
       aria-sort={getColumnAriaSort(columnSort)}
-      className="px-4 py-3 text-left align-middle font-medium text-lt-muted-fg"
+      className="min-w-0 px-4 py-3 text-left align-middle font-medium text-lt-muted-fg"
       role="columnheader"
     >
       {column.sortable ? (
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 font-medium"
+          className="flex w-full items-center gap-1.5 font-medium"
           disabled={processing}
           onClick={() => sort(column)}
         >
-          {`Sort ${column.label}`}
+          <span className="min-w-0 flex-1 truncate text-left">{`Sort ${column.label}`}</span>
           <SortIndicator sort={columnSort} />
         </button>
       ) : (
-        <span>{column.label}</span>
+        <span className="block truncate">{column.label}</span>
       )}
     </div>
   );

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -36,11 +36,12 @@ export function ColumnHeader({
       {column.sortable ? (
         <button
           type="button"
+          aria-label={`Sort ${column.label}`}
           className="flex w-full items-center gap-1.5 font-medium"
           disabled={processing}
           onClick={() => sort(column)}
         >
-          <span className="min-w-0 flex-1 truncate text-left">{`Sort ${column.label}`}</span>
+          <span className="min-w-0 flex-1 truncate text-left">{column.label}</span>
           <SortIndicator sort={columnSort} />
         </button>
       ) : (

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -38,6 +38,7 @@ export function ColumnHeader({
           type="button"
           aria-label={`Sort ${column.label}`}
           className="flex w-full items-center gap-1.5 font-medium"
+          data-test={`sort-${column.key}`}
           disabled={processing}
           onClick={() => sort(column)}
         >

--- a/resources/js/table/components/filter-stack-bar.tsx
+++ b/resources/js/table/components/filter-stack-bar.tsx
@@ -29,6 +29,7 @@ export function FilterStackBar({
             </span>
             <button
               type="button"
+              data-test={`filter-chip-${clause.field}-remove`}
               className="inline-flex size-5 items-center justify-center rounded text-lt-muted-fg hover:bg-lt-muted disabled:opacity-50"
               disabled={processing}
               aria-label={`Remove ${label} filter`}

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -13,6 +13,7 @@ export function FilterValueInput({
   withSearchIcon = false,
   grouped = false,
   ariaLabel,
+  testId,
   onCommit,
   onClear,
 }: {
@@ -23,6 +24,7 @@ export function FilterValueInput({
   withSearchIcon?: boolean;
   grouped?: boolean;
   ariaLabel?: string;
+  testId?: string;
   onCommit: (value: string) => void;
   onClear?: () => void;
 }) {
@@ -38,6 +40,7 @@ export function FilterValueInput({
     return (
       <select
         aria-label={inputLabel}
+        data-test={testId}
         className={`${baseClass} ${groupedClass}`}
         disabled={processing}
         value={value}
@@ -55,6 +58,7 @@ export function FilterValueInput({
       <input
         type="date"
         aria-label={inputLabel}
+        data-test={testId}
         className={`${baseClass} ${groupedClass}`}
         disabled={processing}
         value={draft}
@@ -77,6 +81,7 @@ export function FilterValueInput({
       <input
         type={type === "number" ? "number" : "text"}
         aria-label={inputLabel}
+        data-test={testId}
         className={`${baseClass} ${groupedClass} ${withSearchIcon ? "pl-8" : ""} ${onClear ? "pr-8" : ""}`}
         disabled={processing}
         value={draft}
@@ -96,6 +101,7 @@ export function FilterValueInput({
         <button
           type="button"
           aria-label={`Clear ${label} filter`}
+          data-test={testId ? `${testId}-clear` : undefined}
           className="absolute right-1 inline-flex size-6 items-center justify-center rounded hover:bg-lt-muted disabled:opacity-50"
           disabled={processing}
           onClick={onClear}

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import type { FilterType } from "@lattice/lattice/types/generated";
 
 const baseClass =
-  "h-9 w-full rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal";
+  "h-9 w-full min-w-0 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal";
 
 export function FilterValueInput({
   type,
@@ -11,6 +11,7 @@ export function FilterValueInput({
   value,
   processing,
   withSearchIcon = false,
+  grouped = false,
   ariaLabel,
   onCommit,
   onClear,
@@ -20,12 +21,14 @@ export function FilterValueInput({
   value: string;
   processing: boolean;
   withSearchIcon?: boolean;
+  grouped?: boolean;
   ariaLabel?: string;
   onCommit: (value: string) => void;
   onClear?: () => void;
 }) {
   const [draft, setDraft] = useState(value);
   const inputLabel = ariaLabel ?? `Filter ${label}`;
+  const groupedClass = grouped ? "rounded-r-none" : "";
 
   useEffect(() => {
     setDraft(value);
@@ -35,7 +38,7 @@ export function FilterValueInput({
     return (
       <select
         aria-label={inputLabel}
-        className={baseClass}
+        className={`${baseClass} ${groupedClass}`}
         disabled={processing}
         value={value}
         onChange={(event) => onCommit(event.target.value)}
@@ -52,7 +55,7 @@ export function FilterValueInput({
       <input
         type="date"
         aria-label={inputLabel}
-        className={baseClass}
+        className={`${baseClass} ${groupedClass}`}
         disabled={processing}
         value={draft}
         onChange={(event) => {
@@ -64,7 +67,7 @@ export function FilterValueInput({
   }
 
   return (
-    <div className="relative flex items-center">
+    <div className="relative flex w-full min-w-0 items-center">
       {withSearchIcon && (
         <Search
           aria-hidden="true"
@@ -74,7 +77,7 @@ export function FilterValueInput({
       <input
         type={type === "number" ? "number" : "text"}
         aria-label={inputLabel}
-        className={`${baseClass} ${withSearchIcon ? "pl-8" : ""} ${onClear ? "pr-8" : ""}`}
+        className={`${baseClass} ${groupedClass} ${withSearchIcon ? "pl-8" : ""} ${onClear ? "pr-8" : ""}`}
         disabled={processing}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -35,6 +35,7 @@ export function TablePagination({
           {pagination.hasMore ? (
             <button
               type="button"
+              data-test="pagination-load-more"
               className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
               disabled={processing}
               onClick={onLoadMore}
@@ -49,6 +50,7 @@ export function TablePagination({
         <div className="flex items-center gap-2">
           <button
             type="button"
+            data-test="pagination-previous"
             className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || currentPage <= 1}
             onClick={() => onPage(currentPage - 1)}
@@ -57,6 +59,7 @@ export function TablePagination({
           </button>
           <button
             type="button"
+            data-test="pagination-next"
             className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || !hasNextPage}
             onClick={() => onPage(currentPage + 1)}
@@ -68,6 +71,7 @@ export function TablePagination({
         <div className="flex items-center gap-2">
           <button
             type="button"
+            data-test="pagination-previous"
             className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || currentPage <= 1}
             onClick={() => onPage(currentPage - 1)}
@@ -78,6 +82,7 @@ export function TablePagination({
             <button
               key={pageNumber}
               type="button"
+              data-test={`pagination-page-${pageNumber}`}
               className="inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border font-medium disabled:opacity-50"
               disabled={processing || pageNumber === currentPage}
               aria-current={pageNumber === currentPage ? "page" : undefined}
@@ -89,6 +94,7 @@ export function TablePagination({
           ))}
           <button
             type="button"
+            data-test="pagination-next"
             className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || !hasNextPage}
             onClick={() => onPage(currentPage + 1)}

--- a/resources/js/table/components/table-cell.tsx
+++ b/resources/js/table/components/table-cell.tsx
@@ -69,6 +69,7 @@ function TextCell({ column, row, value }: { column: TableColumn; row: TableRow; 
       <span>{content}</span>
       <button
         type="button"
+        data-test={`copy-${column.key}`}
         className="inline-flex items-center gap-1 rounded border border-lt-border px-2 py-1 text-xs"
         aria-label={`${copied ? "Copied" : "Copy"} ${column.label}`}
         onClick={handleCopy}

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -132,7 +132,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                 className="px-4 py-3 text-right align-middle font-medium text-lt-muted-fg"
                 role="columnheader"
               >
-                Actions
+                <span className="sr-only">Actions</span>
               </div>
             )}
           </div>

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -101,7 +101,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
           onClear={clearSort}
         />
       )}
-      <div className="w-max min-w-full text-sm" role="table">
+      <div className="min-w-full text-sm" role="table">
         <div className="border-b border-lt-border bg-lt-muted/50" role="rowgroup">
           <div
             className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
@@ -144,7 +144,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
             >
               {hasBulkActions && <div className="px-4 py-2" role="cell" />}
               {columns.map((column) => (
-                <div key={column.key} className="px-4 py-2" role="cell">
+                <div key={column.key} className="min-w-0 px-2 py-2" role="cell">
                   {column.filter?.enabled && (
                     <ColumnFilterControl
                       column={column}
@@ -188,14 +188,20 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                     </div>
                   )}
                   {columns.map((column) => (
-                    <div key={column.key} className="grid gap-1 p-4 align-middle" role="cell">
+                    <div
+                      key={column.key}
+                      className="grid min-w-0 gap-1 p-4 align-middle"
+                      role="cell"
+                    >
                       <span
                         aria-hidden="true"
                         className="text-xs font-medium text-lt-muted-fg md:hidden"
                       >
                         {column.label}
                       </span>
-                      <ColumnCell column={column} row={row} />
+                      <div className="min-w-0 truncate">
+                        <ColumnCell column={column} row={row} />
+                      </div>
                     </div>
                   ))}
                   {actions.length > 0 && (

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -124,15 +124,19 @@ export function getColumnGridTemplate(
   hasSelection: boolean,
 ): string {
   const tracks: string[] = columns.map((column) =>
-    column.type === "stack" ? "minmax(16rem, 2fr)" : "minmax(9rem, 1fr)",
+    column.type === "stack" ? "minmax(13rem, 2fr)" : "minmax(7rem, 1fr)",
   );
 
+  // Selection and action tracks use fixed widths, not max-content: the header,
+  // filter, and body rows are independent grids, so a content-sized track would
+  // resolve to a different width in each one, changing the free space left for
+  // the 1fr columns and drifting them out of alignment across rows.
   if (hasActions) {
-    tracks.push("max-content");
+    tracks.push("10rem");
   }
 
   if (hasSelection) {
-    tracks.unshift("max-content");
+    tracks.unshift("3rem");
   }
 
   return tracks.join(" ");

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -407,6 +407,12 @@ export type LayoutNode =
       type: "outlet";
       key?: string;
       props: Outlet;
+    }
+  | {
+      type: "sidebar";
+      key?: string;
+      props: Sidebar;
+      schema?: Node[];
     };
 export type Link = {
   href: string | null;
@@ -580,6 +586,7 @@ export type Select = {
   searchable: boolean | null;
   value: any;
 };
+export type Sidebar = object;
 export type SortDirection = "asc" | "desc";
 export type Stack = {
   align: Align | null;
@@ -681,4 +688,4 @@ export type ToastEffect = {
   readonly message: string;
 };
 export type ToastVariant = "success" | "info" | "warning" | "error";
-export type Width = "full" | "sm" | "md" | "lg";
+export type Width = "full" | "sm" | "md" | "lg" | "fill";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -586,7 +586,10 @@ export type Select = {
   searchable: boolean | null;
   value: any;
 };
-export type Sidebar = object;
+export type Sidebar = {
+  collapsible: boolean;
+  rememberState: boolean;
+};
 export type SortDirection = "asc" | "desc";
 export type Stack = {
   align: Align | null;

--- a/src/Core/Enums/Width.php
+++ b/src/Core/Enums/Width.php
@@ -8,4 +8,5 @@ enum Width: string
     case Small = 'sm';
     case Medium = 'md';
     case Large = 'lg';
+    case Fill = 'fill';
 }

--- a/src/Layouts/Components/MenuItem.php
+++ b/src/Layouts/Components/MenuItem.php
@@ -71,6 +71,10 @@ class MenuItem extends ContainerComponent
 
     public function href(string $href): static
     {
+        if ($this->children !== []) {
+            throw new InvalidArgumentException('A menu item with children cannot be a link; only non-link items can hold a collapsible submenu.');
+        }
+
         $this->href = $href;
 
         return $this;
@@ -95,6 +99,10 @@ class MenuItem extends ContainerComponent
      */
     public function children(array $children): static
     {
+        if ($this->href !== null) {
+            throw new InvalidArgumentException('A link menu item cannot have children; only non-link items can hold a collapsible submenu.');
+        }
+
         return $this->schema($children);
     }
 

--- a/src/Layouts/Components/Sidebar.php
+++ b/src/Layouts/Components/Sidebar.php
@@ -15,9 +15,21 @@ use Lattice\Lattice\Core\Components\ContainerComponent;
 #[Attributes\Component('sidebar')]
 class Sidebar extends ContainerComponent
 {
+    public bool $collapsible = false;
+
+    public bool $rememberState = true;
+
     public static function make(?string $key = null): static
     {
         return new static($key);
+    }
+
+    public function collapsible(bool $collapsible = true, bool $rememberState = true): static
+    {
+        $this->collapsible = $collapsible;
+        $this->rememberState = $rememberState;
+
+        return $this;
     }
 
     /**

--- a/src/Layouts/Components/Sidebar.php
+++ b/src/Layouts/Components/Sidebar.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Layouts\Components;
+
+use Lattice\Lattice\Attributes;
+use Lattice\Lattice\Core\Components\Component;
+use Lattice\Lattice\Core\Components\ContainerComponent;
+
+/**
+ * A fixed-width navigation column rendered alongside the page content in a
+ * layout schema.
+ */
+#[Attributes\Component('sidebar')]
+class Sidebar extends ContainerComponent
+{
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+
+    /**
+     * @param  array<int, Component>  $components
+     */
+    public function items(array $components): static
+    {
+        return $this->schema($components);
+    }
+}

--- a/tests/Browser/LatticePageTest.php
+++ b/tests/Browser/LatticePageTest.php
@@ -41,12 +41,12 @@ it('sorts workbench users in the table', function (): void {
     seedWorkbenchUsers();
 
     visit('/')
-        ->click('Sort Name')
+        ->click('@sort-name')
         ->assertSee('1. Name')
         ->assertSee('Ada Lovelace')
         ->assertSee('Browser User 26')
         ->assertDontSee('Maya Chen')
-        ->click('Sort Email')
+        ->click('@sort-email')
         ->assertSee('2. Email')
         ->click('@clear-name-sort')
         ->assertDontSee('1. Name')

--- a/tests/Feature/LatticeMenuTest.php
+++ b/tests/Feature/LatticeMenuTest.php
@@ -110,3 +110,15 @@ test('fromPage rejects a page without a registered route', function () {
     expect(fn () => MenuItem::fromPage(MenuProductsPage::class))
         ->toThrow(InvalidArgumentException::class);
 });
+
+test('a link menu item cannot be given children', function () {
+    expect(fn () => MenuItem::make('Account')->href('/account')->children([
+        MenuItem::make('Profile')->href('/profile'),
+    ]))->toThrow(InvalidArgumentException::class);
+});
+
+test('a menu item with children cannot become a link', function () {
+    expect(fn () => MenuItem::make('Account')->children([
+        MenuItem::make('Profile')->href('/profile'),
+    ])->href('/account'))->toThrow(InvalidArgumentException::class);
+});

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -15,10 +15,13 @@ use Lattice\Lattice\Layouts\Components\Menu;
 use Lattice\Lattice\Layouts\Components\MenuItem;
 use Lattice\Lattice\Layouts\Components\Outlet;
 use Lattice\Lattice\Layouts\LayoutDefinition;
+use Workbench\App\Pages\DependentDemoPage;
 use Workbench\App\Pages\HomePage;
+use Workbench\App\Pages\ProductCreatePage;
 use Workbench\App\Pages\ProductsPage;
 use Workbench\App\Pages\ShowcasePage;
 use Workbench\App\Pages\TablesPage;
+use Workbench\App\Pages\TabsPage;
 
 #[Layout('app')]
 final class AppLayout extends LayoutDefinition
@@ -35,10 +38,17 @@ final class AppLayout extends LayoutDefinition
                         ->schema([
                             Heading::make('Lattice', 2),
                             Menu::make('sidebar')->items([
-                                MenuItem::fromPage(HomePage::class)->icon(LucideIcon::House),
-                                MenuItem::fromPage(TablesPage::class)->icon(LucideIcon::Table),
-                                MenuItem::fromPage(ProductsPage::class)->icon(LucideIcon::Package),
-                                MenuItem::fromPage(ShowcasePage::class)->label('Form Showcase')->icon(LucideIcon::FormInput),
+                                MenuItem::fromPage(HomePage::class)->label('Home')->icon(LucideIcon::House),
+                                MenuItem::make('Forms')->icon(LucideIcon::FormInput)->children([
+                                    MenuItem::fromPage(ShowcasePage::class)->label('Showcase'),
+                                    MenuItem::fromPage(DependentDemoPage::class)->label('Dependent Fields'),
+                                    MenuItem::fromPage(ProductCreatePage::class)->label('Create Product'),
+                                ]),
+                                MenuItem::make('Tables')->icon(LucideIcon::Table)->children([
+                                    MenuItem::fromPage(ProductsPage::class)->label('Products'),
+                                    MenuItem::fromPage(TablesPage::class)->label('Pagination Modes'),
+                                ]),
+                                MenuItem::fromPage(TabsPage::class)->label('Tabs')->icon(LucideIcon::PanelsTopLeft),
                             ]),
                         ]),
                     Stack::make('app-main')

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -6,7 +6,6 @@ namespace Workbench\App\Layouts;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Layout;
-use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\LucideIcon;
 use Lattice\Lattice\Core\Enums\Width;
@@ -33,8 +32,7 @@ final class AppLayout extends LayoutDefinition
             Stack::make('app-shell')
                 ->direction('row')
                 ->schema([
-                    Sidebar::make('app-sidebar')->items([
-                        Heading::make('Lattice', 2),
+                    Sidebar::make('app-sidebar')->collapsible()->items([
                         Menu::make('sidebar')->items([
                             MenuItem::fromPage(HomePage::class)->label('Home')->icon(LucideIcon::House),
                             MenuItem::make('Forms')->icon(LucideIcon::FormInput)->children([

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -8,12 +8,13 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Layout;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
-use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\LucideIcon;
+use Lattice\Lattice\Core\Enums\Width;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Layouts\Components\Menu;
 use Lattice\Lattice\Layouts\Components\MenuItem;
 use Lattice\Lattice\Layouts\Components\Outlet;
+use Lattice\Lattice\Layouts\Components\Sidebar;
 use Lattice\Lattice\Layouts\LayoutDefinition;
 use Workbench\App\Pages\DependentDemoPage;
 use Workbench\App\Pages\HomePage;
@@ -31,27 +32,25 @@ final class AppLayout extends LayoutDefinition
         return $schema->schema([
             Stack::make('app-shell')
                 ->direction('row')
-                ->gap(Gap::ExtraLarge)
                 ->schema([
-                    Stack::make('app-sidebar')
-                        ->gap(Gap::Small)
-                        ->schema([
-                            Heading::make('Lattice', 2),
-                            Menu::make('sidebar')->items([
-                                MenuItem::fromPage(HomePage::class)->label('Home')->icon(LucideIcon::House),
-                                MenuItem::make('Forms')->icon(LucideIcon::FormInput)->children([
-                                    MenuItem::fromPage(ShowcasePage::class)->label('Showcase'),
-                                    MenuItem::fromPage(DependentDemoPage::class)->label('Dependent Fields'),
-                                    MenuItem::fromPage(ProductCreatePage::class)->label('Create Product'),
-                                ]),
-                                MenuItem::make('Tables')->icon(LucideIcon::Table)->children([
-                                    MenuItem::fromPage(ProductsPage::class)->label('Products'),
-                                    MenuItem::fromPage(TablesPage::class)->label('Pagination Modes'),
-                                ]),
-                                MenuItem::fromPage(TabsPage::class)->label('Tabs')->icon(LucideIcon::PanelsTopLeft),
+                    Sidebar::make('app-sidebar')->items([
+                        Heading::make('Lattice', 2),
+                        Menu::make('sidebar')->items([
+                            MenuItem::fromPage(HomePage::class)->label('Home')->icon(LucideIcon::House),
+                            MenuItem::make('Forms')->icon(LucideIcon::FormInput)->children([
+                                MenuItem::fromPage(ShowcasePage::class)->label('Showcase'),
+                                MenuItem::fromPage(DependentDemoPage::class)->label('Dependent Fields'),
+                                MenuItem::fromPage(ProductCreatePage::class)->label('Create Product'),
                             ]),
+                            MenuItem::make('Tables')->icon(LucideIcon::Table)->children([
+                                MenuItem::fromPage(ProductsPage::class)->label('Products'),
+                                MenuItem::fromPage(TablesPage::class)->label('Pagination Modes'),
+                            ]),
+                            MenuItem::fromPage(TabsPage::class)->label('Tabs')->icon(LucideIcon::PanelsTopLeft),
                         ]),
+                    ]),
                     Stack::make('app-main')
+                        ->width(Width::Fill)
                         ->schema([
                             Outlet::make(),
                         ]),

--- a/workbench/app/Pages/DependentDemoPage.php
+++ b/workbench/app/Pages/DependentDemoPage.php
@@ -10,10 +10,9 @@ use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
-use Lattice\Lattice\Http\Page;
 use Workbench\App\Forms\DependentDemoForm;
 
-class DependentDemoPage extends Page
+class DependentDemoPage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/HomePage.php
+++ b/workbench/app/Pages/HomePage.php
@@ -11,28 +11,15 @@ use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Gap;
-use Lattice\Lattice\Core\Enums\PageContainer;
-use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Tables\Components\Table;
 use Workbench\App\Tables\UsersTable;
 
-final class HomePage extends Page
+final class HomePage extends WorkbenchPage
 {
     public function title(): string
     {
         return 'Lattice Workbench';
-    }
-
-    public function layout(): PageLayout
-    {
-        return PageLayout::App;
-    }
-
-    public function container(): PageContainer
-    {
-        return PageContainer::Default;
     }
 
     public function render(PageSchema $schema): PageSchema

--- a/workbench/app/Pages/ProductCreatePage.php
+++ b/workbench/app/Pages/ProductCreatePage.php
@@ -10,10 +10,9 @@ use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
-use Lattice\Lattice\Http\Page;
 use Workbench\App\Forms\ProductForm;
 
-class ProductCreatePage extends Page
+class ProductCreatePage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -10,11 +10,10 @@ use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
-use Lattice\Lattice\Http\Page;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\Product;
 
-class ProductEditPage extends Page
+class ProductEditPage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/ProductsPage.php
+++ b/workbench/app/Pages/ProductsPage.php
@@ -10,11 +10,10 @@ use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Align;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Tables\Components\Table;
 use Workbench\App\Tables\ProductsTable;
 
-class ProductsPage extends Page
+class ProductsPage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/ShowcasePage.php
+++ b/workbench/app/Pages/ShowcasePage.php
@@ -10,10 +10,9 @@ use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
-use Lattice\Lattice\Http\Page;
 use Workbench\App\Forms\ShowcaseForm;
 
-class ShowcasePage extends Page
+class ShowcasePage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/TablesPage.php
+++ b/workbench/app/Pages/TablesPage.php
@@ -12,14 +12,13 @@ use Lattice\Lattice\Core\Components\Tabs;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Tables\Components\Table;
 use Workbench\App\Tables\UsersInfiniteTable;
 use Workbench\App\Tables\UsersNoneTable;
 use Workbench\App\Tables\UsersSimpleTable;
 use Workbench\App\Tables\UsersTablePaginationTable;
 
-final class TablesPage extends Page
+final class TablesPage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/TabsPage.php
+++ b/workbench/app/Pages/TabsPage.php
@@ -12,9 +12,8 @@ use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\Orientation;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Page;
 
-final class TabsPage extends Page
+final class TabsPage extends WorkbenchPage
 {
     public function title(): string
     {

--- a/workbench/app/Pages/WorkbenchPage.php
+++ b/workbench/app/Pages/WorkbenchPage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Http\Page;
+
+abstract class WorkbenchPage extends Page
+{
+    public function layout(): PageLayout
+    {
+        return PageLayout::App;
+    }
+
+    public function container(): PageContainer
+    {
+        return PageContainer::Default;
+    }
+}

--- a/workbench/resources/css/app.css
+++ b/workbench/resources/css/app.css
@@ -54,7 +54,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.87 0 0);
@@ -77,7 +77,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);

--- a/workbench/resources/js/app.tsx
+++ b/workbench/resources/js/app.tsx
@@ -1,28 +1,22 @@
 import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
-import { createColumnRegistry, createLayoutResolver, Provider, registry } from "@lattice/lattice";
-import type { ComponentType } from "react";
+import {
+  createColumnRegistry,
+  createLayoutResolver,
+  createPageResolver,
+  IconRendererProvider,
+  Provider,
+  registry,
+} from "@lattice/lattice";
 import { createRoot } from "react-dom/client";
-import LatticePage from "@lattice/lattice/page";
 import { appColumns } from "./lattice/columns";
-
-type PageModule = { default: ComponentType<any> };
-
-const workbenchPages = import.meta.glob<PageModule>("./Pages/**/*.tsx", {
-  eager: true,
-});
+import { appIcons } from "./lattice/icons";
 
 const columns = createColumnRegistry(appColumns);
 
 createInertiaApp({
   strictMode: true,
-  resolve: (name: string): PageModule => {
-    if (name === "lattice/page") {
-      return { default: LatticePage };
-    }
-
-    return workbenchPages[`./Pages/${name}.tsx`];
-  },
+  resolve: createPageResolver({}),
   layout: createLayoutResolver(),
   setup({ el, App, props }) {
     if (!el) {
@@ -31,7 +25,9 @@ createInertiaApp({
 
     createRoot(el).render(
       <Provider registry={registry} columns={columns}>
-        <App {...props} />
+        <IconRendererProvider renderer={appIcons}>
+          <App {...props} />
+        </IconRendererProvider>
       </Provider>,
     );
   },

--- a/workbench/resources/js/lattice/icons.tsx
+++ b/workbench/resources/js/lattice/icons.tsx
@@ -1,0 +1,19 @@
+import { FormInput, House, PanelsTopLeft, Table } from "lucide-react";
+import type { IconRendererFunction } from "@lattice/lattice";
+
+const icons = {
+  house: House,
+  "form-input": FormInput,
+  table: Table,
+  "panels-top-left": PanelsTopLeft,
+};
+
+export const appIcons: IconRendererFunction = ({ className, icon }) => {
+  const Icon = icons[icon as keyof typeof icons];
+
+  if (!Icon) {
+    return null;
+  }
+
+  return <Icon aria-hidden="true" className={className} />;
+};


### PR DESCRIPTION
## What & why

Give the workbench a real, collapsible sidebar with grouped navigation, add the package layout primitives that power it, and fix several table layout/styling issues surfaced along the way.

## Package — layout primitives
- **`Sidebar` component**: a fixed-width `<aside>` (`shrink-0`), plus `Width::Fill` (`flex-1 min-w-0`) for the main pane, so a layout can express a true sidebar + flexible content shell.
- **Collapsible sidebar** (`Sidebar::collapsible(bool $collapsible = true, bool $rememberState = true)`): server declares the capability; the client owns the collapsed state and persists it to `localStorage` (keyed by id) when `rememberState` is on. Collapses to a `w-16` icon rail; in the rail, links render icon-only and groups open their submenu as a **flyout** (rendered through a portal so it is never clipped).
- **Collapsible menu groups** (`MenuItem`): non-link items with children render as a collapsible toggle (auto-open when they contain the active route); links and submenus are mutually exclusive (enforced in PHP).

## Package — table fixes
- Header, filter, and body rows are independent grids; gave selection/action columns fixed widths (not `max-content`) and let cells shrink (`min-w-0` + truncation) so the `1fr` columns no longer drift out of alignment.
- Compact column filter: narrower input with the filter button attached as a suffix, capped width so inputs don't stretch with the column.
- Dropped `w-max` and trimmed default column min-width so more columns fit without horizontal scrolling.
- Headers show the plain column label (the "Sort" affordance moved to the sort button's `aria-label`); the Actions header is screen-reader-only.

## Workbench
- Grouped sidebar menu: `Home`, a `Forms` group, a `Tables` group, and `Tabs`.
- `WorkbenchPage` base so every page uses the app layout + full-width container.
- Registered the menu's Lucide icons via `IconRendererProvider`; `app.tsx` resolves pages with `createPageResolver`.
- Fixed the destructive theme token (`--destructive-foreground` was the same red as the background, making Archive button text invisible).

## Verification
- PHP feature/unit: 288 passed · larastan: no errors · Pint: passed
- vitest: 161 passed · `tsc`: clean · oxlint + oxfmt: clean
- Verified in-browser: grouped + collapsible sidebar, icon rail with flyout submenus, aligned table with compact filters, clean headers, readable destructive buttons.