### PR TITLE
Collapsible Section layout component

### DIFF
--- a/docs/content/docs/core/components.mdx
+++ b/docs/content/docs/core/components.mdx
@@ -30,6 +30,8 @@ Layout components arrange their children. They are containers — pass children 
 - **`Grid`** lays children out in columns via `->columns(n)`.
 - **`Card`** wraps children in a bordered panel with an optional title and description —
   `Card::make('Title', 'Description')`.
+- **`Section`** is a titled panel like `Card`, but it can collapse and carry actions in its header —
+  see [below](#section).
 
 <ComponentExample
   php={`Grid::make()->columns(3)->schema([
@@ -38,6 +40,25 @@ Layout components arrange their children. They are containers — pass children 
     Badge::make('Third'),
 ]);`}
   fixture="components.grid"
+/>
+
+### Section
+
+`Section::make('Title', 'Description')` groups content under a heading. Call `->collapsible()` to let
+it fold (pass `collapsed: true` to start folded; `rememberState: false` to not persist the state), and
+`->headerActions([...])` to place buttons or actions in the header.
+
+<ComponentExample
+  php={`Section::make('Members', 'People with access to this team.')
+    ->collapsible()
+    ->headerActions([
+        Button::make('Invite member')->variant(ButtonVariant::Outline),
+    ])
+    ->schema([
+        Text::make('Three people have access to this team.'),
+        Badge::make('3 active'),
+    ]);`}
+  fixture="components.section"
 />
 
 ## Display

--- a/docs/fixtures/components.section.json
+++ b/docs/fixtures/components.section.json
@@ -1,0 +1,38 @@
+[
+    {
+        "props": {
+            "collapsed": false,
+            "collapsible": true,
+            "description": "People with access to this team.",
+            "headerActions": [
+                {
+                    "props": {
+                        "buttonType": "button",
+                        "href": null,
+                        "label": "Invite member",
+                        "variant": "outline"
+                    },
+                    "type": "button"
+                }
+            ],
+            "rememberState": true,
+            "title": "Members"
+        },
+        "schema": [
+            {
+                "props": {
+                    "align": null,
+                    "text": "Three people have access to this team."
+                },
+                "type": "text"
+            },
+            {
+                "props": {
+                    "label": "3 active"
+                },
+                "type": "badge"
+            }
+        ],
+        "type": "section"
+    }
+]

--- a/resources/js/core/components/index.ts
+++ b/resources/js/core/components/index.ts
@@ -7,6 +7,7 @@ import GridComponent from "./grid";
 import HeadingComponent from "./heading";
 import LinkComponent from "./link";
 import ModalComponent from "./modal";
+import SectionComponent from "./section";
 import SegmentedControlComponent from "./segmented-control";
 import StackComponent from "./stack";
 import TabComponent, { TabsComponent } from "./tabs";
@@ -22,6 +23,7 @@ export const coreComponents = createPlugin({
     heading: eagerComponent(HeadingComponent),
     link: eagerComponent(LinkComponent),
     modal: eagerComponent(ModalComponent),
+    section: eagerComponent(SectionComponent),
     "segmented-control": eagerComponent(SegmentedControlComponent),
     stack: eagerComponent(StackComponent),
     tab: eagerComponent(TabComponent),

--- a/resources/js/core/components/section.test.tsx
+++ b/resources/js/core/components/section.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
+import { Renderer } from "@lattice/lattice/core/renderer";
+import type { Node } from "@lattice/lattice/core/types";
+import ButtonComponent from "./button";
+import SectionComponent from "./section";
+import TextComponent from "./text";
+
+const registry = createRegistry({
+  components: {
+    button: eagerComponent(ButtonComponent),
+    section: eagerComponent(SectionComponent),
+    text: eagerComponent(TextComponent),
+  },
+  name: "test/section",
+});
+
+function renderSection(node: Node) {
+  return render(<Renderer nodes={[node]} registry={registry} />);
+}
+
+describe("Section component", () => {
+  it("renders the title, description, content, and header actions", () => {
+    renderSection({
+      id: "members",
+      type: "section",
+      props: {
+        title: "Members",
+        description: "People with access.",
+        headerActions: [{ type: "button", props: { label: "Invite", buttonType: "button" } }],
+      },
+      schema: [{ type: "text", props: { text: "Three people have access." } }],
+    });
+
+    expect(screen.getByText("Members")).toBeVisible();
+    expect(screen.getByText("People with access.")).toBeVisible();
+    expect(screen.getByText("Three people have access.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Invite" })).toBeVisible();
+  });
+
+  it("toggles its content when collapsible", () => {
+    renderSection({
+      id: "advanced",
+      type: "section",
+      props: { title: "Advanced", collapsible: true, rememberState: false },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    expect(screen.getByText("Hidden body")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse section" }));
+    expect(screen.queryByText("Hidden body")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand section" }));
+    expect(screen.getByText("Hidden body")).toBeVisible();
+  });
+});

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -1,0 +1,102 @@
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { Renderer, useRendererContext } from "@lattice/lattice/core/renderer";
+import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import { cn } from "@lattice/lattice/lib/utils";
+
+function readStored(key: string, remember: boolean, fallback: boolean): boolean {
+  if (!remember || typeof window === "undefined") {
+    return fallback;
+  }
+
+  const stored = window.localStorage.getItem(key);
+
+  return stored === null ? fallback : stored === "true";
+}
+
+function getNodes(value: unknown): Node[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(
+    (node): node is Node =>
+      typeof node === "object" && node !== null && "type" in node && typeof node.type === "string",
+  );
+}
+
+const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
+  const { title, description } = node.props;
+  const collapsible = node.props.collapsible === true;
+  const rememberState = node.props.rememberState !== false;
+  const headerActions = getNodes(node.props.headerActions);
+  const { fallback, missingComponent, registry } = useRendererContext();
+  const storageKey = `lattice:section:${node.id ?? "default"}`;
+
+  const [collapsed, setCollapsed] = useState(() =>
+    readStored(storageKey, collapsible && rememberState, node.props.collapsed === true),
+  );
+
+  function toggle(): void {
+    setCollapsed((value) => {
+      const next = !value;
+
+      if (rememberState && typeof window !== "undefined") {
+        window.localStorage.setItem(storageKey, String(next));
+      }
+
+      return next;
+    });
+  }
+
+  const isCollapsed = collapsible && collapsed;
+  const hasHeader = Boolean(title || description || headerActions.length > 0 || collapsible);
+
+  return (
+    <section
+      className="flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-xs"
+      data-lattice-component={node.id}
+    >
+      {hasHeader && (
+        <div className="flex items-start justify-between gap-4 px-6">
+          <div className="flex min-w-0 items-start gap-2">
+            {collapsible && (
+              <button
+                aria-expanded={!isCollapsed}
+                aria-label={isCollapsed ? "Expand section" : "Collapse section"}
+                data-test={`section-toggle-${node.id ?? "default"}`}
+                className="mt-0.5 inline-flex shrink-0 items-center rounded-md p-0.5 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
+                onClick={toggle}
+                type="button"
+              >
+                <ChevronDown
+                  aria-hidden="true"
+                  className={cn("size-4 transition-transform", isCollapsed && "-rotate-90")}
+                />
+              </button>
+            )}
+            <div className="flex min-w-0 flex-col gap-1.5">
+              {title && <div className="font-semibold leading-none">{title}</div>}
+              {description && <div className="text-sm text-lt-muted-fg">{description}</div>}
+            </div>
+          </div>
+
+          {headerActions.length > 0 && (
+            <div className="flex shrink-0 items-center gap-2">
+              <Renderer
+                fallback={fallback}
+                missingComponent={missingComponent}
+                nodes={headerActions}
+                registry={registry}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isCollapsed && children && <div className="flex flex-col gap-6 px-6">{children}</div>}
+    </section>
+  );
+};
+
+export default SectionComponent;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -188,6 +188,12 @@ export type CoreNode =
       schema?: Node[];
     }
   | {
+      type: "section";
+      key?: string;
+      props: Section;
+      schema?: Node[];
+    }
+  | {
       type: "segmented-control";
       key?: string;
       props: SegmentedControl;
@@ -549,6 +555,14 @@ export type RichEditor = {
   readOnly: boolean | null;
   required: boolean | null;
   value: unknown;
+};
+export type Section = {
+  collapsed: boolean;
+  collapsible: boolean;
+  description: string | null;
+  headerActions: undefined[];
+  rememberState: boolean;
+  title: string | null;
 };
 export type SegmentedControl = {
   emits: string | null;

--- a/src/Core/Components/Section.php
+++ b/src/Core/Components/Section.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Lattice\Lattice\Core\Components;
+
+use Lattice\Lattice\Attributes;
+
+#[Attributes\Component('section')]
+class Section extends ContainerComponent
+{
+    public ?string $title = null;
+
+    public ?string $description = null;
+
+    public bool $collapsible = false;
+
+    public bool $collapsed = false;
+
+    public bool $rememberState = true;
+
+    /**
+     * @var array<int, Component>
+     */
+    public array $headerActions = [];
+
+    public static function make(?string $title = null, ?string $description = null, ?string $key = null): static
+    {
+        $section = new static($key);
+
+        if ($title !== null) {
+            $section->title = $title;
+        }
+
+        if ($description !== null) {
+            $section->description = $description;
+        }
+
+        return $section;
+    }
+
+    public function collapsible(bool $collapsible = true, bool $collapsed = false, bool $rememberState = true): static
+    {
+        $this->collapsible = $collapsible;
+        $this->collapsed = $collapsed;
+        $this->rememberState = $rememberState;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, Component>  $actions
+     */
+    public function headerActions(array $actions): static
+    {
+        $this->headerActions = $actions;
+
+        return $this;
+    }
+}

--- a/tests/Unit/ComponentDocsTest.php
+++ b/tests/Unit/ComponentDocsTest.php
@@ -7,6 +7,7 @@ use Lattice\Lattice\Core\Components\Button;
 use Lattice\Lattice\Core\Components\Card;
 use Lattice\Lattice\Core\Components\Grid;
 use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Section;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
@@ -38,5 +39,19 @@ describe('docs fixtures', function (): void {
         ]);
 
         expect('docs/fixtures/components.grid.json')->toBeReadableFile();
+    });
+
+    it('dumps the section example', function (): void {
+        dumpFixture('components.section', [
+            Section::make('Members', 'People with access to this team.')
+                ->collapsible()
+                ->headerActions([Button::make('Invite member')->variant(ButtonVariant::Outline)])
+                ->schema([
+                    Text::make('Three people have access to this team.'),
+                    Badge::make('3 active'),
+                ]),
+        ]);
+
+        expect('docs/fixtures/components.section.json')->toBeReadableFile();
     });
 });

--- a/tests/Unit/SectionTest.php
+++ b/tests/Unit/SectionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Components\Button;
+use Lattice\Lattice\Core\Components\Section;
+use Lattice\Lattice\Core\Components\Text;
+
+it('serializes a section with its content and header', function (): void {
+    $node = wire(
+        Section::make('Members', 'People with access.')
+            ->headerActions([Button::make('Invite')])
+            ->schema([Text::make('Three people have access.')]),
+    );
+
+    expect($node['type'])->toBe('section')
+        ->and($node['props'])->toMatchArray([
+            'title' => 'Members',
+            'description' => 'People with access.',
+            'collapsible' => false,
+            'collapsed' => false,
+            'rememberState' => true,
+        ])
+        ->and($node['props']['headerActions'])->toHaveCount(1)
+        ->and($node['props']['headerActions'][0]['type'])->toBe('button')
+        ->and($node['schema'][0]['type'])->toBe('text');
+});
+
+it('serializes the collapsible flags', function (): void {
+    $node = wire(Section::make('Advanced')->collapsible(collapsed: true, rememberState: false));
+
+    expect($node['props'])->toMatchArray([
+        'collapsible' => true,
+        'collapsed' => true,
+        'rememberState' => false,
+    ]);
+});


### PR DESCRIPTION
Adds the collapsible **Section** layout component (#120) — the most-used Filament layout primitive after Card.

## What it does
`Section::make('Title', 'Description')` groups content under a heading. Like `Card`, but:
- `->collapsible(collapsed: false, rememberState: true)` — folds on a header chevron; remembers open/closed in `localStorage` (same pattern as the sidebar).
- `->headerActions([...])` — places buttons/actions in the header (rendered through the renderer registry, so any component works).

Content goes in `->schema([...])` as usual. Composes the existing `ContainerComponent` infra; serializes/auto-discovers like every other core component.

## Tests & docs
- PHP wire-shape test + vitest (renders title/description/content/header action; collapse toggles content).
- Documented on the Components page with a live `ComponentExample` preview.

## Verification
`composer test` 361 · vitest 211 · pint / phpstan / tsc / oxlint clean · prod + docs builds green.
