### PR TITLE
Unify TypeScript generation behind one command + de-staticise the built-in types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "test:lint": "./vendor/bin/pint --test",
         "rector": "./vendor/bin/rector process",
         "rector:test": "./vendor/bin/rector process --dry-run",
-        "types": "@php vendor/bin/testbench lattice:internal-types",
+        "types": "@php vendor/bin/testbench lattice:typescript",
         "fix": [
             "@rector",
             "@lint",

--- a/src/Actions/Confirmation.php
+++ b/src/Actions/Confirmation.php
@@ -6,12 +6,14 @@ namespace Lattice\Lattice\Actions;
 
 use JsonSerializable;
 use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\TypeScript;
 
 /**
  * The confirmation dialog an action shows before it runs. Built by {@see Action::confirm()}
  * and generated to TypeScript; an action without a confirmation serializes to
  * `null` rather than this object.
  */
+#[TypeScript]
 final readonly class Confirmation implements JsonSerializable
 {
     public function __construct(

--- a/src/Actions/Enums/EffectType.php
+++ b/src/Actions/Enums/EffectType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Actions\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum EffectType: string
 {
     case Toast = 'toast';

--- a/src/Attributes/TypeScript.php
+++ b/src/Attributes/TypeScript.php
@@ -7,9 +7,7 @@ namespace Lattice\Lattice\Attributes;
 use Attribute;
 
 /**
- * Marks a backed enum or value object for inclusion in the generated built-in
- * TypeScript module (resources/js/types/generated.ts). Discovered over src/ by
- * the maintainer build tooling so the allow-list need not be hand-maintained.
+ * Marks an enum or value object for inclusion in the built-in TypeScript module.
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class TypeScript {}

--- a/src/Attributes/TypeScript.php
+++ b/src/Attributes/TypeScript.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Attributes;
+
+use Attribute;
+
+/**
+ * Marks a backed enum or value object for inclusion in the generated built-in
+ * TypeScript module (resources/js/types/generated.ts). Discovered over src/ by
+ * the maintainer build tooling so the allow-list need not be hand-maintained.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class TypeScript {}

--- a/src/Console/Commands/TypeScriptCommand.php
+++ b/src/Console/Commands/TypeScriptCommand.php
@@ -5,22 +5,17 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\File;
-use Lattice\Lattice\Core\Services\DefinitionDiscovery;
-use Lattice\Lattice\Support\TypeScript\AugmentationWriter;
-use Lattice\Lattice\Support\TypeScript\ComponentDiscovery;
-use Lattice\Lattice\Support\TypeScript\ComponentTransformer;
-use Lattice\Lattice\Support\TypeScript\OxfmtFormatter;
 use Lattice\Lattice\Support\TypeScript\TypeScriptGenerator;
+use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Spatie\TypeScriptTransformer\TypeScriptTransformer;
 
 final class TypeScriptCommand extends Command
 {
     protected $signature = 'lattice:typescript';
 
-    protected $description = "Generate TypeScript types for the app's custom Lattice components";
+    protected $description = 'Generate Lattice TypeScript types for the current project';
 
-    public function handle(ComponentDiscovery $discovery, TypeScriptGenerator $generator): int
+    public function handle(TypeScriptProfile $profile, TypeScriptGenerator $generator): int
     {
         if (! class_exists(TypeScriptTransformer::class)) {
             $this->components->error('lattice:typescript needs spatie/typescript-transformer. Install it with: composer require --dev spatie/typescript-transformer');
@@ -28,45 +23,7 @@ final class TypeScriptCommand extends Command
             return self::FAILURE;
         }
 
-        $roots = array_keys(DefinitionDiscovery::configuredPaths());
-        $output = (string) config('lattice.typescript.output');
-        $module = (string) config('lattice.typescript.module', '@lattice-php/lattice');
-
-        if ($roots === []) {
-            File::ensureDirectoryExists(dirname($output));
-            File::put($output, AugmentationWriter::render($module, [], []));
-            $this->components->info(sprintf('Generated 0 type(s) → %s', $output));
-
-            return self::SUCCESS;
-        }
-
-        $discovered = [];
-
-        foreach ($roots as $path) {
-            $discovered = [...$discovered, ...$discovery->discover($path)];
-        }
-
-        $components = [];
-        $columns = [];
-
-        foreach ($discovered as $component) {
-            $components[$component->class] = [$component->type, $component->category];
-
-            if ($component->category === 'column') {
-                $columns[] = $component->class;
-            }
-        }
-
-        $generator->generate(
-            $roots,
-            [new ComponentTransformer(array_keys($components), $columns)],
-            [],
-            new AugmentationWriter($components, $module, basename($output)),
-            dirname($output),
-            new OxfmtFormatter,
-        );
-
-        $this->components->info(sprintf('Generated %d type(s) → %s', count($components), $output));
+        $this->components->info($profile->run($generator));
 
         return self::SUCCESS;
     }

--- a/src/Core/Enums/Align.php
+++ b/src/Core/Enums/Align.php
@@ -2,6 +2,9 @@
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum Align: string
 {
     case Center = 'center';

--- a/src/Core/Enums/ButtonType.php
+++ b/src/Core/Enums/ButtonType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum ButtonType: string
 {
     case Button = 'button';

--- a/src/Core/Enums/ButtonVariant.php
+++ b/src/Core/Enums/ButtonVariant.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum ButtonVariant: string
 {
     case Default = 'default';

--- a/src/Core/Enums/Gap.php
+++ b/src/Core/Enums/Gap.php
@@ -2,6 +2,9 @@
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum Gap: string
 {
     case ExtraSmall = 'xs';

--- a/src/Core/Enums/Op.php
+++ b/src/Core/Enums/Op.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Enums;
 
 use InvalidArgumentException;
+use Lattice\Lattice\Attributes\TypeScript;
 
 /**
  * The shared comparison vocabulary used by both form conditions and table
@@ -12,6 +13,7 @@ use InvalidArgumentException;
  * and FilterApplier (SQL); per-field/column availability is owned by the field
  * and column.
  */
+#[TypeScript]
 enum Op: string
 {
     case Contains = 'contains';

--- a/src/Core/Enums/Orientation.php
+++ b/src/Core/Enums/Orientation.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum Orientation: string
 {
     case Horizontal = 'horizontal';

--- a/src/Core/Enums/PageContainer.php
+++ b/src/Core/Enums/PageContainer.php
@@ -2,6 +2,9 @@
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum PageContainer: string
 {
     case Centered = 'centered';

--- a/src/Core/Enums/PageLayout.php
+++ b/src/Core/Enums/PageLayout.php
@@ -2,6 +2,9 @@
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum PageLayout: string
 {
     case App = 'app';

--- a/src/Core/Enums/ToastVariant.php
+++ b/src/Core/Enums/ToastVariant.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum ToastVariant: string
 {
     case Success = 'success';

--- a/src/Core/Enums/Width.php
+++ b/src/Core/Enums/Width.php
@@ -2,6 +2,9 @@
 
 namespace Lattice\Lattice\Core\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum Width: string
 {
     case Full = 'full';

--- a/src/Core/Option.php
+++ b/src/Core/Option.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 
 /**
  * A `{ label, value }` pair backing every option-driven control (choice, select,
  * segmented control). Generated to TypeScript so the client shares one `Option`
  * type rather than re-declaring the shape per field.
  */
+#[TypeScript]
 final readonly class Option implements JsonSerializable
 {
     public function __construct(

--- a/src/Core/Values/ToastMessage.php
+++ b/src/Core/Values/ToastMessage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Values;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\Link;
 use Lattice\Lattice\Core\Enums\HttpMethod;
@@ -15,6 +16,7 @@ use Lattice\Lattice\Core\Enums\ToastVariant;
  * a close button, and an action rendered in the toast (a link or a full Action
  * that can open a confirm dialog or modal form).
  */
+#[TypeScript]
 final class ToastMessage implements JsonSerializable
 {
     public ?int $duration = null;

--- a/src/Forms/Conditions/Condition.php
+++ b/src/Forms/Conditions/Condition.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Forms\Conditions;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Forms\FormData;
 
+#[TypeScript]
 final class Condition implements JsonSerializable
 {
     public function __construct(

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -25,6 +25,8 @@ use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Layouts\LayoutRegistry;
+use Lattice\Lattice\Support\TypeScript\AugmentProfile;
+use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Lattice\Lattice\Tables\TableRegistry;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -62,6 +64,10 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->singleton(ComponentReferenceSigner::class);
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);
         $this->app->singleton(LatticeRegistry::class);
+
+        // Default TypeScript role: a consumer app augments the package's published
+        // types. The workbench rebinds this to its BaseProfile to regenerate them.
+        $this->app->bind(TypeScriptProfile::class, AugmentProfile::class);
 
         if (! Router::hasMacro('latticePage')) {
             Router::macro('latticePage', fn (string $uri, string $page): Route => Lattice::page($uri, $page));

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -65,8 +65,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);
         $this->app->singleton(LatticeRegistry::class);
 
-        // Default TypeScript role: a consumer app augments the package's published
-        // types. The workbench rebinds this to its BaseProfile to regenerate them.
+        // Default role; the workbench rebinds this to BaseProfile.
         $this->app->bind(TypeScriptProfile::class, AugmentProfile::class);
 
         if (! Router::hasMacro('latticePage')) {

--- a/src/Support/TypeScript/AugmentProfile.php
+++ b/src/Support/TypeScript/AugmentProfile.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\TypeScript;
+
+use Illuminate\Support\Facades\File;
+use Lattice\Lattice\Core\Services\DefinitionDiscovery;
+
+/**
+ * The default profile: discovers an app's own #[Component] classes across the
+ * configured discover roots and writes a module augmentation extending the open
+ * ComponentProps / ColumnProps interfaces the `@lattice-php/lattice` module
+ * exposes, layered on top of the package's built-in types.
+ */
+final class AugmentProfile implements TypeScriptProfile
+{
+    public function __construct(private readonly ComponentDiscovery $discovery) {}
+
+    public function run(TypeScriptGenerator $generator): string
+    {
+        $roots = array_keys(DefinitionDiscovery::configuredPaths());
+        $output = (string) config('lattice.typescript.output');
+        $module = (string) config('lattice.typescript.module', '@lattice-php/lattice');
+
+        if ($roots === []) {
+            File::ensureDirectoryExists(dirname($output));
+            File::put($output, AugmentationWriter::render($module, [], []));
+
+            return sprintf('Generated 0 type(s) → %s', $output);
+        }
+
+        $discovered = [];
+
+        foreach ($roots as $path) {
+            $discovered = [...$discovered, ...$this->discovery->discover($path)];
+        }
+
+        $components = [];
+        $columns = [];
+
+        foreach ($discovered as $component) {
+            $components[$component->class] = [$component->type, $component->category];
+
+            if ($component->category === 'column') {
+                $columns[] = $component->class;
+            }
+        }
+
+        $generator->generate(
+            $roots,
+            [new ComponentTransformer(array_keys($components), $columns)],
+            [],
+            new AugmentationWriter($components, $module, basename($output)),
+            dirname($output),
+            new OxfmtFormatter,
+        );
+
+        return sprintf('Generated %d type(s) → %s', count($components), $output);
+    }
+}

--- a/src/Support/TypeScript/AugmentProfile.php
+++ b/src/Support/TypeScript/AugmentProfile.php
@@ -8,10 +8,8 @@ use Illuminate\Support\Facades\File;
 use Lattice\Lattice\Core\Services\DefinitionDiscovery;
 
 /**
- * The default profile: discovers an app's own #[Component] classes across the
- * configured discover roots and writes a module augmentation extending the open
- * ComponentProps / ColumnProps interfaces the `@lattice-php/lattice` module
- * exposes, layered on top of the package's built-in types.
+ * Default profile: discovers an app's own #[Component] classes and writes a
+ * module augmentation extending the package's published types.
  */
 final class AugmentProfile implements TypeScriptProfile
 {

--- a/src/Support/TypeScript/ComponentDiscovery.php
+++ b/src/Support/TypeScript/ComponentDiscovery.php
@@ -51,10 +51,26 @@ final class ComponentDiscovery
                 container: is_subclass_of($class, ContainerComponent::class),
                 interactive: in_array(IsInteractive::class, class_uses_recursive($class), true),
                 category: $this->categoryFor($class),
+                domain: $this->domainFor($class),
             );
         }
 
         return $discovered;
+    }
+
+    /**
+     * The namespace segment immediately before `\Components\` — every discovered
+     * component lives under `…\{Domain}\Components\…`, so this groups it into its
+     * Node union (Core, Actions, Fragments, Tables, Layouts, Forms).
+     *
+     * @param  class-string  $class
+     */
+    private function domainFor(string $class): string
+    {
+        $parts = explode('\\', $class);
+        $index = array_search('Components', $parts, true);
+
+        return $index !== false && $index > 0 ? $parts[$index - 1] : '';
     }
 
     /**

--- a/src/Support/TypeScript/ComponentDiscovery.php
+++ b/src/Support/TypeScript/ComponentDiscovery.php
@@ -59,9 +59,8 @@ final class ComponentDiscovery
     }
 
     /**
-     * The namespace segment immediately before `\Components\` — every discovered
-     * component lives under `…\{Domain}\Components\…`, so this groups it into its
-     * Node union (Core, Actions, Fragments, Tables, Layouts, Forms).
+     * The namespace segment before `\Components\`, grouping the component into its
+     * Node union.
      *
      * @param  class-string  $class
      */

--- a/src/Support/TypeScript/DiscoveredComponent.php
+++ b/src/Support/TypeScript/DiscoveredComponent.php
@@ -9,6 +9,7 @@ final readonly class DiscoveredComponent
     /**
      * @param  class-string  $class
      * @param  'component'|'field'|'column'  $category
+     * @param  string  $domain  The namespace segment before `\Components\` (e.g. 'Core', 'Forms'), grouping the component into its Node union.
      */
     public function __construct(
         public string $class,
@@ -16,5 +17,6 @@ final readonly class DiscoveredComponent
         public bool $container,
         public bool $interactive,
         public string $category,
+        public string $domain,
     ) {}
 }

--- a/src/Support/TypeScript/DiscoveredComponent.php
+++ b/src/Support/TypeScript/DiscoveredComponent.php
@@ -9,7 +9,7 @@ final readonly class DiscoveredComponent
     /**
      * @param  class-string  $class
      * @param  'component'|'field'|'column'  $category
-     * @param  string  $domain  The namespace segment before `\Components\` (e.g. 'Core', 'Forms'), grouping the component into its Node union.
+     * @param  string  $domain  Namespace segment before `\Components\` (e.g. 'Core'), grouping it into its Node union.
      */
     public function __construct(
         public string $class,

--- a/src/Support/TypeScript/TypeScriptProfile.php
+++ b/src/Support/TypeScript/TypeScriptProfile.php
@@ -5,16 +5,11 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Support\TypeScript;
 
 /**
- * A TypeScript generation role. The `lattice:typescript` command resolves one
- * from the container and runs it: a consumer app gets the default AugmentProfile
- * (extending the package's published types), while the package's own dev
- * environment binds the BaseProfile (regenerating those base types).
+ * A TypeScript generation role resolved by lattice:typescript: AugmentProfile in
+ * a consumer app, BaseProfile in the package's own workbench.
  */
 interface TypeScriptProfile
 {
-    /**
-     * Assemble and run a generation pass, returning a human-readable summary
-     * line for the command to print.
-     */
+    /** Run a generation pass and return a summary line for the command to print. */
     public function run(TypeScriptGenerator $generator): string;
 }

--- a/src/Support/TypeScript/TypeScriptProfile.php
+++ b/src/Support/TypeScript/TypeScriptProfile.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\TypeScript;
+
+/**
+ * A TypeScript generation role. The `lattice:typescript` command resolves one
+ * from the container and runs it: a consumer app gets the default AugmentProfile
+ * (extending the package's published types), while the package's own dev
+ * environment binds the BaseProfile (regenerating those base types).
+ */
+interface TypeScriptProfile
+{
+    /**
+     * Assemble and run a generation pass, returning a human-readable summary
+     * line for the command to print.
+     */
+    public function run(TypeScriptGenerator $generator): string;
+}

--- a/src/Tables/Columns/ColumnData.php
+++ b/src/Tables/Columns/ColumnData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables\Columns;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 /**
@@ -13,6 +14,7 @@ use Lattice\Lattice\Tables\Enums\ColumnType;
  * applicable to a column type are null, so the generated type matches the
  * payload exactly.
  */
+#[TypeScript]
 final readonly class ColumnData implements JsonSerializable
 {
     /**

--- a/src/Tables/Columns/ColumnFilter.php
+++ b/src/Tables/Columns/ColumnFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables\Columns;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Tables\Enums\FilterType;
 
@@ -12,6 +13,7 @@ use Lattice\Lattice\Tables\Enums\FilterType;
  * The wire shape of a column's filter capability. Built by a Filterable column
  * and generated to TypeScript.
  */
+#[TypeScript]
 final readonly class ColumnFilter implements JsonSerializable
 {
     /**

--- a/src/Tables/Enums/ColumnType.php
+++ b/src/Tables/Enums/ColumnType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum ColumnType: string
 {
     case Text = 'text';

--- a/src/Tables/Enums/FilterType.php
+++ b/src/Tables/Enums/FilterType.php
@@ -6,8 +6,10 @@ namespace Lattice\Lattice\Tables\Enums;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
 
+#[TypeScript]
 enum FilterType: string
 {
     case Text = 'text';

--- a/src/Tables/Enums/PaginationType.php
+++ b/src/Tables/Enums/PaginationType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum PaginationType: string
 {
     case None = 'none';

--- a/src/Tables/Enums/SortDirection.php
+++ b/src/Tables/Enums/SortDirection.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Enums;
 
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
 enum SortDirection: string
 {
     case Asc = 'asc';

--- a/src/Tables/FilterClause.php
+++ b/src/Tables/FilterClause.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
 
+#[TypeScript]
 final readonly class FilterClause implements JsonSerializable
 {
     public function __construct(

--- a/src/Tables/TableSort.php
+++ b/src/Tables/TableSort.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables;
 
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Tables\Enums\SortDirection;
 
+#[TypeScript]
 final readonly class TableSort implements JsonSerializable
 {
     public function __construct(public string $key, public SortDirection $direction) {}

--- a/tests/Feature/Console/TypeScriptCommandTest.php
+++ b/tests/Feature/Console/TypeScriptCommandTest.php
@@ -8,8 +8,7 @@ use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 
 use function Pest\Laravel\artisan;
 
-// The workbench binds the BaseProfile by default; these tests exercise the
-// shipped augmentation behaviour, so restore the default AugmentProfile.
+// Restore the default profile; the workbench binds BaseProfile.
 beforeEach(function () {
     app()->bind(TypeScriptProfile::class, AugmentProfile::class);
 });

--- a/tests/Feature/Console/TypeScriptCommandTest.php
+++ b/tests/Feature/Console/TypeScriptCommandTest.php
@@ -3,8 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\File;
+use Lattice\Lattice\Support\TypeScript\AugmentProfile;
+use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 
 use function Pest\Laravel\artisan;
+
+// The workbench binds the BaseProfile by default; these tests exercise the
+// shipped augmentation behaviour, so restore the default AugmentProfile.
+beforeEach(function () {
+    app()->bind(TypeScriptProfile::class, AugmentProfile::class);
+});
 
 it('writes an augmentation file for app components, not built-ins', function () {
     $output = base_path('resources/js/lattice/generated.d.ts');

--- a/tests/Feature/TypeScript/ColumnPropsGenerationTest.php
+++ b/tests/Feature/TypeScript/ColumnPropsGenerationTest.php
@@ -8,8 +8,7 @@ use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 
 use function Pest\Laravel\artisan;
 
-// The workbench binds the BaseProfile by default; this test exercises the
-// shipped augmentation behaviour, so restore the default AugmentProfile.
+// Restore the default profile; the workbench binds BaseProfile.
 beforeEach(function () {
     app()->bind(TypeScriptProfile::class, AugmentProfile::class);
 });

--- a/tests/Feature/TypeScript/ColumnPropsGenerationTest.php
+++ b/tests/Feature/TypeScript/ColumnPropsGenerationTest.php
@@ -3,8 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\File;
+use Lattice\Lattice\Support\TypeScript\AugmentProfile;
+use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 
 use function Pest\Laravel\artisan;
+
+// The workbench binds the BaseProfile by default; this test exercises the
+// shipped augmentation behaviour, so restore the default AugmentProfile.
+beforeEach(function () {
+    app()->bind(TypeScriptProfile::class, AugmentProfile::class);
+});
 
 it('writes a ColumnProps augmentation with own column properties only', function () {
     $output = base_path('resources/js/lattice/generated-column.d.ts');

--- a/tests/Feature/TypeScript/ComponentDiscoveryTest.php
+++ b/tests/Feature/TypeScript/ComponentDiscoveryTest.php
@@ -39,3 +39,13 @@ it('returns an empty array when the path does not exist', function () {
 
     expect($discovered)->toBe([]);
 });
+
+it('derives the domain from the namespace segment before Components', function () {
+    $discovered = (new ComponentDiscovery)->discover(dirname(__DIR__, 3).'/src/Core/Components');
+
+    $card = collect($discovered)->keyBy->type->get('card');
+
+    assert($card instanceof DiscoveredComponent);
+
+    expect($card->domain)->toBe('Core');
+});

--- a/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
+++ b/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
@@ -11,7 +11,8 @@ it('keeps the committed generated.ts in sync with the transformer', function () 
 
     $before = file_get_contents($path);
 
-    artisan('lattice:internal-types')->assertSuccessful();
+    // In the workbench, lattice:typescript regenerates the built-in types (BaseProfile).
+    artisan('lattice:typescript')->assertSuccessful();
 
     $after = file_get_contents($path);
 

--- a/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
+++ b/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
@@ -11,7 +11,6 @@ it('keeps the committed generated.ts in sync with the transformer', function () 
 
     $before = file_get_contents($path);
 
-    // In the workbench, lattice:typescript regenerates the built-in types (BaseProfile).
     artisan('lattice:typescript')->assertSuccessful();
 
     $after = file_get_contents($path);

--- a/tests/Feature/TypeScript/MarkedTypeDiscoveryTest.php
+++ b/tests/Feature/TypeScript/MarkedTypeDiscoveryTest.php
@@ -12,15 +12,11 @@ use Workbench\App\Support\TypeScript\MarkedTypeDiscovery;
 it('splits #[TypeScript]-marked classes into enums and value objects', function () {
     $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
 
-    expect($result['enums'])
-        ->toContain(Align::class)
-        ->toContain(EffectType::class)
-        ->not->toContain(Option::class);
+    expect($result['enums'])->toContain(Align::class)->toContain(EffectType::class);
+    expect($result['enums'])->not->toContain(Option::class);
 
-    expect($result['valueObjects'])
-        ->toContain(Option::class)
-        ->toContain(ToastMessage::class)
-        ->not->toContain(Align::class);
+    expect($result['valueObjects'])->toContain(Option::class)->toContain(ToastMessage::class);
+    expect($result['valueObjects'])->not->toContain(Align::class);
 });
 
 it('excludes classes without the #[TypeScript] attribute', function () {

--- a/tests/Feature/TypeScript/MarkedTypeDiscoveryTest.php
+++ b/tests/Feature/TypeScript/MarkedTypeDiscoveryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Actions\Enums\EffectType;
+use Lattice\Lattice\Core\Components\Card;
+use Lattice\Lattice\Core\Enums\Align;
+use Lattice\Lattice\Core\Option;
+use Lattice\Lattice\Core\Values\ToastMessage;
+use Workbench\App\Support\TypeScript\MarkedTypeDiscovery;
+
+it('splits #[TypeScript]-marked classes into enums and value objects', function () {
+    $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
+
+    expect($result['enums'])
+        ->toContain(Align::class)
+        ->toContain(EffectType::class)
+        ->not->toContain(Option::class);
+
+    expect($result['valueObjects'])
+        ->toContain(Option::class)
+        ->toContain(ToastMessage::class)
+        ->not->toContain(Align::class);
+});
+
+it('excludes classes without the #[TypeScript] attribute', function () {
+    $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
+
+    $all = [...$result['enums'], ...$result['valueObjects']];
+
+    expect($all)->not->toContain(Card::class);
+});
+
+it('sorts each list deterministically by class-string', function () {
+    $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
+
+    $sortedEnums = $result['enums'];
+    sort($sortedEnums);
+    $sortedValueObjects = $result['valueObjects'];
+    sort($sortedValueObjects);
+
+    expect($result['enums'])->toBe($sortedEnums)
+        ->and($result['valueObjects'])->toBe($sortedValueObjects);
+});
+
+it('returns empty lists when the path does not exist', function () {
+    expect((new MarkedTypeDiscovery)->discover('/no/such/path'))
+        ->toBe(['enums' => [], 'valueObjects' => []]);
+});

--- a/workbench/app/Console/Commands/GenerateInternalTypesCommand.php
+++ b/workbench/app/Console/Commands/GenerateInternalTypesCommand.php
@@ -5,47 +5,39 @@ declare(strict_types=1);
 namespace Workbench\App\Console\Commands;
 
 use Illuminate\Console\Command;
-use Lattice\Lattice\Actions\Confirmation;
 use Lattice\Lattice\Actions\Contracts\Effect;
-use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes\Effect as EffectAttribute;
-use Lattice\Lattice\Core\Enums\Align;
-use Lattice\Lattice\Core\Enums\ButtonType;
-use Lattice\Lattice\Core\Enums\ButtonVariant;
-use Lattice\Lattice\Core\Enums\Gap;
-use Lattice\Lattice\Core\Enums\Op;
-use Lattice\Lattice\Core\Enums\Orientation;
-use Lattice\Lattice\Core\Enums\PageContainer;
-use Lattice\Lattice\Core\Enums\PageLayout;
-use Lattice\Lattice\Core\Enums\ToastVariant;
-use Lattice\Lattice\Core\Enums\Width;
-use Lattice\Lattice\Core\Option;
-use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Forms\Components\Form;
-use Lattice\Lattice\Forms\Conditions\Condition;
 use Lattice\Lattice\Support\TypeScript\ComponentDiscovery;
 use Lattice\Lattice\Support\TypeScript\ComponentTransformer;
 use Lattice\Lattice\Support\TypeScript\DiscoveredComponent;
 use Lattice\Lattice\Support\TypeScript\OxfmtFormatter;
 use Lattice\Lattice\Support\TypeScript\TypeScriptGenerator;
-use Lattice\Lattice\Tables\Columns\ColumnData;
-use Lattice\Lattice\Tables\Columns\ColumnFilter;
-use Lattice\Lattice\Tables\Enums\ColumnType;
-use Lattice\Lattice\Tables\Enums\FilterType;
-use Lattice\Lattice\Tables\Enums\PaginationType;
-use Lattice\Lattice\Tables\Enums\SortDirection;
-use Lattice\Lattice\Tables\FilterClause;
-use Lattice\Lattice\Tables\TableSort;
 use Spatie\Attributes\Attributes;
 use Spatie\StructureDiscoverer\Discover;
 use Spatie\TypeScriptTransformer\Writers\FlatModuleWriter;
 use Workbench\App\Support\TypeScript\EnumTransformer;
 use Workbench\App\Support\TypeScript\HttpMethodTransformer;
+use Workbench\App\Support\TypeScript\MarkedTypeDiscovery;
 use Workbench\App\Support\TypeScript\NodesProvider;
 use Workbench\App\Support\TypeScript\ValueObjectTransformer;
 
 final class GenerateInternalTypesCommand extends Command
 {
+    /**
+     * The component domains, in output order, mapped to their generated node-alias
+     * name. This is the one declared, ordered piece of static config: discovery
+     * supplies the components, but the emission order and the (singular) node names
+     * are meaningful and not derivable from the (plural) namespace segments.
+     */
+    private const DOMAIN_NODES = [
+        'Core' => 'CoreNode',
+        'Actions' => 'ActionNode',
+        'Fragments' => 'FragmentNode',
+        'Tables' => 'TableNode',
+        'Layouts' => 'LayoutNode',
+    ];
+
     protected $signature = 'lattice:internal-types';
 
     protected $description = "Regenerate Lattice's built-in TypeScript types (resources/js/types/generated.ts)";
@@ -56,67 +48,33 @@ final class GenerateInternalTypesCommand extends Command
         $src = $packageRoot.'/src';
 
         $effects = $this->discoverEffects($src.'/Actions/Effects');
+        $marked = (new MarkedTypeDiscovery)->discover($src);
 
         $discovered = (new ComponentDiscovery)->discover($src);
 
         $formFields = $this->buildFormFields($discovered);
-        $coreComponents = $this->buildBucket($discovered, 'Lattice\\Lattice\\Core\\Components\\');
-        $actionComponents = $this->buildBucket($discovered, 'Lattice\\Lattice\\Actions\\Components\\');
-        $fragmentComponents = $this->buildBucket($discovered, 'Lattice\\Lattice\\Fragments\\Components\\');
-        $tableComponents = $this->buildBucket($discovered, 'Lattice\\Lattice\\Tables\\Components\\');
-        $layoutComponents = $this->buildBucket($discovered, 'Lattice\\Lattice\\Layouts\\Components\\');
+        $domainNodes = $this->buildDomainNodes($discovered);
 
         $generator->generate(
             [$src],
             [
                 new HttpMethodTransformer,
-                new EnumTransformer([
-                    Align::class,
-                    ButtonType::class,
-                    ButtonVariant::class,
-                    Gap::class,
-                    Width::class,
-                    PageLayout::class,
-                    PageContainer::class,
-                    Orientation::class,
-                    ToastVariant::class,
-                    PaginationType::class,
-                    ColumnType::class,
-                    FilterType::class,
-                    Op::class,
-                    SortDirection::class,
-                    EffectType::class,
-                ]),
+                new EnumTransformer($marked['enums']),
                 new ValueObjectTransformer([
-                    Condition::class,
-                    Confirmation::class,
-                    Option::class,
-                    ColumnData::class,
-                    ColumnFilter::class,
-                    FilterClause::class,
-                    TableSort::class,
-                    ToastMessage::class,
+                    ...$marked['valueObjects'],
                     ...array_keys($effects),
                 ]),
                 new ComponentTransformer([
                     ...array_keys($formFields),
                     Form::class,
-                    ...array_keys($coreComponents),
-                    ...array_keys($actionComponents),
-                    ...array_keys($fragmentComponents),
-                    ...array_keys($tableComponents),
-                    ...array_keys($layoutComponents),
+                    ...$this->componentClasses($domainNodes),
                 ]),
             ],
             [
                 new NodesProvider(
                     $formFields,
                     Form::class,
-                    $coreComponents,
-                    $actionComponents,
-                    $fragmentComponents,
-                    $tableComponents,
-                    $layoutComponents,
+                    $domainNodes,
                     'form',
                     Effect::class,
                     $effects,
@@ -164,12 +122,9 @@ final class GenerateInternalTypesCommand extends Command
      */
     private function buildFormFields(array $discovered): array
     {
-        $prefix = 'Lattice\\Lattice\\Forms\\Components\\';
-
         $fields = array_filter(
             $discovered,
-            fn (DiscoveredComponent $dc): bool => str_starts_with($dc->class, $prefix)
-                && $dc->class !== Form::class,
+            fn (DiscoveredComponent $dc): bool => $dc->domain === 'Forms' && $dc->class !== Form::class,
         );
 
         usort($fields, fn (DiscoveredComponent $a, DiscoveredComponent $b): int => $a->type <=> $b->type);
@@ -182,14 +137,31 @@ final class GenerateInternalTypesCommand extends Command
     }
 
     /**
+     * The components for each domain, keyed by node-alias name in DOMAIN_NODES order.
+     *
+     * @param  list<DiscoveredComponent>  $discovered
+     * @return array<string, array<class-string, array{type: string, container?: bool, interactive?: bool}>>
+     */
+    private function buildDomainNodes(array $discovered): array
+    {
+        $domainNodes = [];
+
+        foreach (self::DOMAIN_NODES as $domain => $nodeName) {
+            $domainNodes[$nodeName] = $this->buildBucket($discovered, $domain);
+        }
+
+        return $domainNodes;
+    }
+
+    /**
      * @param  list<DiscoveredComponent>  $discovered
      * @return array<class-string, array{type: string, container?: bool, interactive?: bool}>
      */
-    private function buildBucket(array $discovered, string $prefix): array
+    private function buildBucket(array $discovered, string $domain): array
     {
         $components = array_filter(
             $discovered,
-            fn (DiscoveredComponent $dc): bool => str_starts_with($dc->class, $prefix),
+            fn (DiscoveredComponent $dc): bool => $dc->domain === $domain,
         );
 
         usort($components, fn (DiscoveredComponent $a, DiscoveredComponent $b): int => $a->type <=> $b->type);
@@ -211,5 +183,22 @@ final class GenerateInternalTypesCommand extends Command
         }
 
         return $result;
+    }
+
+    /**
+     * Flatten the per-domain component class-strings into one allow-list.
+     *
+     * @param  array<string, array<class-string, array{type: string, container?: bool, interactive?: bool}>>  $domainNodes
+     * @return list<class-string>
+     */
+    private function componentClasses(array $domainNodes): array
+    {
+        $classes = [];
+
+        foreach ($domainNodes as $components) {
+            $classes = [...$classes, ...array_keys($components)];
+        }
+
+        return $classes;
     }
 }

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -41,8 +41,7 @@ class WorkbenchServiceProvider extends ServiceProvider
     #[\Override]
     public function register(): void
     {
-        // Rebind the package's default (AugmentProfile) so `lattice:typescript`
-        // regenerates Lattice's own built-in types when run in this dev environment.
+        // Rebind so lattice:typescript regenerates the package's own built-in types.
         $this->app->bind(TypeScriptProfile::class, BaseProfile::class);
         $this->useWorkbenchDatabase();
         $this->readBoostConfigFromPackageRoot();

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -13,12 +13,12 @@ use Laravel\Boost\Install\SkillComposer;
 use Laravel\Boost\Support\Config;
 use Laravel\Roster\Roster;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
 use Workbench\App\Actions\EditProductAction;
 use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
-use Workbench\App\Console\Commands\GenerateInternalTypesCommand;
 use Workbench\App\Forms\DependentDemoForm;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Forms\ShowcaseForm;
@@ -26,6 +26,7 @@ use Workbench\App\Layouts\AppLayout;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
+use Workbench\App\Support\TypeScript\BaseProfile;
 use Workbench\App\Tables\ProductsTable;
 use Workbench\App\Tables\UsersInfiniteTable;
 use Workbench\App\Tables\UsersNoneTable;
@@ -40,7 +41,9 @@ class WorkbenchServiceProvider extends ServiceProvider
     #[\Override]
     public function register(): void
     {
-        $this->commands([GenerateInternalTypesCommand::class]);
+        // Rebind the package's default (AugmentProfile) so `lattice:typescript`
+        // regenerates Lattice's own built-in types when run in this dev environment.
+        $this->app->bind(TypeScriptProfile::class, BaseProfile::class);
         $this->useWorkbenchDatabase();
         $this->readBoostConfigFromPackageRoot();
     }

--- a/workbench/app/Support/TypeScript/BaseProfile.php
+++ b/workbench/app/Support/TypeScript/BaseProfile.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace Workbench\App\Console\Commands;
+namespace Workbench\App\Support\TypeScript;
 
-use Illuminate\Console\Command;
 use Lattice\Lattice\Actions\Contracts\Effect;
 use Lattice\Lattice\Attributes\Effect as EffectAttribute;
 use Lattice\Lattice\Forms\Components\Form;
@@ -13,16 +12,20 @@ use Lattice\Lattice\Support\TypeScript\ComponentTransformer;
 use Lattice\Lattice\Support\TypeScript\DiscoveredComponent;
 use Lattice\Lattice\Support\TypeScript\OxfmtFormatter;
 use Lattice\Lattice\Support\TypeScript\TypeScriptGenerator;
+use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Spatie\Attributes\Attributes;
 use Spatie\StructureDiscoverer\Discover;
 use Spatie\TypeScriptTransformer\Writers\FlatModuleWriter;
-use Workbench\App\Support\TypeScript\EnumTransformer;
-use Workbench\App\Support\TypeScript\HttpMethodTransformer;
-use Workbench\App\Support\TypeScript\MarkedTypeDiscovery;
-use Workbench\App\Support\TypeScript\NodesProvider;
-use Workbench\App\Support\TypeScript\ValueObjectTransformer;
 
-final class GenerateInternalTypesCommand extends Command
+/**
+ * The package's own dev profile: regenerates the built-in TypeScript module
+ * (resources/js/types/generated.ts) — enums, value objects, effects and the
+ * discriminated Node unions — from the package src/. Bound as the default
+ * TypeScriptProfile in the workbench so `php artisan lattice:typescript`
+ * regenerates the base types every other project then augments. Kept in the
+ * workbench so this maintainer-only build code never ships.
+ */
+final class BaseProfile implements TypeScriptProfile
 {
     /**
      * The component domains, in output order, mapped to their generated node-alias
@@ -38,11 +41,7 @@ final class GenerateInternalTypesCommand extends Command
         'Layouts' => 'LayoutNode',
     ];
 
-    protected $signature = 'lattice:internal-types';
-
-    protected $description = "Regenerate Lattice's built-in TypeScript types (resources/js/types/generated.ts)";
-
-    public function handle(TypeScriptGenerator $generator): int
+    public function run(TypeScriptGenerator $generator): string
     {
         $packageRoot = dirname(__DIR__, 4);
         $src = $packageRoot.'/src';
@@ -85,9 +84,7 @@ final class GenerateInternalTypesCommand extends Command
             new OxfmtFormatter,
         );
 
-        $this->components->info('Regenerated built-in TypeScript types.');
-
-        return self::SUCCESS;
+        return 'Regenerated built-in TypeScript types.';
     }
 
     /**

--- a/workbench/app/Support/TypeScript/BaseProfile.php
+++ b/workbench/app/Support/TypeScript/BaseProfile.php
@@ -19,19 +19,15 @@ use Spatie\TypeScriptTransformer\Writers\FlatModuleWriter;
 
 /**
  * The package's own dev profile: regenerates the built-in TypeScript module
- * (resources/js/types/generated.ts) — enums, value objects, effects and the
- * discriminated Node unions — from the package src/. Bound as the default
- * TypeScriptProfile in the workbench so `php artisan lattice:typescript`
- * regenerates the base types every other project then augments. Kept in the
- * workbench so this maintainer-only build code never ships.
+ * (generated.ts) from src/. Bound in the workbench so lattice:typescript rebuilds
+ * the base types every consumer app then augments. Workbench-only, so this
+ * build code never ships.
  */
 final class BaseProfile implements TypeScriptProfile
 {
     /**
-     * The component domains, in output order, mapped to their generated node-alias
-     * name. This is the one declared, ordered piece of static config: discovery
-     * supplies the components, but the emission order and the (singular) node names
-     * are meaningful and not derivable from the (plural) namespace segments.
+     * Component domains in output order, mapped to their node-alias name. The
+     * order and (singular) names are meaningful, so they stay declared here.
      */
     private const DOMAIN_NODES = [
         'Core' => 'CoreNode',

--- a/workbench/app/Support/TypeScript/MarkedTypeDiscovery.php
+++ b/workbench/app/Support/TypeScript/MarkedTypeDiscovery.php
@@ -9,16 +9,13 @@ use ReflectionClass;
 use Spatie\StructureDiscoverer\Discover;
 
 /**
- * Discovers the classes marked with #[TypeScript] under a path and splits them
- * into backed enums and value objects — the allow-lists that drive the enum and
- * value-object transformers for the built-in types. Keeping this in the
- * workbench keeps the maintainer-only build code out of the shipped package.
+ * Discovers #[TypeScript]-marked enums and value objects under a path — the
+ * allow-lists for the built-in enum and value-object transformers.
  */
 final class MarkedTypeDiscovery
 {
     /**
-     * Each list is sorted by class-string so the generated output stays
-     * deterministic regardless of filesystem discovery order.
+     * Lists sorted by class-string to keep generated output deterministic.
      *
      * @return array{enums: list<class-string>, valueObjects: list<class-string>}
      */
@@ -28,11 +25,9 @@ final class MarkedTypeDiscovery
             return ['enums' => [], 'valueObjects' => []];
         }
 
-        // No type filter: ->classes() would exclude enums. The unfiltered get()
-        // returns both classes and enums as class-strings; the #[TypeScript]
-        // check below is the real allow-list. Construct Discover directly
-        // instead of Discover::in() — see ComponentDiscovery for why the cached
-        // variant poisons the typescript-transformer's own discovery.
+        // Unfiltered get() so enums come through (->classes() drops them); the
+        // #[TypeScript] check is the real filter. Construct Discover directly
+        // (not ::in()) to dodge the cache collision noted in ComponentDiscovery.
         /** @var list<class-string> $classes */
         $classes = (new Discover(directories: [$path]))->get();
 

--- a/workbench/app/Support/TypeScript/MarkedTypeDiscovery.php
+++ b/workbench/app/Support/TypeScript/MarkedTypeDiscovery.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Support\TypeScript;
+
+use Lattice\Lattice\Attributes\TypeScript;
+use ReflectionClass;
+use Spatie\StructureDiscoverer\Discover;
+
+/**
+ * Discovers the classes marked with #[TypeScript] under a path and splits them
+ * into backed enums and value objects — the allow-lists that drive the enum and
+ * value-object transformers for the built-in types. Keeping this in the
+ * workbench keeps the maintainer-only build code out of the shipped package.
+ */
+final class MarkedTypeDiscovery
+{
+    /**
+     * Each list is sorted by class-string so the generated output stays
+     * deterministic regardless of filesystem discovery order.
+     *
+     * @return array{enums: list<class-string>, valueObjects: list<class-string>}
+     */
+    public function discover(string $path): array
+    {
+        if (! is_dir($path)) {
+            return ['enums' => [], 'valueObjects' => []];
+        }
+
+        // No type filter: ->classes() would exclude enums. The unfiltered get()
+        // returns both classes and enums as class-strings; the #[TypeScript]
+        // check below is the real allow-list. Construct Discover directly
+        // instead of Discover::in() — see ComponentDiscovery for why the cached
+        // variant poisons the typescript-transformer's own discovery.
+        /** @var list<class-string> $classes */
+        $classes = (new Discover(directories: [$path]))->get();
+
+        $enums = [];
+        $valueObjects = [];
+
+        foreach ($classes as $class) {
+            if ((new ReflectionClass($class))->getAttributes(TypeScript::class) === []) {
+                continue;
+            }
+
+            if (enum_exists($class)) {
+                $enums[] = $class;
+            } else {
+                $valueObjects[] = $class;
+            }
+        }
+
+        sort($enums);
+        sort($valueObjects);
+
+        return ['enums' => $enums, 'valueObjects' => $valueObjects];
+    }
+}

--- a/workbench/app/Support/TypeScript/NodesProvider.php
+++ b/workbench/app/Support/TypeScript/NodesProvider.php
@@ -36,22 +36,14 @@ final class NodesProvider implements TransformedProvider
     /**
      * @param  array<class-string, string>  $formFields  Form field components keyed by class-string, valued by wire type.
      * @param  class-string  $formClass
-     * @param  array<class-string, ComponentSpec>  $coreComponents
-     * @param  array<class-string, ComponentSpec>  $actionComponents
-     * @param  array<class-string, ComponentSpec>  $fragmentComponents
-     * @param  array<class-string, ComponentSpec>  $tableComponents
-     * @param  array<class-string, ComponentSpec>  $layoutComponents
+     * @param  array<string, array<class-string, ComponentSpec>>  $domainNodes  Ordered map of generated node-alias name (e.g. 'CoreNode') to its components. Emission and Node-union order follow this map's order.
      * @param  class-string|null  $effectContract
      * @param  array<class-string, string>  $effects  Effect value objects keyed by class-string, valued by wire type.
      */
     public function __construct(
         private readonly array $formFields,
         private readonly string $formClass,
-        private readonly array $coreComponents,
-        private readonly array $actionComponents,
-        private readonly array $fragmentComponents,
-        private readonly array $tableComponents,
-        private readonly array $layoutComponents,
+        private readonly array $domainNodes,
         private readonly string $formType = 'form',
         private readonly ?string $effectContract = null,
         private readonly array $effects = [],
@@ -66,14 +58,14 @@ final class NodesProvider implements TransformedProvider
             $this->alias('FormFieldNode', $this->formFieldUnion()),
             $this->alias('FormNode', $this->formNodeUnion()),
             $this->alias('FormNodeType', $this->typeAccess('FormNode')),
-            $this->alias('CoreNode', $this->componentsUnion($this->coreComponents)),
-            $this->alias('ActionNode', $this->componentsUnion($this->actionComponents)),
-            $this->alias('FragmentNode', $this->componentsUnion($this->fragmentComponents)),
-            $this->alias('TableNode', $this->componentsUnion($this->tableComponents)),
-            $this->alias('LayoutNode', $this->componentsUnion($this->layoutComponents)),
-            $this->alias('Node', $this->nodeUnion()),
-            $this->alias('NodeType', $this->typeAccess('Node')),
         ];
+
+        foreach ($this->domainNodes as $nodeName => $components) {
+            $transformed[] = $this->alias($nodeName, $this->componentsUnion($components));
+        }
+
+        $transformed[] = $this->alias('Node', $this->nodeUnion());
+        $transformed[] = $this->alias('NodeType', $this->typeAccess('Node'));
 
         if ($this->effectContract !== null && $this->effects !== []) {
             $transformed[] = new Transformed(
@@ -146,7 +138,7 @@ final class NodesProvider implements TransformedProvider
     {
         return new TypeScriptUnion(array_map(
             fn (string $name): TypeScriptReference => new TypeScriptReference($this->selfReference($name)),
-            ['FormNode', 'CoreNode', 'ActionNode', 'FragmentNode', 'TableNode', 'LayoutNode'],
+            ['FormNode', ...array_keys($this->domainNodes)],
         ));
     }
 

--- a/workbench/app/Support/TypeScript/NodesProvider.php
+++ b/workbench/app/Support/TypeScript/NodesProvider.php
@@ -36,7 +36,7 @@ final class NodesProvider implements TransformedProvider
     /**
      * @param  array<class-string, string>  $formFields  Form field components keyed by class-string, valued by wire type.
      * @param  class-string  $formClass
-     * @param  array<string, array<class-string, ComponentSpec>>  $domainNodes  Ordered map of generated node-alias name (e.g. 'CoreNode') to its components. Emission and Node-union order follow this map's order.
+     * @param  array<string, array<class-string, ComponentSpec>>  $domainNodes  Node-alias name (e.g. 'CoreNode') to its components, in emission order.
      * @param  class-string|null  $effectContract
      * @param  array<class-string, string>  $effects  Effect value objects keyed by class-string, valued by wire type.
      */


### PR DESCRIPTION
## Why

The internal type generation was heavily static and split across two commands:

- `lattice:typescript` (shipped) — discovers an app's `#[Component]` classes and writes a **module augmentation**.
- `lattice:internal-types` (workbench) — regenerates the package's own **base** `generated.ts` (enums, value objects, effects, the `Node` unions), with hand-maintained allow-lists and six hardcoded namespace-prefix buckets.

This PR makes that generation attribute/namespace-driven and collapses the two commands into one, so `php artisan lattice:typescript` regenerates the package's own types in local dev (the package eats its own dog food).

## What changed

**Step 1 — de-staticise (commit `ae5d04e`)**
- New `#[TypeScript]` marker attribute on the 15 enums + 8 value objects, discovered over `src/` by a workbench `MarkedTypeDiscovery` (split into enums vs value objects, sorted deterministically). Replaces two hand-maintained allow-lists + ~20 imports.
- `DiscoveredComponent` gains a `domain`, derived from the namespace segment before `\Components\`. The six namespace-prefix buckets collapse into one ordered `domain → node` map.
- `NodesProvider` takes that ordered map instead of six positional bucket params.

**Step 2 — unify the commands (commit `6538358`)**
- New `TypeScriptProfile` interface. `AugmentProfile` (shipped, default) holds the app-augmentation path; `BaseProfile` (workbench-only, so build code never ships) holds the base-generation path.
- `lattice:typescript` resolves a `TypeScriptProfile` and runs it. The package binds `AugmentProfile`; the workbench rebinds `BaseProfile`.
- `lattice:internal-types` is deleted; `composer types` now calls `lattice:typescript`.

## The one remaining static bit

A single declared, ordered `domain → node-alias` map (`Core→CoreNode`, `Actions→ActionNode`, …). The output order is meaningful (not alphabetical) and the node names are singular while the namespaces are plural, so it can't be derived. It replaces six scattered prefix constants + six positional args.

## Verification

- **`GeneratedTypesSnapshotTest` keeps `resources/js/types/generated.ts` byte-identical** — this is a pure refactor; the committed output does not change. The snapshot now drives `lattice:typescript`.
- New tests: domain derivation in `ComponentDiscoveryTest`; `MarkedTypeDiscoveryTest` (enum/value-object split, attribute filtering, deterministic order, missing path).
- The two augment feature tests override the binding back to `AugmentProfile` (the workbench binds `BaseProfile` by default).
- Gates green locally: `composer test` (363 passed), `composer test:lint` (pint), `composer analyse` (phpstan). Backend-only change; the browser suite is unaffected (generated types identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)