### PR TITLE
docs: toast builder options and new button variants

### DIFF
--- a/docs/content/docs/actions/effects.md
+++ b/docs/content/docs/actions/effects.md
@@ -45,7 +45,8 @@ return ActionResult::success()
 
 `->toast()` accepts a message and an optional `ToastVariant` (`Success`, `Error`, `Warning`, `Info`).
 The variant can come first or second — both `->toast('Saved.')` and
-`->toast(ToastVariant::Error, 'Could not save.')` read naturally.
+`->toast(ToastVariant::Error, 'Could not save.')` read naturally. Pass a `ToastMessage` instead to
+set a lifetime, control dismissal, or attach a link or action — see [Toasts](/core/toasts/).
 
 ### Refreshing what changed
 

--- a/docs/content/docs/advanced/enums.md
+++ b/docs/content/docs/advanced/enums.md
@@ -26,7 +26,7 @@ client type can't drift. The string value is what ends up on the wire.
 
 | Enum            | Cases (value)                                                                         |
 | --------------- | ------------------------------------------------------------------------------------- |
-| `ButtonVariant` | `Default` (default), `Destructive` (destructive), `Ghost` (ghost), `Link` (link), `Outline` (outline), `Secondary` (secondary) |
+| `ButtonVariant` | `Default` (default), `Destructive` (destructive), `Ghost` (ghost), `Info` (info), `Link` (link), `Outline` (outline), `Secondary` (secondary), `Success` (success) |
 | `ButtonType`    | `Button` (button), `Submit` (submit), `Reset` (reset)                                 |
 | `HttpMethod`    | `Get` (get), `Post` (post), `Put` (put), `Patch` (patch), `Delete` (delete)           |
 | `ToastVariant`  | `Success` (success), `Info` (info), `Warning` (warning), `Error` (error)              |

--- a/docs/content/docs/core/toasts.md
+++ b/docs/content/docs/core/toasts.md
@@ -42,10 +42,31 @@ The flashed toast is delivered with the next Inertia response and shown once.
 
 ## Building a message directly
 
-Both paths wrap a `ToastMessage` value object. Build one explicitly when you need to pass it around:
+Both paths wrap a `ToastMessage` value object. Build one explicitly to set a lifetime, control
+dismissal, or attach an action, then pass it to `->toast()` (or `Effect::toast()`):
 
 ```php
 use Lattice\Lattice\Core\Values\ToastMessage;
 
-ToastMessage::make(ToastVariant::Warning, 'Your trial ends tomorrow.');
+return ActionResult::success()->toast(
+    ToastMessage::make(ToastVariant::Success, 'Product archived.')
+        ->duration(8000)                       // auto-dismiss after 8s (default 4000ms)
+        ->link('View products', '/products'),  // a link rendered in the toast
+);
 ```
+
+The builder options:
+
+| Method                            | Effect                                                                 |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| `->duration($ms)`                 | Auto-dismiss after `$ms` milliseconds (default 4000).                  |
+| `->persistent()`                  | Never auto-dismiss; the toast stays until it is closed.                |
+| `->dismissible(false)`            | Hide the close button.                                                 |
+| `->link($label, $href, $method)`  | Render a link in the toast (`$method` defaults to `HttpMethod::Get`).  |
+| `->action($component)`            | Render an action instead of a link — e.g. an [`Action`](/actions/overview/) that opens a confirm dialog or [modal form](/actions/confirmation-and-forms/). |
+
+## Rendering
+
+Toasts render through the `<Toaster>` the Lattice `Provider` mounts by default, anchored bottom
+center and dismissing each after its duration. Pass `toaster={false}` to the `Provider` to opt out
+and mount your own.


### PR DESCRIPTION
Follow-up to #49 (merged). Documents the toast features that PR added but the reference pages didn't yet cover.

- **Toasts** — document the `ToastMessage` builder (`duration`, `persistent`, `dismissible`, `link`, `action`) and how toasts render via the Provider's `<Toaster>`.
- **Enums** — add `Info` and `Success` to the `ButtonVariant` row.
- **Effects** — point the toast section at the Toasts page for the richer options.

Theming needs no change: the `lt-success`/`lt-info` tokens are auto-derived from `lattice.css`.

Docs build passes (`npm run docs:build`).