### PR TITLE
feat: toast notifications (Radix Toast) with link & modal-form actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.16",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-toast": "^1.2.16",
         "@tiptap/extension-details": "^3.26.0",
         "@tiptap/extension-highlight": "^3.26.0",
         "@tiptap/extension-link": "^3.26.0",
@@ -3869,6 +3870,32 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
@@ -4200,6 +4227,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.16.tgz",
+      "integrity": "sha512-WUymDDiN2DpoGudRN1aW4wF5O3BNQjZZO/5nngPoNiEVqjyOzirvZZNO0R6dC1ifucSINVaSv8JX1aq47VGgiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-visually-hidden": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
@@ -4332,6 +4393,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.5.tgz",
+      "integrity": "sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.16",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toast": "^1.2.16",
     "@tiptap/extension-details": "^3.26.0",
     "@tiptap/extension-highlight": "^3.26.0",
     "@tiptap/extension-link": "^3.26.0",

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -77,6 +77,30 @@
   --radius-lt: var(--lt-radius);
   --radius-lt-sm: var(--lt-radius-sm);
   --radius-lt-xs: var(--lt-radius-xs);
+  --animate-lt-toast-in: lt-toast-in 160ms ease-out;
+  --animate-lt-toast-out: lt-toast-out 120ms ease-in;
+}
+
+@keyframes lt-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes lt-toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
 }
 
 /*

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -20,6 +20,10 @@
   --lt-input: var(--input, oklch(0.922 0 0));
   --lt-ring: var(--ring, oklch(0.87 0 0));
   --lt-warning: var(--warning, oklch(0.852 0.156 91));
+  --lt-success: var(--success, oklch(0.596 0.145 163));
+  --lt-success-fg: var(--success-foreground, oklch(0.985 0 0));
+  --lt-info: var(--info, oklch(0.588 0.158 241));
+  --lt-info-fg: var(--info-foreground, oklch(0.985 0 0));
   --lt-radius: var(--radius, 0.625rem);
   --lt-radius-sm: calc(var(--lt-radius) - 2px);
   --lt-radius-xs: calc(var(--lt-radius) - 4px);
@@ -49,6 +53,10 @@
   --lt-input: var(--input, oklch(0.269 0 0));
   --lt-ring: var(--ring, oklch(0.439 0 0));
   --lt-warning: var(--warning, oklch(0.68 0.14 75));
+  --lt-success: var(--success, oklch(0.696 0.17 162));
+  --lt-success-fg: var(--success-foreground, oklch(0.205 0 0));
+  --lt-info: var(--info, oklch(0.685 0.15 238));
+  --lt-info-fg: var(--info-foreground, oklch(0.205 0 0));
 
   color-scheme: dark;
 }
@@ -74,6 +82,10 @@
   --color-lt-input: var(--lt-input);
   --color-lt-ring: var(--lt-ring);
   --color-lt-warning: var(--lt-warning);
+  --color-lt-success: var(--lt-success);
+  --color-lt-success-fg: var(--lt-success-fg);
+  --color-lt-info: var(--lt-info);
+  --color-lt-info-fg: var(--lt-info-fg);
   --radius-lt: var(--lt-radius);
   --radius-lt-sm: var(--lt-radius-sm);
   --radius-lt-xs: var(--lt-radius-xs);

--- a/resources/js/core/components/button.test.tsx
+++ b/resources/js/core/components/button.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "./button";
+
+describe("Button variants", () => {
+  it("applies the success variant classes", () => {
+    render(<Button variant="success">Save</Button>);
+
+    expect(screen.getByRole("button")).toHaveClass("bg-lt-success", "text-lt-success-fg");
+  });
+
+  it("applies the info variant classes", () => {
+    render(<Button variant="info">Details</Button>);
+
+    expect(screen.getByRole("button")).toHaveClass("bg-lt-info", "text-lt-info-fg");
+  });
+});

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -16,6 +16,8 @@ const buttonVariants = cva(
         default: "bg-lt-primary text-lt-primary-fg shadow-xs hover:bg-lt-primary/90",
         destructive:
           "bg-lt-danger text-lt-danger-fg shadow-xs hover:bg-lt-danger/90 focus-visible:ring-lt-danger/20 dark:focus-visible:ring-lt-danger/40",
+        success: "bg-lt-success text-lt-success-fg shadow-xs hover:bg-lt-success/90",
+        info: "bg-lt-info text-lt-info-fg shadow-xs hover:bg-lt-info/90",
         outline:
           "border border-lt-input bg-lt-bg shadow-xs hover:bg-lt-accent hover:text-lt-accent-fg",
         secondary: "bg-lt-secondary text-lt-secondary-fg shadow-xs hover:bg-lt-secondary/80",

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -6,13 +6,13 @@ import type { RendererComponent } from "@lattice/lattice/core/types";
 import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 
 type ModalEvent = CustomEvent<{
-  modal?: string;
+  modal?: string | null;
 }>;
 
 function matchesModal(event: Event, modal: string): boolean {
   const target = (event as ModalEvent).detail?.modal;
 
-  return target === undefined || target === modal;
+  return target == null || target === modal;
 }
 
 const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -6,7 +6,7 @@ import type { RendererComponent } from "@lattice/lattice/core/types";
 import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 
 type ModalEvent = CustomEvent<{
-  modal?: string | null;
+  modal: string | null;
 }>;
 
 function matchesModal(event: Event, modal: string): boolean {

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -42,7 +42,7 @@ function FormResetListener({
 }) {
   useEffect(() => {
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ form?: string }>).detail;
+      const detail = (event as CustomEvent<{ form?: string | null }>).detail;
 
       if (!detail?.form || detail.form === componentId) {
         reset();

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -42,7 +42,7 @@ function FormResetListener({
 }) {
   useEffect(() => {
     const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ form?: string | null }>).detail;
+      const detail = (event as CustomEvent<{ form: string | null }>).detail;
 
       if (!detail?.form || detail.form === componentId) {
         reset();

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -12,6 +12,7 @@ export { IconRenderer, IconRendererProvider } from "./icons";
 export { createLayoutResolver, createPageResolver, pageComponentName } from "./inertia";
 export { layoutComponents, OutletContext, SchemaLayout } from "./layout";
 export { Provider, useColumnRegistry, useRegistry } from "./provider";
+export { Toaster } from "./toast";
 export {
   createPlugin,
   createRegistry,

--- a/resources/js/provider.tsx
+++ b/resources/js/provider.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { ComponentRegistry } from "./core/registry";
 import { registry as defaultRegistry } from "./registry";
 import type { ColumnRegistry } from "./table/column-registry";
+import { Toaster } from "./toast";
 
 type ContextValue = {
   columns: ColumnRegistry;
@@ -20,14 +21,21 @@ export function Provider({
   children,
   columns = defaultColumns,
   registry = defaultRegistry,
+  toaster = true,
 }: {
   children: ReactNode;
   columns?: ColumnRegistry;
   registry?: ComponentRegistry;
+  toaster?: boolean;
 }) {
   const value = useMemo(() => ({ columns, registry }), [columns, registry]);
 
-  return <RegistryContext.Provider value={value}>{children}</RegistryContext.Provider>;
+  return (
+    <RegistryContext.Provider value={value}>
+      {children}
+      {toaster ? <Toaster /> : null}
+    </RegistryContext.Provider>
+  );
 }
 
 export function useRegistry(): ComponentRegistry {

--- a/resources/js/toast/index.ts
+++ b/resources/js/toast/index.ts
@@ -1,0 +1,1 @@
+export { Toaster } from "./toaster";

--- a/resources/js/toast/toaster.test.tsx
+++ b/resources/js/toast/toaster.test.tsx
@@ -1,0 +1,68 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
+import { Provider } from "@lattice/lattice/provider";
+import { Toaster } from "./toaster";
+
+vi.mock("@inertiajs/react", () => ({
+  Link: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+function emit(detail: unknown): void {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(LATTICE_EVENT.toast, { detail }));
+  });
+}
+
+function renderToaster() {
+  return render(
+    <Provider toaster={false}>
+      <Toaster />
+    </Provider>,
+  );
+}
+
+describe("Toaster", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("renders a toast dispatched on the lattice toast event", () => {
+    renderToaster();
+
+    emit({ message: "Saved.", variant: "success" });
+
+    expect(screen.getByText("Saved.")).toBeVisible();
+  });
+
+  it("ignores payloads without a message", () => {
+    renderToaster();
+
+    emit({ variant: "success" });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("dismisses a toast via the close button", () => {
+    renderToaster();
+
+    emit({ message: "Saved.", variant: "success" });
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByText("Saved.")).not.toBeInTheDocument();
+  });
+
+  it("renders a link action inside the toast", () => {
+    renderToaster();
+
+    emit({
+      message: "Archived.",
+      variant: "success",
+      persistent: true,
+      action: { type: "link", props: { label: "Undo", href: "/undo" } },
+    });
+
+    expect(screen.getByRole("link", { name: "Undo" })).toHaveAttribute("href", "/undo");
+  });
+});

--- a/resources/js/toast/toaster.test.tsx
+++ b/resources/js/toast/toaster.test.tsx
@@ -11,9 +11,11 @@ vi.mock("@inertiajs/react", () => ({
   ),
 }));
 
-function emit(detail: unknown): void {
+function emit(toast: unknown): void {
   act(() => {
-    window.dispatchEvent(new CustomEvent(LATTICE_EVENT.toast, { detail }));
+    window.dispatchEvent(
+      new CustomEvent(LATTICE_EVENT.toast, { detail: { type: "toast", toast } }),
+    );
   });
 }
 

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -4,13 +4,12 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Renderer } from "@lattice/lattice/core/renderer";
 import type { Node } from "@lattice/lattice/core/types";
+import type { ToastVariant } from "@lattice/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 import { cn } from "@lattice/lattice/lib/utils";
 import { useRegistry } from "@lattice/lattice/provider";
 
-const variants = ["success", "info", "warning", "error"] as const;
-
-type ToastVariant = (typeof variants)[number];
+const variants = ["success", "info", "warning", "error"] as const satisfies readonly ToastVariant[];
 
 type ToastItem = {
   action?: Node;
@@ -59,7 +58,7 @@ function normalize(detail: unknown): Omit<ToastItem, "id"> | null {
   }
 
   return {
-    action: (data.action as Node | undefined) ?? undefined,
+    action: data.action as Node | undefined,
     dismissible: data.dismissible !== false,
     duration: typeof data.duration === "number" ? data.duration : null,
     message: data.message,

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -4,21 +4,19 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Renderer } from "@lattice/lattice/core/renderer";
 import type { Node } from "@lattice/lattice/core/types";
-import type { ToastVariant } from "@lattice/lattice/types/generated";
+import type { ToastMessage, ToastVariant } from "@lattice/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 import { cn } from "@lattice/lattice/lib/utils";
 import { useRegistry } from "@lattice/lattice/provider";
 
 const variants = ["success", "info", "warning", "error"] as const satisfies readonly ToastVariant[];
 
-type ToastItem = {
+// `action` is re-typed from the wire `Node` to the renderer's `Node`: the
+// generated `ToastMessage.action` describes the wire shape, but the Toaster
+// hands it to the `Renderer`, which works with the loose render-side node.
+type ToastItem = Omit<ToastMessage, "action"> & {
   action: Node | null;
-  dismissible: boolean;
-  duration: number | null;
   id: number;
-  message: string;
-  persistent: boolean;
-  variant: ToastVariant;
 };
 
 const variantStyles: Record<ToastVariant, { accent: string; icon: ReactNode }> = {

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -1,0 +1,124 @@
+import * as Toast from "@radix-ui/react-toast";
+import { CircleAlert, CircleCheck, CircleX, Info, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import type { Node } from "@lattice/lattice/core/types";
+import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
+import { cn } from "@lattice/lattice/lib/utils";
+import { useRegistry } from "@lattice/lattice/provider";
+
+const variants = ["success", "info", "warning", "error"] as const;
+
+type ToastVariant = (typeof variants)[number];
+
+type ToastItem = {
+  action?: Node;
+  dismissible: boolean;
+  duration?: number | null;
+  id: number;
+  message: string;
+  persistent: boolean;
+  variant: ToastVariant;
+};
+
+const variantIcon: Record<ToastVariant, ReactNode> = {
+  success: <CircleCheck className="size-5 shrink-0 text-emerald-500" />,
+  info: <Info className="size-5 shrink-0 text-sky-500" />,
+  warning: <CircleAlert className="size-5 shrink-0 text-amber-500" />,
+  error: <CircleX className="size-5 shrink-0 text-lt-danger" />,
+};
+
+function isVariant(value: unknown): value is ToastVariant {
+  return variants.some((variant) => variant === value);
+}
+
+let nextId = 0;
+
+function normalize(detail: unknown): Omit<ToastItem, "id"> | null {
+  if (typeof detail !== "object" || detail === null) {
+    return null;
+  }
+
+  const data = detail as Record<string, unknown>;
+
+  if (typeof data.message !== "string" || data.message === "") {
+    return null;
+  }
+
+  return {
+    action: (data.action as Node | undefined) ?? undefined,
+    dismissible: data.dismissible !== false,
+    duration: typeof data.duration === "number" ? data.duration : null,
+    message: data.message,
+    persistent: data.persistent === true,
+    variant: isVariant(data.variant) ? data.variant : "success",
+  };
+}
+
+export function Toaster({ duration = 4000 }: { duration?: number }) {
+  const registry = useRegistry();
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  function push(detail: unknown): void {
+    const item = normalize(detail);
+
+    if (item) {
+      setToasts((current) => [...current, { ...item, id: nextId++ }]);
+    }
+  }
+
+  function dismiss(id: number): void {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }
+
+  useEffect(() => {
+    const listener = (event: Event): void => push((event as CustomEvent).detail);
+
+    window.addEventListener(LATTICE_EVENT.toast, listener);
+
+    return () => window.removeEventListener(LATTICE_EVENT.toast, listener);
+  }, []);
+
+  return (
+    <Toast.Provider duration={duration} swipeDirection="down">
+      {toasts.map((toast) => (
+        <Toast.Root
+          key={toast.id}
+          className={cn(
+            "flex items-start gap-3 rounded-lt border border-lt-border bg-lt-popover p-4 text-lt-popover-fg shadow-lg",
+            "data-[state=open]:animate-lt-toast-in data-[state=closed]:animate-lt-toast-out",
+            "data-[swipe=move]:translate-y-[var(--radix-toast-swipe-move-y)] data-[swipe=cancel]:translate-y-0 data-[swipe=cancel]:transition-transform",
+          )}
+          data-test={`toast-${toast.variant}`}
+          duration={toast.persistent ? Infinity : (toast.duration ?? duration)}
+          onOpenChange={(open) => {
+            if (!open) {
+              dismiss(toast.id);
+            }
+          }}
+        >
+          {variantIcon[toast.variant]}
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <Toast.Title className="text-sm text-lt-fg">{toast.message}</Toast.Title>
+            {toast.action ? (
+              <div className="flex flex-wrap gap-2">
+                <Renderer nodes={[toast.action]} registry={registry} />
+              </div>
+            ) : null}
+          </div>
+          {toast.dismissible ? (
+            <Toast.Close
+              aria-label="Dismiss"
+              className="shrink-0 rounded-md p-1 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
+              data-test="toast-dismiss"
+            >
+              <X className="size-4" />
+            </Toast.Close>
+          ) : null}
+        </Toast.Root>
+      ))}
+      <Toast.Viewport className="fixed inset-x-0 bottom-0 z-[100] mx-auto flex w-full max-w-sm flex-col gap-2 p-4 outline-none" />
+    </Toast.Provider>
+  );
+}

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -12,9 +12,9 @@ import { useRegistry } from "@lattice/lattice/provider";
 const variants = ["success", "info", "warning", "error"] as const satisfies readonly ToastVariant[];
 
 type ToastItem = {
-  action?: Node;
+  action: Node | null;
   dismissible: boolean;
-  duration?: number | null;
+  duration: number | null;
   id: number;
   message: string;
   persistent: boolean;
@@ -51,19 +51,25 @@ function normalize(detail: unknown): Omit<ToastItem, "id"> | null {
     return null;
   }
 
-  const data = detail as Record<string, unknown>;
+  const data = (detail as { toast?: unknown }).toast;
 
-  if (typeof data.message !== "string" || data.message === "") {
+  if (typeof data !== "object" || data === null) {
+    return null;
+  }
+
+  const toast = data as Record<string, unknown>;
+
+  if (typeof toast.message !== "string" || toast.message === "") {
     return null;
   }
 
   return {
-    action: data.action as Node | undefined,
-    dismissible: data.dismissible !== false,
-    duration: typeof data.duration === "number" ? data.duration : null,
-    message: data.message,
-    persistent: data.persistent === true,
-    variant: isVariant(data.variant) ? data.variant : "success",
+    action: (toast.action as Node | null) ?? null,
+    dismissible: toast.dismissible !== false,
+    duration: typeof toast.duration === "number" ? toast.duration : null,
+    message: toast.message,
+    persistent: toast.persistent === true,
+    variant: isVariant(toast.variant) ? toast.variant : "success",
   };
 }
 

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -3,7 +3,6 @@ import { CircleAlert, CircleCheck, CircleX, Info, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Renderer } from "@lattice/lattice/core/renderer";
-import type { Node } from "@lattice/lattice/core/types";
 import type { ToastMessage, ToastVariant } from "@lattice/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice/lattice/events/event-names";
 import { cn } from "@lattice/lattice/lib/utils";
@@ -11,13 +10,7 @@ import { useRegistry } from "@lattice/lattice/provider";
 
 const variants = ["success", "info", "warning", "error"] as const satisfies readonly ToastVariant[];
 
-// `action` is re-typed from the wire `Node` to the renderer's `Node`: the
-// generated `ToastMessage.action` describes the wire shape, but the Toaster
-// hands it to the `Renderer`, which works with the loose render-side node.
-type ToastItem = Omit<ToastMessage, "action"> & {
-  action: Node | null;
-  id: number;
-};
+type ToastItem = ToastMessage & { id: number };
 
 const variantStyles: Record<ToastVariant, { accent: string; icon: ReactNode }> = {
   success: {
@@ -44,7 +37,7 @@ function isVariant(value: unknown): value is ToastVariant {
 
 let nextId = 0;
 
-function normalize(detail: unknown): Omit<ToastItem, "id"> | null {
+function normalize(detail: unknown): ToastMessage | null {
   if (typeof detail !== "object" || detail === null) {
     return null;
   }
@@ -62,7 +55,7 @@ function normalize(detail: unknown): Omit<ToastItem, "id"> | null {
   }
 
   return {
-    action: (toast.action as Node | null) ?? null,
+    action: (toast.action as ToastMessage["action"]) ?? null,
     dismissible: toast.dismissible !== false,
     duration: typeof toast.duration === "number" ? toast.duration : null,
     message: toast.message,

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -22,11 +22,23 @@ type ToastItem = {
   variant: ToastVariant;
 };
 
-const variantIcon: Record<ToastVariant, ReactNode> = {
-  success: <CircleCheck className="size-5 shrink-0 text-emerald-500" />,
-  info: <Info className="size-5 shrink-0 text-sky-500" />,
-  warning: <CircleAlert className="size-5 shrink-0 text-amber-500" />,
-  error: <CircleX className="size-5 shrink-0 text-lt-danger" />,
+const variantStyles: Record<ToastVariant, { accent: string; icon: ReactNode }> = {
+  success: {
+    accent: "border-l-lt-success",
+    icon: <CircleCheck className="size-5 shrink-0 text-lt-success" />,
+  },
+  info: {
+    accent: "border-l-lt-info",
+    icon: <Info className="size-5 shrink-0 text-lt-info" />,
+  },
+  warning: {
+    accent: "border-l-lt-warning",
+    icon: <CircleAlert className="size-5 shrink-0 text-lt-warning" />,
+  },
+  error: {
+    accent: "border-l-lt-danger",
+    icon: <CircleX className="size-5 shrink-0 text-lt-danger" />,
+  },
 };
 
 function isVariant(value: unknown): value is ToastVariant {
@@ -86,7 +98,8 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
         <Toast.Root
           key={toast.id}
           className={cn(
-            "flex items-start gap-3 rounded-lt border border-lt-border bg-lt-popover p-4 text-lt-popover-fg shadow-lg",
+            "flex items-start gap-3 rounded-lt border border-l-4 border-lt-border bg-lt-popover p-4 text-lt-popover-fg shadow-lg",
+            variantStyles[toast.variant].accent,
             "data-[state=open]:animate-lt-toast-in data-[state=closed]:animate-lt-toast-out",
             "data-[swipe=move]:translate-y-[var(--radix-toast-swipe-move-y)] data-[swipe=cancel]:translate-y-0 data-[swipe=cancel]:transition-transform",
           )}
@@ -98,7 +111,7 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
             }
           }}
         >
-          {variantIcon[toast.variant]}
+          {variantStyles[toast.variant].icon}
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             <Toast.Title className="text-sm text-lt-fg">{toast.message}</Toast.Title>
             {toast.action ? (

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -57,7 +57,15 @@ export type Button = {
   variant: ButtonVariant | null;
 };
 export type ButtonType = "button" | "submit" | "reset";
-export type ButtonVariant = "default" | "destructive" | "ghost" | "link" | "outline" | "secondary";
+export type ButtonVariant =
+  | "default"
+  | "destructive"
+  | "ghost"
+  | "info"
+  | "link"
+  | "outline"
+  | "secondary"
+  | "success";
 export type Card = {
   description: string | null;
   title: string | null;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -110,7 +110,7 @@ export type Choice = {
   value: unknown;
 };
 export type CloseModalEffect = {
-  readonly modal?: string | null;
+  readonly modal: string | null;
 };
 export type ColumnData = {
   readonly key: string;
@@ -530,7 +530,7 @@ export type ReloadComponentEffect = {
 };
 export type ReloadPageEffect = object;
 export type ResetFormEffect = {
-  readonly form?: string | null;
+  readonly form: string | null;
 };
 export type RichEditor = {
   conditions: {
@@ -673,12 +673,15 @@ export type Textarea = {
   value: unknown;
 };
 export type ToastEffect = {
-  readonly variant: ToastVariant;
-  readonly message: string;
-  readonly duration?: number | null;
-  readonly persistent: boolean;
-  readonly dismissible: boolean;
-  readonly action?: Node;
+  readonly toast: ToastMessage;
+};
+export type ToastMessage = {
+  duration: number | null;
+  persistent: boolean;
+  dismissible: boolean;
+  action: Node | null;
+  variant: ToastVariant;
+  message: string;
 };
 export type ToastVariant = "success" | "info" | "warning" | "error";
 export type Width = "full" | "sm" | "md" | "lg" | "fill";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -667,6 +667,10 @@ export type Textarea = {
 export type ToastEffect = {
   readonly variant: ToastVariant;
   readonly message: string;
+  readonly duration?: number | null;
+  readonly persistent: boolean;
+  readonly dismissible: boolean;
+  readonly action?: Node;
 };
 export type ToastVariant = "success" | "info" | "warning" | "error";
 export type Width = "full" | "sm" | "md" | "lg" | "fill";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -422,7 +422,7 @@ export type Link = {
   method: HttpMethod | null;
   tabIndex: number | null;
 };
-export type Menu = object;
+export type Menu = Record<string, never>;
 export type MenuItem = {
   href: string | null;
   icon: string | null;
@@ -486,7 +486,7 @@ export type Option = {
   readonly value: string;
 };
 export type Orientation = "horizontal" | "vertical";
-export type Outlet = object;
+export type Outlet = Record<string, never>;
 export type PageContainer = "centered" | "default";
 export type PageLayout = "app" | "auth" | "none";
 export type PaginationType = "none" | "simple" | "table" | "infinite";

--- a/src/Actions/Effect.php
+++ b/src/Actions/Effect.php
@@ -27,7 +27,14 @@ final class Effect
             default => throw new \InvalidArgumentException('A toast message string is required.'),
         };
 
-        return new ToastEffect($toast->variant, $toast->message);
+        return new ToastEffect(
+            $toast->variant,
+            $toast->message,
+            $toast->duration,
+            $toast->persistent,
+            $toast->dismissible,
+            $toast->action,
+        );
     }
 
     public static function reloadComponent(string $component): ReloadComponentEffect

--- a/src/Actions/Effect.php
+++ b/src/Actions/Effect.php
@@ -27,14 +27,7 @@ final class Effect
             default => throw new \InvalidArgumentException('A toast message string is required.'),
         };
 
-        return new ToastEffect(
-            $toast->variant,
-            $toast->message,
-            $toast->duration,
-            $toast->persistent,
-            $toast->dismissible,
-            $toast->action,
-        );
+        return new ToastEffect($toast);
     }
 
     public static function reloadComponent(string $component): ReloadComponentEffect

--- a/src/Actions/Effects/CloseModalEffect.php
+++ b/src/Actions/Effects/CloseModalEffect.php
@@ -6,13 +6,11 @@ namespace Lattice\Lattice\Actions\Effects;
 
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
-use Spatie\TypeScriptTransformer\Attributes\Optional;
 
 #[Attributes\Effect(EffectType::CloseModal)]
 final readonly class CloseModalEffect extends Effect
 {
     public function __construct(
-        #[Optional]
         public ?string $modal = null,
     ) {}
 }

--- a/src/Actions/Effects/Effect.php
+++ b/src/Actions/Effects/Effect.php
@@ -16,10 +16,7 @@ abstract readonly class Effect implements EffectContract
      */
     public function jsonSerialize(): array
     {
-        return array_filter(
-            ['type' => $this->type(), ...get_object_vars($this)],
-            fn (mixed $value): bool => $value !== null,
-        );
+        return ['type' => $this->type(), ...get_object_vars($this)];
     }
 
     private function type(): string

--- a/src/Actions/Effects/ResetFormEffect.php
+++ b/src/Actions/Effects/ResetFormEffect.php
@@ -6,13 +6,11 @@ namespace Lattice\Lattice\Actions\Effects;
 
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
-use Spatie\TypeScriptTransformer\Attributes\Optional;
 
 #[Attributes\Effect(EffectType::ResetForm)]
 final readonly class ResetFormEffect extends Effect
 {
     public function __construct(
-        #[Optional]
         public ?string $form = null,
     ) {}
 }

--- a/src/Actions/Effects/ToastEffect.php
+++ b/src/Actions/Effects/ToastEffect.php
@@ -6,23 +6,12 @@ namespace Lattice\Lattice\Actions\Effects;
 
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
-use Lattice\Lattice\Core\Components\Component;
-use Lattice\Lattice\Core\Enums\ToastVariant;
-use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
-use Spatie\TypeScriptTransformer\Attributes\Optional;
+use Lattice\Lattice\Core\Values\ToastMessage;
 
 #[Attributes\Effect(EffectType::Toast)]
 final readonly class ToastEffect extends Effect
 {
     public function __construct(
-        public ToastVariant $variant,
-        public string $message,
-        #[Optional]
-        public ?int $duration = null,
-        public bool $persistent = false,
-        public bool $dismissible = true,
-        #[Optional]
-        #[LiteralTypeScriptType('Node')]
-        public ?Component $action = null,
+        public ToastMessage $toast,
     ) {}
 }

--- a/src/Actions/Effects/ToastEffect.php
+++ b/src/Actions/Effects/ToastEffect.php
@@ -6,7 +6,10 @@ namespace Lattice\Lattice\Actions\Effects;
 
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
+use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Enums\ToastVariant;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
+use Spatie\TypeScriptTransformer\Attributes\Optional;
 
 #[Attributes\Effect(EffectType::Toast)]
 final readonly class ToastEffect extends Effect
@@ -14,5 +17,12 @@ final readonly class ToastEffect extends Effect
     public function __construct(
         public ToastVariant $variant,
         public string $message,
+        #[Optional]
+        public ?int $duration = null,
+        public bool $persistent = false,
+        public bool $dismissible = true,
+        #[Optional]
+        #[LiteralTypeScriptType('Node')]
+        public ?Component $action = null,
     ) {}
 }

--- a/src/Core/Enums/ButtonVariant.php
+++ b/src/Core/Enums/ButtonVariant.php
@@ -9,7 +9,9 @@ enum ButtonVariant: string
     case Default = 'default';
     case Destructive = 'destructive';
     case Ghost = 'ghost';
+    case Info = 'info';
     case Link = 'link';
     case Outline = 'outline';
     case Secondary = 'secondary';
+    case Success = 'success';
 }

--- a/src/Core/Values/ToastMessage.php
+++ b/src/Core/Values/ToastMessage.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\Link;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\ToastVariant;
+use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 
 /**
  * Builder for a toast notification: a message and variant plus optional lifetime,
@@ -23,6 +24,7 @@ final class ToastMessage implements JsonSerializable
 
     public bool $dismissible = true;
 
+    #[LiteralTypeScriptType('Node | null')]
     public ?Component $action = null;
 
     private function __construct(
@@ -73,13 +75,13 @@ final class ToastMessage implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return array_filter([
+        return [
             'variant' => $this->variant->value,
             'message' => $this->message,
             'duration' => $this->duration,
             'persistent' => $this->persistent,
             'dismissible' => $this->dismissible,
             'action' => $this->action,
-        ], fn (mixed $value): bool => $value !== null);
+        ];
     }
 }

--- a/src/Core/Values/ToastMessage.php
+++ b/src/Core/Values/ToastMessage.php
@@ -5,10 +5,26 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Values;
 
 use JsonSerializable;
+use Lattice\Lattice\Core\Components\Component;
+use Lattice\Lattice\Core\Components\Link;
+use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\ToastVariant;
 
-final readonly class ToastMessage implements JsonSerializable
+/**
+ * Builder for a toast notification: a message and variant plus optional lifetime,
+ * a close button, and an action rendered in the toast (a link or a full Action
+ * that can open a confirm dialog or modal form).
+ */
+final class ToastMessage implements JsonSerializable
 {
+    public ?int $duration = null;
+
+    public bool $persistent = false;
+
+    public bool $dismissible = true;
+
+    public ?Component $action = null;
+
     private function __construct(
         public ToastVariant $variant,
         public string $message,
@@ -19,14 +35,51 @@ final readonly class ToastMessage implements JsonSerializable
         return new self($variant, $message);
     }
 
+    public function duration(int $milliseconds): self
+    {
+        $this->duration = $milliseconds;
+
+        return $this;
+    }
+
+    public function persistent(bool $persistent = true): self
+    {
+        $this->persistent = $persistent;
+
+        return $this;
+    }
+
+    public function dismissible(bool $dismissible = true): self
+    {
+        $this->dismissible = $dismissible;
+
+        return $this;
+    }
+
+    public function link(string $label, string $href, HttpMethod $method = HttpMethod::Get): self
+    {
+        return $this->action(Link::make($label)->href($href)->method($method));
+    }
+
+    public function action(Component $action): self
+    {
+        $this->action = $action;
+
+        return $this;
+    }
+
     /**
-     * @return array{variant: string, message: string}
+     * @return array<string, mixed>
      */
     public function jsonSerialize(): array
     {
-        return [
+        return array_filter([
             'variant' => $this->variant->value,
             'message' => $this->message,
-        ];
+            'duration' => $this->duration,
+            'persistent' => $this->persistent,
+            'dismissible' => $this->dismissible,
+            'action' => $this->action,
+        ], fn (mixed $value): bool => $value !== null);
     }
 }

--- a/src/Core/Values/ToastMessage.php
+++ b/src/Core/Values/ToastMessage.php
@@ -9,7 +9,6 @@ use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\Link;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\ToastVariant;
-use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 
 /**
  * Builder for a toast notification: a message and variant plus optional lifetime,
@@ -24,7 +23,6 @@ final class ToastMessage implements JsonSerializable
 
     public bool $dismissible = true;
 
-    #[LiteralTypeScriptType('Node | null')]
     public ?Component $action = null;
 
     private function __construct(

--- a/src/Support/TypeScript/ComponentTransformer.php
+++ b/src/Support/TypeScript/ComponentTransformer.php
@@ -6,11 +6,18 @@ namespace Lattice\Lattice\Support\TypeScript;
 
 use ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionClass as RoaveReflectionClass;
+use Spatie\TypeScriptTransformer\Data\TransformationContext;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
 use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\Transformers\ClassTransformer;
 use Spatie\TypeScriptTransformer\TypeResolvers\Data\ParsedClass;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptGeneric;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIdentifier;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptNever;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptNode;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptObject;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptString;
 
 /**
  * Emits TypeScript prop types for an explicit allow-list of components. Every
@@ -33,6 +40,29 @@ final class ComponentTransformer extends ClassTransformer
     protected function shouldTransform(PhpClassNode $phpClassNode): bool
     {
         return in_array($phpClassNode->getName(), $this->allowed, true);
+    }
+
+    /**
+     * Emit `Record<string, never>` rather than `object` for a propless component
+     * (e.g. Menu, Outlet). `object` has no index signature, so it would not be
+     * assignable to the renderer's loose `props` bag and the wire node could not
+     * flow into the renderer; `Record<string, never>` keeps that path open.
+     */
+    protected function getTypeScriptNode(
+        PhpClassNode $phpClassNode,
+        TransformationContext $context,
+        ?ParsedClass $parsedClass = null,
+    ): TypeScriptNode {
+        $node = parent::getTypeScriptNode($phpClassNode, $context, $parsedClass);
+
+        if ($node instanceof TypeScriptObject && $node->properties === []) {
+            return new TypeScriptGeneric(
+                new TypeScriptIdentifier('Record'),
+                [new TypeScriptString, new TypeScriptNever],
+            );
+        }
+
+        return $node;
     }
 
     /**

--- a/tests/Browser/ToastTest.php
+++ b/tests/Browser/ToastTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Workbench\App\Models\Product;
+
+it('shows a toast after an action and dismisses it', function (): void {
+    Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
+
+    visit('/products')
+        ->click('@action-archive')
+        ->click('@confirm-accept')
+        ->assertSee('Product archived.')
+        ->click('@toast-dismiss')
+        ->assertDontSee('Product archived.')
+        ->assertNoSmoke();
+});
+
+it('renders a link inside a toast', function (): void {
+    Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
+
+    visit('/products')
+        ->click('@action-archive')
+        ->click('@confirm-accept')
+        ->assertSee('Product archived.')
+        ->click('View products')
+        ->assertSee('Create product')
+        ->assertNoSmoke();
+});
+
+it('opens a modal form from a toast action', function (): void {
+    $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
+
+    visit('/products')
+        ->click('@action-quick-edit')
+        ->assertValue('#name', 'Desk Lamp')
+        ->click('@action-form-submit')
+        ->assertSee('Product updated.')
+        ->click('@action-reject-product')
+        ->assertSee('Reject product?')
+        ->fill('Reason', 'Counterfeit listing')
+        ->click('@action-form-submit')
+        ->assertNoSmoke();
+
+    expect($product->fresh()->status)->toBe('archived');
+});

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -976,6 +976,8 @@ test('registered actions serialize their configured endpoint method label and ef
                         'type' => 'toast',
                         'message' => 'Ready.',
                         'variant' => 'success',
+                        'persistent' => false,
+                        'dismissible' => true,
                     ],
                     [
                         'type' => 'reloadComponent',
@@ -1087,12 +1089,16 @@ test('toast messages serialize for flash data and action effects', function () {
         ->toBe([
             'variant' => 'warning',
             'message' => 'Review the settings.',
+            'persistent' => false,
+            'dismissible' => true,
         ])
         ->and(wire(Effect::toast(ToastVariant::Warning, 'Review the settings.')))
         ->toBe([
             'type' => 'toast',
             'variant' => 'warning',
             'message' => 'Review the settings.',
+            'persistent' => false,
+            'dismissible' => true,
         ])
         ->and(wire(ActionResult::success()->toast('Saved.')))
         ->toMatchArray([
@@ -1101,6 +1107,8 @@ test('toast messages serialize for flash data and action effects', function () {
                     'type' => 'toast',
                     'variant' => 'success',
                     'message' => 'Saved.',
+                    'persistent' => false,
+                    'dismissible' => true,
                 ],
             ],
         ])
@@ -1111,9 +1119,42 @@ test('toast messages serialize for flash data and action effects', function () {
                     'type' => 'toast',
                     'variant' => 'warning',
                     'message' => 'Review the settings.',
+                    'persistent' => false,
+                    'dismissible' => true,
                 ],
             ],
         ]);
+});
+
+test('a toast serializes its lifetime, dismissibility and link', function () {
+    $wire = wire(Effect::toast(
+        ToastMessage::make(ToastVariant::Success, 'Saved.')
+            ->duration(8000)
+            ->dismissible(false)
+            ->link('Undo', '/undo', HttpMethod::Patch),
+    ));
+
+    expect($wire['type'])->toBe('toast')
+        ->and($wire['duration'])->toBe(8000)
+        ->and($wire['persistent'])->toBeFalse()
+        ->and($wire['dismissible'])->toBeFalse()
+        ->and($wire['action']['type'])->toBe('link')
+        ->and($wire['action']['props']['label'])->toBe('Undo')
+        ->and($wire['action']['props']['href'])->toBe('/undo')
+        ->and($wire['action']['props']['method'])->toBe('patch');
+});
+
+test('a toast can carry an action component', function () {
+    $wire = wire(Effect::toast(
+        ToastMessage::make(ToastVariant::Info, 'Done.')
+            ->persistent()
+            ->action(ActionComponent::make('demo.toast-action')->endpoint('/x')->label('Open')),
+    ));
+
+    expect($wire['persistent'])->toBeTrue()
+        ->and($wire['action']['type'])->toBe('action')
+        ->and($wire['action']['props']['label'])->toBe('Open')
+        ->and($wire['action']['props']['endpoint'])->toBe('/x');
 });
 
 test('registered action endpoints require a valid component reference', function () {

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -974,10 +974,14 @@ test('registered actions serialize their configured endpoint method label and ef
                 'effects' => [
                     [
                         'type' => 'toast',
-                        'message' => 'Ready.',
-                        'variant' => 'success',
-                        'persistent' => false,
-                        'dismissible' => true,
+                        'toast' => [
+                            'variant' => 'success',
+                            'message' => 'Ready.',
+                            'duration' => null,
+                            'persistent' => false,
+                            'dismissible' => true,
+                            'action' => null,
+                        ],
                     ],
                     [
                         'type' => 'reloadComponent',
@@ -1065,8 +1069,8 @@ test('registered actions can be handled through the package endpoint', function 
         ->assertJsonPath('data.handled', 'Taylor')
         ->assertJsonPath('data.team', 'trusted-team')
         ->assertJsonPath('effects.0.type', 'toast')
-        ->assertJsonPath('effects.0.message', 'Action handled.')
-        ->assertJsonPath('effects.0.variant', 'info')
+        ->assertJsonPath('effects.0.toast.message', 'Action handled.')
+        ->assertJsonPath('effects.0.toast.variant', 'info')
         ->assertJsonPath('effects.1.type', 'reloadComponent')
         ->assertJsonPath('effects.1.component', 'workbench.users');
 });
@@ -1089,26 +1093,36 @@ test('toast messages serialize for flash data and action effects', function () {
         ->toBe([
             'variant' => 'warning',
             'message' => 'Review the settings.',
+            'duration' => null,
             'persistent' => false,
             'dismissible' => true,
+            'action' => null,
         ])
         ->and(wire(Effect::toast(ToastVariant::Warning, 'Review the settings.')))
         ->toBe([
             'type' => 'toast',
-            'variant' => 'warning',
-            'message' => 'Review the settings.',
-            'persistent' => false,
-            'dismissible' => true,
+            'toast' => [
+                'variant' => 'warning',
+                'message' => 'Review the settings.',
+                'duration' => null,
+                'persistent' => false,
+                'dismissible' => true,
+                'action' => null,
+            ],
         ])
         ->and(wire(ActionResult::success()->toast('Saved.')))
         ->toMatchArray([
             'effects' => [
                 [
                     'type' => 'toast',
-                    'variant' => 'success',
-                    'message' => 'Saved.',
-                    'persistent' => false,
-                    'dismissible' => true,
+                    'toast' => [
+                        'variant' => 'success',
+                        'message' => 'Saved.',
+                        'duration' => null,
+                        'persistent' => false,
+                        'dismissible' => true,
+                        'action' => null,
+                    ],
                 ],
             ],
         ])
@@ -1117,10 +1131,14 @@ test('toast messages serialize for flash data and action effects', function () {
             'effects' => [
                 [
                     'type' => 'toast',
-                    'variant' => 'warning',
-                    'message' => 'Review the settings.',
-                    'persistent' => false,
-                    'dismissible' => true,
+                    'toast' => [
+                        'variant' => 'warning',
+                        'message' => 'Review the settings.',
+                        'duration' => null,
+                        'persistent' => false,
+                        'dismissible' => true,
+                        'action' => null,
+                    ],
                 ],
             ],
         ]);
@@ -1135,13 +1153,13 @@ test('a toast serializes its lifetime, dismissibility and link', function () {
     ));
 
     expect($wire['type'])->toBe('toast')
-        ->and($wire['duration'])->toBe(8000)
-        ->and($wire['persistent'])->toBeFalse()
-        ->and($wire['dismissible'])->toBeFalse()
-        ->and($wire['action']['type'])->toBe('link')
-        ->and($wire['action']['props']['label'])->toBe('Undo')
-        ->and($wire['action']['props']['href'])->toBe('/undo')
-        ->and($wire['action']['props']['method'])->toBe('patch');
+        ->and($wire['toast']['duration'])->toBe(8000)
+        ->and($wire['toast']['persistent'])->toBeFalse()
+        ->and($wire['toast']['dismissible'])->toBeFalse()
+        ->and($wire['toast']['action']['type'])->toBe('link')
+        ->and($wire['toast']['action']['props']['label'])->toBe('Undo')
+        ->and($wire['toast']['action']['props']['href'])->toBe('/undo')
+        ->and($wire['toast']['action']['props']['method'])->toBe('patch');
 });
 
 test('a toast can carry an action component', function () {
@@ -1151,10 +1169,10 @@ test('a toast can carry an action component', function () {
             ->action(ActionComponent::make('demo.toast-action')->endpoint('/x')->label('Open')),
     ));
 
-    expect($wire['persistent'])->toBeTrue()
-        ->and($wire['action']['type'])->toBe('action')
-        ->and($wire['action']['props']['label'])->toBe('Open')
-        ->and($wire['action']['props']['endpoint'])->toBe('/x');
+    expect($wire['toast']['persistent'])->toBeTrue()
+        ->and($wire['toast']['action']['type'])->toBe('action')
+        ->and($wire['toast']['action']['props']['label'])->toBe('Open')
+        ->and($wire['toast']['action']['props']['endpoint'])->toBe('/x');
 });
 
 test('registered action endpoints require a valid component reference', function () {
@@ -1182,7 +1200,7 @@ test('action results expose the full effect vocabulary', function () {
         ['type' => 'download', 'url' => '/exports/report.csv'],
         ['type' => 'resetForm', 'form' => 'teams.create'],
     ])
-        ->and(wire(Effect::resetForm()))->toBe(['type' => 'resetForm'])
+        ->and(wire(Effect::resetForm()))->toBe(['type' => 'resetForm', 'form' => null])
         ->and(wire(Effect::reloadPage()))->toBe(['type' => 'reloadPage']);
 });
 

--- a/workbench/app/Actions/ArchiveProductAction.php
+++ b/workbench/app/Actions/ArchiveProductAction.php
@@ -12,6 +12,7 @@ use Lattice\Lattice\Attributes\Action;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\ToastVariant;
+use Lattice\Lattice\Core\Values\ToastMessage;
 use Workbench\App\Models\Product;
 
 #[Action('workbench.products.archive')]
@@ -37,7 +38,11 @@ class ArchiveProductAction extends ActionDefinition
         $product->update(['status' => 'archived']);
 
         return ActionResult::success(['id' => $product->getKey()])
-            ->toast(ToastVariant::Success, 'Product archived.')
+            ->toast(
+                ToastMessage::make(ToastVariant::Success, 'Product archived.')
+                    ->link('View products', '/products')
+                    ->persistent(),
+            )
             ->reloadComponent('workbench.products');
     }
 

--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -11,6 +11,7 @@ use Lattice\Lattice\Actions\FormActionDefinition;
 use Lattice\Lattice\Attributes\Action as ActionAttribute;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\ToastVariant;
+use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\Product;
@@ -54,7 +55,15 @@ class EditProductAction extends FormActionDefinition
         );
 
         return ActionResult::success(['id' => $product->getKey()])
-            ->toast(ToastVariant::Success, 'Product updated.')
+            ->toast(
+                ToastMessage::make(ToastVariant::Success, 'Product updated.')
+                    ->action(
+                        Action::use(RejectProductAction::class)
+                            ->label('Reject product')
+                            ->context(['product_id' => $product->getKey()]),
+                    )
+                    ->persistent(),
+            )
             ->reloadComponent('workbench.products');
     }
 

--- a/workbench/app/Console/Commands/GenerateInternalTypesCommand.php
+++ b/workbench/app/Console/Commands/GenerateInternalTypesCommand.php
@@ -20,6 +20,7 @@ use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\Enums\ToastVariant;
 use Lattice\Lattice\Core\Enums\Width;
 use Lattice\Lattice\Core\Option;
+use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Conditions\Condition;
 use Lattice\Lattice\Support\TypeScript\ComponentDiscovery;
@@ -94,6 +95,7 @@ final class GenerateInternalTypesCommand extends Command
                     ColumnFilter::class,
                     FilterClause::class,
                     TableSort::class,
+                    ToastMessage::class,
                     ...array_keys($effects),
                 ]),
                 new ComponentTransformer([

--- a/workbench/app/Pages/HomePage.php
+++ b/workbench/app/Pages/HomePage.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Workbench\App\Pages;
 
 use Lattice\Lattice\Core\Components\Badge;
+use Lattice\Lattice\Core\Components\Button;
 use Lattice\Lattice\Core\Components\Card;
 use Lattice\Lattice\Core\Components\Grid;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Tables\Components\Table;
@@ -40,6 +42,19 @@ final class HomePage extends WorkbenchPage
                         ->schema([
                             Card::make('Components', 'Server-side component trees serialize to typed React nodes.'),
                             Card::make('Renderer', 'The package renderer resolves registered component types.'),
+                        ]),
+                    Heading::make('Button variants', 2),
+                    Stack::make('workbench-buttons')
+                        ->direction('row')
+                        ->gap(Gap::Small)
+                        ->schema([
+                            Button::make('Default')->variant(ButtonVariant::Default),
+                            Button::make('Secondary')->variant(ButtonVariant::Secondary),
+                            Button::make('Success')->variant(ButtonVariant::Success),
+                            Button::make('Info')->variant(ButtonVariant::Info),
+                            Button::make('Destructive')->variant(ButtonVariant::Destructive),
+                            Button::make('Outline')->variant(ButtonVariant::Outline),
+                            Button::make('Ghost')->variant(ButtonVariant::Ghost),
                         ]),
                     Heading::make('Workbench users', 2),
                     Table::use(UsersTable::class),

--- a/workbench/app/Support/TypeScript/ComponentToNodeClassPropertyProcessor.php
+++ b/workbench/app/Support/TypeScript/ComponentToNodeClassPropertyProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Support\TypeScript;
+
+use Lattice\Lattice\Core\Components\Component;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
+use Spatie\TypeScriptTransformer\References\ClassStringReference;
+use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptProperty;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptReference;
+use Spatie\TypeScriptTransformer\Visitor\Visitor;
+use Spatie\TypeScriptTransformer\Visitor\VisitorOperation;
+
+/**
+ * Rewrites any property typed as a Lattice Component (e.g. `?Component`,
+ * `Component[]`) to the generated `Node` union. Component is an abstract base
+ * with no TypeScript type of its own; its wire representation is a `Node`.
+ */
+final class ComponentToNodeClassPropertyProcessor implements ClassPropertyProcessor
+{
+    private readonly Visitor $visitor;
+
+    public function __construct()
+    {
+        $this->visitor = Visitor::create()->before(function (TypeScriptReference $reference): VisitorOperation {
+            $target = $reference->reference;
+
+            if ($target instanceof ClassStringReference && is_a($target->classString, Component::class, true)) {
+                return VisitorOperation::replace(new TypeScriptReference(NodesProvider::nodeReference()));
+            }
+
+            return VisitorOperation::keep();
+        }, [TypeScriptReference::class]);
+    }
+
+    public function execute(
+        PhpPropertyNode $phpPropertyNode,
+        ?TypeNode $annotation,
+        TypeScriptProperty $property,
+    ): TypeScriptProperty {
+        $property->type = $this->visitor->execute($property->type);
+
+        return $property;
+    }
+}

--- a/workbench/app/Support/TypeScript/NodesProvider.php
+++ b/workbench/app/Support/TypeScript/NodesProvider.php
@@ -182,6 +182,11 @@ final class NodesProvider implements TransformedProvider
         );
     }
 
+    public static function nodeReference(): CustomReference
+    {
+        return new CustomReference(self::REFERENCE_KEY, 'Node');
+    }
+
     private function selfReference(string $name): CustomReference
     {
         return new CustomReference(self::REFERENCE_KEY, $name);

--- a/workbench/app/Support/TypeScript/ValueObjectTransformer.php
+++ b/workbench/app/Support/TypeScript/ValueObjectTransformer.php
@@ -36,6 +36,7 @@ final class ValueObjectTransformer extends ClassTransformer
         return [
             ...parent::classPropertyProcessors(),
             new MixedToUnknownClassPropertyProcessor,
+            new ComponentToNodeClassPropertyProcessor,
         ];
     }
 }


### PR DESCRIPTION
## What & why

The workbench never mounted a toaster, so action toast effects were invisible (flagged in the browser-test PR). This adds a real toast system: action `toast` effects (and any `lattice:toast` event) render through a Radix-based `Toaster` mounted by `Provider`, so toasts work for every consumer out of the box.

Toasts support a **lifetime**, a **close button**, and an **action** — either a **link** or a full **Action** component, which can open a confirm dialog or **modal form**.

## Library
`@radix-ui/react-toast` — consistent with the package's Radix-primitive + Tailwind + `lt-*` token approach (unstyled, accessible: live region, swipe/keyboard dismiss). Sonner was the alternative but imposes its own styling paradigm.

## Backend
- `ToastMessage` is now a fluent builder: `duration()`, `persistent()`, `dismissible()`, `link(label, href, method)`, `action(Component)`.
- The toast **action is a component node** (`Link` or `Action`) — one field, rendered by the existing `Renderer`. `Action::use(...)` serializes standalone (signed ref), so a toast can carry a confirm/modal-form follow-up.
- `ToastEffect` mirrors the data; `action` is typed as `Node` in TypeScript (`#[LiteralTypeScriptType]`). Wire stays flat.

## Frontend
- `Toaster`: **bottom-center**, **4000ms** default, variant icons, close button, `persistent` (`duration={Infinity}`); the action node renders through the `Renderer` so links navigate and actions open their modal. Mounted by `Provider` (opt out via `toaster={false}`).

## Workbench demo
- Archiving shows a toast with a **"View products" link**.
- Quick-edit shows a toast whose action opens the **reject modal form**.

## Verification
- Browser (Pest): 41 passed (3 new toast tests: render+dismiss, link, modal-form-from-toast)
- vitest: 207 passed (4 new Toaster tests) · PHP: 358 passed (+ rich-toast serialization tests)
- tsc / oxlint / oxfmt / Pint / larastan: clean
- Verified in-browser: bottom-center toast with link + close; modal form opens from a toast action.

Note: server-side Inertia **flash** toasts aren't auto-rendered by the Toaster yet (it listens to `lattice:toast`); `EventBridge` still exposes flash via `onToast`. Auto-rendering flash is a reasonable follow-up.