### PR TITLE
feat: form-in-action — modal forms on actions

### DIFF
--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -1,0 +1,129 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRegistry, Renderer } from "@lattice/lattice";
+import type { Node } from "@lattice/lattice";
+import { formComponents } from "@lattice/lattice/form";
+import { actionComponents } from "../index";
+
+vi.mock("@inertiajs/react", () => ({
+  router: { reload: vi.fn<() => void>(), visit: vi.fn<() => void>() },
+  useHttp: () => ({
+    delete: vi.fn<() => void>(),
+    get: vi.fn<() => void>(),
+    patch: vi.fn<() => void>(),
+    post: vi.fn<() => void>(),
+    processing: false,
+    put: vi.fn<() => void>(),
+  }),
+  Form: ({ children }: { children: ReactNode }) => <form>{children}</form>,
+  Link: ({ children, ...props }: { children: ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+type FetchMock = (input: string, init: RequestInit) => Promise<Response>;
+
+function rejectAction(precognitive = false): Node {
+  return {
+    id: "test.reject",
+    type: "action",
+    props: {
+      confirmation: { confirmLabel: "Submit", title: "Reject item?" },
+      endpoint: "/lattice/actions/test.reject",
+      form: {
+        id: "test.reject-form",
+        props: { precognitive },
+        schema: [
+          { key: "reason", props: { label: "Reason", name: "reason" }, type: "form.text-input" },
+        ],
+        type: "form",
+      },
+      label: "Reject",
+      method: "post",
+      ref: "sealed-ref",
+    },
+  } as unknown as Node;
+}
+
+function renderAction(node: Node) {
+  return render(
+    <Renderer nodes={[node]} registry={createRegistry(actionComponents, formComponents)} />,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("action form modal", () => {
+  it("collects the form values and posts them to the action endpoint", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => ({ effects: [], ok: true }),
+      ok: true,
+      status: 200,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(rejectAction());
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+
+    fireEvent.change(await screen.findByRole("textbox", { name: "Reason" }), {
+      target: { value: "spam" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const [url, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+    expect(url).toBe("/lattice/actions/test.reject");
+    expect(JSON.parse(init.body as string)).toMatchObject({ reason: "spam" });
+    expect((init.headers as Record<string, string>)["X-Lattice-Ref"]).toBe("sealed-ref");
+
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox", { name: "Reason" })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("shows server validation errors returned on submit", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => ({ errors: { reason: ["The Reason field is required."] } }),
+      ok: false,
+      status: 422,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(rejectAction());
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Submit" }));
+
+    expect(await screen.findByText("The Reason field is required.")).toBeVisible();
+  });
+
+  it("validates precognitively as the user types", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn<FetchMock>()
+      .mockResolvedValue({ json: async () => ({}), ok: true, status: 204 } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(rejectAction(true));
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Reason" }), { target: { value: "x" } });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const [, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Precognition).toBe("true");
+    expect(headers["Precognition-Validate-Only"]).toBe("reason");
+  });
+});

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -1,0 +1,279 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import { Button } from "@lattice/lattice/core/components/button";
+import { Spinner } from "@lattice/lattice/core/components/spinner";
+import { Renderer, useRendererContext } from "@lattice/lattice/core/renderer";
+import type { Node } from "@lattice/lattice/core/types";
+import { FormProvider } from "@lattice/lattice/form/components/context";
+import { walkFields } from "@lattice/lattice/form/components/field-props";
+import { FORM_DEBOUNCE_MS, xsrfToken } from "@lattice/lattice/form/components/form-transport";
+import { FormValuesProvider, useFormValues } from "@lattice/lattice/form/components/values";
+import { dispatchActionError } from "../effects";
+import type { ActionResponse } from "../effects";
+
+type FieldErrors = Record<string, string | undefined>;
+
+type ActionFormProps = {
+  cancelLabel: string;
+  componentRef: string;
+  description?: string;
+  endpoint: string;
+  /** Extra payload merged into every request, e.g. a bulk action's selection. */
+  extraData?: Record<string, unknown>;
+  formNode: Node;
+  method: string;
+  onClose: () => void;
+  onSuccess: (response: ActionResponse) => void;
+  submitLabel: string;
+  title: string;
+};
+
+function firstErrors(errors: Record<string, string[] | string> | undefined): FieldErrors {
+  const result: FieldErrors = {};
+
+  for (const [key, value] of Object.entries(errors ?? {})) {
+    result[key] = Array.isArray(value) ? value[0] : value;
+  }
+
+  return result;
+}
+
+function collectInitialValues(formNode: Node): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+
+  walkFields(formNode.schema, (props) => {
+    if (props.name && props.value !== undefined) {
+      values[props.name] = props.value;
+    }
+  });
+
+  return { ...values, ...(formNode.props?.state as Record<string, unknown> | undefined) };
+}
+
+function collectLabels(formNode: Node): Record<string, string> {
+  const labels: Record<string, string> = {};
+
+  walkFields(formNode.schema, (props) => {
+    if (props.name && props.label) {
+      labels[props.name] = props.label;
+    }
+  });
+
+  return labels;
+}
+
+function ActionFormBody({
+  cancelLabel,
+  componentRef,
+  endpoint,
+  extraData,
+  fieldLabels,
+  formNode,
+  method,
+  onClose,
+  onSuccess,
+  precognitive,
+  submitLabel,
+}: Omit<ActionFormProps, "description" | "title"> & {
+  fieldLabels: Record<string, string>;
+  precognitive: boolean;
+}) {
+  const { fallback, missingComponent, registry } = useRendererContext();
+  const values = useFormValues();
+  // fetch only upper-cases the standardized methods, leaving PATCH/DELETE as
+  // given; some servers reject a lower-case method line, so normalize it here.
+  const httpMethod = method.toUpperCase();
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+  const extraDataRef = useRef(extraData);
+  extraDataRef.current = extraData;
+
+  const requestBody = useCallback(
+    () => JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
+    [],
+  );
+
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [processing, setProcessing] = useState(false);
+  const timer = useRef<number | undefined>(undefined);
+
+  const headers = useCallback(
+    (extra: Record<string, string> = {}): Record<string, string> => ({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+      "X-XSRF-TOKEN": xsrfToken(),
+      ...withRefHeader(componentRef),
+      ...extra,
+    }),
+    [componentRef],
+  );
+
+  const clearErrors = useCallback((field: string) => {
+    setErrors((current) =>
+      current[field] === undefined ? current : { ...current, [field]: undefined },
+    );
+  }, []);
+
+  const validate = useCallback(
+    (field: string) => {
+      if (!precognitive) {
+        return;
+      }
+
+      window.clearTimeout(timer.current);
+      timer.current = window.setTimeout(() => {
+        void fetch(endpoint, {
+          body: requestBody(),
+          credentials: "same-origin",
+          headers: headers({ Precognition: "true", "Precognition-Validate-Only": field }),
+          method: httpMethod,
+        })
+          .then(async (response) => {
+            if (response.status === 422) {
+              const body = (await response.json()) as { errors?: Record<string, string[]> };
+              setErrors((current) => ({ ...current, ...firstErrors(body.errors) }));
+
+              return;
+            }
+
+            clearErrors(field);
+          })
+          .catch(() => {});
+      }, FORM_DEBOUNCE_MS);
+    },
+    [clearErrors, endpoint, headers, httpMethod, precognitive, requestBody],
+  );
+
+  const submit = useCallback(() => {
+    setProcessing(true);
+
+    void fetch(endpoint, {
+      body: requestBody(),
+      credentials: "same-origin",
+      headers: headers(),
+      method: httpMethod,
+    })
+      .then(async (response) => {
+        if (response.status === 422) {
+          const body = (await response.json()) as { errors?: Record<string, string[]> };
+          setErrors(firstErrors(body.errors));
+
+          return;
+        }
+
+        if (!response.ok) {
+          dispatchActionError(new Error(`Action request failed with status ${response.status}`));
+
+          return;
+        }
+
+        onSuccess((await response.json()) as ActionResponse);
+      })
+      .catch((error: unknown) => dispatchActionError(error))
+      .finally(() => setProcessing(false));
+  }, [endpoint, headers, httpMethod, onSuccess, requestBody]);
+
+  const context = useMemo(
+    () => ({
+      action: endpoint,
+      clearErrors,
+      componentRef,
+      errors,
+      fieldLabels,
+      precognitive,
+      processing,
+      validate,
+    }),
+    [clearErrors, componentRef, endpoint, errors, fieldLabels, precognitive, processing, validate],
+  );
+
+  return (
+    <FormProvider value={context}>
+      <form
+        className="flex flex-col gap-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+      >
+        <Renderer
+          fallback={fallback}
+          missingComponent={missingComponent}
+          nodes={formNode.schema ?? []}
+          registry={registry}
+        />
+
+        <div className="flex justify-end gap-3">
+          <Button disabled={processing} onClick={onClose} type="button" variant="ghost">
+            {cancelLabel}
+          </Button>
+
+          <Button disabled={processing} type="submit">
+            {processing && <Spinner />}
+            {submitLabel}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}
+
+export function ActionForm({ description, formNode, onClose, title, ...rest }: ActionFormProps) {
+  const precognitive = Boolean(formNode.props?.precognitive);
+  const fieldLabels = useMemo(() => collectLabels(formNode), [formNode]);
+  const initialValues = useMemo(() => collectInitialValues(formNode), [formNode]);
+
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content
+          {...(description ? {} : { "aria-describedby": undefined })}
+          className="fixed left-1/2 top-1/2 z-50 max-h-[min(680px,calc(100vh-2rem))] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="grid gap-2">
+              <Dialog.Title className="text-lg font-semibold leading-none tracking-tight">
+                {title}
+              </Dialog.Title>
+
+              {description && (
+                <Dialog.Description className="text-sm text-lt-muted-fg">
+                  {description}
+                </Dialog.Description>
+              )}
+            </div>
+
+            <Dialog.Close asChild>
+              <Button aria-label="Close" size="icon" variant="ghost">
+                <X aria-hidden="true" className="size-4" />
+              </Button>
+            </Dialog.Close>
+          </div>
+
+          <div className="mt-6">
+            <FormValuesProvider initial={initialValues}>
+              <ActionFormBody
+                fieldLabels={fieldLabels}
+                formNode={formNode}
+                onClose={onClose}
+                precognitive={precognitive}
+                {...rest}
+              />
+            </FormValuesProvider>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -40,28 +40,31 @@ function firstErrors(errors: Record<string, string[] | string> | undefined): Fie
   return result;
 }
 
-function collectInitialValues(formNode: Node): Record<string, unknown> {
+type CollectedFields = {
+  labels: Record<string, string>;
+  values: Record<string, unknown>;
+};
+
+function collectFields(formNode: Node): CollectedFields {
+  const labels: Record<string, string> = {};
   const values: Record<string, unknown> = {};
 
   walkFields(formNode.schema, (props) => {
-    if (props.name && props.value !== undefined) {
+    if (!props.name) {
+      return;
+    }
+    if (props.label) {
+      labels[props.name] = props.label;
+    }
+    if (props.value !== undefined) {
       values[props.name] = props.value;
     }
   });
 
-  return { ...values, ...(formNode.props?.state as Record<string, unknown> | undefined) };
-}
-
-function collectLabels(formNode: Node): Record<string, string> {
-  const labels: Record<string, string> = {};
-
-  walkFields(formNode.schema, (props) => {
-    if (props.name && props.label) {
-      labels[props.name] = props.label;
-    }
-  });
-
-  return labels;
+  return {
+    labels,
+    values: { ...values, ...(formNode.props?.state as Record<string, unknown> | undefined) },
+  };
 }
 
 function ActionFormBody({
@@ -82,33 +85,33 @@ function ActionFormBody({
 }) {
   const { fallback, missingComponent, registry } = useRendererContext();
   const values = useFormValues();
-  // fetch only upper-cases the standardized methods, leaving PATCH/DELETE as
-  // given; some servers reject a lower-case method line, so normalize it here.
-  const httpMethod = method.toUpperCase();
   const valuesRef = useRef(values);
   valuesRef.current = values;
   const extraDataRef = useRef(extraData);
   extraDataRef.current = extraData;
 
-  const requestBody = useCallback(
-    () => JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
-    [],
-  );
-
   const [errors, setErrors] = useState<FieldErrors>({});
   const [processing, setProcessing] = useState(false);
   const timer = useRef<number | undefined>(undefined);
 
-  const headers = useCallback(
-    (extra: Record<string, string> = {}): Record<string, string> => ({
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "X-Requested-With": "XMLHttpRequest",
-      "X-XSRF-TOKEN": xsrfToken(),
-      ...withRefHeader(componentRef),
-      ...extra,
-    }),
-    [componentRef],
+  const request = useCallback(
+    (extraHeaders?: Record<string, string>): Promise<Response> =>
+      fetch(endpoint, {
+        body: JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
+        credentials: "same-origin",
+        // fetch only upper-cases the standardized methods, leaving PATCH/DELETE as
+        // given; some servers reject a lower-case method line, so normalize it.
+        method: method.toUpperCase(),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+          "X-XSRF-TOKEN": xsrfToken(),
+          ...withRefHeader(componentRef),
+          ...extraHeaders,
+        },
+      }),
+    [componentRef, endpoint, method],
   );
 
   const clearErrors = useCallback((field: string) => {
@@ -125,12 +128,7 @@ function ActionFormBody({
 
       window.clearTimeout(timer.current);
       timer.current = window.setTimeout(() => {
-        void fetch(endpoint, {
-          body: requestBody(),
-          credentials: "same-origin",
-          headers: headers({ Precognition: "true", "Precognition-Validate-Only": field }),
-          method: httpMethod,
-        })
+        void request({ Precognition: "true", "Precognition-Validate-Only": field })
           .then(async (response) => {
             if (response.status === 422) {
               const body = (await response.json()) as { errors?: Record<string, string[]> };
@@ -144,18 +142,13 @@ function ActionFormBody({
           .catch(() => {});
       }, FORM_DEBOUNCE_MS);
     },
-    [clearErrors, endpoint, headers, httpMethod, precognitive, requestBody],
+    [clearErrors, precognitive, request],
   );
 
   const submit = useCallback(() => {
     setProcessing(true);
 
-    void fetch(endpoint, {
-      body: requestBody(),
-      credentials: "same-origin",
-      headers: headers(),
-      method: httpMethod,
-    })
+    void request()
       .then(async (response) => {
         if (response.status === 422) {
           const body = (await response.json()) as { errors?: Record<string, string[]> };
@@ -174,7 +167,7 @@ function ActionFormBody({
       })
       .catch((error: unknown) => dispatchActionError(error))
       .finally(() => setProcessing(false));
-  }, [endpoint, headers, httpMethod, onSuccess, requestBody]);
+  }, [onSuccess, request]);
 
   const context = useMemo(
     () => ({
@@ -223,8 +216,10 @@ function ActionFormBody({
 
 export function ActionForm({ description, formNode, onClose, title, ...rest }: ActionFormProps) {
   const precognitive = Boolean(formNode.props?.precognitive);
-  const fieldLabels = useMemo(() => collectLabels(formNode), [formNode]);
-  const initialValues = useMemo(() => collectInitialValues(formNode), [formNode]);
+  const { labels: fieldLabels, values: initialValues } = useMemo(
+    () => collectFields(formNode),
+    [formNode],
+  );
 
   return (
     <Dialog.Root

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -5,10 +5,11 @@ import { withRefHeader } from "@lattice/lattice/core/component-ref";
 import { Button } from "@lattice/lattice/core/components/button";
 import { ConfirmDialog } from "@lattice/lattice/core/components/confirm-dialog";
 import { Spinner } from "@lattice/lattice/core/components/spinner";
-import type { RendererComponent } from "@lattice/lattice/core/types";
+import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { IconRenderer } from "@lattice/lattice/icons";
 import { dispatchActionEffects, dispatchActionError, getActionEffects } from "../effects";
 import type { ActionResponse } from "../effects";
+import { ActionForm } from "./action-form";
 
 const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const endpoint = node.props.endpoint ?? "";
@@ -18,8 +19,12 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const method: Method = node.props.method ?? "post";
   const http = useHttp<Record<string, never>, ActionResponse>({});
   const [isConfirming, setIsConfirming] = useState(false);
+  const [isFilling, setIsFilling] = useState(false);
   const confirmation = node.props.confirmation;
   const variant = node.props.variant ?? "default";
+  // The wire carries the embedded form as a full node; the generated prop type
+  // reflects Form's props, so read it through the Node lens the renderer uses.
+  const form = node.props.form as unknown as Node | null;
 
   const submit = async (): Promise<void> => {
     if (!endpoint) {
@@ -47,6 +52,12 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   };
 
   const requestSubmit = (): void => {
+    if (form) {
+      setIsFilling(true);
+
+      return;
+    }
+
     if (confirmation) {
       setIsConfirming(true);
 
@@ -84,6 +95,28 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
           confirmDisabled={!endpoint}
           onConfirm={() => void submit()}
           onCancel={() => setIsConfirming(false)}
+        />
+      )}
+
+      {isFilling && form && (
+        <ActionForm
+          cancelLabel={confirmationCancelLabel}
+          componentRef={componentRef}
+          description={confirmation?.description}
+          endpoint={endpoint}
+          formNode={form}
+          method={method}
+          onClose={() => setIsFilling(false)}
+          onSuccess={(response) => {
+            const responseEffects = getActionEffects(response.effects);
+
+            dispatchActionEffects(
+              responseEffects.length > 0 ? responseEffects : getActionEffects(node.props.effects),
+            );
+            setIsFilling(false);
+          }}
+          submitLabel={confirmationConfirmLabel}
+          title={confirmationTitle}
         />
       )}
     </>

--- a/resources/js/table/bulk.ts
+++ b/resources/js/table/bulk.ts
@@ -1,4 +1,5 @@
 import type { Method } from "@inertiajs/core";
+import type { Node } from "@lattice/lattice/core/types";
 import type { Action, ActionNode, ButtonVariant } from "@lattice/lattice/types/generated";
 
 export type BulkAction = {
@@ -9,6 +10,7 @@ export type BulkAction = {
   ref: string;
   variant: ButtonVariant;
   confirmation: Action["confirmation"];
+  form: Node | null;
 };
 
 export function getBulkActions(actions: ActionNode[] | undefined): BulkAction[] {
@@ -32,6 +34,7 @@ export function getBulkActions(actions: ActionNode[] | undefined): BulkAction[] 
         ref: props.ref ?? "",
         variant: props.variant ?? "default",
         confirmation: props.confirmation,
+        form: (props.form as unknown as Node | null) ?? null,
       },
     ];
   });

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -1,5 +1,6 @@
 import { useHttp } from "@inertiajs/react";
 import { useState } from "react";
+import { ActionForm } from "@lattice/lattice/action/components/action-form";
 import {
   dispatchActionEffects,
   dispatchActionError,
@@ -38,6 +39,10 @@ export function BulkBar({
 }) {
   const http = useHttp<BulkData, ActionResponse>({});
   const [confirming, setConfirming] = useState<BulkAction | null>(null);
+  const [filling, setFilling] = useState<BulkAction | null>(null);
+
+  const selectionPayload = (): Record<string, unknown> =>
+    allMatching ? { allMatching: true, ...query } : { selected: selectedKeys };
 
   async function submit(action: BulkAction): Promise<void> {
     try {
@@ -59,6 +64,12 @@ export function BulkBar({
   }
 
   function run(action: BulkAction): void {
+    if (action.form) {
+      setFilling(action);
+
+      return;
+    }
+
     if (action.confirmation) {
       setConfirming(action);
 
@@ -109,6 +120,26 @@ export function BulkBar({
           processing={http.processing}
           onConfirm={() => void submit(confirming)}
           onCancel={() => setConfirming(null)}
+        />
+      )}
+
+      {filling?.form && (
+        <ActionForm
+          cancelLabel={filling.confirmation?.cancelLabel ?? "Cancel"}
+          componentRef={filling.ref}
+          description={filling.confirmation?.description}
+          endpoint={filling.endpoint}
+          extraData={selectionPayload()}
+          formNode={filling.form}
+          method={filling.method}
+          onClose={() => setFilling(null)}
+          onSuccess={(response) => {
+            dispatchActionEffects(getActionEffects(response.effects));
+            setFilling(null);
+            onCompleted();
+          }}
+          submitLabel={filling.confirmation?.confirmLabel ?? filling.label}
+          title={filling.confirmation?.title ?? filling.label}
         />
       )}
     </div>

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -7,6 +7,7 @@ export type Action = {
   } | null;
   effects: Effect[];
   endpoint: string | null;
+  form: Form | null;
   icon: string | null;
   label: string | null;
   method: HttpMethod | null;
@@ -50,6 +51,7 @@ export type BulkAction = {
   } | null;
   effects: Effect[];
   endpoint: string | null;
+  form: Form | null;
   icon: string | null;
   label: string | null;
   method: HttpMethod | null;

--- a/src/Actions/ActionDefinition.php
+++ b/src/Actions/ActionDefinition.php
@@ -6,11 +6,14 @@ namespace Lattice\Lattice\Actions;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Concerns\ValidatesActionForm;
 use Lattice\Lattice\Actions\Contracts\ProvidesAction;
 use Lattice\Lattice\Core\Definition;
 
 abstract class ActionDefinition extends Definition implements ProvidesAction
 {
+    use ValidatesActionForm;
+
     abstract public function definition(Action $action): Action;
 
     abstract public function handle(Request $request): ActionResult;

--- a/src/Actions/BulkActionDefinition.php
+++ b/src/Actions/BulkActionDefinition.php
@@ -7,11 +7,14 @@ namespace Lattice\Lattice\Actions;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Concerns\ValidatesActionForm;
 use Lattice\Lattice\Actions\Contracts\ProvidesBulkAction;
 use Lattice\Lattice\Core\Definition;
 
 abstract class BulkActionDefinition extends Definition implements ProvidesBulkAction
 {
+    use ValidatesActionForm;
+
     abstract public function definition(Action $action): Action;
 
     /**

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -11,6 +11,8 @@ use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\IsInteractive;
 use Lattice\Lattice\Core\Concerns\HasHttpMethod;
 use Lattice\Lattice\Core\Concerns\HasVariant;
+use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\Components\Form;
 
 #[Attributes\Component('action')]
 class Action extends Component
@@ -34,6 +36,8 @@ class Action extends Component
      * @var array<int, Effect>
      */
     public array $effects = [];
+
+    public ?Form $form = null;
 
     public static function make(string $id): static
     {
@@ -94,6 +98,21 @@ class Action extends Component
     public function effects(array $effects): static
     {
         $this->effects = $effects;
+
+        return $this;
+    }
+
+    /**
+     * Attach a form schema rendered in a modal before the action runs. The
+     * collected values are posted to the action endpoint and validated server-side.
+     *
+     * @param  array<int, Field>  $fields
+     */
+    public function form(array $fields): static
+    {
+        $this->form = Form::make(($this->id ?? 'action').'-form')
+            ->schema($fields)
+            ->precognitive();
 
         return $this;
     }

--- a/src/Actions/Concerns/ValidatesActionForm.php
+++ b/src/Actions/Concerns/ValidatesActionForm.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Actions\Concerns;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Forms\FieldValidator;
+
+trait ValidatesActionForm
+{
+    /**
+     * Validate the request against this action's embedded form schema and return
+     * the validated, cast input. Returns an empty array when no form is attached.
+     *
+     * @return array<string, mixed>
+     */
+    public function validate(Request $request): array
+    {
+        $fields = $this->definition(Action::make('action'))->form?->fields() ?? collect();
+
+        return app(FieldValidator::class)->validate($fields, $request);
+    }
+}

--- a/src/Forms/FieldValidator.php
+++ b/src/Forms/FieldValidator.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms;
+
+use Illuminate\Contracts\Validation\Factory as ValidationFactory;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\Validator;
+use Lattice\Lattice\Forms\Components\Field;
+
+/**
+ * Single-pass validation for a list of form fields: resolves dependencies,
+ * evaluates visibility/locked state, builds the rule set, runs one validator
+ * (honoring precognition), and post-processes server/locked/cast values.
+ *
+ * Shared by FormDefinition and by actions that embed a form schema.
+ */
+final class FieldValidator
+{
+    /**
+     * @param  iterable<int, Field>  $fields
+     * @return array<string, mixed>
+     */
+    public function validate(iterable $fields, Request $request): array
+    {
+        $data = FormData::fromRequest($request);
+
+        /** @var Collection<int, Field> $fields */
+        $fields = collect($fields)->each(fn (Field $field) => $field->applyResolution($data, $request));
+
+        $input = $request->all();
+        $rules = [];
+        $messages = [];
+        $attributes = [];
+
+        /** @var array<int, array{field: Field, name: string, visible: bool, serverValue: bool, locked: bool}> $plan */
+        $plan = [];
+
+        foreach ($fields as $field) {
+            $name = $field->name();
+            $visible = $field->isVisible($data);
+            $locked = $field->isReadOnly($data) || $field->isDisabled($data);
+            $serverValue = $field->hasResolvedValue() || ($locked && $field->hasValue());
+
+            $plan[] = [
+                'field' => $field,
+                'name' => $name,
+                'visible' => $visible,
+                'serverValue' => $serverValue,
+                'locked' => $locked,
+            ];
+
+            if ($serverValue) {
+                $input[$name] = $field->resolvedValue();
+            }
+
+            if (! $visible) {
+                continue;
+            }
+
+            $fieldRules = $field->resolveRules($data, $request);
+
+            if ($field->isRequired($data) && ! in_array('required', $fieldRules, true)) {
+                array_unshift($fieldRules, 'required');
+            }
+
+            if ($fieldRules !== []) {
+                $rules[$name] = $fieldRules;
+            }
+
+            foreach ($field->messages() as $rule => $message) {
+                $messages["{$name}.{$rule}"] = $message;
+            }
+
+            if (($label = $field->getLabel()) !== null) {
+                $attributes[$name] = $label;
+            }
+        }
+
+        $validated = $this->validator($input, $rules, $messages, $attributes, $request)->validate();
+
+        foreach ($plan as ['field' => $field, 'name' => $name, 'visible' => $visible, 'serverValue' => $serverValue, 'locked' => $locked]) {
+            if (! $visible) {
+                unset($validated[$name]);
+
+                continue;
+            }
+
+            if ($serverValue) {
+                $validated[$name] = $field->resolvedValue();
+
+                continue;
+            }
+
+            if ($locked) {
+                unset($validated[$name]);
+
+                continue;
+            }
+
+            if (array_key_exists($name, $validated)) {
+                $validated[$name] = $field->castValue($validated[$name]);
+            }
+        }
+
+        return $validated;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  array<string, array<int, mixed>>  $rules
+     * @param  array<string, string>  $messages
+     * @param  array<string, string>  $attributes
+     */
+    protected function validator(array $input, array $rules, array $messages, array $attributes, Request $request): Validator
+    {
+        $validator = app(ValidationFactory::class)->make($input, $rules, $messages, $attributes);
+
+        if ($request->isPrecognitive()) {
+            $validator->setRules(
+                $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders()),
+            );
+        }
+
+        return $validator;
+    }
+}

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Forms;
 
 use Illuminate\Contracts\Support\Responsable;
-use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
-use Illuminate\Validation\Validator;
 use Lattice\Lattice\Core\Concerns\CreatesToastMessages;
 use Lattice\Lattice\Core\Definition;
 use Lattice\Lattice\Forms\Components\Field;
@@ -30,85 +27,10 @@ abstract class FormDefinition extends Definition implements ProvidesForm
      */
     public function validate(Request $request): array
     {
-        $data = FormData::fromRequest($request);
-        $fields = $this->resolvedFields($request, $data);
-
-        $input = $request->all();
-        $rules = [];
-        $messages = [];
-        $attributes = [];
-
-        /** @var array<int, array{field: Field, name: string, visible: bool, serverValue: bool, locked: bool}> $plan */
-        $plan = [];
-
-        foreach ($fields as $field) {
-            $name = $field->name();
-            $visible = $field->isVisible($data);
-            $locked = $field->isReadOnly($data) || $field->isDisabled($data);
-            $serverValue = $field->hasResolvedValue() || ($locked && $field->hasValue());
-
-            $plan[] = [
-                'field' => $field,
-                'name' => $name,
-                'visible' => $visible,
-                'serverValue' => $serverValue,
-                'locked' => $locked,
-            ];
-
-            if ($serverValue) {
-                $input[$name] = $field->resolvedValue();
-            }
-
-            if (! $visible) {
-                continue;
-            }
-
-            $fieldRules = $field->resolveRules($data, $request);
-
-            if ($field->isRequired($data) && ! in_array('required', $fieldRules, true)) {
-                array_unshift($fieldRules, 'required');
-            }
-
-            if ($fieldRules !== []) {
-                $rules[$name] = $fieldRules;
-            }
-
-            foreach ($field->messages() as $rule => $message) {
-                $messages["{$name}.{$rule}"] = $message;
-            }
-
-            if (($label = $field->getLabel()) !== null) {
-                $attributes[$name] = $label;
-            }
-        }
-
-        $validated = $this->validator($input, $rules, $messages, $attributes, $request)->validate();
-
-        foreach ($plan as ['field' => $field, 'name' => $name, 'visible' => $visible, 'serverValue' => $serverValue, 'locked' => $locked]) {
-            if (! $visible) {
-                unset($validated[$name]);
-
-                continue;
-            }
-
-            if ($serverValue) {
-                $validated[$name] = $field->resolvedValue();
-
-                continue;
-            }
-
-            if ($locked) {
-                unset($validated[$name]);
-
-                continue;
-            }
-
-            if (array_key_exists($name, $validated)) {
-                $validated[$name] = $field->castValue($validated[$name]);
-            }
-        }
-
-        return $validated;
+        return app(FieldValidator::class)->validate(
+            $this->buildForm($request)->fields(),
+            $request,
+        );
     }
 
     /**
@@ -159,42 +81,10 @@ abstract class FormDefinition extends Definition implements ProvidesForm
     }
 
     /**
-     * Build the form and run each field's resolution pass (dependsOn closures, value resolvers)
-     * so visibility, rules, and computed values reflect the current request data.
-     *
-     * @return Collection<int, Field>
-     */
-    protected function resolvedFields(Request $request, FormData $data): Collection
-    {
-        return $this->buildForm($request)
-            ->fields()
-            ->each(fn (Field $field) => $field->applyResolution($data, $request));
-    }
-
-    /**
      * Build this form's component tree for the current request.
      */
     protected function buildForm(Request $request): Form
     {
         return $this->definition(Form::make('form'), $request);
-    }
-
-    /**
-     * @param  array<string, mixed>  $input
-     * @param  array<string, array<int, mixed>>  $rules
-     * @param  array<string, string>  $messages
-     * @param  array<string, string>  $attributes
-     */
-    protected function validator(array $input, array $rules, array $messages, array $attributes, Request $request): Validator
-    {
-        $validator = app(ValidationFactory::class)->make($input, $rules, $messages, $attributes);
-
-        if ($request->isPrecognitive()) {
-            $validator->setRules(
-                $request->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders()),
-            );
-        }
-
-        return $validator;
     }
 }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
+use Symfony\Component\HttpFoundation\Response;
 
 final class ActionController
 {
+    use HandlesPrecognition;
     use InteractsWithLatticeComponents;
 
     public function __construct(
@@ -19,9 +21,15 @@ final class ActionController
         private readonly SignsComponentReferences $references,
     ) {}
 
-    public function __invoke(Request $request, string $action): JsonResponse
+    public function __invoke(Request $request, string $action): Response
     {
+        $this->markPrecognitive($request);
+
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->actions, 'action', $action);
+
+        if ($request->isPrecognitive()) {
+            return $this->validatePrecognitive($request, fn () => $definition->validate($request));
+        }
 
         return response()->json(
             $definition->handle($request),

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\BulkActionRegistry;
 use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableRegistry;
+use Symfony\Component\HttpFoundation\Response;
 
 final class BulkActionController
 {
+    use HandlesPrecognition;
     use InteractsWithLatticeComponents;
 
     public function __construct(
@@ -25,9 +27,15 @@ final class BulkActionController
         private readonly SignsComponentReferences $references,
     ) {}
 
-    public function __invoke(Request $request, string $bulkAction): JsonResponse
+    public function __invoke(Request $request, string $bulkAction): Response
     {
+        $this->markPrecognitive($request);
+
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->bulkActions, 'bulkAction', $bulkAction);
+
+        if ($request->isPrecognitive()) {
+            return $this->validatePrecognitive($request, fn () => $definition->validate($request));
+        }
 
         $tableKey = $this->trustedTableKey($request);
         $table = $this->resolveTable($tableKey);

--- a/src/Http/Controllers/Concerns/HandlesPrecognition.php
+++ b/src/Http/Controllers/Concerns/HandlesPrecognition.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http\Controllers\Concerns;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response;
+
+trait HandlesPrecognition
+{
+    protected function markPrecognitive(Request $request): void
+    {
+        if ($request->isAttemptingPrecognition()) {
+            $request->attributes->set('precognitive', true);
+        }
+    }
+
+    /**
+     * Run the given validation closure and translate the outcome into a
+     * precognition response: 204 on success, 422 with the errors otherwise.
+     */
+    protected function validatePrecognitive(Request $request, Closure $validate): Response
+    {
+        try {
+            $validate();
+        } catch (ValidationException $exception) {
+            return $this->precognitiveResponse(new JsonResponse([
+                'message' => $exception->getMessage(),
+                'errors' => $exception->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY));
+        }
+
+        return $this->precognitiveResponse(new Response('', Response::HTTP_NO_CONTENT, [
+            'Precognition-Success' => 'true',
+        ]));
+    }
+
+    private function precognitiveResponse(Response $response): Response
+    {
+        $response->headers->set('Precognition', 'true');
+        $response->headers->set('Vary', trim(implode(', ', array_filter([
+            $response->headers->get('Vary'),
+            'Precognition',
+        ]))));
+
+        return $response;
+    }
+}

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -7,15 +7,15 @@ namespace Lattice\Lattice\Http\Controllers;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
 use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
-use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Forms\FormRegistry;
+use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
 use Symfony\Component\HttpFoundation\Response;
 
 final class FormController
 {
+    use HandlesPrecognition;
     use InteractsWithLatticeComponents;
 
     public function __construct(
@@ -25,9 +25,7 @@ final class FormController
 
     public function __invoke(Request $request, string $form): Response|Responsable
     {
-        if ($request->isAttemptingPrecognition()) {
-            $request->attributes->set('precognitive', true);
-        }
+        $this->markPrecognitive($request);
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->forms, 'form', $form);
 
@@ -40,36 +38,9 @@ final class FormController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, $definition);
+            return $this->validatePrecognitive($request, fn () => $definition->validate($request));
         }
 
         return $definition->handle($request);
-    }
-
-    private function validatePrecognitive(Request $request, FormDefinition $definition): Response
-    {
-        try {
-            $definition->validate($request);
-        } catch (ValidationException $exception) {
-            return $this->precognitiveResponse(new JsonResponse([
-                'message' => $exception->getMessage(),
-                'errors' => $exception->errors(),
-            ], Response::HTTP_UNPROCESSABLE_ENTITY));
-        }
-
-        return $this->precognitiveResponse(new Response('', Response::HTTP_NO_CONTENT, [
-            'Precognition-Success' => 'true',
-        ]));
-    }
-
-    private function precognitiveResponse(Response $response): Response
-    {
-        $response->headers->set('Precognition', 'true');
-        $response->headers->set('Vary', trim(implode(', ', array_filter([
-            $response->headers->get('Vary'),
-            'Precognition',
-        ]))));
-
-        return $response;
     }
 }

--- a/tests/Browser/ProductsTest.php
+++ b/tests/Browser/ProductsTest.php
@@ -81,6 +81,30 @@ it('attaches related products via search when creating', function (): void {
     expect($product->relatedProducts->pluck('name')->all())->toBe(['Walnut Desk']);
 });
 
+it('collects a reason in a modal form before rejecting a product', function (): void {
+    Product::factory()->create([
+        'name' => 'Desk Lamp',
+        'sku' => 'LAMP-001',
+        'price' => '49.99',
+        'status' => 'active',
+    ]);
+
+    visit('/products')
+        ->assertSee('Desk Lamp')
+        ->click('Reject')
+        ->assertSee('Reject product?')
+        ->click('Submit rejection')
+        ->wait(1)
+        ->assertSee('The Reason field is required.')
+        ->fill('Reason', 'Counterfeit listing')
+        ->wait(1)
+        ->click('Submit rejection')
+        ->wait(1)
+        ->assertNoSmoke();
+
+    expect(Product::query()->where('sku', 'LAMP-001')->value('status'))->toBe('archived');
+});
+
 it('creates and edits products through the form flow', function (): void {
     visit('/products')
         ->assertSee('Products')

--- a/tests/Feature/ActionFormTest.php
+++ b/tests/Feature/ActionFormTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\Action;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Textarea;
+
+use function Pest\Laravel\postJson;
+
+it('validates the embedded form and hands the data to handle', function (): void {
+    Lattice::actions([RejectActionFixture::class]);
+    $ref = componentRef(wire(ActionComponent::use(RejectActionFixture::class)));
+
+    postJson('/lattice/actions/test.reject', ['reason' => 'spam'], latticeHeaders($ref))
+        ->assertOk()
+        ->assertJsonPath('ok', true)
+        ->assertJsonPath('data.reason', 'spam');
+});
+
+it('rejects an invalid embedded form with a 422', function (): void {
+    Lattice::actions([RejectActionFixture::class]);
+    $ref = componentRef(wire(ActionComponent::use(RejectActionFixture::class)));
+
+    postJson('/lattice/actions/test.reject', ['reason' => ''], latticeHeaders($ref))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('reason');
+});
+
+it('validates the embedded form precognitively without running handle', function (): void {
+    Lattice::actions([RejectActionFixture::class]);
+    $ref = componentRef(wire(ActionComponent::use(RejectActionFixture::class)));
+
+    $precognition = array_merge(latticeHeaders($ref), [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'reason',
+    ]);
+
+    postJson('/lattice/actions/test.reject', ['reason' => 'this reason is far too long'], $precognition)
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('reason');
+
+    postJson('/lattice/actions/test.reject', ['reason' => 'ok'], $precognition)
+        ->assertNoContent();
+});
+
+#[Action('test.reject')]
+class RejectActionFixture extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action
+            ->label('Reject')
+            ->method(HttpMethod::Post)
+            ->form([
+                Textarea::make('reason', 'Reason')->required()->rules(['max:10']),
+            ]);
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $data = $this->validate($request);
+
+        return ActionResult::success(['reason' => $data['reason']]);
+    }
+}

--- a/tests/Feature/ActionIconTest.php
+++ b/tests/Feature/ActionIconTest.php
@@ -19,6 +19,7 @@ test('actions serialize lucide icon enum values', function () {
                 'method' => null,
                 'confirmation' => null,
                 'effects' => [],
+                'form' => null,
                 'variant' => null,
                 'ref' => null,
             ],

--- a/tests/Feature/ActionWireShapeTest.php
+++ b/tests/Feature/ActionWireShapeTest.php
@@ -10,6 +10,7 @@ use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\LucideIcon;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Textarea;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
 
@@ -57,6 +58,29 @@ it('accepts arbitrary string icons', function (): void {
 
     expect($payload['props']['icon'])->toBe('custom.spark');
     expect($payload['props']['method'])->toBe('delete');
+});
+
+it('serializes an embedded form schema', function (): void {
+    $action = Action::make('reject')
+        ->label('Reject')
+        ->form([
+            Textarea::make('reason', 'Reason')->required(),
+        ]);
+
+    $payload = json_decode(json_encode($action), true);
+
+    expect($payload['props']['form']['type'])->toBe('form');
+    expect($payload['props']['form']['schema'])->toHaveCount(1);
+    expect($payload['props']['form']['schema'][0]['type'])->toBe('form.textarea');
+    expect($payload['props']['form']['schema'][0]['props']['name'])->toBe('reason');
+});
+
+it('serializes a null form when none is attached', function (): void {
+    $action = Action::make('plain')->label('Plain');
+
+    $payload = json_decode(json_encode($action), true);
+
+    expect($payload['props']['form'])->toBeNull();
 });
 
 it('drops null confirmation entries and includes empty effects', function (): void {

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -85,31 +85,6 @@ use function Pest\Laravel\withoutVite;
 use function Pest\Laravel\withSession;
 
 /**
- * @param  array<string, mixed>  $component
- */
-function componentRef(array $component): string
-{
-    $props = $component['props'] ?? [];
-    $ref = is_array($props) ? ($props['ref'] ?? null) : null;
-
-    if (! is_string($ref)) {
-        throw new RuntimeException('Lattice component ref is missing.');
-    }
-
-    expect($ref)->not->toBe('');
-
-    return $ref;
-}
-
-/**
- * @return array<string, string>
- */
-function latticeHeaders(string $ref): array
-{
-    return ['X-Lattice-Ref' => $ref];
-}
-
-/**
  * @return TestResponse<JsonResponse>
  */
 function latticeGet(string $url, string $ref): TestResponse
@@ -180,6 +155,7 @@ test('lattice can discover attributed definitions from a path and namespace', fu
                 'icon' => null,
                 'confirmation' => null,
                 'effects' => [],
+                'form' => null,
                 'variant' => null,
             ],
         ])
@@ -992,6 +968,7 @@ test('registered actions serialize their configured endpoint method label and ef
                 'variant' => 'secondary',
                 'icon' => null,
                 'confirmation' => null,
+                'form' => null,
                 'effects' => [
                     [
                         'type' => 'toast',
@@ -1041,6 +1018,7 @@ test('action groups serialize grouped child actions', function () {
                         'icon' => null,
                         'confirmation' => null,
                         'effects' => [],
+                        'form' => null,
                         'variant' => null,
                         'ref' => componentRef($group['schema'][0]),
                     ],
@@ -1055,6 +1033,7 @@ test('action groups serialize grouped child actions', function () {
                         'icon' => null,
                         'confirmation' => null,
                         'effects' => [],
+                        'form' => null,
                         'variant' => 'destructive',
                         'ref' => componentRef($group['schema'][1]),
                     ],
@@ -1231,6 +1210,7 @@ test('actions can serialize confirmation modal configuration', function () {
                     'cancelLabel' => 'Keep account',
                 ],
                 'effects' => [],
+                'form' => null,
                 'variant' => 'destructive',
                 'ref' => null,
             ],

--- a/tests/Feature/ProductsTest.php
+++ b/tests/Feature/ProductsTest.php
@@ -16,6 +16,7 @@ use Lattice\Lattice\Tables\TableQuery;
 use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
+use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\Product;
 use Workbench\App\Seeders\ProductSeeder;
@@ -429,15 +430,17 @@ test('the products table is serialized as striped', function () {
 
 test('the products table serializes bulk actions bound to the table', function () {
     Lattice::tables([ProductsTable::class]);
-    Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
+    Lattice::bulkActions([ArchiveSelectedProductsAction::class, RejectSelectedProductsAction::class]);
 
     $bulkActions = data_get(wire(Table::use(ProductsTable::class)), 'props.bulkActions');
 
-    expect($bulkActions)->toBeArray()->toHaveCount(1)
+    expect($bulkActions)->toBeArray()->toHaveCount(2)
         ->and($bulkActions[0]['id'])->toBe('workbench.products.archive-selected')
         ->and($bulkActions[0]['props']['endpoint'])
         ->toBe('/lattice/bulk-actions/workbench.products.archive-selected')
-        ->and($bulkActions[0]['props']['ref'])->toBeString();
+        ->and($bulkActions[0]['props']['ref'])->toBeString()
+        ->and($bulkActions[1]['id'])->toBe('workbench.products.reject-selected')
+        ->and($bulkActions[1]['props']['form']['schema'][0]['props']['name'])->toBe('reason');
 });
 
 test('bulk actions can target every row matching the current filter', function () {
@@ -527,4 +530,68 @@ test('the products table rejects a filter operator not allowed for the column', 
         InvalidTableQuery::class,
         'Operator [contains] is not allowed for filter [featured] on table [workbench.products].',
     );
+});
+
+test('bulk form actions validate the submitted reason before archiving', function () {
+    Lattice::tables([ProductsTable::class]);
+    Lattice::bulkActions([RejectSelectedProductsAction::class]);
+
+    $product = Product::factory()->create(['status' => 'active']);
+
+    $ref = app(ComponentReferenceSigner::class)->seal(
+        'bulkAction',
+        'workbench.products.reject-selected',
+        ['table' => 'workbench.products'],
+    );
+
+    $headers = ['Accept' => 'application/json', 'X-Lattice-Ref' => $ref];
+
+    patch('/lattice/bulk-actions/workbench.products.reject-selected', [
+        'selected' => [$product->getKey()],
+    ], $headers)
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('reason');
+
+    expect($product->fresh()->status)->toBe('active');
+
+    patch('/lattice/bulk-actions/workbench.products.reject-selected', [
+        'reason' => 'Counterfeit',
+        'selected' => [$product->getKey()],
+    ], $headers)
+        ->assertOk()
+        ->assertJsonPath('data.archived', 1)
+        ->assertJsonPath('data.reason', 'Counterfeit');
+
+    expect($product->fresh()->status)->toBe('archived');
+});
+
+test('bulk form actions validate precognitively without archiving', function () {
+    Lattice::tables([ProductsTable::class]);
+    Lattice::bulkActions([RejectSelectedProductsAction::class]);
+
+    $product = Product::factory()->create(['status' => 'active']);
+
+    $ref = app(ComponentReferenceSigner::class)->seal(
+        'bulkAction',
+        'workbench.products.reject-selected',
+        ['table' => 'workbench.products'],
+    );
+
+    $precognition = [
+        'X-Lattice-Ref' => $ref,
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'reason',
+    ];
+
+    patch('/lattice/bulk-actions/workbench.products.reject-selected', [
+        'reason' => '',
+        'selected' => [$product->getKey()],
+    ], $precognition)->assertStatus(422)->assertJsonValidationErrors('reason');
+
+    patch('/lattice/bulk-actions/workbench.products.reject-selected', [
+        'reason' => 'Counterfeit',
+        'selected' => [$product->getKey()],
+    ], $precognition)->assertNoContent();
+
+    expect($product->fresh()->status)->toBe('active');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,6 +20,33 @@ function wire(mixed $value): array
 }
 
 /**
+ * Extract the signed ref from a serialized interactive component.
+ *
+ * @param  array<string, mixed>  $component
+ */
+function componentRef(array $component): string
+{
+    $props = $component['props'] ?? [];
+    $ref = is_array($props) ? ($props['ref'] ?? null) : null;
+
+    if (! is_string($ref)) {
+        throw new RuntimeException('Lattice component ref is missing.');
+    }
+
+    expect($ref)->not->toBe('');
+
+    return $ref;
+}
+
+/**
+ * @return array<string, string>
+ */
+function latticeHeaders(string $ref): array
+{
+    return ['X-Lattice-Ref' => $ref];
+}
+
+/**
  * Dump an array of nodes to docs/fixtures/<key>.json so the docs site can render
  * a real, test-generated example instead of hand-maintained JSON.
  *

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -10,12 +10,9 @@ arch('tables do not depend on forms')
     ->expect('Lattice\Lattice\Tables')
     ->not->toUse('Lattice\Lattice\Forms');
 
-arch('actions do not depend on forms or tables')
+arch('actions do not depend on tables')
     ->expect('Lattice\Lattice\Actions')
-    ->not->toUse([
-        'Lattice\Lattice\Forms',
-        'Lattice\Lattice\Tables',
-    ]);
+    ->not->toUse('Lattice\Lattice\Tables');
 
 arch('fragments do not depend on forms, tables or actions')
     ->expect('Lattice\Lattice\Fragments')

--- a/workbench/app/Actions/RejectProductAction.php
+++ b/workbench/app/Actions/RejectProductAction.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Actions;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\Action;
+use Lattice\Lattice\Core\Enums\ButtonVariant;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\Enums\ToastVariant;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Workbench\App\Models\Product;
+
+#[Action('workbench.products.reject')]
+class RejectProductAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action
+            ->label('Reject')
+            ->method(HttpMethod::Patch)
+            ->variant(ButtonVariant::Destructive)
+            ->confirm('Reject product?', 'Tell the seller why this product is rejected.', 'Submit rejection')
+            ->form([
+                Textarea::make('reason', 'Reason')->required()->rules(['string', 'max:255']),
+            ]);
+    }
+
+    public function authorize(Request $request): bool
+    {
+        return $this->product($request)->status !== 'archived';
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $data = $this->validate($request);
+
+        $product = $this->product($request);
+        $product->update(['status' => 'archived']);
+
+        return ActionResult::success(['id' => $product->getKey(), 'reason' => $data['reason']])
+            ->toast(ToastVariant::Success, "Rejected: {$data['reason']}")
+            ->reloadComponent('workbench.products');
+    }
+
+    private function product(Request $request): Product
+    {
+        return Product::query()->findOrFail($this->context($request, 'product_id'));
+    }
+}

--- a/workbench/app/Actions/RejectSelectedProductsAction.php
+++ b/workbench/app/Actions/RejectSelectedProductsAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Actions;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\BulkAction;
+use Lattice\Lattice\Core\Enums\ButtonVariant;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\Enums\ToastVariant;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Workbench\App\Models\Product;
+
+#[BulkAction('workbench.products.reject-selected')]
+class RejectSelectedProductsAction extends BulkActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action
+            ->label('Reject selected')
+            ->method(HttpMethod::Patch)
+            ->variant(ButtonVariant::Destructive)
+            ->confirm('Reject selected products?', 'Tell the sellers why these products are rejected.', 'Submit rejection')
+            ->form([
+                Textarea::make('reason', 'Reason')->required()->rules(['string', 'max:255']),
+            ]);
+    }
+
+    /**
+     * @param  Collection<int, mixed>  $records
+     */
+    public function handle(Collection $records, Request $request): ActionResult
+    {
+        $data = $this->validate($request);
+
+        $records->each(function (mixed $product): void {
+            if ($product instanceof Product) {
+                $product->update(['status' => 'archived']);
+            }
+        });
+
+        return ActionResult::success(['archived' => $records->count(), 'reason' => $data['reason']])
+            ->toast(ToastVariant::Success, "Rejected {$records->count()} products: {$data['reason']}")
+            ->reloadComponent('workbench.products');
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -15,6 +15,8 @@ use Laravel\Roster\Roster;
 use Lattice\Lattice\Facades\Lattice;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
+use Workbench\App\Actions\RejectProductAction;
+use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Console\Commands\GenerateInternalTypesCommand;
 use Workbench\App\Forms\DependentDemoForm;
 use Workbench\App\Forms\ProductForm;
@@ -79,10 +81,12 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         Lattice::actions([
             ArchiveProductAction::class,
+            RejectProductAction::class,
         ]);
 
         Lattice::bulkActions([
             ArchiveSelectedProductsAction::class,
+            RejectSelectedProductsAction::class,
         ]);
 
         Lattice::forms([

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -17,6 +17,8 @@ use Lattice\Lattice\Tables\EloquentTableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
+use Workbench\App\Actions\RejectProductAction;
+use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Models\Product;
 use Workbench\App\Tables\Columns\StatusBadgeColumn;
 
@@ -71,6 +73,8 @@ class ProductsTable extends EloquentTableDefinition
                 ->href('/products/'.$row['id'].'/edit'),
             Action::use(ArchiveProductAction::class)
                 ->context(['product_id' => $row['id']]),
+            Action::use(RejectProductAction::class)
+                ->context(['product_id' => $row['id']]),
         ];
     }
 
@@ -81,6 +85,7 @@ class ProductsTable extends EloquentTableDefinition
     {
         return [
             BulkAction::use(ArchiveSelectedProductsAction::class),
+            BulkAction::use(RejectSelectedProductsAction::class),
         ];
     }
 }


### PR DESCRIPTION
Wires an Action (and bulk action) to render a Form in a modal, collect and validate input, then pass it to `handle()`. Closes the highest-leverage T1 gap ("Reject with reason", "Assign category to selected", …).

## How it works
Declare a schema on the action — it renders as a pre-submit modal, validates precognitively against the **existing** action endpoint, and submits the collected values:

```php
#[Action('products.reject')]
class RejectProductAction extends ActionDefinition
{
    public function definition(Action $action): Action
    {
        return $action->label('Reject')->method(HttpMethod::Patch)
            ->confirm('Reject product?', 'Tell the seller why.', 'Submit rejection')
            ->form([ Textarea::make('reason', 'Reason')->required()->rules(['max:255']) ]);
    }

    public function handle(Request $request): ActionResult
    {
        $data = $this->validate($request);          // validated + cast input
        // …
    }
}
```

## What changed
- **`Action::form([...])`** (BulkAction inherits) — serializes the form node under `props.form`; precognitive by default.
- **`Forms\FieldValidator`** — the single-pass validation engine extracted from `FormDefinition::validate()` (conditions, locked/server values, casting, precognition filtering); `FormDefinition` now delegates. No behavior change.
- **`ValidatesActionForm`** trait → `validate(Request): array` on both action definitions.
- **`HandlesPrecognition`** trait → precognition branch on `ActionController`/`BulkActionController` (and `FormController` refactored onto it). No new endpoints.
- **Frontend** `action-form.tsx` — renders the schema via the existing field registry + form value/context providers; live precognition + submit preserving action-effect semantics (toast/reload/close). Wired into `action.tsx` and `bulk-bar.tsx` (selection rides along as `extraData`).
- Arch rule relaxed so Actions may use Forms (Tables boundary kept).

## Notable fix
`fetch` doesn't upper-case `PATCH`/`DELETE`, and a strict server rejects a lowercase method line — every PATCH/DELETE action form would have failed. The client now normalizes the method.

## Tests
PHP 293, JS 158, browser 25 — all green. Adds wire-shape, validation, precognition (row + bulk) feature tests; `action-form` vitest (submit, precognition headers, 422 error display); and a browser test driving the reject modal end-to-end.

## Deferred (agreed)
Per-record "edit in modal" prefill, and searchable/computed fields inside action forms.