### PR TITLE
Rename field readonly prop to readOnly

### DIFF
--- a/docs/fixtures/checkbox.basic.json
+++ b/docs/fixtures/checkbox.basic.json
@@ -9,7 +9,7 @@
             "hidden": null,
             "label": "Subscribe to the newsletter",
             "name": "newsletter",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null

--- a/docs/fixtures/choice.basic.json
+++ b/docs/fixtures/choice.basic.json
@@ -23,7 +23,7 @@
                     "value": "enterprise"
                 }
             ],
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null

--- a/docs/fixtures/date-input.basic.json
+++ b/docs/fixtures/date-input.basic.json
@@ -11,7 +11,7 @@
             "max": "2026-01-01",
             "min": null,
             "name": "birthday",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null

--- a/docs/fixtures/field.default-value.json
+++ b/docs/fixtures/field.default-value.json
@@ -11,7 +11,7 @@
             "label": "Team name",
             "name": "name",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/field.disabled.json
+++ b/docs/fixtures/field.disabled.json
@@ -11,7 +11,7 @@
             "label": "Team name",
             "name": "name",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/field.read-only.json
+++ b/docs/fixtures/field.read-only.json
@@ -11,7 +11,7 @@
             "label": "Slug",
             "name": "slug",
             "placeholder": null,
-            "readonly": true,
+            "readOnly": true,
             "required": null,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -23,7 +23,7 @@
                     "value": "US"
                 }
             ],
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null
@@ -50,7 +50,7 @@
             "label": "VAT ID",
             "name": "vat",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/field.required.json
+++ b/docs/fixtures/field.required.json
@@ -11,7 +11,7 @@
             "label": "Team name",
             "name": "name",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": true,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -19,7 +19,7 @@
                     "value": "individual"
                 }
             ],
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null
@@ -46,7 +46,7 @@
             "label": "VAT ID",
             "name": "vat",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/number-input.basic.json
+++ b/docs/fixtures/number-input.basic.json
@@ -12,7 +12,7 @@
             "min": 0,
             "name": "age",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "slider": null,
             "step": null,

--- a/docs/fixtures/number-input.slider.json
+++ b/docs/fixtures/number-input.slider.json
@@ -12,7 +12,7 @@
             "min": 0,
             "name": "satisfaction",
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "slider": true,
             "step": null,

--- a/docs/fixtures/password-input.basic.json
+++ b/docs/fixtures/password-input.basic.json
@@ -14,7 +14,7 @@
             "name": "password",
             "passwordRules": null,
             "placeholder": "Your password",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null

--- a/docs/fixtures/password-input.confirmation.json
+++ b/docs/fixtures/password-input.confirmation.json
@@ -18,7 +18,7 @@
             "name": "password",
             "passwordRules": null,
             "placeholder": null,
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "value": null

--- a/docs/fixtures/rich-editor.basic.json
+++ b/docs/fixtures/rich-editor.basic.json
@@ -9,7 +9,7 @@
             "label": "Article",
             "name": "article",
             "placeholder": "Write your article\u2026",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "value": null
         },

--- a/docs/fixtures/select.basic.json
+++ b/docs/fixtures/select.basic.json
@@ -29,7 +29,7 @@
                 }
             ],
             "placeholder": "Pick a country",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "searchable": null,
             "tabIndex": null,

--- a/docs/fixtures/select.multiple.json
+++ b/docs/fixtures/select.multiple.json
@@ -29,7 +29,7 @@
                 }
             ],
             "placeholder": "Choose languages",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "searchable": null,
             "tabIndex": null,

--- a/docs/fixtures/text-input.email.json
+++ b/docs/fixtures/text-input.email.json
@@ -11,7 +11,7 @@
             "label": "Email address",
             "name": "email",
             "placeholder": "you@example.com",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "tabIndex": null,
             "type": "email",

--- a/docs/fixtures/text-input.required.json
+++ b/docs/fixtures/text-input.required.json
@@ -11,7 +11,7 @@
             "label": "Team name",
             "name": "name",
             "placeholder": "My team",
-            "readonly": null,
+            "readOnly": null,
             "required": true,
             "tabIndex": null,
             "type": null,

--- a/docs/fixtures/textarea.basic.json
+++ b/docs/fixtures/textarea.basic.json
@@ -10,7 +10,7 @@
             "label": "Bio",
             "name": "bio",
             "placeholder": "Tell us about yourself",
-            "readonly": null,
+            "readOnly": null,
             "required": null,
             "rows": 4,
             "tabIndex": null,

--- a/resources/js/form/components/conditions.ts
+++ b/resources/js/form/components/conditions.ts
@@ -5,21 +5,21 @@ export type Condition = { field: string; operator: Op; value: unknown };
 export type FieldConditions = {
   visible?: Condition[];
   required?: Condition[];
-  readonly?: Condition[];
+  readOnly?: Condition[];
   disabled?: Condition[];
 };
 
 export type FieldFlags = {
   hidden?: boolean;
   required?: boolean;
-  readonly?: boolean;
+  readOnly?: boolean;
   disabled?: boolean;
 };
 
 export type FieldState = {
   hidden: boolean;
   required: boolean;
-  readonly: boolean;
+  readOnly: boolean;
   disabled: boolean;
 };
 
@@ -135,7 +135,7 @@ export function evaluateConditions(
   return {
     hidden: Boolean(flags.hidden) || !visible,
     required: Boolean(flags.required) || anyMatch(conditions?.required, values),
-    readonly: Boolean(flags.readonly) || anyMatch(conditions?.readonly, values),
+    readOnly: Boolean(flags.readOnly) || anyMatch(conditions?.readOnly, values),
     disabled: Boolean(flags.disabled) || anyMatch(conditions?.disabled, values),
   };
 }

--- a/resources/js/form/components/field-props.ts
+++ b/resources/js/form/components/field-props.ts
@@ -15,7 +15,7 @@ export type FieldProps = {
   hidden?: boolean | null;
   label?: string | null;
   name?: string;
-  readonly?: boolean | null;
+  readOnly?: boolean | null;
   required?: boolean | null;
   value?: unknown;
 };

--- a/resources/js/form/components/fields/checkbox.tsx
+++ b/resources/js/form/components/fields/checkbox.tsx
@@ -9,7 +9,7 @@ import { useFormValue, useSetFormValue } from "../values";
 
 export const CheckboxComponent: RendererComponent<"form.checkbox"> = ({ node }) => {
   const { clearErrors, precognitive, validate } = useFormContext();
-  const { hidden, readonly, disabled } = useDependentField(node);
+  const { hidden, readOnly, disabled } = useDependentField(node);
   const name = node.props.name;
   const setValue = useSetFormValue();
   const storedValue = useFormValue(name);
@@ -27,7 +27,7 @@ export const CheckboxComponent: RendererComponent<"form.checkbox"> = ({ node }) 
       <Checkbox
         autoFocus={node.props.autoFocus ?? undefined}
         checked={checked}
-        disabled={readonly || disabled}
+        disabled={readOnly || disabled}
         id={name}
         name={name}
         onCheckedChange={(next) => {

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -8,7 +8,7 @@ import { useSeedDefault } from "../use-seed-default";
 
 export const ChoiceComponent: RendererComponent<"form.choice"> = ({ node }) => {
   const resolvedNode = useResolvedNode(node);
-  const { name, value, error, hidden, required, readonly, disabled, commit } =
+  const { name, value, error, hidden, required, readOnly, disabled, commit } =
     useControlledField(node);
   const options = useMemo(
     () => (resolvedNode.props as { options?: Option[] }).options ?? [],
@@ -29,7 +29,7 @@ export const ChoiceComponent: RendererComponent<"form.choice"> = ({ node }) => {
       <SegmentedPills
         ariaLabel={node.props.label ?? undefined}
         autoFocus={node.props.autoFocus ?? undefined}
-        disabled={readonly || disabled}
+        disabled={readOnly || disabled}
         name={name}
         onSelect={commit}
         options={options}

--- a/resources/js/form/components/fields/date-input.tsx
+++ b/resources/js/form/components/fields/date-input.tsx
@@ -7,7 +7,7 @@ export const DateInputComponent: RendererComponent<"form.date-input"> = ({ node 
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, value, readonly, disabled, commit }) => (
+      {({ name, value, readOnly, disabled, commit }) => (
         <Input
           autoFocus={props.autoFocus ?? false}
           disabled={disabled}
@@ -16,7 +16,7 @@ export const DateInputComponent: RendererComponent<"form.date-input"> = ({ node 
           min={props.min || undefined}
           name={name}
           onChange={(event) => commit(event.target.value)}
-          readOnly={readonly}
+          readOnly={readOnly}
           tabIndex={props.tabIndex ?? undefined}
           type="date"
           value={value}

--- a/resources/js/form/components/fields/number-input.tsx
+++ b/resources/js/form/components/fields/number-input.tsx
@@ -7,7 +7,7 @@ export const NumberInputComponent: RendererComponent<"form.number-input"> = ({ n
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, value, readonly, disabled, commit }) => {
+      {({ name, value, readOnly, disabled, commit }) => {
         const onChange = (event: React.ChangeEvent<HTMLInputElement>): void =>
           commit(event.target.value);
 
@@ -16,7 +16,7 @@ export const NumberInputComponent: RendererComponent<"form.number-input"> = ({ n
             <input
               aria-label={props.label ?? ""}
               className="h-2 w-full cursor-pointer appearance-none rounded-lt-sm bg-lt-muted accent-lt-primary disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={disabled || readonly}
+              disabled={disabled || readOnly}
               id={name}
               max={props.max ?? undefined}
               min={props.min ?? undefined}
@@ -41,7 +41,7 @@ export const NumberInputComponent: RendererComponent<"form.number-input"> = ({ n
             name={name}
             onChange={onChange}
             placeholder={props.placeholder ?? ""}
-            readOnly={readonly}
+            readOnly={readOnly}
             step={props.step ?? undefined}
             tabIndex={props.tabIndex ?? undefined}
             type="number"

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -8,7 +8,7 @@ import { useFormContext } from "../context";
 export const PasswordInputComponent: RendererComponent<"form.password-input"> = ({ node }) => {
   const props = node.props;
   const { errors } = useFormContext();
-  const { hidden, required, readonly, disabled } = useDependentField(node);
+  const { hidden, required, readOnly, disabled } = useDependentField(node);
   const { commit } = useFieldCommit();
   const name = props.name ?? "";
   const confirmation = props.confirmation;
@@ -43,7 +43,7 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
           onChange={onChange(name)}
           placeholder={props.placeholder ?? ""}
           passwordrules={passwordRules}
-          readOnly={readonly}
+          readOnly={readOnly}
           tabIndex={props.tabIndex ?? undefined}
         />
       </FormFieldFrame>
@@ -63,7 +63,7 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
             onChange={onChange(confirmationName)}
             placeholder={confirmation.placeholder ?? confirmation.label ?? "Confirm password"}
             passwordrules={passwordRules}
-            readOnly={readonly}
+            readOnly={readOnly}
             tabIndex={props.tabIndex ?? undefined}
           />
         </FormFieldFrame>

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -308,11 +308,11 @@ function Toolbar({ editor }: { editor: Editor }) {
 
 export const RichEditorComponent: RendererComponent<"form.rich-editor"> = ({ node }) => {
   const { errors } = useFormContext();
-  const { hidden, required, readonly, disabled } = useDependentField(node);
+  const { hidden, required, readOnly, disabled } = useDependentField(node);
   const { change, blur } = useFieldCommit();
   const name = node.props.name;
   const storedValue = useFormValue(name);
-  const locked = readonly || disabled;
+  const locked = readOnly || disabled;
   const initialContent =
     typeof storedValue === "object" && storedValue !== null
       ? (storedValue as object)

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -28,7 +28,7 @@ function toValues(stored: unknown, fallback: string | string[] | undefined): str
 export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
   const props = node.props;
   const { action, componentRef, errors } = useFormContext();
-  const { hidden, required, readonly, disabled } = useDependentField(node);
+  const { hidden, required, readOnly, disabled } = useDependentField(node);
   const { change, blur } = useFieldCommit();
   const resolvedNode = useResolvedNode(node);
   const name = props.name;
@@ -57,7 +57,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
   }, [staticOptions, results]);
   const labelFor = (value: string) => labels.get(value) ?? value;
 
-  const locked = readonly || disabled;
+  const locked = readOnly || disabled;
 
   useEffect(() => {
     if (!searchable) {

--- a/resources/js/form/components/fields/text-input.tsx
+++ b/resources/js/form/components/fields/text-input.tsx
@@ -7,7 +7,7 @@ export const TextInputComponent: RendererComponent<"form.text-input"> = ({ node 
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, value, readonly, disabled, commit }) => (
+      {({ name, value, readOnly, disabled, commit }) => (
         <Input
           autoComplete={props.autoComplete ?? ""}
           autoFocus={props.autoFocus ?? false}
@@ -16,7 +16,7 @@ export const TextInputComponent: RendererComponent<"form.text-input"> = ({ node 
           name={name}
           onChange={(event) => commit(event.target.value)}
           placeholder={props.placeholder ?? ""}
-          readOnly={readonly}
+          readOnly={readOnly}
           tabIndex={props.tabIndex ?? undefined}
           type={props.type ?? "text"}
           value={value}

--- a/resources/js/form/components/fields/textarea.tsx
+++ b/resources/js/form/components/fields/textarea.tsx
@@ -7,7 +7,7 @@ export const TextareaComponent: RendererComponent<"form.textarea"> = ({ node }) 
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, value, readonly, disabled, commit }) => (
+      {({ name, value, readOnly, disabled, commit }) => (
         <Textarea
           autoFocus={props.autoFocus ?? false}
           disabled={disabled}
@@ -15,7 +15,7 @@ export const TextareaComponent: RendererComponent<"form.textarea"> = ({ node }) 
           name={name}
           onChange={(event) => commit(event.target.value)}
           placeholder={props.placeholder ?? ""}
-          readOnly={readonly}
+          readOnly={readOnly}
           rows={props.rows ?? undefined}
           tabIndex={props.tabIndex ?? undefined}
           value={value}

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -117,7 +117,7 @@ describe("Lattice form schema components", () => {
         label: "Email address",
         name: "email",
         placeholder: "email@example.com",
-        readonly: true,
+        readOnly: true,
         required: true,
         value: "taylor@example.com",
       },

--- a/resources/js/form/components/use-dependent-field.ts
+++ b/resources/js/form/components/use-dependent-field.ts
@@ -10,7 +10,7 @@ export function useDependentField(node: Node): FieldState {
   return evaluateConditions(props.conditions ?? undefined, values, {
     hidden: props.hidden ?? false,
     required: props.required ?? false,
-    readonly: props.readonly ?? false,
+    readOnly: props.readOnly ?? false,
     disabled: props.disabled ?? false,
   });
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -88,7 +88,7 @@ export type Checkbox = {
   hidden: boolean | null;
   label: string | null;
   name: string;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
   value: any;
@@ -113,7 +113,7 @@ export type Choice = {
     label: string;
     value: string;
   }[];
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
   value: any;
@@ -231,7 +231,7 @@ export type DateInput = {
   max: string | null;
   min: string | null;
   name: string;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
   value: any;
@@ -389,7 +389,7 @@ export type HiddenInput = {
   hidden: boolean | null;
   label: string | null;
   name: string;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   value: any;
 };
@@ -459,7 +459,7 @@ export type NumberInput = {
   min: number | null;
   name: string;
   placeholder: string | null;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   slider: boolean | null;
   step: number | null;
@@ -519,7 +519,7 @@ export type PasswordInput = {
   name: string;
   passwordRules: string | null;
   placeholder: string | null;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
   value: any;
@@ -550,7 +550,7 @@ export type RichEditor = {
   label: string | null;
   name: string;
   placeholder: string | null;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   value: any;
 };
@@ -586,7 +586,7 @@ export type Select = {
     value: string;
   }[];
   placeholder: string | null;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   searchable: boolean | null;
   tabIndex: number | null;
@@ -659,7 +659,7 @@ export type TextInput = {
   label: string | null;
   name: string;
   placeholder: string | null;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
   type: string | null;
@@ -682,7 +682,7 @@ export type Textarea = {
   label: string | null;
   name: string;
   placeholder: string | null;
-  readonly: boolean | null;
+  readOnly: boolean | null;
   required: boolean | null;
   rows: number | null;
   tabIndex: number | null;

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -23,7 +23,7 @@ abstract class Field extends Component
 
     public ?bool $required = null;
 
-    public ?bool $readonly = null;
+    public ?bool $readOnly = null;
 
     public ?bool $disabled = null;
 
@@ -48,7 +48,7 @@ abstract class Field extends Component
     protected array $rules = [];
 
     /**
-     * Conditional state rules keyed by intent (visible/required/readonly/disabled).
+     * Conditional state rules keyed by intent (visible/required/readOnly/disabled).
      * Sets are created lazily as conditions are added.
      *
      * @var array<string, ConditionSet>
@@ -186,7 +186,7 @@ abstract class Field extends Component
 
     public function readOnlyWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
     {
-        return $this->addCondition('readonly', $field, $operatorOrValue, $value);
+        return $this->addCondition('readOnly', $field, $operatorOrValue, $value);
     }
 
     public function disabledWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
@@ -225,7 +225,7 @@ abstract class Field extends Component
 
     public function readOnly(bool $readOnly = true): static
     {
-        $this->readonly = $readOnly;
+        $this->readOnly = $readOnly;
 
         return $this;
     }
@@ -318,7 +318,7 @@ abstract class Field extends Component
      */
     public function isReadOnly(FormData $data): bool
     {
-        return $this->readonly === true || $this->anyConditionMatches('readonly', $data);
+        return $this->readOnly === true || $this->anyConditionMatches('readOnly', $data);
     }
 
     /**
@@ -339,7 +339,7 @@ abstract class Field extends Component
     }
 
     /**
-     * Required/readonly/disabled apply when any condition in the group holds, so
+     * Required/readOnly/disabled apply when any condition in the group holds, so
      * an empty group defaults to off.
      */
     private function anyConditionMatches(string $group, FormData $data): bool

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -384,7 +384,7 @@ test('password inputs can request automatic confirmation fields', function () {
                 'labelAction' => null,
                 'value' => null,
                 'hidden' => null,
-                'readonly' => null,
+                'readOnly' => null,
                 'disabled' => null,
                 'conditions' => null,
                 'dependsOnKeys' => null,


### PR DESCRIPTION
Renames the field wire prop `readonly` → `readOnly` (ticket #138). It was the one lowercase key in an otherwise camelCase field payload (`autoComplete`, `autoFocus`, `tabIndex`, `dependsOnKeys`, `dependsOnAny`).

## Scope
- **PHP** (`Field`) — the `$readOnly` property and the `readOnly` **condition group key** (so `conditions.readOnly` matches `conditions.{visible,required,disabled}` styling). The `readOnly()` / `readOnlyWhen()` builder methods were already camelCase and are unchanged.
- **React** — `field-props`, `use-dependent-field`, `conditions` (`FieldConditions`/`FieldFlags`/`FieldState` + `evaluateConditions`), and every field component's destructure/usage.
- **Generated TS types** — regenerated; `readOnly: boolean | null` across all field types.
- **Fixtures** — 19 docs fixtures regenerated to the `readOnly` key.

## Left untouched (deliberately)
- The PHP `readonly` property/class keyword and TS `readonly` type modifiers.
- The HTML `readonly` DOM attribute (React lowercases the rendered `readOnly` attribute; the `form.test.tsx` `toHaveAttribute("readonly")` assertion stays).

## Verification
`composer test` 356 · vitest 203 · `pint` / `phpstan` / `tsc` / `oxlint` clean · prod + docs builds green.
