### PR TITLE
fix: render docs component previews in production

### DIFF
--- a/docs/components/Preview.tsx
+++ b/docs/components/Preview.tsx
@@ -10,7 +10,7 @@ type Props = {
 export default function Preview({ nodes, values = {} }: Props) {
   return (
     <FormValuesProvider initial={values}>
-      <Renderer nodes={nodes} registry={registry} />
+      <Renderer nodes={nodes} registry={registry.components} />
     </FormValuesProvider>
   );
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "types": ["vite/client", "node"],
+    "paths": {
+      "@lattice/lattice": ["../resources/js/index.ts"],
+      "@lattice/lattice/*": ["../resources/js/*"],
+      "@components/*": ["./components/*"],
+      "@lib/*": ["./lib/*"]
+    }
+  },
+  "include": ["components/**/*.ts", "components/**/*.tsx", "lib/**/*.ts", "lib/**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "prepack": "npm run build:lib",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
+    "docs:typecheck": "tsc --noEmit -p docs/tsconfig.json",
     "lint": "oxlint resources/js workbench/resources/js",
     "lint:fix": "oxlint resources/js workbench/resources/js --fix",
     "lint:github": "oxlint resources/js workbench/resources/js --format=github",


### PR DESCRIPTION
## What

- Fix empty **Preview** and **Style** tabs on docs component examples (e.g. latticephp.com/forms/fields/text-input).
- Add a docs typecheck (`docs:typecheck`) covering the docs React components.

## Why

`docs/components/Preview.tsx` passed the full `Registry` object (`{ components, columns }`) to `<Renderer>`, but the renderer indexes `registry[node.type]` and expects the component map. Every node resolved to `undefined` and fell through to `MissingComponent`, which returns `null` outside dev (`import.meta.env.DEV`). So in the production build the Preview tab rendered nothing, and the Style tab — which derives its token list by scanning the same preview — showed "No tokens detected". The Tree tab was unaffected because it doesn't use the renderer.

Fix: pass `registry.components`, matching how the app resolves the registry via `useRegistry()`.

The docs sources weren't typechecked, so this prop mismatch slipped through. The new `docs:typecheck` catches it (verified it fails before the fix, passes after).

## Verification

- `npm run docs:typecheck` ✅ (fails on the unfixed bug, passes with the fix)
- `npm run typecheck` ✅ (unchanged)
- `npm test` ✅ 216 passed
- Production `astro preview`: Preview tab renders the field; Style tab lists 8 theme tokens.