### PR TITLE
Badge, Icon, and Image column types

### DIFF
--- a/docs/content/docs/tables/columns.mdx
+++ b/docs/content/docs/tables/columns.mdx
@@ -53,6 +53,32 @@ TextColumn::make('role');`}
   fixture="table.stack"
 />
 
+## Badge, Icon & Image columns
+
+For richer cells, three dedicated column types render a value as a coloured badge, an icon, or an
+image instead of plain text.
+
+<ComponentExample
+  php={`ImageColumn::make('avatar')->circular()->size(32);
+TextColumn::make('name');
+BadgeColumn::make('status')->colors([
+    'active' => 'green', 'invited' => 'yellow', 'archived' => 'gray',
+]);
+IconColumn::make('verified')
+    ->icons(['1' => LucideIcon::Check, '0' => LucideIcon::Minus])
+    ->colors(['1' => 'green', '0' => 'gray']);`}
+  fixture="table.column-types"
+/>
+
+- **`BadgeColumn`** renders the value as a pill. `->colors([value => color])` maps values to a colour
+  name — `gray`, `red`, `green`, `yellow`, `blue`, `purple`, or `orange` (unmapped values fall back to
+  gray). It is sortable and filterable like a text column.
+- **`IconColumn`** shows an icon. `->icon(LucideIcon::Star)` shows the same icon for every row;
+  `->icons([value => LucideIcon])` picks an icon per value. Add `->colors([value => color])` to tint
+  them.
+- **`ImageColumn`** renders the cell value as an image URL. `->circular()` makes it a round avatar and
+  `->size(40)` sets the pixel size.
+
 ## Sortable and filterable
 
 `->sortable()` and `->filterable()` are **capabilities** a column opts into, not display options. They

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -1,0 +1,115 @@
+[
+    {
+        "id": "members",
+        "props": {
+            "bulkActions": [],
+            "columns": [
+                {
+                    "columns": null,
+                    "copyable": null,
+                    "date": null,
+                    "filter": null,
+                    "key": "avatar",
+                    "label": "",
+                    "link": null,
+                    "props": {
+                        "circular": true,
+                        "size": 32
+                    },
+                    "sortable": null,
+                    "type": "image"
+                },
+                {
+                    "columns": null,
+                    "copyable": null,
+                    "date": null,
+                    "filter": null,
+                    "key": "name",
+                    "label": "Name",
+                    "link": null,
+                    "props": null,
+                    "sortable": null,
+                    "type": "text"
+                },
+                {
+                    "columns": null,
+                    "copyable": null,
+                    "date": null,
+                    "filter": null,
+                    "key": "status",
+                    "label": "Status",
+                    "link": null,
+                    "props": {
+                        "colors": {
+                            "active": "green",
+                            "archived": "gray",
+                            "invited": "yellow"
+                        }
+                    },
+                    "sortable": null,
+                    "type": "badge"
+                },
+                {
+                    "columns": null,
+                    "copyable": null,
+                    "date": null,
+                    "filter": null,
+                    "key": "verified",
+                    "label": "Verified",
+                    "link": null,
+                    "props": {
+                        "colors": [
+                            "gray",
+                            "green"
+                        ],
+                        "icons": [
+                            "minus",
+                            "check"
+                        ]
+                    },
+                    "sortable": null,
+                    "type": "icon"
+                }
+            ],
+            "data": [
+                {
+                    "avatar": "https://i.pravatar.cc/64?img=1",
+                    "name": "Ada Lovelace",
+                    "status": "active",
+                    "verified": "1"
+                },
+                {
+                    "avatar": "https://i.pravatar.cc/64?img=2",
+                    "name": "Alan Turing",
+                    "status": "invited",
+                    "verified": "0"
+                },
+                {
+                    "avatar": "https://i.pravatar.cc/64?img=3",
+                    "name": "Grace Hopper",
+                    "status": "archived",
+                    "verified": "1"
+                }
+            ],
+            "endpoint": null,
+            "layout": null,
+            "lazy": null,
+            "pagination": {
+                "from": 1,
+                "hasMore": false,
+                "mode": "none",
+                "nextPage": null,
+                "to": 3,
+                "total": 3
+            },
+            "state": {
+                "filters": [],
+                "page": 1,
+                "perPage": 25,
+                "sorts": []
+            },
+            "striped": null
+        },
+        "type": "table"
+    }
+]

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -116,6 +116,85 @@
 }
 
 /*
+ * Status colours for Badge and Icon table cells. Each tone sets a soft
+ * background and a readable foreground in oklch; the `.dark` block swaps them.
+ * Defined here (not as utility strings in the renderer) so the palette lives
+ * with the theme and can be overridden, and so the cells can pick a tone by
+ * name without Tailwind needing to see every class. Gray follows the muted token.
+ */
+.lt-cell-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: var(--lt-radius-sm);
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  background-color: var(--lt-cell-bg, var(--lt-muted));
+  color: var(--lt-cell-fg, var(--lt-muted-fg));
+}
+
+.lt-cell-icon {
+  display: inline-flex;
+  color: var(--lt-cell-fg, var(--lt-fg));
+}
+
+.lt-cell-tone-gray {
+  --lt-cell-bg: var(--lt-muted);
+  --lt-cell-fg: var(--lt-muted-fg);
+}
+.lt-cell-tone-red {
+  --lt-cell-bg: oklch(0.94 0.03 25);
+  --lt-cell-fg: oklch(0.51 0.19 27);
+}
+.lt-cell-tone-orange {
+  --lt-cell-bg: oklch(0.95 0.04 65);
+  --lt-cell-fg: oklch(0.55 0.14 55);
+}
+.lt-cell-tone-yellow {
+  --lt-cell-bg: oklch(0.96 0.05 100);
+  --lt-cell-fg: oklch(0.52 0.1 85);
+}
+.lt-cell-tone-green {
+  --lt-cell-bg: oklch(0.95 0.05 155);
+  --lt-cell-fg: oklch(0.52 0.13 152);
+}
+.lt-cell-tone-blue {
+  --lt-cell-bg: oklch(0.95 0.03 245);
+  --lt-cell-fg: oklch(0.54 0.17 252);
+}
+.lt-cell-tone-purple {
+  --lt-cell-bg: oklch(0.95 0.03 305);
+  --lt-cell-fg: oklch(0.53 0.19 305);
+}
+
+.dark .lt-cell-tone-red {
+  --lt-cell-bg: oklch(0.29 0.08 27);
+  --lt-cell-fg: oklch(0.83 0.11 27);
+}
+.dark .lt-cell-tone-orange {
+  --lt-cell-bg: oklch(0.3 0.07 65);
+  --lt-cell-fg: oklch(0.84 0.1 65);
+}
+.dark .lt-cell-tone-yellow {
+  --lt-cell-bg: oklch(0.31 0.06 100);
+  --lt-cell-fg: oklch(0.87 0.11 100);
+}
+.dark .lt-cell-tone-green {
+  --lt-cell-bg: oklch(0.3 0.07 155);
+  --lt-cell-fg: oklch(0.85 0.13 155);
+}
+.dark .lt-cell-tone-blue {
+  --lt-cell-bg: oklch(0.3 0.07 245);
+  --lt-cell-fg: oklch(0.84 0.11 250);
+}
+.dark .lt-cell-tone-purple {
+  --lt-cell-bg: oklch(0.3 0.07 305);
+  --lt-cell-fg: oklch(0.85 0.11 305);
+}
+
+/*
  * Rich text content styling. Applied to the rich editor and reusable for rendered
  * output (wrap stored HTML in `.lattice-prose`). Restores the element styles that
  * Tailwind's preflight resets, using the theme tokens so it adapts to dark mode.

--- a/resources/js/table/column-registry.test.tsx
+++ b/resources/js/table/column-registry.test.tsx
@@ -130,4 +130,56 @@ describe("column registry", () => {
 
     expect(screen.getByText("custom-stack")).toBeVisible();
   });
+
+  function renderCell(column: ColumnData, row: Record<string, unknown>) {
+    return render(
+      <Provider columns={createColumnRegistry()}>
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <ColumnCell column={column} row={row} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </Provider>,
+    );
+  }
+
+  it("renders a badge cell with its mapped colour", () => {
+    renderCell(
+      col({
+        key: "status",
+        label: "Status",
+        type: "badge",
+        props: { colors: { active: "green" } },
+      }),
+      { status: "active" },
+    );
+
+    const badge = screen.getByText("active");
+    expect(badge).toBeVisible();
+    expect(badge.className).toContain("lt-cell-tone-green");
+  });
+
+  it("renders an icon cell from the value map", () => {
+    renderCell(
+      col({ key: "verified", label: "Verified", type: "icon", props: { icons: { "1": "check" } } }),
+      { verified: "1" },
+    );
+
+    expect(screen.getByLabelText("1")).toBeVisible();
+  });
+
+  it("renders an image cell as a circular avatar", () => {
+    renderCell(
+      col({ key: "avatar", label: "Avatar", type: "image", props: { circular: true, size: 40 } }),
+      { avatar: "https://example.com/a.png" },
+    );
+
+    const img = screen.getByRole("img", { name: "Avatar" });
+    expect(img).toHaveAttribute("src", "https://example.com/a.png");
+    expect(img.className).toContain("rounded-full");
+  });
 });

--- a/resources/js/table/components/cells/badge-cell.tsx
+++ b/resources/js/table/components/cells/badge-cell.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@lattice/lattice/lib/utils";
+import { formatCell } from "../../format";
+import type { TableColumn } from "../../types";
+import { columnMap } from "./column-map";
+
+export function BadgeCell({ column, value }: { column: TableColumn; value: unknown }) {
+  const label = formatCell(value, column);
+
+  if (label === "") {
+    return null;
+  }
+
+  const color = columnMap(column, "colors")[String(value)] ?? "gray";
+
+  return <span className={cn("lt-cell-badge", `lt-cell-tone-${color}`)}>{label}</span>;
+}

--- a/resources/js/table/components/cells/column-map.ts
+++ b/resources/js/table/components/cells/column-map.ts
@@ -1,0 +1,8 @@
+import type { TableColumn } from "../../types";
+
+/** Read a `{ value: x }` lookup stored in a column's props (badge colours, icon names). */
+export function columnMap(column: TableColumn, key: string): Record<string, string> {
+  const value = column.props?.[key];
+
+  return value && typeof value === "object" ? (value as Record<string, string>) : {};
+}

--- a/resources/js/table/components/cells/icon-cell.tsx
+++ b/resources/js/table/components/cells/icon-cell.tsx
@@ -1,0 +1,24 @@
+import { IconRenderer } from "@lattice/lattice/icons";
+import { cn } from "@lattice/lattice/lib/utils";
+import type { TableColumn } from "../../types";
+import { columnMap } from "./column-map";
+
+export function IconCell({ column, value }: { column: TableColumn; value: unknown }) {
+  const icon =
+    columnMap(column, "icons")[String(value)] ?? (column.props?.icon as string | undefined);
+
+  if (!icon) {
+    return null;
+  }
+
+  const color = columnMap(column, "colors")[String(value)];
+
+  return (
+    <span
+      aria-label={String(value)}
+      className={cn("lt-cell-icon", color && `lt-cell-tone-${color}`)}
+    >
+      <IconRenderer className="size-4" icon={icon} />
+    </span>
+  );
+}

--- a/resources/js/table/components/cells/image-cell.tsx
+++ b/resources/js/table/components/cells/image-cell.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@lattice/lattice/lib/utils";
+import type { TableColumn } from "../../types";
+
+export function ImageCell({ column, value }: { column: TableColumn; value: unknown }) {
+  const url = typeof value === "string" ? value : "";
+
+  if (url === "") {
+    return null;
+  }
+
+  const circular = column.props?.circular === true;
+  const size = typeof column.props?.size === "number" ? column.props.size : 32;
+
+  return (
+    <img
+      alt={column.label}
+      src={url}
+      width={size}
+      height={size}
+      className={cn("object-cover", circular ? "rounded-full" : "rounded-lt-sm")}
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -1,0 +1,70 @@
+import { copyToClipboard } from "@lattice/lattice/clipboard";
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+import { formatCell, resolveLink } from "../../format";
+import type { TableColumn, TableRow } from "../../types";
+
+export function TextCell({
+  column,
+  row,
+  value,
+}: {
+  column: TableColumn;
+  row: TableRow;
+  value: unknown;
+}) {
+  const text = formatCell(value, column);
+  const [copied, setCopied] = useState(false);
+  const href = resolveLink(column, row, value);
+  const content = href ? (
+    <a
+      className="underline underline-offset-2"
+      href={href}
+      rel={column.link?.external ? "noreferrer" : undefined}
+      target={column.link?.external ? "_blank" : undefined}
+    >
+      {text}
+    </a>
+  ) : (
+    text
+  );
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setCopied(false), 1500);
+
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  function handleCopy(): void {
+    void copyToClipboard(text);
+    setCopied(true);
+  }
+
+  if (!column.copyable) {
+    return content;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span>{content}</span>
+      <button
+        type="button"
+        data-test={`copy-${column.key}`}
+        className="inline-flex items-center gap-1 rounded border border-lt-border px-2 py-1 text-xs"
+        aria-label={`${copied ? "Copied" : "Copy"} ${column.label}`}
+        onClick={handleCopy}
+      >
+        {copied ? (
+          <Check aria-hidden="true" className="size-3" />
+        ) : (
+          <Copy aria-hidden="true" className="size-3" />
+        )}
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </span>
+  );
+}

--- a/resources/js/table/components/table-cell.tsx
+++ b/resources/js/table/components/table-cell.tsx
@@ -1,9 +1,9 @@
-import { copyToClipboard } from "@lattice/lattice/clipboard";
-import { Check, Copy } from "lucide-react";
-import { useEffect, useState } from "react";
 import { useColumnRegistry } from "../../provider";
-import { formatCell, resolveLink } from "../format";
 import type { TableColumn, TableRow } from "../types";
+import { BadgeCell } from "./cells/badge-cell";
+import { IconCell } from "./cells/icon-cell";
+import { ImageCell } from "./cells/image-cell";
+import { TextCell } from "./cells/text-cell";
 
 export function ColumnCell({ column, row }: { column: TableColumn; row: TableRow }) {
   const columnRegistry = useColumnRegistry();
@@ -25,62 +25,17 @@ export function ColumnCell({ column, row }: { column: TableColumn; row: TableRow
     );
   }
 
+  if (column.type === "badge") {
+    return <BadgeCell column={column} value={row[column.key]} />;
+  }
+
+  if (column.type === "icon") {
+    return <IconCell column={column} value={row[column.key]} />;
+  }
+
+  if (column.type === "image") {
+    return <ImageCell column={column} value={row[column.key]} />;
+  }
+
   return <TextCell column={column} row={row} value={row[column.key]} />;
-}
-
-function TextCell({ column, row, value }: { column: TableColumn; row: TableRow; value: unknown }) {
-  const text = formatCell(value, column);
-  const [copied, setCopied] = useState(false);
-  const href = resolveLink(column, row, value);
-  const content = href ? (
-    <a
-      className="underline underline-offset-2"
-      href={href}
-      rel={column.link?.external ? "noreferrer" : undefined}
-      target={column.link?.external ? "_blank" : undefined}
-    >
-      {text}
-    </a>
-  ) : (
-    text
-  );
-
-  useEffect(() => {
-    if (!copied) {
-      return;
-    }
-
-    const timeout = window.setTimeout(() => setCopied(false), 1500);
-
-    return () => window.clearTimeout(timeout);
-  }, [copied]);
-
-  function handleCopy(): void {
-    void copyToClipboard(text);
-    setCopied(true);
-  }
-
-  if (!column.copyable) {
-    return content;
-  }
-
-  return (
-    <span className="inline-flex items-center gap-2">
-      <span>{content}</span>
-      <button
-        type="button"
-        data-test={`copy-${column.key}`}
-        className="inline-flex items-center gap-1 rounded border border-lt-border px-2 py-1 text-xs"
-        aria-label={`${copied ? "Copied" : "Copy"} ${column.label}`}
-        onClick={handleCopy}
-      >
-        {copied ? (
-          <Check aria-hidden="true" className="size-3" />
-        ) : (
-          <Copy aria-hidden="true" className="size-3" />
-        )}
-        {copied ? "Copied" : "Copy"}
-      </button>
-    </span>
-  );
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -137,7 +137,7 @@ export type ColumnFilter = {
   readonly operators: Op[];
   readonly defaultOperator: Op;
 };
-export type ColumnType = "text" | "stack";
+export type ColumnType = "text" | "stack" | "badge" | "icon" | "image";
 export type Condition = {
   readonly field: string;
   readonly operator: Op;

--- a/src/Tables/Columns/BadgeColumn.php
+++ b/src/Tables/Columns/BadgeColumn.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Columns;
+
+use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
+use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
+use Lattice\Lattice\Tables\Enums\ColumnType;
+
+class BadgeColumn extends Column implements Filterable, Sortable
+{
+    use IsFilterable;
+    use IsSortable;
+
+    /**
+     * @var array<array-key, string>
+     */
+    protected array $colors = [];
+
+    /**
+     * Map cell values to a colour name (gray, red, green, yellow, blue, purple,
+     * orange). Unmapped values fall back to gray.
+     *
+     * @param  array<array-key, string>  $colors
+     */
+    public function colors(array $colors): static
+    {
+        $this->colors = $colors;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function toData(): ColumnData
+    {
+        return new ColumnData(
+            key: $this->key,
+            label: $this->label,
+            type: ColumnType::Badge,
+            sortable: $this->sortableValue(),
+            filter: $this->filterValue(),
+            props: $this->colors === [] ? null : ['colors' => $this->colors],
+        );
+    }
+}

--- a/src/Tables/Columns/IconColumn.php
+++ b/src/Tables/Columns/IconColumn.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Columns;
+
+use BackedEnum;
+use Lattice\Lattice\Tables\Enums\ColumnType;
+
+class IconColumn extends Column
+{
+    protected ?string $icon = null;
+
+    /**
+     * @var array<array-key, string>
+     */
+    protected array $icons = [];
+
+    /**
+     * @var array<array-key, string>
+     */
+    protected array $colors = [];
+
+    /**
+     * The icon shown for every row.
+     */
+    public function icon(BackedEnum|string $icon): static
+    {
+        $this->icon = self::iconValue($icon);
+
+        return $this;
+    }
+
+    /**
+     * Map cell values to icons, so each row shows an icon based on its value.
+     *
+     * @param  array<array-key, BackedEnum|string>  $icons
+     */
+    public function icons(array $icons): static
+    {
+        $this->icons = array_map(self::iconValue(...), $icons);
+
+        return $this;
+    }
+
+    private static function iconValue(BackedEnum|string $icon): string
+    {
+        return $icon instanceof BackedEnum ? (string) $icon->value : $icon;
+    }
+
+    /**
+     * Map cell values to a colour name (gray, red, green, yellow, blue, purple,
+     * orange).
+     *
+     * @param  array<array-key, string>  $colors
+     */
+    public function colors(array $colors): static
+    {
+        $this->colors = $colors;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function toData(): ColumnData
+    {
+        $props = array_filter([
+            'icon' => $this->icon,
+            'icons' => $this->icons === [] ? null : $this->icons,
+            'colors' => $this->colors === [] ? null : $this->colors,
+        ], static fn (mixed $value): bool => $value !== null);
+
+        return new ColumnData(
+            key: $this->key,
+            label: $this->label,
+            type: ColumnType::Icon,
+            props: $props === [] ? null : $props,
+        );
+    }
+}

--- a/src/Tables/Columns/ImageColumn.php
+++ b/src/Tables/Columns/ImageColumn.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Columns;
+
+use Lattice\Lattice\Tables\Enums\ColumnType;
+
+class ImageColumn extends Column
+{
+    protected bool $circular = false;
+
+    protected ?int $size = null;
+
+    /**
+     * Render the image as a circle — useful for avatars.
+     */
+    public function circular(bool $circular = true): static
+    {
+        $this->circular = $circular;
+
+        return $this;
+    }
+
+    /**
+     * The rendered image size in pixels (square).
+     */
+    public function size(int $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function toData(): ColumnData
+    {
+        $props = array_filter([
+            'circular' => $this->circular ? true : null,
+            'size' => $this->size,
+        ], static fn (mixed $value): bool => $value !== null);
+
+        return new ColumnData(
+            key: $this->key,
+            label: $this->label,
+            type: ColumnType::Image,
+            props: $props === [] ? null : $props,
+        );
+    }
+}

--- a/src/Tables/Enums/ColumnType.php
+++ b/src/Tables/Enums/ColumnType.php
@@ -11,4 +11,7 @@ enum ColumnType: string
 {
     case Text = 'text';
     case Stack = 'stack';
+    case Badge = 'badge';
+    case Icon = 'icon';
+    case Image = 'image';
 }

--- a/tests/Unit/ColumnTypesTest.php
+++ b/tests/Unit/ColumnTypesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Enums\LucideIcon;
+use Lattice\Lattice\Tables\Columns\BadgeColumn;
+use Lattice\Lattice\Tables\Columns\IconColumn;
+use Lattice\Lattice\Tables\Columns\ImageColumn;
+
+it('serializes a badge column with its colour map', function (): void {
+    $data = wire(
+        BadgeColumn::make('status')->label('Status')->sortable()->filterable()
+            ->colors(['active' => 'green', 'archived' => 'red']),
+    );
+
+    expect($data['type'])->toBe('badge')
+        ->and($data['sortable'])->toBeTrue()
+        ->and($data['filter']['enabled'])->toBeTrue()
+        ->and($data['props']['colors'])->toBe(['active' => 'green', 'archived' => 'red']);
+});
+
+it('serializes an icon column with a value map and colours', function (): void {
+    $data = wire(
+        IconColumn::make('verified')->label('Verified')
+            ->icons(['1' => LucideIcon::Check, '0' => LucideIcon::X])
+            ->colors(['1' => 'green', '0' => 'gray']),
+    );
+
+    expect($data['type'])->toBe('icon')
+        ->and($data['props']['icons'])->toBe(['1' => 'check', '0' => 'x'])
+        ->and($data['props']['colors'])->toBe(['1' => 'green', '0' => 'gray']);
+});
+
+it('serializes a static icon column', function (): void {
+    $data = wire(IconColumn::make('link')->icon(LucideIcon::ExternalLink));
+
+    expect($data['type'])->toBe('icon')
+        ->and($data['props']['icon'])->toBe('external-link');
+});
+
+it('serializes an image column', function (): void {
+    $data = wire(ImageColumn::make('avatar')->label('Avatar')->circular()->size(40));
+
+    expect($data['type'])->toBe('image')
+        ->and($data['props'])->toBe(['circular' => true, 'size' => 40]);
+});

--- a/tests/Unit/TableDocsTest.php
+++ b/tests/Unit/TableDocsTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Enums\LucideIcon;
+use Lattice\Lattice\Tables\Columns\BadgeColumn;
+use Lattice\Lattice\Tables\Columns\IconColumn;
+use Lattice\Lattice\Tables\Columns\ImageColumn;
 use Lattice\Lattice\Tables\Columns\StackColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 use Lattice\Lattice\Tables\Components\Table;
@@ -52,5 +56,30 @@ describe('docs fixtures', function (): void {
         ]);
 
         expect('docs/fixtures/table.stack.json')->toBeReadableFile();
+    });
+
+    it('dumps the column types table example', function (): void {
+        dumpFixture('table.column-types', [
+            Table::make('members')
+                ->columns([
+                    ImageColumn::make('avatar')->label('')->circular()->size(32),
+                    TextColumn::make('name')->label('Name'),
+                    BadgeColumn::make('status')->label('Status')
+                        ->colors(['active' => 'green', 'invited' => 'yellow', 'archived' => 'gray']),
+                    IconColumn::make('verified')->label('Verified')
+                        ->icons(['1' => LucideIcon::Check, '0' => LucideIcon::Minus])
+                        ->colors(['1' => 'green', '0' => 'gray']),
+                ])
+                ->result(
+                    TableResult::fromItems(collect([
+                        ['avatar' => 'https://i.pravatar.cc/64?img=1', 'name' => 'Ada Lovelace', 'status' => 'active', 'verified' => '1'],
+                        ['avatar' => 'https://i.pravatar.cc/64?img=2', 'name' => 'Alan Turing', 'status' => 'invited', 'verified' => '0'],
+                        ['avatar' => 'https://i.pravatar.cc/64?img=3', 'name' => 'Grace Hopper', 'status' => 'archived', 'verified' => '1'],
+                    ])),
+                    TableQuery::empty(),
+                ),
+        ]);
+
+        expect('docs/fixtures/table.column-types.json')->toBeReadableFile();
     });
 });


### PR DESCRIPTION
Adds three dedicated table column types (#118) beyond `TextColumn`'s display flags.

- **`BadgeColumn`** — renders the value as a coloured pill; `->colors([value => color])` maps values to a named colour (gray/red/green/yellow/blue/purple/orange, gray fallback). Sortable + filterable like a text column.
- **`IconColumn`** — `->icon(LucideIcon::Star)` for a static icon, or `->icons([value => LucideIcon])` per value; `->colors([value => color])` tints them. Renders via the existing `IconRenderer`.
- **`ImageColumn`** — renders the cell value as an image URL; `->circular()` for round avatars, `->size(px)`.

New `ColumnType` cases (`badge`/`icon`/`image`) render inline in `ColumnCell` (same place as `text`/`stack`); the column-type-specific config rides the generic `ColumnData.props` field, matching the existing custom-column convention.

## Tests & docs
- PHP wire-shape tests for all three; vitest cell-render tests (badge colour, icon-by-value, circular avatar).
- Documented on the Columns page with a live `ComponentExample` preview.

## Note
`->icons([...])`/`->colors([...])` accept `array<array-key, …>` — PHP coerces numeric-string value keys (e.g. `'1'`/`'0'` for a verified flag) to ints, and they serialize to string JSON keys the cells read by value.

## Verification
`composer test` 363 · vitest · pint / phpstan / tsc / oxlint clean · prod + docs builds green.
