### PR TITLE
refactor: generate shared value-object types for the wire shape

### DIFF
--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -92,7 +92,7 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
       {isConfirming && confirmation && (
         <ConfirmDialog
           title={confirmationTitle}
-          description={confirmation.description}
+          description={confirmation.description ?? undefined}
           confirmLabel={confirmationConfirmLabel}
           cancelLabel={confirmationCancelLabel}
           confirmVariant={variant}
@@ -107,7 +107,7 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
         <ActionForm
           cancelLabel={confirmationCancelLabel}
           componentRef={componentRef}
-          description={confirmation?.description}
+          description={confirmation?.description ?? undefined}
           endpoint={endpoint}
           formNode={formNode}
           method={method}

--- a/resources/js/core/types.ts
+++ b/resources/js/core/types.ts
@@ -2,6 +2,7 @@ import type { ComponentType as ReactComponentType, ReactNode } from "react";
 import type {
   Node as WireNode,
   NodeType,
+  Option,
   PageContainer as KnownPageContainer,
 } from "@lattice/lattice/types/generated";
 
@@ -11,10 +12,7 @@ export type { KnownPageContainer, NodeType, WireNode };
 export type NodeProps = Record<string, unknown>;
 
 /** A `{ label, value }` pair used by the choice, select and segmented controls. */
-export type Option = {
-  label: string;
-  value: string;
-};
+export type { Option };
 
 /**
  * A node whose `type` is not one of the generated built-ins. This is the escape

--- a/resources/js/form/components/conditions.ts
+++ b/resources/js/form/components/conditions.ts
@@ -1,6 +1,6 @@
-import type { Op } from "@lattice/lattice/types/generated";
+import type { Condition, Op } from "@lattice/lattice/types/generated";
 
-export type Condition = { field: string; operator: Op; value: unknown };
+export type { Condition };
 
 export type FieldConditions = {
   visible?: Condition[];

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -11,7 +11,7 @@ import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFormValue } from "../values";
 
-function toValues(stored: unknown, fallback: string | string[] | undefined): string[] {
+function toValues(stored: unknown, fallback: unknown): string[] {
   const source = stored ?? fallback;
 
   if (Array.isArray(source)) {

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -115,7 +115,7 @@ export function BulkBar({
       {confirming?.confirmation && (
         <ConfirmDialog
           title={confirming.confirmation.title ?? confirming.label}
-          description={confirming.confirmation.description}
+          description={confirming.confirmation.description ?? undefined}
           confirmLabel={confirming.confirmation.confirmLabel ?? confirming.label}
           cancelLabel={confirming.confirmation.cancelLabel ?? "Cancel"}
           confirmVariant={confirming.variant}
@@ -129,7 +129,7 @@ export function BulkBar({
         <ActionForm
           cancelLabel={filling.confirmation?.cancelLabel ?? "Cancel"}
           componentRef={filling.ref}
-          description={filling.confirmation?.description}
+          description={filling.confirmation?.description ?? undefined}
           endpoint={filling.endpoint}
           extraData={selectionPayload()}
           formNode={filling.form}

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1,10 +1,5 @@
 export type Action = {
-  confirmation: {
-    title: string;
-    description?: string;
-    confirmLabel?: string;
-    cancelLabel?: string;
-  } | null;
+  confirmation: Confirmation | null;
   effects: Effect[];
   endpoint: string | null;
   form: Form | null;
@@ -44,12 +39,7 @@ export type Badge = {
   label: string;
 };
 export type BulkAction = {
-  confirmation: {
-    title: string;
-    description?: string;
-    confirmLabel?: string;
-    cancelLabel?: string;
-  } | null;
+  confirmation: Confirmation | null;
   effects: Effect[];
   endpoint: string | null;
   form: Form | null;
@@ -74,14 +64,12 @@ export type Card = {
 };
 export type Checkbox = {
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -91,32 +79,27 @@ export type Checkbox = {
   readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type Choice = {
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
   hidden: boolean | null;
   label: string | null;
   name: string;
-  options: {
-    label: string;
-    value: string;
-  }[];
+  options: Option[];
   readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type CloseModalEffect = {
   readonly modal?: string | null;
@@ -136,7 +119,7 @@ export type ColumnData = {
     external: boolean;
   } | null;
   readonly columns: ColumnData[] | null;
-  readonly props: Record<string, any> | null;
+  readonly props: Record<string, unknown> | null;
 };
 export type ColumnFilter = {
   readonly enabled: boolean;
@@ -145,6 +128,17 @@ export type ColumnFilter = {
   readonly defaultOperator: Op;
 };
 export type ColumnType = "text" | "stack";
+export type Condition = {
+  readonly field: string;
+  readonly operator: Op;
+  readonly value: unknown;
+};
+export type Confirmation = {
+  readonly title: string;
+  readonly description: string | null;
+  readonly confirmLabel: string | null;
+  readonly cancelLabel: string | null;
+};
 export type CoreNode =
   | {
       type: "badge";
@@ -215,14 +209,12 @@ export type CoreNode =
     };
 export type DateInput = {
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -234,7 +226,7 @@ export type DateInput = {
   readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type DownloadEffect = {
   readonly url: string;
@@ -287,7 +279,7 @@ export type Form = {
   ref: string | null;
   resetOnError: string[] | boolean | null;
   resetOnSuccess: string[] | boolean | null;
-  state: Record<string, any>;
+  state: Record<string, unknown>;
   status: string | null;
   submitButton: boolean | null;
   submitLabel: string | null;
@@ -375,14 +367,12 @@ export type Heading = {
   text: string;
 };
 export type HiddenInput = {
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -391,7 +381,7 @@ export type HiddenInput = {
   name: string;
   readOnly: boolean | null;
   required: boolean | null;
-  value: any;
+  value: unknown;
 };
 export type HttpMethod = import("@inertiajs/core").Method;
 export type LayoutNode =
@@ -442,14 +432,12 @@ export type Node = FormNode | CoreNode | ActionNode | FragmentNode | TableNode |
 export type NodeType = Node["type"];
 export type NumberInput = {
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -464,7 +452,7 @@ export type NumberInput = {
   slider: boolean | null;
   step: number | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type Op =
   | "contains"
@@ -485,6 +473,10 @@ export type Op =
 export type OpenModalEffect = {
   readonly modal: string;
 };
+export type Option = {
+  readonly label: string;
+  readonly value: string;
+};
 export type Orientation = "horizontal" | "vertical";
 export type Outlet = object;
 export type PageContainer = "centered" | "default";
@@ -493,14 +485,12 @@ export type PaginationType = "none" | "simple" | "table" | "infinite";
 export type PasswordInput = {
   autoComplete: string | null;
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   confirmation: {
     label: string;
     name: string;
@@ -522,7 +512,7 @@ export type PasswordInput = {
   readOnly: boolean | null;
   required: boolean | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type RedirectEffect = {
   readonly url: string;
@@ -535,14 +525,12 @@ export type ResetFormEffect = {
   readonly form?: string | null;
 };
 export type RichEditor = {
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -552,28 +540,23 @@ export type RichEditor = {
   placeholder: string | null;
   readOnly: boolean | null;
   required: boolean | null;
-  value: any;
+  value: unknown;
 };
 export type SegmentedControl = {
   emits: string | null;
   label: string | null;
   name: string;
-  options: {
-    label: string;
-    value: string;
-  }[];
+  options: Option[];
   value: string | null;
 };
 export type Select = {
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -581,16 +564,13 @@ export type Select = {
   label: string | null;
   multiple: boolean | null;
   name: string;
-  options: {
-    label: string;
-    value: string;
-  }[];
+  options: Option[];
   placeholder: string | null;
   readOnly: boolean | null;
   required: boolean | null;
   searchable: boolean | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type Sidebar = {
   collapsible: boolean;
@@ -644,14 +624,12 @@ export type Text = {
 export type TextInput = {
   autoComplete: string | null;
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -663,18 +641,16 @@ export type TextInput = {
   required: boolean | null;
   tabIndex: number | null;
   type: string | null;
-  value: any;
+  value: unknown;
 };
 export type Textarea = {
   autoFocus: boolean | null;
-  conditions: Record<
-    string,
-    {
-      field: string;
-      operator: string;
-      value: any;
-    }[]
-  > | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
   dependsOnAny: boolean | null;
   dependsOnKeys: string[] | null;
   disabled: boolean | null;
@@ -686,7 +662,7 @@ export type Textarea = {
   required: boolean | null;
   rows: number | null;
   tabIndex: number | null;
-  value: any;
+  value: unknown;
 };
 export type ToastEffect = {
   readonly variant: ToastVariant;

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Actions\Components;
 use BackedEnum;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionRegistry;
+use Lattice\Lattice\Actions\Confirmation;
 use Lattice\Lattice\Actions\Contracts\Effect;
 use Lattice\Lattice\Attributes;
 use Lattice\Lattice\Core\Components\Component;
@@ -28,9 +29,10 @@ class Action extends Component
     public ?string $icon = null;
 
     /**
-     * @var array{title: string, description?: string, confirmLabel?: string, cancelLabel?: string}|null
+     * The confirmation dialog shown before the action runs, or `null` until
+     * {@see confirm()} sets one.
      */
-    public ?array $confirmation = null;
+    public ?Confirmation $confirmation = null;
 
     /**
      * @var array<int, Effect>
@@ -84,12 +86,7 @@ class Action extends Component
         ?string $confirmLabel = null,
         ?string $cancelLabel = null,
     ): static {
-        $this->confirmation = array_filter([
-            'title' => $title,
-            'description' => $description,
-            'confirmLabel' => $confirmLabel,
-            'cancelLabel' => $cancelLabel,
-        ], fn (mixed $value): bool => $value !== null);
+        $this->confirmation = new Confirmation($title, $description, $confirmLabel, $cancelLabel);
 
         return $this;
     }

--- a/src/Actions/Confirmation.php
+++ b/src/Actions/Confirmation.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Actions;
+
+use JsonSerializable;
+use Lattice\Lattice\Actions\Components\Action;
+
+/**
+ * The confirmation dialog an action shows before it runs. Built by {@see Action::confirm()}
+ * and generated to TypeScript; an action without a confirmation serializes to
+ * `null` rather than this object.
+ */
+final readonly class Confirmation implements JsonSerializable
+{
+    public function __construct(
+        public string $title,
+        public ?string $description = null,
+        public ?string $confirmLabel = null,
+        public ?string $cancelLabel = null,
+    ) {}
+
+    /**
+     * @return array{title: string, description: string|null, confirmLabel: string|null, cancelLabel: string|null}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'title' => $this->title,
+            'description' => $this->description,
+            'confirmLabel' => $this->confirmLabel,
+            'cancelLabel' => $this->cancelLabel,
+        ];
+    }
+}

--- a/src/Actions/Contracts/InteractsWithForm.php
+++ b/src/Actions/Contracts/InteractsWithForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Actions\Contracts;
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form;
 
 /**
@@ -22,7 +23,7 @@ interface InteractsWithForm
     public function resolveFormSchema(Request $request): ?Form;
 
     /**
-     * @return array{options: array<int, array{label: string, value: string}>}
+     * @return array{options: list<Option>}
      */
     public function searchOptions(Request $request): array;
 

--- a/src/Core/Concerns/HasOptions.php
+++ b/src/Core/Concerns/HasOptions.php
@@ -7,32 +7,35 @@ namespace Lattice\Lattice\Core\Concerns;
 use BackedEnum;
 use Illuminate\Support\Str;
 use Lattice\Lattice\Core\Contracts\HasLabel;
+use Lattice\Lattice\Core\Option;
 use UnitEnum;
 
 trait HasOptions
 {
     /**
-     * @var array<int, array{label: string, value: string}>
+     * @var list<Option>
      */
     public array $options = [];
 
-    /**
-     * @return array{label: string, value: string}
-     */
-    public static function option(string $label, string $value): array
+    public static function option(string $label, string $value): Option
     {
-        return [
-            'label' => $label,
-            'value' => $value,
-        ];
+        return new Option($label, $value);
     }
 
     /**
-     * @param  array<int, array{label: string, value: string}>  $options
+     * Accepts {@see Option} instances or raw `{label, value}` arrays, normalizing
+     * both to the value objects the wire shape is generated from.
+     *
+     * @param  array<int, Option|array{label: string, value: string}>  $options
      */
     public function options(array $options): static
     {
-        $this->options = $options;
+        $this->options = array_values(array_map(
+            static fn (Option|array $option): Option => $option instanceof Option
+                ? $option
+                : new Option((string) $option['label'], (string) $option['value']),
+            $options,
+        ));
 
         return $this;
     }
@@ -50,7 +53,7 @@ trait HasOptions
         $cases = is_string($enum) ? $enum::cases() : $enum;
 
         return $this->options(array_map(
-            static fn (UnitEnum $case): array => self::option(
+            static fn (UnitEnum $case): Option => self::option(
                 $case instanceof HasLabel ? $case->getLabel() : Str::headline($case->name),
                 $case instanceof BackedEnum ? (string) $case->value : $case->name,
             ),

--- a/src/Core/Option.php
+++ b/src/Core/Option.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core;
+
+use JsonSerializable;
+
+/**
+ * A `{ label, value }` pair backing every option-driven control (choice, select,
+ * segmented control). Generated to TypeScript so the client shares one `Option`
+ * type rather than re-declaring the shape per field.
+ */
+final readonly class Option implements JsonSerializable
+{
+    public function __construct(
+        public string $label,
+        public string $value,
+    ) {}
+
+    /**
+     * @return array{label: string, value: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'label' => $this->label,
+            'value' => $this->value,
+        ];
+    }
+}

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -28,7 +28,12 @@ abstract class Field extends Component
     public ?bool $disabled = null;
 
     /**
-     * @var array<string, array<int, array{field: string, operator: string, value: mixed}>>|null
+     * @var array{
+     *     visible?: list<Condition>,
+     *     required?: list<Condition>,
+     *     readOnly?: list<Condition>,
+     *     disabled?: list<Condition>,
+     * }|null
      */
     public ?array $conditions = null;
 
@@ -384,21 +389,29 @@ abstract class Field extends Component
     }
 
     /**
+     * The conditions declared for one intent (visible/required/readOnly/disabled),
+     * as the value objects that serialize to the field's `conditions` wire shape.
+     *
+     * @return list<Condition>
+     */
+    private function conditionsFor(string $intent): array
+    {
+        return ($this->conditionSets[$intent] ?? null)?->all() ?? [];
+    }
+
+    /**
      * @param  array<string, mixed>  $data
      * @return array<string, mixed>
      */
     #[SerializationHook(priority: 190)]
     protected function projectComputedProps(array $data): array
     {
-        $conditions = [];
-
-        foreach ($this->conditionSets as $group => $set) {
-            $serialised = $set->jsonSerialize();
-
-            if ($serialised !== []) {
-                $conditions[$group] = $serialised;
-            }
-        }
+        $conditions = array_filter([
+            'visible' => $this->conditionsFor('visible'),
+            'required' => $this->conditionsFor('required'),
+            'readOnly' => $this->conditionsFor('readOnly'),
+            'disabled' => $this->conditionsFor('disabled'),
+        ], static fn (array $set): bool => $set !== []);
 
         $this->conditions = $conditions === [] ? null : $conditions;
 

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -10,6 +10,7 @@ use Lattice\Lattice\Core\Concerns\HasAutoFocus;
 use Lattice\Lattice\Core\Concerns\HasOptions;
 use Lattice\Lattice\Core\Concerns\HasPlaceholder;
 use Lattice\Lattice\Core\Concerns\HasTabIndex;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.select')]
@@ -40,7 +41,7 @@ class Select extends Field
      * current form data and request) and returns the matching options. The option
      * value is the entity identifier and is fully controlled by the resolver.
      *
-     * @param  Closure(string, FormData, Request): (array<int, array{label: string, value: string|int}>|Collection<int, array{label: string, value: string|int}>)  $resolver
+     * @param  Closure(string, FormData, Request): (array<int, Option|array{label: string, value: string|int}>|Collection<int, Option|array{label: string, value: string|int}>)  $resolver
      */
     public function searchable(Closure $resolver): static
     {
@@ -63,7 +64,7 @@ class Select extends Field
      * The resolver always receives an array of values (one entry for a single select),
      * so a `whereIn` query works for both single and multiple selects.
      *
-     * @param  Closure(array<int, string>): (array<int, array{label: string, value: string|int}>|Collection<int, array{label: string, value: string|int}>)  $resolver
+     * @param  Closure(array<int, string>): (array<int, Option|array{label: string, value: string|int}>|Collection<int, Option|array{label: string, value: string|int}>)  $resolver
      */
     public function resolveSelectedUsing(Closure $resolver): static
     {
@@ -75,7 +76,7 @@ class Select extends Field
     /**
      * @internal
      *
-     * @return array<int, array{label: string, value: string}>
+     * @return list<Option>
      */
     public function resolveSearch(string $query, FormData $data, Request $request): array
     {
@@ -105,10 +106,10 @@ class Select extends Field
         $existing = $this->options;
 
         $merged = [...$existing];
-        $seen = array_column($existing, 'value');
+        $seen = array_map(static fn (Option $option): string => $option->value, $existing);
 
         foreach ($resolved as $option) {
-            if (! in_array($option['value'], $seen, true)) {
+            if (! in_array($option->value, $seen, true)) {
                 $merged[] = $option;
             }
         }
@@ -117,8 +118,8 @@ class Select extends Field
     }
 
     /**
-     * @param  array<int, array{label: string, value: string|int}>|Collection<int, array{label: string, value: string|int}>  $options
-     * @return array<int, array{label: string, value: string}>
+     * @param  array<int, Option|array{label: string, value: string|int}>|Collection<int, Option|array{label: string, value: string|int}>  $options
+     * @return list<Option>
      */
     private function normalizeOptions(array|Collection $options): array
     {
@@ -127,10 +128,9 @@ class Select extends Field
         }
 
         return array_values(array_map(
-            static fn (array $option): array => [
-                'label' => (string) $option['label'],
-                'value' => (string) $option['value'],
-            ],
+            static fn (Option|array $option): Option => $option instanceof Option
+                ? $option
+                : new Option((string) $option['label'], (string) $option['value']),
             $options,
         ));
     }

--- a/src/Forms/Concerns/ResolvesFormFields.php
+++ b/src/Forms/Concerns/ResolvesFormFields.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Forms\Concerns;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Field;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
@@ -29,7 +30,7 @@ trait ResolvesFormFields
      * Resolve the searchable options for a single field. The field's own resolver
      * owns the query, so this never touches an arbitrary model.
      *
-     * @return array{options: array<int, array{label: string, value: string}>}
+     * @return array{options: list<Option>}
      */
     public function searchOptions(Request $request): array
     {

--- a/src/Forms/Conditions/ConditionSet.php
+++ b/src/Forms/Conditions/ConditionSet.php
@@ -10,13 +10,21 @@ use Lattice\Lattice\Forms\FormData;
 final class ConditionSet implements JsonSerializable
 {
     /**
-     * @var array<int, Condition>
+     * @var list<Condition>
      */
     private array $conditions = [];
 
     public function add(Condition $condition): void
     {
         $this->conditions[] = $condition;
+    }
+
+    /**
+     * @return list<Condition>
+     */
+    public function all(): array
+    {
+        return $this->conditions;
     }
 
     public function anyMatches(FormData $data): bool

--- a/src/Support/TypeScript/ComponentTransformer.php
+++ b/src/Support/TypeScript/ComponentTransformer.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\TypeScript;
 
+use ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClass as RoaveReflectionClass;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
+use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\Transformers\ClassTransformer;
+use Spatie\TypeScriptTransformer\TypeResolvers\Data\ParsedClass;
 
 /**
  * Emits TypeScript prop types for an explicit allow-list of components. Every
@@ -29,6 +33,63 @@ final class ComponentTransformer extends ClassTransformer
     protected function shouldTransform(PhpClassNode $phpClassNode): bool
     {
         return in_array($phpClassNode->getName(), $this->allowed, true);
+    }
+
+    /**
+     * Resolve a trait property's docblock against the trait that declares it rather
+     * than the using class. PHP reports a trait property's declaring class as the
+     * *using* class, so a docblock like `@var list<Option>` would otherwise resolve
+     * `Option` against the using class's imports — which a class such as Choice does
+     * not have, yielding `unknown[]`. Native property types are unaffected; reflection
+     * resolves those without a docblock.
+     *
+     * @return array{0: mixed, 1: PhpClassNode}
+     */
+    protected function resolvePropertyAnnotation(
+        PhpPropertyNode $phpPropertyNode,
+        PhpClassNode $phpClassNode,
+        ?ParsedClass $parsedClass,
+    ): array {
+        [$annotation, $context] = parent::resolvePropertyAnnotation($phpPropertyNode, $phpClassNode, $parsedClass);
+
+        $trait = $this->traitDeclaring($phpClassNode->reflection, $phpPropertyNode->getName());
+
+        return $trait === null ? [$annotation, $context] : [$annotation, PhpClassNode::fromReflection($trait)];
+    }
+
+    /**
+     * The trait that declares $name with a docblock — searched recursively, since
+     * traits can use traits — or null when the property is declared on the class itself.
+     *
+     * @param  ReflectionClass<object>|RoaveReflectionClass  $class
+     * @return ReflectionClass<object>|RoaveReflectionClass|null
+     */
+    private function traitDeclaring(
+        ReflectionClass|RoaveReflectionClass $class,
+        string $name,
+    ): ReflectionClass|RoaveReflectionClass|null {
+        foreach ($class->getTraits() as $trait) {
+            if ($nested = $this->traitDeclaring($trait, $name)) {
+                return $nested;
+            }
+
+            if ($trait->hasProperty($name) && $trait->getProperty($name)->getDocComment() !== false) {
+                return $trait;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<ClassPropertyProcessor>
+     */
+    protected function classPropertyProcessors(): array
+    {
+        return [
+            ...parent::classPropertyProcessors(),
+            new MixedToUnknownClassPropertyProcessor,
+        ];
     }
 
     /**

--- a/src/Support/TypeScript/MixedToUnknownClassPropertyProcessor.php
+++ b/src/Support/TypeScript/MixedToUnknownClassPropertyProcessor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\TypeScript;
+
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
+use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptAny;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptProperty;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptUnknown;
+use Spatie\TypeScriptTransformer\Visitor\Visitor;
+use Spatie\TypeScriptTransformer\Visitor\VisitorOperation;
+
+/**
+ * Rewrites every `any` (PHP `mixed`) in a property's type to `unknown`, including
+ * `any` nested inside arrays, records and unions. PHP `mixed` carries no more
+ * guarantee than `unknown`, so this keeps the generated types honest: reads have
+ * to narrow rather than silently passing an unchecked value downstream.
+ */
+final class MixedToUnknownClassPropertyProcessor implements ClassPropertyProcessor
+{
+    private readonly Visitor $visitor;
+
+    public function __construct()
+    {
+        $this->visitor = Visitor::create()->before(
+            fn (TypeScriptAny $any): VisitorOperation => VisitorOperation::replace(new TypeScriptUnknown),
+            [TypeScriptAny::class],
+        );
+    }
+
+    public function execute(
+        PhpPropertyNode $phpPropertyNode,
+        ?TypeNode $annotation,
+        TypeScriptProperty $property,
+    ): TypeScriptProperty {
+        $property->type = $this->visitor->execute($property->type);
+
+        return $property;
+    }
+}

--- a/tests/Feature/ActionWireShapeTest.php
+++ b/tests/Feature/ActionWireShapeTest.php
@@ -83,12 +83,17 @@ it('serializes a null form when none is attached', function (): void {
     expect($payload['props']['form'])->toBeNull();
 });
 
-it('drops null confirmation entries and includes empty effects', function (): void {
+it('serializes the full confirmation shape and includes empty effects', function (): void {
     $action = Action::make('simple')->confirm('Sure?');
 
     $payload = json_decode(json_encode($action), true);
 
-    expect($payload['props']['confirmation'])->toBe(['title' => 'Sure?']);
+    expect($payload['props']['confirmation'])->toBe([
+        'title' => 'Sure?',
+        'description' => null,
+        'confirmLabel' => null,
+        'cancelLabel' => null,
+    ]);
     expect($payload['props']['effects'])->toBe([]);
 });
 
@@ -122,6 +127,8 @@ it('carries typed props through Action::use from the registry', function (): voi
         'confirmation' => [
             'title' => 'Archive product?',
             'description' => 'This hides the product from the catalogue.',
+            'confirmLabel' => null,
+            'cancelLabel' => null,
         ],
     ]);
     expect($payload['props']['ref'])->toBeString();

--- a/tests/Feature/SelectSearchTest.php
+++ b/tests/Feature/SelectSearchTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\Select;
@@ -45,10 +46,10 @@ it('resolves options for a searchable field', function (): void {
         Request::create('/', 'POST', ['_search' => 'author_id', 'q' => 'jane']),
     );
 
-    expect($result)->toBe([
+    expect($result)->toEqual([
         'options' => [
-            ['label' => 'Match: jane', 'value' => '1'],
-            ['label' => 'Other', 'value' => '2'],
+            new Option('Match: jane', '1'),
+            new Option('Other', '2'),
         ],
     ]);
 });

--- a/tests/Unit/SelectTest.php
+++ b/tests/Unit/SelectTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
 
@@ -46,9 +47,9 @@ it('runs the search resolver and normalizes options to strings', function (): vo
 
     $options = $field->resolveSearch('ja', FormData::make([]), Request::create('/'));
 
-    expect($options)->toBe([
-        ['label' => 'Jane Doe', 'value' => '5'],
-        ['label' => 'Janet Roe', 'value' => '9'],
+    expect($options)->toEqual([
+        new Option('Jane Doe', '5'),
+        new Option('Janet Roe', '9'),
     ]);
 });
 
@@ -59,7 +60,7 @@ it('passes the query to the resolver', function (): void {
         ]);
 
     expect($field->resolveSearch('berlin', FormData::make([]), Request::create('/')))
-        ->toBe([['label' => 'BERLIN', 'value' => 'berlin']]);
+        ->toEqual([new Option('BERLIN', 'berlin')]);
 });
 
 it('returns no options when the field is not searchable', function (): void {

--- a/workbench/app/Actions/RejectProductAction.php
+++ b/workbench/app/Actions/RejectProductAction.php
@@ -12,6 +12,7 @@ use Lattice\Lattice\Attributes\Action;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\ToastVariant;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\Textarea;
 use Workbench\App\Models\Product;
@@ -35,7 +36,7 @@ class RejectProductAction extends ActionDefinition
                         ->orderBy('name')
                         ->limit(10)
                         ->get()
-                        ->map(fn (Product $product): array => Select::option($product->name, (string) $product->getKey()))
+                        ->map(fn (Product $product): Option => Select::option($product->name, (string) $product->getKey()))
                         ->all())
                     ->rules(['nullable']),
             ]);

--- a/workbench/app/Console/Commands/GenerateInternalTypesCommand.php
+++ b/workbench/app/Console/Commands/GenerateInternalTypesCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Workbench\App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Lattice\Lattice\Actions\Confirmation;
 use Lattice\Lattice\Actions\Contracts\Effect;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes\Effect as EffectAttribute;
@@ -18,7 +19,9 @@ use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\Enums\ToastVariant;
 use Lattice\Lattice\Core\Enums\Width;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Conditions\Condition;
 use Lattice\Lattice\Support\TypeScript\ComponentDiscovery;
 use Lattice\Lattice\Support\TypeScript\ComponentTransformer;
 use Lattice\Lattice\Support\TypeScript\DiscoveredComponent;
@@ -84,6 +87,9 @@ final class GenerateInternalTypesCommand extends Command
                     EffectType::class,
                 ]),
                 new ValueObjectTransformer([
+                    Condition::class,
+                    Confirmation::class,
+                    Option::class,
                     ColumnData::class,
                     ColumnFilter::class,
                     FilterClause::class,

--- a/workbench/app/Support/TypeScript/ValueObjectTransformer.php
+++ b/workbench/app/Support/TypeScript/ValueObjectTransformer.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Workbench\App\Support\TypeScript;
 
+use Lattice\Lattice\Support\TypeScript\MixedToUnknownClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
+use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\Transformers\ClassTransformer;
 
 /**
@@ -24,5 +26,16 @@ final class ValueObjectTransformer extends ClassTransformer
     protected function shouldTransform(PhpClassNode $phpClassNode): bool
     {
         return in_array($phpClassNode->getName(), $this->allowed, true);
+    }
+
+    /**
+     * @return array<ClassPropertyProcessor>
+     */
+    protected function classPropertyProcessors(): array
+    {
+        return [
+            ...parent::classPropertyProcessors(),
+            new MixedToUnknownClassPropertyProcessor,
+        ];
     }
 }


### PR DESCRIPTION
## What

Cleans up the package's PHP → TypeScript type generation so the generated wire types are DRY, precise, and honest. No runtime behaviour change except where noted.

### Shared value-object types (instead of repeated inline shapes)
- **`Condition`** — the form-field `conditions` map (previously a `Record<string, {field; operator: string; value: any}[]>` inlined into ~10 field types) now references one shared `Condition` type with named intent keys (`visible/required/readonly/disabled`), `operator: Op`, and `value: unknown`. Backed by the existing `Condition` value object (stored, not array-serialized).
- **`Option`** — choice / select / segmented-control share one generated `Option` type; options are first-class `Option` value objects on the PHP side (`HasOptions`, `Select`), with raw `{label,value}` arrays still accepted for back-compat.
- **`Confirmation`** — action confirmations are a `Confirmation` value object (`Action`/`BulkAction`), generating `Confirmation | null`.

### `mixed` → `unknown`
A `MixedToUnknownClassPropertyProcessor` rewrites every `any` (PHP `mixed`) to `unknown` in generated props — `value`, `Form.state`, `ColumnData.props`, etc. The generated file now contains **zero `any`**.

### Trait-property type resolution
`ComponentTransformer` now resolves a trait property's docblock against the **trait that declares it**, not the using class. PHP reports a trait property's declaring class as the using class, so `@var list<Option>` would otherwise resolve `Option` against a class (e.g. `Choice`) that doesn't import it and emit `unknown[]`. Native-typed trait props are unaffected.

## Behaviour change
Action `confirmation` now serializes the **full shape with present `null` keys** (e.g. `description: null`) instead of dropping null keys — consistent with `ColumnData` and the rest of the wire philosophy. Updated the two tests that asserted the old omit-null shape; client `description` reads coerce `?? undefined`.

## Verification
- `tsc`, vitest (203), oxlint, oxfmt — green
- Pint (stock Laravel preset), PHPStan — green
- Pest: Unit + Feature (356) and Browser (38) — green
- `generated.ts` regenerated; snapshot guard passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)