### PR TITLE
feat: edit-in-modal — lazy, prefillable action form schemas

### DIFF
--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -46,6 +46,22 @@ function rejectAction(precognitive = false): Node {
   } as unknown as Node;
 }
 
+function lazyAction(): Node {
+  return {
+    id: "test.edit",
+    type: "action",
+    props: {
+      confirmation: { confirmLabel: "Submit", title: "Edit item?" },
+      endpoint: "/lattice/actions/test.edit",
+      form: null,
+      label: "Edit",
+      lazyForm: true,
+      method: "post",
+      ref: "sealed-ref",
+    },
+  } as unknown as Node;
+}
+
 function renderAction(node: Node) {
   return render(
     <Renderer nodes={[node]} registry={createRegistry(actionComponents, formComponents)} />,
@@ -102,6 +118,37 @@ describe("action form modal", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Submit" }));
 
     expect(await screen.findByText("The Reason field is required.")).toBeVisible();
+  });
+
+  it("lazily fetches the schema when the action declares a lazy form", async () => {
+    const formNode = {
+      id: "test.edit-form",
+      props: {},
+      schema: [{ key: "title", props: { label: "Title", name: "title" }, type: "form.text-input" }],
+      type: "form",
+    };
+    const fetchMock = vi.fn<FetchMock>().mockImplementation((_url, init) => {
+      const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+      const payload = body._form ? formNode : { effects: [], ok: true };
+
+      return Promise.resolve({
+        json: async () => payload,
+        ok: true,
+        status: 200,
+      } as unknown as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(lazyAction());
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(await screen.findByRole("textbox", { name: "Title" })).toBeVisible();
+    expect(
+      fetchMock.mock.calls.some(
+        ([, init]) => (JSON.parse(String((init as RequestInit).body)) as { _form?: boolean })._form,
+      ),
+    ).toBe(true);
   });
 
   it("validates precognitively as the user types", async () => {

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { withRefHeader } from "@lattice/lattice/core/component-ref";
 import { Button } from "@lattice/lattice/core/components/button";
 import { Spinner } from "@lattice/lattice/core/components/spinner";
@@ -24,13 +24,63 @@ type ActionFormProps = {
   endpoint: string;
   /** Extra payload merged into every request, e.g. a bulk action's selection. */
   extraData?: Record<string, unknown>;
-  formNode: Node;
+  /** The form to render; null while a lazy schema is still being fetched. */
+  formNode: Node | null;
   method: string;
   onClose: () => void;
   onSuccess: (response: ActionResponse) => void;
   submitLabel: string;
   title: string;
 };
+
+function jsonHeaders(componentRef: string, extra?: Record<string, string>): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-Requested-With": "XMLHttpRequest",
+    "X-XSRF-TOKEN": xsrfToken(),
+    ...withRefHeader(componentRef),
+    ...extra,
+  };
+}
+
+/**
+ * Fetch a lazily-served form schema from the action endpoint while `enabled`,
+ * so it can be prefilled per record. Returns null until it arrives.
+ */
+export function useLazyActionForm(
+  endpoint: string,
+  method: string,
+  componentRef: string,
+  enabled: boolean,
+): Node | null {
+  const [node, setNode] = useState<Node | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setNode(null);
+
+      return;
+    }
+
+    const controller = new AbortController();
+
+    void fetch(endpoint, {
+      body: JSON.stringify({ _form: true }),
+      credentials: "same-origin",
+      headers: jsonHeaders(componentRef),
+      method: method.toUpperCase(),
+      signal: controller.signal,
+    })
+      .then((response) => (response.ok ? (response.json() as Promise<Node>) : null))
+      .then((fetched) => setNode(fetched))
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [enabled, endpoint, method, componentRef]);
+
+  return node;
+}
 
 function firstErrors(errors: Record<string, string[] | string> | undefined): FieldErrors {
   const result: FieldErrors = {};
@@ -40,6 +90,16 @@ function firstErrors(errors: Record<string, string[] | string> | undefined): Fie
   }
 
   return result;
+}
+
+function ActionFormSkeleton() {
+  return (
+    <div className="space-y-4" data-lattice-action-form-loading>
+      <div className="h-4 w-24 animate-pulse rounded bg-lt-muted" />
+      <div className="h-10 w-full animate-pulse rounded bg-lt-muted" />
+      <div className="h-10 w-full animate-pulse rounded bg-lt-muted" />
+    </div>
+  );
 }
 
 type CollectedFields = {
@@ -83,6 +143,7 @@ function ActionFormBody({
   submitLabel,
 }: Omit<ActionFormProps, "description" | "title"> & {
   fieldLabels: Record<string, string>;
+  formNode: Node;
   precognitive: boolean;
 }) {
   const { fallback, missingComponent, registry } = useRendererContext();
@@ -105,14 +166,7 @@ function ActionFormBody({
         // fetch only upper-cases the standardized methods, leaving PATCH/DELETE as
         // given; some servers reject a lower-case method line, so normalize it.
         method: method.toUpperCase(),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "X-Requested-With": "XMLHttpRequest",
-          "X-XSRF-TOKEN": xsrfToken(),
-          ...withRefHeader(componentRef),
-          ...extraHeaders,
-        },
+        headers: jsonHeaders(componentRef, extraHeaders),
       }),
     [componentRef, endpoint, method],
   );
@@ -219,13 +273,29 @@ function ActionFormBody({
   );
 }
 
-export function ActionForm({ description, formNode, onClose, title, ...rest }: ActionFormProps) {
+function ActionFormContent({
+  formNode,
+  ...rest
+}: Omit<ActionFormProps, "description" | "title"> & { formNode: Node }) {
   const precognitive = Boolean(formNode.props?.precognitive);
   const { labels: fieldLabels, values: initialValues } = useMemo(
     () => collectFields(formNode),
     [formNode],
   );
 
+  return (
+    <FormValuesProvider initial={initialValues}>
+      <ActionFormBody
+        fieldLabels={fieldLabels}
+        formNode={formNode}
+        precognitive={precognitive}
+        {...rest}
+      />
+    </FormValuesProvider>
+  );
+}
+
+export function ActionForm({ description, formNode, onClose, title, ...rest }: ActionFormProps) {
   return (
     <Dialog.Root
       open
@@ -262,15 +332,11 @@ export function ActionForm({ description, formNode, onClose, title, ...rest }: A
           </div>
 
           <div className="mt-6">
-            <FormValuesProvider initial={initialValues}>
-              <ActionFormBody
-                fieldLabels={fieldLabels}
-                formNode={formNode}
-                onClose={onClose}
-                precognitive={precognitive}
-                {...rest}
-              />
-            </FormValuesProvider>
+            {formNode ? (
+              <ActionFormContent formNode={formNode} onClose={onClose} {...rest} />
+            ) : (
+              <ActionFormSkeleton />
+            )}
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -9,7 +9,7 @@ import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { IconRenderer } from "@lattice/lattice/icons";
 import { dispatchActionEffects, dispatchActionError, getActionEffects } from "../effects";
 import type { ActionResponse } from "../effects";
-import { ActionForm } from "./action-form";
+import { ActionForm, useLazyActionForm } from "./action-form";
 
 const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const endpoint = node.props.endpoint ?? "";
@@ -24,7 +24,11 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const variant = node.props.variant ?? "default";
   // The wire carries the embedded form as a full node; the generated prop type
   // reflects Form's props, so read it through the Node lens the renderer uses.
-  const form = node.props.form as unknown as Node | null;
+  const inlineForm = node.props.form as unknown as Node | null;
+  const lazyForm = node.props.lazyForm === true;
+  const hasForm = Boolean(inlineForm) || lazyForm;
+  const lazyNode = useLazyActionForm(endpoint, method, componentRef, isFilling && lazyForm);
+  const formNode = lazyForm ? lazyNode : inlineForm;
 
   const submit = async (): Promise<void> => {
     if (!endpoint) {
@@ -52,7 +56,7 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   };
 
   const requestSubmit = (): void => {
-    if (form) {
+    if (hasForm) {
       setIsFilling(true);
 
       return;
@@ -98,13 +102,13 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
         />
       )}
 
-      {isFilling && form && (
+      {isFilling && hasForm && (
         <ActionForm
           cancelLabel={confirmationCancelLabel}
           componentRef={componentRef}
           description={confirmation?.description}
           endpoint={endpoint}
-          formNode={form}
+          formNode={formNode}
           method={method}
           onClose={() => setIsFilling(false)}
           onSuccess={(response) => {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -10,6 +10,7 @@ export type Action = {
   form: Form | null;
   icon: string | null;
   label: string | null;
+  lazyForm: boolean | null;
   method: HttpMethod | null;
   ref: string | null;
   variant: ButtonVariant | null;
@@ -54,6 +55,7 @@ export type BulkAction = {
   form: Form | null;
   icon: string | null;
   label: string | null;
+  lazyForm: boolean | null;
   method: HttpMethod | null;
   ref: string | null;
   variant: ButtonVariant | null;

--- a/src/Actions/ActionDefinition.php
+++ b/src/Actions/ActionDefinition.php
@@ -7,10 +7,11 @@ namespace Lattice\Lattice\Actions;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Actions\Concerns\InteractsWithActionForm;
+use Lattice\Lattice\Actions\Contracts\InteractsWithForm;
 use Lattice\Lattice\Actions\Contracts\ProvidesAction;
 use Lattice\Lattice\Core\Definition;
 
-abstract class ActionDefinition extends Definition implements ProvidesAction
+abstract class ActionDefinition extends Definition implements InteractsWithForm, ProvidesAction
 {
     use InteractsWithActionForm;
 

--- a/src/Actions/ActionRegistry.php
+++ b/src/Actions/ActionRegistry.php
@@ -21,9 +21,16 @@ final class ActionRegistry extends DefinitionRegistry
     {
         $key = $this->registeredKeyFor($action);
 
-        return $this->make($action)
-            ->definition(ActionComponent::make($key))
+        $definition = $this->make($action);
+
+        $component = $definition->definition(ActionComponent::make($key))
             ->endpoint($this->endpointFor($key));
+
+        if ($definition instanceof FormActionDefinition) {
+            $component->lazyForm();
+        }
+
+        return $component;
     }
 
     /**

--- a/src/Actions/BulkActionDefinition.php
+++ b/src/Actions/BulkActionDefinition.php
@@ -8,10 +8,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Actions\Concerns\InteractsWithActionForm;
+use Lattice\Lattice\Actions\Contracts\InteractsWithForm;
 use Lattice\Lattice\Actions\Contracts\ProvidesBulkAction;
 use Lattice\Lattice\Core\Definition;
 
-abstract class BulkActionDefinition extends Definition implements ProvidesBulkAction
+abstract class BulkActionDefinition extends Definition implements InteractsWithForm, ProvidesBulkAction
 {
     use InteractsWithActionForm;
 

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -39,6 +39,8 @@ class Action extends Component
 
     public ?Form $form = null;
 
+    public ?bool $lazyForm = null;
+
     public static function make(string $id): static
     {
         return (new static)->id($id);
@@ -115,5 +117,30 @@ class Action extends Component
             ->precognitive();
 
         return $this;
+    }
+
+    /**
+     * Defer the form schema: ship a flag instead of the schema and let the client
+     * fetch it (prefilled, per record) from the action endpoint when the modal opens.
+     */
+    public function lazyForm(): static
+    {
+        $this->lazyForm = true;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[Attributes\SerializationHook(priority: 250)]
+    protected function stripLazyFormSchema(array $data): array
+    {
+        if ($this->lazyForm === true) {
+            $data['props']['form'] = null;
+        }
+
+        return $data;
     }
 }

--- a/src/Actions/Concerns/InteractsWithActionForm.php
+++ b/src/Actions/Concerns/InteractsWithActionForm.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Concerns\ResolvesFormFields;
 use Lattice\Lattice\Forms\FieldValidator;
 
@@ -32,10 +33,20 @@ trait InteractsWithActionForm
     }
 
     /**
+     * The form rendered for this action's modal. Static by default (the schema
+     * declared via Action::form); FormActionDefinition overrides this to build a
+     * request-aware, prefilled schema on demand.
+     */
+    public function resolveFormSchema(Request $request): ?Form
+    {
+        return $this->definition(Action::make('action'))->form;
+    }
+
+    /**
      * @return Collection<int, Field>
      */
     protected function formFields(Request $request): Collection
     {
-        return $this->definition(Action::make('action'))->form?->fields() ?? collect();
+        return $this->resolveFormSchema($request)?->fields() ?? collect();
     }
 }

--- a/src/Actions/Contracts/InteractsWithForm.php
+++ b/src/Actions/Contracts/InteractsWithForm.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Actions\Contracts;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Forms\Components\Form;
+
+/**
+ * An action definition that drives an embedded form: it validates the submission
+ * and answers the form sub-requests (lazy schema, option search, field resolution)
+ * the modal makes against the action endpoint.
+ */
+interface InteractsWithForm
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function validate(Request $request): array;
+
+    public function resolveFormSchema(Request $request): ?Form;
+
+    /**
+     * @return array{options: array<int, array{label: string, value: string}>}
+     */
+    public function searchOptions(Request $request): array;
+
+    /**
+     * @return array{fields: array<string, mixed>, values: array<string, mixed>}
+     */
+    public function resolveFields(Request $request): array;
+}

--- a/src/Actions/FormActionDefinition.php
+++ b/src/Actions/FormActionDefinition.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Actions;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Forms\Components\Form;
+
+/**
+ * An action whose form is built per request and rendered lazily in a modal. The
+ * schema is fetched on open (so it can be prefilled from the trusted record
+ * context) rather than inlined into the page. Submit still returns ActionResult
+ * effects — reuse a FormDefinition's schema via formSchema() when convenient:
+ *
+ *     public function formSchema(Form $form, Request $request): Form
+ *     {
+ *         return app(MyForm::class)->definition($form, $request);
+ *     }
+ */
+abstract class FormActionDefinition extends ActionDefinition
+{
+    abstract public function formSchema(Form $form, Request $request): Form;
+
+    public function resolveFormSchema(Request $request): ?Form
+    {
+        return $this->formSchema(Form::make('form'), $request);
+    }
+}

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -37,14 +37,6 @@ abstract class FormDefinition extends Definition implements ProvidesForm
      */
     protected function formFields(Request $request): Collection
     {
-        return $this->buildForm($request)->fields();
-    }
-
-    /**
-     * Build this form's component tree for the current request.
-     */
-    protected function buildForm(Request $request): Form
-    {
-        return $this->definition(Form::make('form'), $request);
+        return $this->definition(Form::make('form'), $request)->fields();
     }
 }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -28,6 +28,10 @@ final class ActionController
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->actions, 'action', $action);
 
+        if ($request->boolean('_form')) {
+            return new JsonResponse($definition->resolveFormSchema($request));
+        }
+
         if ($request->filled('_search')) {
             return new JsonResponse($definition->searchOptions($request));
         }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Lattice\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
 use Symfony\Component\HttpFoundation\Response;
 
 final class ActionController
 {
+    use HandlesFormSubRequests;
     use HandlesPrecognition;
     use InteractsWithLatticeComponents;
 
@@ -28,16 +29,8 @@ final class ActionController
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->actions, 'action', $action);
 
-        if ($request->boolean('_form')) {
-            return new JsonResponse($definition->resolveFormSchema($request));
-        }
-
-        if ($request->filled('_search')) {
-            return new JsonResponse($definition->searchOptions($request));
-        }
-
-        if ($request->boolean('_resolve')) {
-            return new JsonResponse($definition->resolveFields($request));
+        if (($response = $this->formSubRequest($request, $definition)) !== null) {
+            return $response;
         }
 
         if ($request->isPrecognitive()) {

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Http\Controllers;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\BulkActionRegistry;
 use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class BulkActionController
 {
+    use HandlesFormSubRequests;
     use HandlesPrecognition;
     use InteractsWithLatticeComponents;
 
@@ -34,16 +35,8 @@ final class BulkActionController
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->bulkActions, 'bulkAction', $bulkAction);
 
-        if ($request->boolean('_form')) {
-            return new JsonResponse($definition->resolveFormSchema($request));
-        }
-
-        if ($request->filled('_search')) {
-            return new JsonResponse($definition->searchOptions($request));
-        }
-
-        if ($request->boolean('_resolve')) {
-            return new JsonResponse($definition->resolveFields($request));
+        if (($response = $this->formSubRequest($request, $definition)) !== null) {
+            return $response;
         }
 
         if ($request->isPrecognitive()) {

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -34,6 +34,10 @@ final class BulkActionController
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->bulkActions, 'bulkAction', $bulkAction);
 
+        if ($request->boolean('_form')) {
+            return new JsonResponse($definition->resolveFormSchema($request));
+        }
+
         if ($request->filled('_search')) {
             return new JsonResponse($definition->searchOptions($request));
         }

--- a/src/Http/Controllers/Concerns/HandlesFormSubRequests.php
+++ b/src/Http/Controllers/Concerns/HandlesFormSubRequests.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http\Controllers\Concerns;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\Contracts\InteractsWithForm;
+use Symfony\Component\HttpFoundation\Response;
+
+trait HandlesFormSubRequests
+{
+    /**
+     * Dispatch the sub-requests an embedded action form makes against the action
+     * endpoint — lazy schema fetch, option search, field resolution — returning
+     * null when the request is the action invocation itself.
+     */
+    protected function formSubRequest(Request $request, InteractsWithForm $definition): ?Response
+    {
+        if ($request->boolean('_form')) {
+            return new JsonResponse($definition->resolveFormSchema($request));
+        }
+
+        if ($request->filled('_search')) {
+            return new JsonResponse($definition->searchOptions($request));
+        }
+
+        if ($request->boolean('_resolve')) {
+            return new JsonResponse($definition->resolveFields($request));
+        }
+
+        return null;
+    }
+}

--- a/tests/Browser/ProductsTest.php
+++ b/tests/Browser/ProductsTest.php
@@ -105,6 +105,29 @@ it('collects a reason in a modal form before rejecting a product', function (): 
     expect(Product::query()->where('sku', 'LAMP-001')->value('status'))->toBe('archived');
 });
 
+it('edits a product in a prefilled modal form', function (): void {
+    Product::factory()->create([
+        'name' => 'Desk Lamp',
+        'sku' => 'LAMP-001',
+        'price' => '49.99',
+        'status' => 'active',
+    ]);
+
+    visit('/products')
+        ->assertSee('Desk Lamp')
+        ->click('Quick edit')
+        ->assertSee('Edit product')
+        ->wait(1)
+        ->assertValue('#name', 'Desk Lamp')
+        ->fill('#name', 'Renamed Lamp')
+        ->wait(1)
+        ->click('Save changes')
+        ->wait(1)
+        ->assertNoSmoke();
+
+    expect(Product::query()->where('sku', 'LAMP-001')->value('name'))->toBe('Renamed Lamp');
+});
+
 it('searches products inside an action form modal', function (): void {
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-001', 'status' => 'active']);
     Product::factory()->create(['name' => 'Walnut Desk', 'sku' => 'DESK-001', 'status' => 'active']);

--- a/tests/Feature/ActionFormTest.php
+++ b/tests/Feature/ActionFormTest.php
@@ -6,15 +6,70 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Actions\FormActionDefinition;
 use Lattice\Lattice\Attributes\Action;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormData;
 
 use function Pest\Laravel\postJson;
+
+it('marks a form-action component as lazy without inlining the schema', function (): void {
+    Lattice::actions([EditActionFixture::class]);
+
+    $payload = wire(ActionComponent::use(EditActionFixture::class));
+
+    expect($payload['props']['lazyForm'])->toBeTrue()
+        ->and($payload['props']['form'])->toBeNull();
+});
+
+it('returns a prefilled schema for a lazy form action', function (): void {
+    Lattice::actions([EditActionFixture::class]);
+    $ref = componentRef(wire(ActionComponent::use(EditActionFixture::class)->context(['current_title' => 'Existing'])));
+
+    postJson('/lattice/actions/test.edit', ['_form' => true], latticeHeaders($ref))
+        ->assertOk()
+        ->assertJsonPath('type', 'form')
+        ->assertJsonPath('props.state.title', 'Existing');
+});
+
+it('validates submitted values against a lazy form schema', function (): void {
+    Lattice::actions([EditActionFixture::class]);
+    $ref = componentRef(wire(ActionComponent::use(EditActionFixture::class)->context(['current_title' => 'Existing'])));
+
+    postJson('/lattice/actions/test.edit', ['title' => ''], latticeHeaders($ref))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('title');
+
+    postJson('/lattice/actions/test.edit', ['title' => 'Renamed'], latticeHeaders($ref))
+        ->assertOk()
+        ->assertJsonPath('data.title', 'Renamed');
+});
+
+#[Action('test.edit')]
+class EditActionFixture extends FormActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Edit')->method(HttpMethod::Patch);
+    }
+
+    public function formSchema(FormComponent $form, Request $request): FormComponent
+    {
+        return $form
+            ->schema([TextInput::make('title', 'Title')->required()])
+            ->fill(['title' => $this->context($request, 'current_title')]);
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success($this->validate($request));
+    }
+}
 
 it('validates the embedded form and hands the data to handle', function (): void {
     Lattice::actions([RejectActionFixture::class]);

--- a/tests/Feature/ActionIconTest.php
+++ b/tests/Feature/ActionIconTest.php
@@ -20,6 +20,7 @@ test('actions serialize lucide icon enum values', function () {
                 'confirmation' => null,
                 'effects' => [],
                 'form' => null,
+                'lazyForm' => null,
                 'variant' => null,
                 'ref' => null,
             ],

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -156,6 +156,7 @@ test('lattice can discover attributed definitions from a path and namespace', fu
                 'confirmation' => null,
                 'effects' => [],
                 'form' => null,
+                'lazyForm' => null,
                 'variant' => null,
             ],
         ])
@@ -969,6 +970,7 @@ test('registered actions serialize their configured endpoint method label and ef
                 'icon' => null,
                 'confirmation' => null,
                 'form' => null,
+                'lazyForm' => null,
                 'effects' => [
                     [
                         'type' => 'toast',
@@ -1019,6 +1021,7 @@ test('action groups serialize grouped child actions', function () {
                         'confirmation' => null,
                         'effects' => [],
                         'form' => null,
+                        'lazyForm' => null,
                         'variant' => null,
                         'ref' => componentRef($group['schema'][0]),
                     ],
@@ -1034,6 +1037,7 @@ test('action groups serialize grouped child actions', function () {
                         'confirmation' => null,
                         'effects' => [],
                         'form' => null,
+                        'lazyForm' => null,
                         'variant' => 'destructive',
                         'ref' => componentRef($group['schema'][1]),
                     ],
@@ -1211,6 +1215,7 @@ test('actions can serialize confirmation modal configuration', function () {
                 ],
                 'effects' => [],
                 'form' => null,
+                'lazyForm' => null,
                 'variant' => 'destructive',
                 'ref' => null,
             ],

--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Actions;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\FormActionDefinition;
+use Lattice\Lattice\Attributes\Action as ActionAttribute;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\Enums\ToastVariant;
+use Lattice\Lattice\Forms\Components\Form;
+use Workbench\App\Forms\ProductForm;
+use Workbench\App\Models\Product;
+
+#[ActionAttribute('workbench.products.edit-modal')]
+class EditProductAction extends FormActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action
+            ->label('Quick edit')
+            ->method(HttpMethod::Patch)
+            ->confirm('Edit product', 'Update the product details.', 'Save changes');
+    }
+
+    public function formSchema(Form $form, Request $request): Form
+    {
+        $product = $this->product($request);
+
+        // Reuse the registered form's schema, then prefill the record's values.
+        return app(ProductForm::class)->definition($form, $request)->fill([
+            'name' => $product->name,
+            'sku' => $product->sku,
+            'price' => $product->price,
+            'status' => $product->status,
+            'related_products' => $product->relatedProducts()->pluck('products.id')->all(),
+        ]);
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $data = $this->validate($request);
+        $product = $this->product($request);
+
+        $relatedIds = $data['related_products'] ?? [];
+        unset($data['related_products']);
+
+        $product->update($data);
+        $product->relatedProducts()->sync(
+            Product::query()->whereIn('id', $relatedIds)->pluck('id')->all(),
+        );
+
+        return ActionResult::success(['id' => $product->getKey()])
+            ->toast(ToastVariant::Success, 'Product updated.')
+            ->reloadComponent('workbench.products');
+    }
+
+    private function product(Request $request): Product
+    {
+        return Product::query()->findOrFail($this->context($request, 'product_id'));
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -15,6 +15,7 @@ use Laravel\Roster\Roster;
 use Lattice\Lattice\Facades\Lattice;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
+use Workbench\App\Actions\EditProductAction;
 use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Console\Commands\GenerateInternalTypesCommand;
@@ -81,6 +82,7 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         Lattice::actions([
             ArchiveProductAction::class,
+            EditProductAction::class,
             RejectProductAction::class,
         ]);
 

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -17,6 +17,7 @@ use Lattice\Lattice\Tables\EloquentTableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
+use Workbench\App\Actions\EditProductAction;
 use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Models\Product;
@@ -71,6 +72,8 @@ class ProductsTable extends EloquentTableDefinition
         return [
             Link::make('Edit')
                 ->href('/products/'.$row['id'].'/edit'),
+            Action::use(EditProductAction::class)
+                ->context(['product_id' => $row['id']]),
             Action::use(ArchiveProductAction::class)
                 ->context(['product_id' => $row['id']]),
             Action::use(RejectProductAction::class)


### PR DESCRIPTION
Stacked on #44. Adds **edit-in-modal**: a row action that opens a form prefilled with that record's current values, saved via action effects (toast + reload, no navigation). The enabling primitive is **lazy schema fetch**.

## Why the two are connected
Per-record prefill needs the record at *schema-build* time. A row action's record is identified by its **sealed per-row context**, which only reaches the server on interaction — not at page render. So the prefilled schema must be built on demand → lazy fetch. (Inline-per-row would mean N record loads + N schemas + stale data; rejected.)

## What changed
- **`FormActionDefinition`** — abstract `formSchema(Form $form, Request $request): Form`, a request-aware builder (mirrors `FormDefinition::definition`). Reuse a registered form's schema in one line: `return app(ProductForm::class)->definition($form, $request)`.
- **Lazy delivery** — such actions serialize `lazyForm: true` instead of the schema; the modal fetches it via a new `_form` branch on the action/bulk controllers (sits beside `_search`/`_resolve`/precognition — no new endpoints). `Action::lazyForm()` opts a static form into the same deferral (the general payload optimization).
- **`resolveFormSchema(Request)`** unifies the static and request-aware sources, so validation/search/resolve all see the prefilled, record-aware form.
- **Frontend** — `useLazyActionForm` fetches the schema on open with a loading skeleton, then renders the existing modal form.
- **Security** — the `_form` build loads only from the trusted sealed context and runs `authorize()` first (prefilled values are sent to the client).

## Example
```php
class EditProductAction extends FormActionDefinition {
    public function definition(Action $action): Action {
        return $action->label('Quick edit')->method(HttpMethod::Patch)
            ->confirm('Edit product', 'Update the product details.', 'Save changes');
    }
    public function formSchema(Form $form, Request $request): Form {
        $product = $this->product($request);
        return app(ProductForm::class)->definition($form, $request)->fill($product->only([...]));
    }
    public function handle(Request $request): ActionResult {
        $data = $this->validate($request);
        $this->product($request)->update($data);
        return ActionResult::success()->toast(Success, 'Product updated.')->reloadComponent('products');
    }
}
```

## Tests
PHP 298, JS 159, browser 27 — all green. Adds wire-shape (lazy marker), `_form` prefill + lazy validation feature tests, a lazy-fetch vitest, and a browser test editing a product through the prefilled modal.

Closes deferred follow-up #1 (edit-in-modal prefill) and #3 (lazy schema fetch).