### PR TITLE
Docs: Toasts and Enums reference

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
             { label: "Pages", link: "/core/pages/" },
             { label: "Components", link: "/core/components/" },
             { label: "Fragments", link: "/core/fragments/" },
+            { label: "Toasts", link: "/core/toasts/" },
             { label: "Navigation", link: "/core/navigation/" },
             { label: "Theming", link: "/core/theming/" },
           ],
@@ -113,6 +114,7 @@ export default defineConfig({
           items: [
             { label: "Authorization", link: "/advanced/authorization/" },
             { label: "Security", link: "/advanced/security/" },
+            { label: "Enums reference", link: "/advanced/enums/" },
           ],
         },
         {

--- a/docs/content/docs/advanced/enums.md
+++ b/docs/content/docs/advanced/enums.md
@@ -1,0 +1,60 @@
+---
+title: Enums reference
+description: The backed enums used across Lattice builders, and their string values.
+---
+
+Lattice uses backed enums for the fixed vocabularies that appear in builders — alignments, gaps,
+variants, operators, and so on. Each is generated to a TypeScript union too, so the PHP value and the
+client type can't drift. The string value is what ends up on the wire.
+
+## Layout & display
+
+`Lattice\Lattice\Core\Enums`
+
+| Enum             | Cases (value)                                                                 |
+| ---------------- | ----------------------------------------------------------------------------- |
+| `Align`          | `Center` (center), `Left` (left), `Start` (start), `Stretch` (stretch)        |
+| `Gap`            | `ExtraSmall` (xs), `Small` (sm), `Medium` (md), `Large` (lg), `ExtraLarge` (xl) |
+| `Width`          | `Full` (full), `Small` (sm), `Medium` (md), `Large` (lg), `Fill` (fill)       |
+| `Orientation`    | `Horizontal` (horizontal), `Vertical` (vertical)                              |
+| `PageLayout`     | `App` (app), `Auth` (auth), `None` (none)                                     |
+| `PageContainer`  | `Centered` (centered), `Default` (default)                                    |
+
+## Interactive & feedback
+
+`Lattice\Lattice\Core\Enums`
+
+| Enum            | Cases (value)                                                                         |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `ButtonVariant` | `Default` (default), `Destructive` (destructive), `Ghost` (ghost), `Link` (link), `Outline` (outline), `Secondary` (secondary) |
+| `ButtonType`    | `Button` (button), `Submit` (submit), `Reset` (reset)                                 |
+| `HttpMethod`    | `Get` (get), `Post` (post), `Put` (put), `Patch` (patch), `Delete` (delete)           |
+| `ToastVariant`  | `Success` (success), `Info` (info), `Warning` (warning), `Error` (error)              |
+
+## Operators
+
+`Lattice\Lattice\Core\Enums\Op` — the shared comparison vocabulary used by both
+[form conditions](/forms/conditional-fields/#operators) and [table filters](/tables/sorting-filtering-pagination/#filtering).
+
+`Contains` (contains), `StartsWith` (starts_with), `EndsWith` (ends_with), `Equals` (eq),
+`NotEquals` (neq), `GreaterThan` (gt), `GreaterThanOrEqual` (gte), `LessThan` (lt),
+`LessThanOrEqual` (lte), `In` (in), `NotIn` (not_in), `Before` (before), `After` (after),
+`Empty` (empty), `Filled` (filled).
+
+## Tables
+
+`Lattice\Lattice\Tables\Enums`
+
+| Enum             | Cases (value)                                                            |
+| ---------------- | ------------------------------------------------------------------------ |
+| `ColumnType`     | `Text` (text), `Stack` (stack)                                           |
+| `FilterType`     | `Text` (text), `Number` (number), `Date` (date), `Boolean` (boolean)     |
+| `PaginationType` | `None` (none), `Simple` (simple), `Table` (table), `Infinite` (infinite) |
+| `SortDirection`  | `Asc` (asc), `Desc` (desc)                                               |
+
+## Actions
+
+`Lattice\Lattice\Actions\Enums\EffectType` — the kind of [effect](/actions/effects/) an action returns.
+
+`Toast` (toast), `ReloadComponent` (reloadComponent), `ReloadPage` (reloadPage), `Redirect` (redirect),
+`Download` (download), `OpenModal` (openModal), `CloseModal` (closeModal), `ResetForm` (resetForm).

--- a/docs/content/docs/core/toasts.md
+++ b/docs/content/docs/core/toasts.md
@@ -1,0 +1,51 @@
+---
+title: Toasts
+description: Transient notifications raised from the server — from an action's result or flashed from a form.
+---
+
+A toast is a short notification the client shows and dismisses. Toasts are raised on the server and
+carry a `ToastVariant` — `Success`, `Info`, `Warning`, or `Error` — that styles them.
+
+## From an action
+
+The most common source is an [action](/actions/overview/). Add a toast to the `ActionResult` it
+returns; the variant can come first or second:
+
+```php
+return ActionResult::success()
+    ->toast('Product archived.')                       // defaults to Success
+    ->toast(ToastVariant::Error, 'Could not reach the warehouse.');
+```
+
+See [Effects & results](/actions/effects/#toasts) for the full effect list.
+
+## From a form or definition
+
+A definition can flash a toast that appears on the next page — handy after a form submit that
+redirects. `$this->toast()` flashes the message; return your redirect as usual:
+
+```php
+use Lattice\Lattice\Core\Enums\ToastVariant;
+
+public function handle(Request $request): Response
+{
+    $this->validate($request);
+    // … persist …
+
+    $this->toast(ToastVariant::Success, 'Profile saved.');
+
+    return redirect('/profile');
+}
+```
+
+The flashed toast is delivered with the next Inertia response and shown once.
+
+## Building a message directly
+
+Both paths wrap a `ToastMessage` value object. Build one explicitly when you need to pass it around:
+
+```php
+use Lattice\Lattice\Core\Values\ToastMessage;
+
+ToastMessage::make(ToastVariant::Warning, 'Your trial ends tomorrow.');
+```


### PR DESCRIPTION
Rounds out the Phase-1 reference docs with the two pieces folded/deferred from PR #48 (ticket #110).

- **Toasts** (`core/toasts`) — raising notifications from an action's `ActionResult` and flashing one from a form/definition via `$this->toast()`, plus the `ToastMessage`/`ToastVariant` value types.
- **Enums reference** (`advanced/enums`) — the backed enums used across builders (layout, interactive, operators, tables, effects) with their wire values, cross-linked to where they're used.

Both added to the sidebar (Core → Toasts, Advanced → Enums reference).

## Verification
Docs build green (both pages render). Docs-only change — no PHP/JS touched.
