### PR TITLE
feat: Icon schema component + token-driven icon sizing

### DIFF
--- a/docs/content/docs/core/icons.md
+++ b/docs/content/docs/core/icons.md
@@ -85,6 +85,26 @@ Action::make('app.send')->icon(Icon::Send);
 `Lattice\Lattice\Core\Enums\Icon` covers Lattice's own icon set. For your full set (Lattice's plus your
 own), generate an enum — see below.
 
+## As a component
+
+`Icon` is also a component, so a standalone icon can go anywhere in a schema. It renders through the
+same renderer as `->icon()`, with structured `size`/`color` plus a raw `class` escape hatch:
+
+```php
+use Lattice\Lattice\Core\Components\Icon;
+use Lattice\Lattice\Core\Enums\Color;
+use Lattice\Lattice\Core\Enums\Size;
+
+Stack::make()->schema([
+    Icon::make('house'),                                       // size defaults to Md
+    Icon::make('circle-check')->size(Size::Lg)->color(Color::Success),
+    Icon::make('spark')->class('opacity-70'),
+]);
+```
+
+`size` defaults to `Size::Md`; `color` is optional and inherits `currentColor` when unset. Sizes resolve
+to themeable tokens (`--lt-icon-xs` … `--lt-icon-xl`).
+
 ## Type-safe icon names
 
 The plugin can generate a type module and/or a PHP enum from the built sprite, so icon names stay

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -28,6 +28,12 @@
   --lt-radius-sm: calc(var(--lt-radius) - 2px);
   --lt-radius-xs: calc(var(--lt-radius) - 4px);
 
+  --lt-icon-xs: 0.75rem;
+  --lt-icon-sm: 0.875rem;
+  --lt-icon-md: 1rem;
+  --lt-icon-lg: 1.25rem;
+  --lt-icon-xl: 1.5rem;
+
   color-scheme: light;
 }
 
@@ -89,6 +95,11 @@
   --radius-lt: var(--lt-radius);
   --radius-lt-sm: var(--lt-radius-sm);
   --radius-lt-xs: var(--lt-radius-xs);
+  --spacing-lt-icon-xs: var(--lt-icon-xs);
+  --spacing-lt-icon-sm: var(--lt-icon-sm);
+  --spacing-lt-icon-md: var(--lt-icon-md);
+  --spacing-lt-icon-lg: var(--lt-icon-lg);
+  --spacing-lt-icon-xl: var(--lt-icon-xl);
   --animate-lt-toast-in: lt-toast-in 160ms ease-out;
   --animate-lt-toast-out: lt-toast-out 120ms ease-in;
 }

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -332,7 +332,7 @@ export function ActionForm({ description, formNode, onClose, title, ...rest }: A
 
             <Dialog.Close asChild>
               <Button aria-label="Close" size="icon" variant="ghost">
-                <Icon name="x" aria-hidden="true" className="size-4" />
+                <Icon name="x" aria-hidden="true" className="size-lt-icon-md" />
               </Button>
             </Dialog.Close>
           </div>

--- a/resources/js/action/components/action-group.tsx
+++ b/resources/js/action/components/action-group.tsx
@@ -17,7 +17,7 @@ const ActionGroupComponent: RendererComponent<"action.group"> = ({ children, nod
             type="button"
             variant="ghost"
           >
-            <Icon name="more-horizontal" aria-hidden="true" className="size-4" />
+            <Icon name="more-horizontal" aria-hidden="true" className="size-lt-icon-md" />
           </Button>
         </Popover.Trigger>
 

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -142,7 +142,7 @@ describe("Lattice action component", () => {
     );
 
     expect(iconRenderer).toHaveBeenCalledWith({
-      className: "size-4",
+      className: "size-lt-icon-md",
       icon: "custom.spark",
     });
     expect(screen.getByTestId("action-icon")).toHaveTextContent("custom.spark");

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -85,7 +85,11 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
         type="button"
         variant={variant}
       >
-        {http.processing ? <Spinner /> : icon && <IconRenderer className="size-4" icon={icon} />}
+        {http.processing ? (
+          <Spinner />
+        ) : (
+          icon && <IconRenderer className="size-lt-icon-md" icon={icon} />
+        )}
         {label}
       </Button>
 

--- a/resources/js/core/components/badge.tsx
+++ b/resources/js/core/components/badge.tsx
@@ -5,7 +5,7 @@ import { cn } from "@lattice/lattice/lib/utils";
 import type { RendererComponent } from "@lattice/lattice/core/types";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-lt-sm border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-lt-sm border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-lt-icon-xs gap-1 [&>svg]:pointer-events-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -9,7 +9,7 @@ import type { ButtonVariant } from "@lattice/lattice/types/generated";
 export type { ButtonVariant };
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lt-sm text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lt-sm text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-lt-icon-md [&_svg]:shrink-0 outline-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
   {
     variants: {
       variant: {

--- a/resources/js/core/components/icon.test.tsx
+++ b/resources/js/core/components/icon.test.tsx
@@ -5,7 +5,12 @@ import { fakeNode } from "@lattice/lattice/test-support";
 import type { Color, Size } from "@lattice/lattice/types/generated";
 import IconComponent from "./icon";
 
-function renderIcon(props: { name: string; size: Size; color: Color | null; class: string | null }) {
+function renderIcon(props: {
+  name: string;
+  size: Size;
+  color: Color | null;
+  class: string | null;
+}) {
   return render(
     <SpriteProvider sprite={{ href: "", ids: [props.name] }}>
       <IconComponent node={fakeNode({ type: "icon", props })}>{null}</IconComponent>

--- a/resources/js/core/components/icon.test.tsx
+++ b/resources/js/core/components/icon.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SpriteProvider } from "@lattice/lattice";
+import { fakeNode } from "@lattice/lattice/test-support";
+import type { Color, Size } from "@lattice/lattice/types/generated";
+import IconComponent from "./icon";
+
+function renderIcon(props: { name: string; size: Size; color: Color | null; class: string | null }) {
+  return render(
+    <SpriteProvider sprite={{ href: "", ids: [props.name] }}>
+      <IconComponent node={fakeNode({ type: "icon", props })}>{null}</IconComponent>
+    </SpriteProvider>,
+  );
+}
+
+describe("Lattice icon component", () => {
+  it("maps size and colour to tokens and forwards the raw class", () => {
+    const { container } = renderIcon({
+      name: "house",
+      size: "lg",
+      color: "danger",
+      class: "opacity-80",
+    });
+
+    expect(container.querySelector("svg")).toHaveClass(
+      "size-lt-icon-lg",
+      "text-lt-danger",
+      "opacity-80",
+    );
+  });
+
+  it("renders the md token and omits colour when unset", () => {
+    const { container } = renderIcon({ name: "house", size: "md", color: null, class: null });
+    const svg = container.querySelector("svg");
+
+    expect(svg).toHaveClass("size-lt-icon-md");
+    expect(svg).not.toHaveClass("text-lt-danger");
+  });
+});

--- a/resources/js/core/components/icon.tsx
+++ b/resources/js/core/components/icon.tsx
@@ -1,0 +1,34 @@
+import type { RendererComponent } from "@lattice/lattice/core/types";
+import { IconRenderer } from "@lattice/lattice/icons";
+import { cn } from "@lattice/lattice/lib/utils";
+import type { Color, Size } from "@lattice/lattice/types/generated";
+
+const sizeClass: Record<Size, string> = {
+  xs: "size-lt-icon-xs",
+  sm: "size-lt-icon-sm",
+  md: "size-lt-icon-md",
+  lg: "size-lt-icon-lg",
+  xl: "size-lt-icon-xl",
+};
+
+const colorClass: Record<Color, string> = {
+  muted: "text-lt-muted-fg",
+  primary: "text-lt-primary",
+  success: "text-lt-success",
+  info: "text-lt-info",
+  warning: "text-lt-warning",
+  danger: "text-lt-danger",
+};
+
+const IconComponent: RendererComponent<"icon"> = ({ node }) => {
+  const { name, size, color, class: className } = node.props;
+
+  return (
+    <IconRenderer
+      icon={name}
+      className={cn(sizeClass[size], color ? colorClass[color] : undefined, className)}
+    />
+  );
+};
+
+export default IconComponent;

--- a/resources/js/core/components/index.ts
+++ b/resources/js/core/components/index.ts
@@ -5,6 +5,7 @@ import CardComponent from "./card";
 import FragmentComponent from "./fragment";
 import GridComponent from "./grid";
 import HeadingComponent from "./heading";
+import IconComponent from "./icon";
 import LinkComponent from "./link";
 import ModalComponent from "./modal";
 import SectionComponent from "./section";
@@ -21,6 +22,7 @@ export const coreComponents = createPlugin({
     fragment: eagerComponent(FragmentComponent),
     grid: eagerComponent(GridComponent),
     heading: eagerComponent(HeadingComponent),
+    icon: eagerComponent(IconComponent),
     link: eagerComponent(LinkComponent),
     modal: eagerComponent(ModalComponent),
     section: eagerComponent(SectionComponent),

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -66,7 +66,7 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
 
             <Dialog.Close asChild>
               <Button aria-label={closeLabel} size="icon" variant="ghost">
-                <Icon name="x" aria-hidden="true" className="size-4" />
+                <Icon name="x" aria-hidden="true" className="size-lt-icon-md" />
               </Button>
             </Dialog.Close>
           </div>

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -71,7 +71,10 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
               >
                 <Icon
                   name="chevron-down"
-                  className={cn("size-4 transition-transform", isCollapsed && "-rotate-90")}
+                  className={cn(
+                    "size-lt-icon-md transition-transform",
+                    isCollapsed && "-rotate-90",
+                  )}
                 />
               </button>
             )}

--- a/resources/js/form/components/base/checkbox.tsx
+++ b/resources/js/form/components/base/checkbox.tsx
@@ -18,7 +18,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
       >
-        <Icon name="check" className="size-3.5" />
+        <Icon name="check" className="size-lt-icon-sm" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/resources/js/form/components/base/password-input.tsx
+++ b/resources/js/form/components/base/password-input.tsx
@@ -31,9 +31,9 @@ export default function PasswordInput({ className, ref, ...props }: PasswordInpu
         tabIndex={-1}
       >
         {showPassword ? (
-          <Icon name="eye-off" className="size-4" />
+          <Icon name="eye-off" className="size-lt-icon-md" />
         ) : (
-          <Icon name="eye" className="size-4" />
+          <Icon name="eye" className="size-lt-icon-md" />
         )}
       </button>
     </div>

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -216,7 +216,7 @@ function EmojiPicker({ editor }: { editor: Editor }) {
       <button
         aria-label="Insert emoji"
         data-test="editor-emoji"
-        className="inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg [&_svg]:size-4"
+        className="inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg [&_svg]:size-lt-icon-md"
         onClick={() => setOpen((value) => !value)}
         onMouseDown={(event) => event.preventDefault()}
         title="Insert emoji"
@@ -259,7 +259,7 @@ function Toolbar({ editor }: { editor: Editor }) {
             aria-pressed={item.isActive(editor)}
             data-test={`editor-${item.label.toLowerCase().replace(/\s+/g, "-")}`}
             className={cn(
-              "inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg disabled:pointer-events-none disabled:opacity-40 [&_svg]:size-4",
+              "inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg disabled:pointer-events-none disabled:opacity-40 [&_svg]:size-lt-icon-md",
               item.isActive(editor) && "bg-lt-accent text-lt-accent-fg",
             )}
             disabled={item.isDisabled?.(editor) ?? false}

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -161,7 +161,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
                   <button
                     aria-label={`Remove ${labelFor(value)}`}
                     data-test={`select-${name}-remove-${value}`}
-                    className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-3"
+                    className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-xs"
                     onClick={() => remove(value)}
                     type="button"
                   >
@@ -201,7 +201,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
               ) : (
                 <span className="text-lt-muted-fg">{placeholder}</span>
               )}
-              <Icon name="chevrons-up-down" className="size-4 shrink-0 text-lt-muted-fg" />
+              <Icon name="chevrons-up-down" className="size-lt-icon-md shrink-0 text-lt-muted-fg" />
             </button>
           </Popover.Trigger>
 
@@ -221,7 +221,10 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
                   value={query}
                 />
                 {loading && (
-                  <Icon name="loader-2" className="size-4 shrink-0 animate-spin text-lt-muted-fg" />
+                  <Icon
+                    name="loader-2"
+                    className="size-lt-icon-md shrink-0 animate-spin text-lt-muted-fg"
+                  />
                 )}
               </div>
               <div className="max-h-60 overflow-y-auto p-1" role="listbox">
@@ -245,7 +248,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
                         type="button"
                       >
                         {option.label}
-                        {isSelected && <Icon name="check" className="size-4 shrink-0" />}
+                        {isSelected && <Icon name="check" className="size-lt-icon-md shrink-0" />}
                       </button>
                     );
                   })

--- a/resources/js/icons/icon-renderer.test.tsx
+++ b/resources/js/icons/icon-renderer.test.tsx
@@ -17,7 +17,7 @@ describe("Lattice icon renderer", () => {
     );
 
     const svg = container.querySelector("svg");
-    expect(svg).toHaveClass("size-4", "text-lt-primary");
+    expect(svg).toHaveClass("size-lt-icon-md", "text-lt-primary");
     expect(svg?.querySelector("use")?.getAttribute("href")).toBe("/build/sprite.svg#edit");
   });
 

--- a/resources/js/icons/icon-renderer.tsx
+++ b/resources/js/icons/icon-renderer.tsx
@@ -63,7 +63,7 @@ function MissingIcon({ className }: { className?: string }) {
   return (
     <svg
       aria-hidden="true"
-      className={cn("size-4 text-lt-muted-fg", className)}
+      className={cn("size-lt-icon-md text-lt-muted-fg", className)}
       data-lattice-missing-icon=""
       fill="none"
       stroke="currentColor"

--- a/resources/js/icons/sprite.tsx
+++ b/resources/js/icons/sprite.tsx
@@ -58,7 +58,7 @@ export function Icon({
   }
 
   return (
-    <svg aria-hidden="true" {...props} className={cn("size-4", className)}>
+    <svg aria-hidden="true" {...props} className={cn("size-lt-icon-md", className)}>
       <use href={`${href}#${name}`} />
     </svg>
   );

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -26,7 +26,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
 
   const content = (
     <>
-      {icon ? <IconRenderer className="size-4 shrink-0" icon={icon} /> : null}
+      {icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} /> : null}
       <span className={cn(collapsed && "sr-only")}>{label}</span>
     </>
   );
@@ -104,7 +104,10 @@ function CollapsibleItem({
         {content}
         <Icon
           name="chevron-right"
-          className={cn("ml-auto size-4 shrink-0 transition-transform", open && "rotate-90")}
+          className={cn(
+            "ml-auto size-lt-icon-md shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
         />
       </button>
       {open ? <ul className="mt-1 flex flex-col gap-1 pl-3">{children}</ul> : null}
@@ -152,7 +155,11 @@ function FlyoutGroup({
         title={label}
         type="button"
       >
-        {icon ? <IconRenderer className="size-4 shrink-0" icon={icon} /> : <span>{label}</span>}
+        {icon ? (
+          <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} />
+        ) : (
+          <span>{label}</span>
+        )}
       </button>
       {open
         ? createPortal(

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -56,7 +56,7 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
             onClick={toggle}
             type="button"
           >
-            <Icon name="panel-left" aria-hidden="true" className="size-4 shrink-0" />
+            <Icon name="panel-left" aria-hidden="true" className="size-lt-icon-md shrink-0" />
           </button>
         ) : null}
         {children}

--- a/resources/js/table/components/cells/icon-cell.tsx
+++ b/resources/js/table/components/cells/icon-cell.tsx
@@ -18,7 +18,7 @@ export function IconCell({ column, value }: { column: TableColumn; value: unknow
       aria-label={String(value)}
       className={cn("lt-cell-icon", color && `lt-cell-tone-${color}`)}
     >
-      <IconRenderer className="size-4" icon={icon} />
+      <IconRenderer className="size-lt-icon-md" icon={icon} />
     </span>
   );
 }

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -61,9 +61,9 @@ export function TextCell({
         onClick={handleCopy}
       >
         {copied ? (
-          <Icon name="check" className="size-3" />
+          <Icon name="check" className="size-lt-icon-xs" />
         ) : (
-          <Icon name="copy" className="size-3" />
+          <Icon name="copy" className="size-lt-icon-xs" />
         )}
         {copied ? "Copied" : "Copy"}
       </button>

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -74,7 +74,7 @@ export function ColumnFilterControl({
             className="relative -ml-px inline-flex size-9 shrink-0 items-center justify-center rounded-r-lt-sm border border-lt-input disabled:opacity-50 data-[state=open]:z-10 data-[state=open]:border-lt-primary"
             disabled={processing}
           >
-            <Icon name="filter" aria-hidden="true" className="size-4" />
+            <Icon name="filter" aria-hidden="true" className="size-lt-icon-md" />
             {clauses.length > 0 && (
               <span className="absolute -right-1.5 -top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-lt-primary text-[10px] font-medium text-lt-primary-fg">
                 {clauses.length}
@@ -182,7 +182,7 @@ function FilterClauseList({
           disabled={processing}
           onClick={() => setAdding(true)}
         >
-          <Icon name="plus" aria-hidden="true" className="size-4" />
+          <Icon name="plus" aria-hidden="true" className="size-lt-icon-md" />
           Add filter
         </button>
       </div>
@@ -240,7 +240,7 @@ function FilterClauseRow({
           disabled={processing}
           onClick={onRemove}
         >
-          <Icon name="trash-2" aria-hidden="true" className="size-4" />
+          <Icon name="trash-2" aria-hidden="true" className="size-lt-icon-md" />
         </button>
       </div>
       {!valueless && (

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -4,15 +4,19 @@ import type { TableColumn, TableSort, TableState } from "../types";
 
 function SortIndicator({ sort }: { sort: TableSort | undefined }) {
   if (sort?.direction === "asc") {
-    return <Icon name="arrow-up" aria-hidden="true" className="size-3.5 shrink-0" />;
+    return <Icon name="arrow-up" aria-hidden="true" className="size-lt-icon-sm shrink-0" />;
   }
 
   if (sort?.direction === "desc") {
-    return <Icon name="arrow-down" aria-hidden="true" className="size-3.5 shrink-0" />;
+    return <Icon name="arrow-down" aria-hidden="true" className="size-lt-icon-sm shrink-0" />;
   }
 
   return (
-    <Icon name="chevrons-up-down" aria-hidden="true" className="size-3.5 shrink-0 opacity-50" />
+    <Icon
+      name="chevrons-up-down"
+      aria-hidden="true"
+      className="size-lt-icon-sm shrink-0 opacity-50"
+    />
   );
 }
 

--- a/resources/js/table/components/filter-stack-bar.tsx
+++ b/resources/js/table/components/filter-stack-bar.tsx
@@ -35,7 +35,7 @@ export function FilterStackBar({
               aria-label={`Remove ${label} filter`}
               onClick={() => onRemove(index)}
             >
-              <Icon name="x" aria-hidden="true" className="size-3.5" />
+              <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
             </button>
           </span>
         );

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -76,7 +76,7 @@ export function FilterValueInput({
         <Icon
           name="search"
           aria-hidden="true"
-          className="pointer-events-none absolute left-2 size-4 text-lt-muted-fg"
+          className="pointer-events-none absolute left-2 size-lt-icon-md text-lt-muted-fg"
         />
       )}
       <input
@@ -107,7 +107,7 @@ export function FilterValueInput({
           disabled={processing}
           onClick={onClear}
         >
-          <Icon name="x" aria-hidden="true" className="size-3.5" />
+          <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
         </button>
       )}
     </div>

--- a/resources/js/table/components/sort-bar.tsx
+++ b/resources/js/table/components/sort-bar.tsx
@@ -28,7 +28,7 @@ export function SortBar({
               role="img"
               aria-hidden={false}
               aria-label={getSortDirectionLabel(sort.direction)}
-              className="size-3.5 text-lt-muted-fg"
+              className="size-lt-icon-sm text-lt-muted-fg"
             />
             <button
               type="button"
@@ -38,7 +38,7 @@ export function SortBar({
               data-test={`clear-${sort.key}-sort`}
               onClick={() => onClear(sort)}
             >
-              <Icon name="x" className="size-3.5" />
+              <Icon name="x" className="size-lt-icon-sm" />
             </button>
           </span>
         );

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -15,19 +15,19 @@ type ToastItem = ToastMessage & { id: number };
 const variantStyles: Record<ToastVariant, { accent: string; icon: ReactNode }> = {
   success: {
     accent: "border-l-lt-success",
-    icon: <Icon name="circle-check" className="size-5 shrink-0 text-lt-success" />,
+    icon: <Icon name="circle-check" className="size-lt-icon-lg shrink-0 text-lt-success" />,
   },
   info: {
     accent: "border-l-lt-info",
-    icon: <Icon name="info" className="size-5 shrink-0 text-lt-info" />,
+    icon: <Icon name="info" className="size-lt-icon-lg shrink-0 text-lt-info" />,
   },
   warning: {
     accent: "border-l-lt-warning",
-    icon: <Icon name="circle-alert" className="size-5 shrink-0 text-lt-warning" />,
+    icon: <Icon name="circle-alert" className="size-lt-icon-lg shrink-0 text-lt-warning" />,
   },
   error: {
     accent: "border-l-lt-danger",
-    icon: <Icon name="circle-x" className="size-5 shrink-0 text-lt-danger" />,
+    icon: <Icon name="circle-x" className="size-lt-icon-lg shrink-0 text-lt-danger" />,
   },
 };
 
@@ -122,7 +122,7 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
               className="shrink-0 rounded-md p-1 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
               data-test="toast-dismiss"
             >
-              <Icon name="x" className="size-4" />
+              <Icon name="x" className="size-lt-icon-md" />
             </Toast.Close>
           ) : null}
         </Toast.Root>

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -117,6 +117,7 @@ export type Choice = {
 export type CloseModalEffect = {
   readonly modal: string | null;
 };
+export type Color = "muted" | "primary" | "success" | "info" | "warning" | "danger";
 export type ColumnData = {
   readonly key: string;
   readonly label: string;
@@ -177,6 +178,11 @@ export type CoreNode =
       type: "heading";
       key?: string;
       props: Heading;
+    }
+  | {
+      type: "icon";
+      key?: string;
+      props: Icon;
     }
   | {
       type: "link";
@@ -404,6 +410,12 @@ export type HiddenInput = {
   value: unknown;
 };
 export type HttpMethod = import("@inertiajs/core").Method;
+export type Icon = {
+  class: string | null;
+  color: Color | null;
+  name: string;
+  size: Size;
+};
 export type IconColumnProps = {
   readonly icon: string | null;
   readonly icons: Record<string | number, string> | null;
@@ -619,6 +631,7 @@ export type Sidebar = {
   collapsible: boolean;
   rememberState: boolean;
 };
+export type Size = "xs" | "sm" | "md" | "lg" | "xl";
 export type SortDirection = "asc" | "desc";
 export type Stack = {
   align: Align | null;

--- a/src/Core/Components/Icon.php
+++ b/src/Core/Components/Icon.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Lattice\Lattice\Core\Components;
+
+use BackedEnum;
+use Lattice\Lattice\Attributes;
+use Lattice\Lattice\Core\Enums\Color;
+use Lattice\Lattice\Core\Enums\Size;
+
+#[Attributes\Component('icon')]
+class Icon extends Component
+{
+    public string $name = '';
+
+    public Size $size = Size::Md;
+
+    public ?Color $color = null;
+
+    public ?string $class = null;
+
+    public static function make(BackedEnum|string $name, ?string $key = null): static
+    {
+        $icon = new static($key);
+        $icon->name = (string) $icon->enumValue($name);
+
+        return $icon;
+    }
+
+    public function size(Size $size): static
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    public function color(Color $color): static
+    {
+        $this->color = $color;
+
+        return $this;
+    }
+
+    public function class(string $class): static
+    {
+        $this->class = $class;
+
+        return $this;
+    }
+}

--- a/src/Core/Enums/Color.php
+++ b/src/Core/Enums/Color.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lattice\Lattice\Core\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum Color: string
+{
+    case Muted = 'muted';
+    case Primary = 'primary';
+    case Success = 'success';
+    case Info = 'info';
+    case Warning = 'warning';
+    case Danger = 'danger';
+}

--- a/src/Core/Enums/Size.php
+++ b/src/Core/Enums/Size.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lattice\Lattice\Core\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum Size: string
+{
+    case Xs = 'xs';
+    case Sm = 'sm';
+    case Md = 'md';
+    case Lg = 'lg';
+    case Xl = 'xl';
+}

--- a/tests/Feature/IconComponentTest.php
+++ b/tests/Feature/IconComponentTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Components\Icon;
+use Lattice\Lattice\Core\Enums\Color;
+use Lattice\Lattice\Core\Enums\Icon as IconName;
+use Lattice\Lattice\Core\Enums\Size;
+
+it('serializes an icon with name, size, color and class', function (): void {
+    $data = wire(
+        Icon::make('house')->size(Size::Lg)->color(Color::Danger)->class('opacity-80'),
+    );
+
+    expect($data['type'])->toBe('icon')
+        ->and($data['props'])->toBe([
+            'name' => 'house',
+            'size' => 'lg',
+            'color' => 'danger',
+            'class' => 'opacity-80',
+        ]);
+});
+
+it('resolves a backed enum name and defaults size to md', function (): void {
+    $data = wire(Icon::make(IconName::Send));
+
+    expect($data['type'])->toBe('icon')
+        ->and($data['props'])->toBe([
+            'name' => 'send',
+            'size' => 'md',
+            'color' => null,
+            'class' => null,
+        ]);
+});


### PR DESCRIPTION
## Summary

Adds an `Icon` **component** placeable in any `->schema([...])`, sharing the existing `IconRenderer` (override stack → SVG sprite) with `MenuItem`/`Action` icons. Also introduces themeable icon-size tokens and migrates the codebase's hardcoded icon sizes onto them.

## The component

```php
use Lattice\Lattice\Core\Components\Icon;
use Lattice\Lattice\Core\Enums\{Color, Size};

Stack::make()->schema([
    Icon::make('house'),                                       // size defaults to Md
    Icon::make('circle-check')->size(Size::Lg)->color(Color::Success),
    Icon::make('spark')->class('opacity-70'),                  // raw Tailwind escape hatch
]);
```

Props: `name` (string|BackedEnum), `size` (`Size`, **default `Md`, non-nullable**), `color` (`?Color` — inherits `currentColor` when unset), `class` (`?string`). The React renderer maps `size`/`color` to token classes and delegates to `IconRenderer`.

## Tokens + sweep

- New `Size` (`Xs–Xl`) and `Color` (`Muted`/`Primary`/`Success`/`Info`/`Warning`/`Danger`) enums.
- Themeable icon-size tokens: `--lt-icon-*` in `:root` → `size-lt-icon-*` utilities via `@theme` (values equal the old `size-3/3.5/4/5/6`, so nothing changes visually).
- Migrated ~49 hardcoded icon-glyph sizes (`size-3/3.5/4/5`, incl. the `Icon`/`IconRenderer` defaults) onto the tokens, **leaving** the `size-6/7/8/9` button/container hit-areas.

## Verification
pint · phpstan · **composer 380** · typecheck · **222 JS tests** (incl. PHP wire-shape + React renderer tests for `Icon`) · format · lint · `build:lib` · workbench build · docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)