### PR TITLE
feat: Repeater form field (repeatable nested schema)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
                 { label: "Password input", link: "/forms/fields/password-input/" },
                 { label: "Hidden input", link: "/forms/fields/hidden-input/" },
                 { label: "Rich editor", link: "/forms/fields/rich-editor/" },
+                { label: "Repeater", link: "/forms/fields/repeater/" },
               ],
             },
             { label: "Validation", link: "/forms/validation/" },

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -10,8 +10,8 @@ Fields are the building blocks of a form. Lattice ships
 [Select](/forms/fields/select/), [Choice](/forms/fields/choice/),
 [Checkbox](/forms/fields/checkbox/), [Date input](/forms/fields/date-input/),
 [Number input](/forms/fields/number-input/), [Password input](/forms/fields/password-input/),
-[Hidden input](/forms/fields/hidden-input/), and [Rich editor](/forms/fields/rich-editor/) — and you
-can add your own. Each field type has its own page for the options unique to it; this page covers the
+[Hidden input](/forms/fields/hidden-input/), [Rich editor](/forms/fields/rich-editor/), and
+[Repeater](/forms/fields/repeater/) — and you can add your own. Each field type has its own page for the options unique to it; this page covers the
 options every field shares.
 
 The submit button is not a field: the form renders it for you from `->submitLabel()`. See

--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -1,0 +1,93 @@
+---
+title: Repeater
+description: A repeatable nested schema — rows of fields that submit as an array of row objects.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+The repeater renders a repeatable group of fields. Each row is its own copy of the schema, and the
+field submits an array of row objects — one object per row, keyed by the child field names. Create one
+with `Repeater::make()` and define the row template with `->schema()`.
+
+<ComponentExample
+  php={`Repeater::make('items', 'Line items')
+    ->schema([
+        TextInput::make('name', 'Name')->required(),
+        TextInput::make('qty', 'Qty')->rules(['numeric']),
+    ])
+    ->minItems(1)
+    ->maxItems(5)
+    ->reorderable()
+    ->addLabel('Add line')
+    ->defaultItems(1)`}
+  fixture="repeater.basic"
+  values={{ items: [] }}
+/>
+
+## Schema
+
+`->schema()` takes the array of fields that make up a single row. Each child is a normal field, so it
+keeps its own label, placeholder, default value, and rules. The example above submits as:
+
+```php
+['items' => [['name' => 'Widget', 'qty' => '3'], ['name' => 'Gadget', 'qty' => '1']]]
+```
+
+## Row counts
+
+`->minItems()` and `->maxItems()` bound how many rows the form accepts; both are enforced as
+array-level validation rules. `->defaultItems()` sets how many empty rows a fresh form starts with
+(default `1`).
+
+```php
+Repeater::make('items', 'Line items')
+    ->schema([TextInput::make('name', 'Name')])
+    ->minItems(1)
+    ->maxItems(5)
+    ->defaultItems(2);
+```
+
+## Reordering
+
+Rows are reorderable by default through up/down controls. Pass `->reorderable(false)` to fix the
+order.
+
+```php
+Repeater::make('items', 'Line items')
+    ->schema([TextInput::make('name', 'Name')])
+    ->reorderable(false);
+```
+
+## Labels
+
+`->addLabel()` sets the text on the button that appends a row (default "Add"). `->itemLabel()` sets a
+per-row heading shown above each row's fields.
+
+```php
+Repeater::make('items', 'Line items')
+    ->schema([TextInput::make('name', 'Name')])
+    ->addLabel('Add line')
+    ->itemLabel('Line');
+```
+
+## Validation
+
+Each child field's rules apply to every row through the `items.*.field` wildcard, so a child marked
+`->required()` is required in each row and an error points at the offending row. The array-level
+`minItems`/`maxItems` rules validate the number of rows independently of the per-row rules. See
+[Validation](/forms/validation/) for how field rules are resolved.
+
+## Not yet supported (v1)
+
+These are follow-ups, not part of the first release:
+
+- Nested repeaters (a repeater inside a repeater row).
+- Row-scoped conditions — `visibleWhen`/`requiredWhen` evaluated against sibling fields inside the
+  same row.
+- Relationship auto-save (persisting rows straight to a related model).
+
+## Common options
+
+`Repeater` shares label, required, disabled, read-only, and visibility options with every field — see
+[Fields](/forms/fields/overview/). For validation and conditional behavior, see
+[Validation](/forms/validation/) and [Conditional fields](/forms/conditional-fields/).

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -1,0 +1,68 @@
+[
+    {
+        "props": {
+            "addLabel": "Add line",
+            "conditions": null,
+            "defaultItems": 1,
+            "dependsOnAny": null,
+            "dependsOnKeys": null,
+            "disabled": null,
+            "helperText": null,
+            "hidden": null,
+            "itemLabel": null,
+            "label": "Line items",
+            "maxItems": 5,
+            "minItems": 1,
+            "name": "items",
+            "readOnly": null,
+            "reorderable": true,
+            "required": null,
+            "value": null
+        },
+        "schema": [
+            {
+                "props": {
+                    "autoComplete": null,
+                    "autoFocus": null,
+                    "conditions": null,
+                    "dependsOnAny": null,
+                    "dependsOnKeys": null,
+                    "disabled": null,
+                    "helperText": null,
+                    "hidden": null,
+                    "label": "Name",
+                    "name": "name",
+                    "placeholder": null,
+                    "readOnly": null,
+                    "required": true,
+                    "tabIndex": null,
+                    "type": null,
+                    "value": null
+                },
+                "type": "form.text-input"
+            },
+            {
+                "props": {
+                    "autoComplete": null,
+                    "autoFocus": null,
+                    "conditions": null,
+                    "dependsOnAny": null,
+                    "dependsOnKeys": null,
+                    "disabled": null,
+                    "helperText": null,
+                    "hidden": null,
+                    "label": "Qty",
+                    "name": "qty",
+                    "placeholder": null,
+                    "readOnly": null,
+                    "required": null,
+                    "tabIndex": null,
+                    "type": null,
+                    "value": null
+                },
+                "type": "form.text-input"
+            }
+        ],
+        "type": "form.repeater"
+    }
+]

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -90,3 +90,7 @@ function NodeRenderer({ node }: { node: Node }) {
 
   return renderedComponent;
 }
+
+export function RenderNode({ node }: { node: Node }): ReactNode {
+  return <NodeRenderer node={node} />;
+}

--- a/resources/js/form/components/field-scope.test.tsx
+++ b/resources/js/form/components/field-scope.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { expect, it } from "vitest";
+import { FieldScopeProvider, useFieldScope } from "./field-scope";
+
+function Probe() {
+  const scope = useFieldScope();
+  return (
+    <div>
+      <span data-testid="dom">{scope?.scopedName("name")}</span>
+      <span data-testid="err">{scope?.errorKey("name")}</span>
+      <span data-testid="val">{String(scope?.getValue("name"))}</span>
+    </div>
+  );
+}
+
+it("derives scoped DOM name, error key, and row value", () => {
+  render(
+    <FieldScopeProvider base="items" index={2} row={{ name: "hi" }} onChange={() => {}}>
+      <Probe />
+    </FieldScopeProvider>,
+  );
+
+  expect(screen.getByTestId("dom").textContent).toBe("items[2][name]");
+  expect(screen.getByTestId("err").textContent).toBe("items.2.name");
+  expect(screen.getByTestId("val").textContent).toBe("hi");
+});
+
+it("returns null scope outside a provider", () => {
+  render(<Probe />);
+  expect(screen.getByTestId("dom").textContent).toBe("");
+});

--- a/resources/js/form/components/field-scope.tsx
+++ b/resources/js/form/components/field-scope.tsx
@@ -25,7 +25,7 @@ export function FieldScopeProvider({
   const value = useMemo<FieldScopeValue>(
     () => ({
       getValue: (name) => row[name],
-      setValue: (name, next) => onChange(name, next),
+      setValue: onChange,
       scopedName: (name) => `${base}[${index}][${name}]`,
       errorKey: (name) => `${base}.${index}.${name}`,
     }),

--- a/resources/js/form/components/field-scope.tsx
+++ b/resources/js/form/components/field-scope.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useMemo } from "react";
+
+export type FieldScopeValue = {
+  getValue: (name: string) => unknown;
+  setValue: (name: string, value: unknown) => void;
+  scopedName: (name: string) => string;
+  errorKey: (name: string) => string;
+};
+
+const FieldScopeContext = createContext<FieldScopeValue | null>(null);
+
+export function FieldScopeProvider({
+  base,
+  index,
+  row,
+  onChange,
+  children,
+}: {
+  base: string;
+  index: number;
+  row: Record<string, unknown>;
+  onChange: (name: string, value: unknown) => void;
+  children: React.ReactNode;
+}) {
+  const value = useMemo<FieldScopeValue>(
+    () => ({
+      getValue: (name) => row[name],
+      setValue: (name, next) => onChange(name, next),
+      scopedName: (name) => `${base}[${index}][${name}]`,
+      errorKey: (name) => `${base}.${index}.${name}`,
+    }),
+    [base, index, row, onChange],
+  );
+
+  return <FieldScopeContext.Provider value={value}>{children}</FieldScopeContext.Provider>;
+}
+
+/** Null when not inside a repeater row — callers fall back to the global flat store. */
+export function useFieldScope(): FieldScopeValue | null {
+  return useContext(FieldScopeContext);
+}

--- a/resources/js/form/components/fields/repeater-rows.test.ts
+++ b/resources/js/form/components/fields/repeater-rows.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "vitest";
+import { addRow, moveRow, removeRow, seedRows } from "./repeater-rows";
+
+it("seeds rows from an existing value", () => {
+  expect(seedRows([{ name: "a" }], 3)).toEqual([{ name: "a" }]);
+});
+
+it("seeds defaultItems blanks when value is empty or missing", () => {
+  expect(seedRows(undefined, 2)).toEqual([{}, {}]);
+  expect(seedRows([], 2)).toEqual([{}, {}]);
+  expect(seedRows(null, 1)).toEqual([{}]);
+});
+
+it("seeds zero rows when defaultItems is 0 and no value", () => {
+  expect(seedRows(undefined, 0)).toEqual([]);
+});
+
+it("copies seeded rows (no shared reference with the input)", () => {
+  const input = [{ name: "a" }];
+  const seeded = seedRows(input, 1);
+  expect(seeded[0]).not.toBe(input[0]);
+  expect(seeded[0]).toEqual({ name: "a" });
+});
+
+it("adds a blank row", () => {
+  expect(addRow([{ name: "a" }])).toEqual([{ name: "a" }, {}]);
+});
+
+it("removes a row by index", () => {
+  expect(removeRow([{ n: 0 }, { n: 1 }, { n: 2 }], 1)).toEqual([{ n: 0 }, { n: 2 }]);
+});
+
+it("moves a row from one index to another", () => {
+  expect(moveRow([{ n: 0 }, { n: 1 }, { n: 2 }], 0, 2)).toEqual([{ n: 1 }, { n: 2 }, { n: 0 }]);
+  expect(moveRow([{ n: 0 }, { n: 1 }, { n: 2 }], 2, 0)).toEqual([{ n: 2 }, { n: 0 }, { n: 1 }]);
+});
+
+it("does not mutate the input array", () => {
+  const rows = [{ n: 0 }, { n: 1 }];
+  addRow(rows);
+  removeRow(rows, 0);
+  moveRow(rows, 0, 1);
+  expect(rows).toEqual([{ n: 0 }, { n: 1 }]);
+});

--- a/resources/js/form/components/fields/repeater-rows.ts
+++ b/resources/js/form/components/fields/repeater-rows.ts
@@ -1,0 +1,25 @@
+export type RepeaterRow = Record<string, unknown>;
+
+/** Seed the row list from a stored value, falling back to `defaultItems` blank rows. */
+export function seedRows(value: unknown, defaultItems: number): RepeaterRow[] {
+  if (Array.isArray(value) && value.length > 0) {
+    return value.map((row) => (row && typeof row === "object" ? { ...(row as RepeaterRow) } : {}));
+  }
+
+  return Array.from({ length: Math.max(0, defaultItems) }, () => ({}));
+}
+
+export function addRow(rows: RepeaterRow[]): RepeaterRow[] {
+  return [...rows, {}];
+}
+
+export function removeRow(rows: RepeaterRow[], index: number): RepeaterRow[] {
+  return rows.filter((_, i) => i !== index);
+}
+
+export function moveRow(rows: RepeaterRow[], from: number, to: number): RepeaterRow[] {
+  const next = [...rows];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -1,0 +1,87 @@
+import { expect, it, vi, beforeAll, afterAll } from "vitest";
+import { configure, getConfig, fireEvent, render, screen } from "@testing-library/react";
+
+// The form convention is data-test; scope the RTL testIdAttribute to this file only.
+let prevTestIdAttribute: string;
+beforeAll(() => {
+  prevTestIdAttribute = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+afterAll(() => {
+  configure({ testIdAttribute: prevTestIdAttribute });
+});
+
+// Mock the child-node renderer so the test doesn't need the full registry.
+// The stub reads the FieldScope to prove each row scopes its children.
+vi.mock("@lattice/lattice/core/renderer", async () => {
+  const { useFieldScope } = await import("../field-scope");
+  return {
+    RenderNode: ({ node }: { node: { props: { name: string } } }) => {
+      const scope = useFieldScope();
+      return (
+        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+      );
+    },
+  };
+});
+
+import { FormProvider } from "../context";
+import { FormValuesProvider } from "../values";
+import { RepeaterComponent } from "./repeater";
+
+const repeaterNode = {
+  id: "r",
+  type: "form.repeater",
+  props: {
+    name: "items",
+    reorderable: true,
+    defaultItems: 1,
+    addLabel: "Add line",
+    minItems: 0,
+    maxItems: 3,
+    label: "Line items",
+  },
+  schema: [{ id: "c", type: "form.text-input", props: { name: "name", label: "Name" } }],
+} as never;
+
+function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
+  return render(
+    <FormProvider
+      value={{
+        action: "#",
+        clearErrors: () => {},
+        componentRef: "",
+        errors: {},
+        fieldLabels: {},
+        precognitive: false,
+        processing: false,
+        validate: () => {},
+      }}
+    >
+      <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>
+    </FormProvider>,
+  );
+}
+
+it("renders defaultItems rows, each scoping its children", () => {
+  wrap(<RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>);
+  const children = screen.getAllByTestId("child");
+  expect(children).toHaveLength(1);
+  expect(children[0].textContent).toBe("items[0][name]");
+});
+
+it("adds a row up to maxItems", () => {
+  wrap(<RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>);
+  fireEvent.click(screen.getByTestId("repeater-items-add"));
+  const children = screen.getAllByTestId("child");
+  expect(children.map((c) => c.textContent)).toEqual(["items[0][name]", "items[1][name]"]);
+});
+
+it("removes a row", () => {
+  wrap(<RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>, {
+    items: [{ name: "a" }, { name: "b" }],
+  });
+  expect(screen.getAllByTestId("child")).toHaveLength(2);
+  fireEvent.click(screen.getByTestId("repeater-items-remove-0"));
+  expect(screen.getAllByTestId("child")).toHaveLength(1);
+});

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -11,15 +11,29 @@ afterAll(() => {
   configure({ testIdAttribute: prevTestIdAttribute });
 });
 
+// Per-scoped-key render counter, shared with the mock factory below.
+const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
+
 // Mock the child-node renderer so the test doesn't need the full registry.
-// The stub reads the FieldScope to prove each row scopes its children.
+// The stub reads the FieldScope to prove each row scopes its children, counts
+// its own renders, and exposes a button that commits a value into its row.
 vi.mock("@lattice/lattice/core/renderer", async () => {
   const { useFieldScope } = await import("../field-scope");
   return {
     RenderNode: ({ node }: { node: { props: { name: string } } }) => {
       const scope = useFieldScope();
+      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
+      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
       return (
-        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+        <>
+          <span data-test="child">{key}</span>
+          <button
+            aria-label={`commit ${key}`}
+            data-test={`commit-${key}`}
+            type="button"
+            onClick={() => scope?.setValue(node.props.name, "x")}
+          />
+        </>
       );
     },
   };
@@ -97,4 +111,16 @@ it("shows the array-level error for the repeater field", () => {
     { items: "Must have at least 1 item" },
   );
   expect(screen.getByText("Must have at least 1 item")).toBeInTheDocument();
+});
+
+it("does not re-render sibling rows when one row changes", () => {
+  wrap(<RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>, {
+    items: [{ name: "a" }, { name: "b" }],
+  });
+
+  renderCounts.clear();
+  fireEvent.click(screen.getByTestId("commit-items[0][name]"));
+
+  expect(renderCounts.get("items[0][name]") ?? 0).toBeGreaterThanOrEqual(1);
+  expect(renderCounts.get("items[1][name]") ?? 0).toBe(0);
 });

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -44,14 +44,18 @@ const repeaterNode = {
   schema: [{ id: "c", type: "form.text-input", props: { name: "name", label: "Name" } }],
 } as never;
 
-function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
+function wrap(
+  ui: React.ReactNode,
+  initial: Record<string, unknown> = {},
+  errors: Record<string, string> = {},
+) {
   return render(
     <FormProvider
       value={{
         action: "#",
         clearErrors: () => {},
         componentRef: "",
-        errors: {},
+        errors,
         fieldLabels: {},
         precognitive: false,
         processing: false,
@@ -84,4 +88,13 @@ it("removes a row", () => {
   expect(screen.getAllByTestId("child")).toHaveLength(2);
   fireEvent.click(screen.getByTestId("repeater-items-remove-0"));
   expect(screen.getAllByTestId("child")).toHaveLength(1);
+});
+
+it("shows the array-level error for the repeater field", () => {
+  wrap(
+    <RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>,
+    {},
+    { items: "Must have at least 1 item" },
+  );
+  expect(screen.getByText("Must have at least 1 item")).toBeInTheDocument();
 });

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -1,13 +1,37 @@
 import { Icon } from "@lattice/lattice/icons";
+import type { ReactNode } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { RenderNode } from "@lattice/lattice/core/renderer";
-import { useMemo } from "react";
 import { FormFieldFrame } from "../base/field";
 import { FieldScopeProvider } from "../field-scope";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFormValue, useSetFormValue } from "../values";
 import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+
+function RowButton({
+  label,
+  testId,
+  onClick,
+  children,
+}: {
+  label: string;
+  testId: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      data-test={testId}
+      className="text-lt-muted-fg hover:text-lt-fg"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
 
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
@@ -16,10 +40,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
   const { hidden, required } = useDependentField(node);
   const setValue = useSetFormValue();
   const stored = useFormValue(name);
-  const rows = useMemo<RepeaterRow[]>(
-    () => seedRows(stored, props.defaultItems ?? 1),
-    [stored, props.defaultItems],
-  );
+  const rows = seedRows(stored, props.defaultItems ?? 1);
   const template: Node[] = node.schema ?? [];
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
@@ -51,37 +72,31 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
               </span>
               <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
                 {props.reorderable && index > 0 && (
-                  <button
-                    type="button"
-                    aria-label="Move up"
-                    data-test={`repeater-${name}-up-${index}`}
-                    className="text-lt-muted-fg hover:text-lt-fg"
+                  <RowButton
+                    label="Move up"
+                    testId={`repeater-${name}-up-${index}`}
                     onClick={() => writeRows(moveRow(rows, index, index - 1))}
                   >
                     <Icon name="arrow-up" />
-                  </button>
+                  </RowButton>
                 )}
                 {props.reorderable && index < rows.length - 1 && (
-                  <button
-                    type="button"
-                    aria-label="Move down"
-                    data-test={`repeater-${name}-down-${index}`}
-                    className="text-lt-muted-fg hover:text-lt-fg"
+                  <RowButton
+                    label="Move down"
+                    testId={`repeater-${name}-down-${index}`}
                     onClick={() => writeRows(moveRow(rows, index, index + 1))}
                   >
                     <Icon name="arrow-down" />
-                  </button>
+                  </RowButton>
                 )}
                 {!atMin && (
-                  <button
-                    type="button"
-                    aria-label="Remove"
-                    data-test={`repeater-${name}-remove-${index}`}
-                    className="text-lt-muted-fg hover:text-lt-fg"
+                  <RowButton
+                    label="Remove"
+                    testId={`repeater-${name}-remove-${index}`}
                     onClick={() => writeRows(removeRow(rows, index))}
                   >
                     <Icon name="trash-2" />
-                  </button>
+                  </RowButton>
                 )}
               </div>
             </div>
@@ -96,7 +111,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             >
               <div className="flex flex-col gap-4">
                 {template.map((child) => (
-                  <RenderNode key={child.id} node={child} />
+                  <RenderNode key={child.key ?? child.id} node={child} />
                 ))}
               </div>
             </FieldScopeProvider>

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -4,6 +4,7 @@ import { RenderNode } from "@lattice/lattice/core/renderer";
 import { useMemo } from "react";
 import { FormFieldFrame } from "../base/field";
 import { FieldScopeProvider } from "../field-scope";
+import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFormValue, useSetFormValue } from "../values";
 import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
@@ -11,6 +12,7 @@ import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeat
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
   const name = props.name;
+  const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
   const setValue = useSetFormValue();
   const stored = useFormValue(name);
@@ -30,7 +32,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
 
   return (
     <FormFieldFrame
-      error={undefined}
+      error={errors[name]}
       helperText={props.helperText ?? undefined}
       label={props.label ?? ""}
       name={name}

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@lattice/lattice/icons";
 import type { ReactNode } from "react";
+import { memo, useCallback } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { RenderNode } from "@lattice/lattice/core/renderer";
 import { FormFieldFrame } from "../base/field";
@@ -8,6 +9,8 @@ import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFormValue, useSetFormValue } from "../values";
 import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+
+const EMPTY_TEMPLATE: Node[] = [];
 
 function RowButton({
   label,
@@ -33,19 +36,133 @@ function RowButton({
   );
 }
 
+type RepeaterRowProps = {
+  base: string;
+  index: number;
+  row: RepeaterRow;
+  template: Node[];
+  reorderable: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  removable: boolean;
+  itemLabel: string | null;
+  onField: (index: number, field: string, value: unknown) => void;
+  onRemove: (index: number) => void;
+  onMove: (index: number, delta: number) => void;
+};
+
+// Memoised so editing one row doesn't re-render its siblings. Its props are kept
+// referentially stable by the parent: `row` survives untouched via functional
+// store updates, and the handlers are `useCallback`-stable.
+const RepeaterRowItem = memo(function RepeaterRowItem({
+  base,
+  index,
+  row,
+  template,
+  reorderable,
+  isFirst,
+  isLast,
+  removable,
+  itemLabel,
+  onField,
+  onRemove,
+  onMove,
+}: RepeaterRowProps) {
+  return (
+    <div
+      data-test={`repeater-${base}-row-${index}`}
+      className="rounded-lt border border-lt-border bg-lt-surface p-4"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-lt-muted-fg">
+          {itemLabel ? `${itemLabel} ${index + 1}` : `#${index + 1}`}
+        </span>
+        <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
+          {reorderable && !isFirst && (
+            <RowButton
+              label="Move up"
+              testId={`repeater-${base}-up-${index}`}
+              onClick={() => onMove(index, -1)}
+            >
+              <Icon name="arrow-up" />
+            </RowButton>
+          )}
+          {reorderable && !isLast && (
+            <RowButton
+              label="Move down"
+              testId={`repeater-${base}-down-${index}`}
+              onClick={() => onMove(index, 1)}
+            >
+              <Icon name="arrow-down" />
+            </RowButton>
+          )}
+          {removable && (
+            <RowButton
+              label="Remove"
+              testId={`repeater-${base}-remove-${index}`}
+              onClick={() => onRemove(index)}
+            >
+              <Icon name="trash-2" />
+            </RowButton>
+          )}
+        </div>
+      </div>
+
+      <FieldScopeProvider
+        base={base}
+        index={index}
+        row={row}
+        onChange={(field, value) => onField(index, field, value)}
+      >
+        <div className="flex flex-col gap-4">
+          {template.map((child) => (
+            <RenderNode key={child.key ?? child.id} node={child} />
+          ))}
+        </div>
+      </FieldScopeProvider>
+    </div>
+  );
+});
+
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
   const name = props.name;
+  const defaultItems = props.defaultItems ?? 1;
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
   const setValue = useSetFormValue();
   const stored = useFormValue(name);
-  const rows = seedRows(stored, props.defaultItems ?? 1);
-  const template: Node[] = node.schema ?? [];
+  const rows: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
+  const template = node.schema ?? EMPTY_TEMPLATE;
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
 
-  const writeRows = (next: RepeaterRow[]): void => setValue(name, next);
+  // Functional store updates preserve the identity of untouched rows, which lets
+  // the memoised RepeaterRowItem skip re-rendering siblings on a single-row edit.
+  const mutate = useCallback(
+    (fn: (rows: RepeaterRow[]) => RepeaterRow[]): void => {
+      setValue(name, (prev: unknown) =>
+        fn(Array.isArray(prev) ? (prev as RepeaterRow[]) : seedRows(prev, defaultItems)),
+      );
+    },
+    [setValue, name, defaultItems],
+  );
+  const onField = useCallback(
+    (index: number, field: string, value: unknown): void => {
+      mutate((current) => current.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+    },
+    [mutate],
+  );
+  const onRemove = useCallback(
+    (index: number): void => mutate((current) => removeRow(current, index)),
+    [mutate],
+  );
+  const onMove = useCallback(
+    (index: number, delta: number): void =>
+      mutate((current) => moveRow(current, index, index + delta)),
+    [mutate],
+  );
+  const onAdd = useCallback((): void => mutate(addRow), [mutate]);
 
   if (hidden) {
     return null;
@@ -61,61 +178,21 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
     >
       <div className="flex flex-col gap-3">
         {rows.map((row, index) => (
-          <div
+          <RepeaterRowItem
             key={index}
-            data-test={`repeater-${name}-row-${index}`}
-            className="rounded-lt border border-lt-border bg-lt-surface p-4"
-          >
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-sm font-medium text-lt-muted-fg">
-                {props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
-              </span>
-              <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
-                {props.reorderable && index > 0 && (
-                  <RowButton
-                    label="Move up"
-                    testId={`repeater-${name}-up-${index}`}
-                    onClick={() => writeRows(moveRow(rows, index, index - 1))}
-                  >
-                    <Icon name="arrow-up" />
-                  </RowButton>
-                )}
-                {props.reorderable && index < rows.length - 1 && (
-                  <RowButton
-                    label="Move down"
-                    testId={`repeater-${name}-down-${index}`}
-                    onClick={() => writeRows(moveRow(rows, index, index + 1))}
-                  >
-                    <Icon name="arrow-down" />
-                  </RowButton>
-                )}
-                {!atMin && (
-                  <RowButton
-                    label="Remove"
-                    testId={`repeater-${name}-remove-${index}`}
-                    onClick={() => writeRows(removeRow(rows, index))}
-                  >
-                    <Icon name="trash-2" />
-                  </RowButton>
-                )}
-              </div>
-            </div>
-
-            <FieldScopeProvider
-              base={name}
-              index={index}
-              row={row}
-              onChange={(field, value) =>
-                writeRows(rows.map((r, i) => (i === index ? { ...r, [field]: value } : r)))
-              }
-            >
-              <div className="flex flex-col gap-4">
-                {template.map((child) => (
-                  <RenderNode key={child.key ?? child.id} node={child} />
-                ))}
-              </div>
-            </FieldScopeProvider>
-          </div>
+            base={name}
+            index={index}
+            row={row}
+            template={template}
+            reorderable={props.reorderable ?? false}
+            isFirst={index === 0}
+            isLast={index === rows.length - 1}
+            removable={!atMin}
+            itemLabel={props.itemLabel ?? null}
+            onField={onField}
+            onRemove={onRemove}
+            onMove={onMove}
+          />
         ))}
 
         {!atMax && (
@@ -123,7 +200,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             type="button"
             data-test={`repeater-${name}-add`}
             className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
-            onClick={() => writeRows(addRow(rows))}
+            onClick={onAdd}
           >
             <Icon name="plus" />
             {props.addLabel ?? "Add"}

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -1,0 +1,118 @@
+import { Icon } from "@lattice/lattice/icons";
+import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import { RenderNode } from "@lattice/lattice/core/renderer";
+import { useMemo } from "react";
+import { FormFieldFrame } from "../base/field";
+import { FieldScopeProvider } from "../field-scope";
+import { useDependentField } from "../use-dependent-field";
+import { useFormValue, useSetFormValue } from "../values";
+import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+
+export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
+  const props = node.props;
+  const name = props.name;
+  const { hidden, required } = useDependentField(node);
+  const setValue = useSetFormValue();
+  const stored = useFormValue(name);
+  const rows = useMemo<RepeaterRow[]>(
+    () => seedRows(stored, props.defaultItems ?? 1),
+    [stored, props.defaultItems],
+  );
+  const template: Node[] = node.schema ?? [];
+  const atMax = props.maxItems != null && rows.length >= props.maxItems;
+  const atMin = props.minItems != null && rows.length <= props.minItems;
+
+  const writeRows = (next: RepeaterRow[]): void => setValue(name, next);
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <FormFieldFrame
+      error={undefined}
+      helperText={props.helperText ?? undefined}
+      label={props.label ?? ""}
+      name={name}
+      required={required}
+    >
+      <div className="flex flex-col gap-3">
+        {rows.map((row, index) => (
+          <div
+            key={index}
+            data-test={`repeater-${name}-row-${index}`}
+            className="rounded-lt border border-lt-border bg-lt-surface p-4"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm font-medium text-lt-muted-fg">
+                {props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
+              </span>
+              <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
+                {props.reorderable && index > 0 && (
+                  <button
+                    type="button"
+                    aria-label="Move up"
+                    data-test={`repeater-${name}-up-${index}`}
+                    className="text-lt-muted-fg hover:text-lt-fg"
+                    onClick={() => writeRows(moveRow(rows, index, index - 1))}
+                  >
+                    <Icon name="arrow-up" />
+                  </button>
+                )}
+                {props.reorderable && index < rows.length - 1 && (
+                  <button
+                    type="button"
+                    aria-label="Move down"
+                    data-test={`repeater-${name}-down-${index}`}
+                    className="text-lt-muted-fg hover:text-lt-fg"
+                    onClick={() => writeRows(moveRow(rows, index, index + 1))}
+                  >
+                    <Icon name="arrow-down" />
+                  </button>
+                )}
+                {!atMin && (
+                  <button
+                    type="button"
+                    aria-label="Remove"
+                    data-test={`repeater-${name}-remove-${index}`}
+                    className="text-lt-muted-fg hover:text-lt-fg"
+                    onClick={() => writeRows(removeRow(rows, index))}
+                  >
+                    <Icon name="trash-2" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <FieldScopeProvider
+              base={name}
+              index={index}
+              row={row}
+              onChange={(field, value) =>
+                writeRows(rows.map((r, i) => (i === index ? { ...r, [field]: value } : r)))
+              }
+            >
+              <div className="flex flex-col gap-4">
+                {template.map((child) => (
+                  <RenderNode key={child.id} node={child} />
+                ))}
+              </div>
+            </FieldScopeProvider>
+          </div>
+        ))}
+
+        {!atMax && (
+          <button
+            type="button"
+            data-test={`repeater-${name}-add`}
+            className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
+            onClick={() => writeRows(addRow(rows))}
+          >
+            <Icon name="plus" />
+            {props.addLabel ?? "Add"}
+          </button>
+        )}
+      </div>
+    </FormFieldFrame>
+  );
+};

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -10,6 +10,7 @@ import { FORM_DEBOUNCE_MS, postFormAction } from "../form-transport";
 import { useResolvedNode } from "../resolved-nodes";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
+import { useFieldScope } from "../field-scope";
 import { useFormValue } from "../values";
 
 function toValues(stored: unknown, fallback: unknown): string[] {
@@ -34,6 +35,9 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
   const { change, blur } = useFieldCommit();
   const resolvedNode = useResolvedNode(node);
   const name = props.name;
+  const scope = useFieldScope();
+  const domName = scope ? scope.scopedName(name) : name;
+  const errorKey = scope ? scope.errorKey(name) : name;
   const placeholder = props.placeholder || "Select…";
   const multiple = props.multiple ?? false;
   const searchable = props.searchable ?? false;
@@ -42,7 +46,8 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
     [resolvedNode.props],
   );
 
-  const storedValue = useFormValue(name);
+  const globalValue = useFormValue(name);
+  const storedValue = scope ? scope.getValue(name) : globalValue;
   const selected = useMemo(() => toValues(storedValue, props.value), [storedValue, props.value]);
 
   const [open, setOpen] = useState(false);
@@ -136,7 +141,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
 
   return (
     <FormFieldFrame
-      error={errors[name]}
+      error={errors[errorKey]}
       helperText={props.helperText ?? undefined}
       label={props.label ?? ""}
       name={name}
@@ -144,10 +149,10 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
     >
       {multiple ? (
         selected.map((value) => (
-          <input key={value} name={`${name}[]`} type="hidden" value={value} />
+          <input key={value} name={`${domName}[]`} type="hidden" value={value} />
         ))
       ) : (
-        <input name={name} type="hidden" value={selected[0] ?? ""} />
+        <input name={domName} type="hidden" value={selected[0] ?? ""} />
       )}
 
       <div>

--- a/resources/js/form/components/index.ts
+++ b/resources/js/form/components/index.ts
@@ -5,6 +5,7 @@ export { FormComponent } from "./form";
 export { HiddenInputComponent } from "./fields/hidden-input";
 export { NumberInputComponent } from "./fields/number-input";
 export { PasswordInputComponent } from "./fields/password-input";
+export { RepeaterComponent } from "./fields/repeater";
 export { SelectComponent } from "./fields/select";
 export { TextareaComponent } from "./fields/textarea";
 export { TextInputComponent } from "./fields/text-input";

--- a/resources/js/form/components/use-controlled-field.ts
+++ b/resources/js/form/components/use-controlled-field.ts
@@ -1,6 +1,7 @@
 import type { Node } from "@lattice/lattice/core/types";
 import type { FieldState } from "./conditions";
 import { fieldProps } from "./field-props";
+import { useFieldScope } from "./field-scope";
 import { useFormContext } from "./context";
 import { useDependentField } from "./use-dependent-field";
 import { useFieldCommit } from "./use-field-commit";
@@ -16,18 +17,24 @@ export type ControlledField = FieldState & {
 /** Shared wiring read by every store-controlled, condition-aware field. */
 export function useControlledField(node: Node): ControlledField {
   const { errors } = useFormContext();
+  const scope = useFieldScope();
   const state = useDependentField(node);
   const props = fieldProps(node);
-  const name = props.name ?? "";
-  const storedValue = useFormValue(name);
+  const localName = props.name ?? "";
+
+  const globalValue = useFormValue(localName);
+  const storedValue = scope ? scope.getValue(localName) : globalValue;
   const currentValue = storedValue !== undefined ? storedValue : props.value;
   const value =
     typeof currentValue === "string" || typeof currentValue === "number"
       ? String(currentValue)
       : "";
 
-  const { commit: commitField } = useFieldCommit();
-  const commit = (next: unknown): void => commitField(name, next);
+  const domName = scope ? scope.scopedName(localName) : localName;
+  const errorKey = scope ? scope.errorKey(localName) : localName;
 
-  return { ...state, name, value, error: errors[name], commit };
+  const { commit: commitField } = useFieldCommit();
+  const commit = (next: unknown): void => commitField(localName, next);
+
+  return { ...state, name: domName, value, error: errors[errorKey], commit };
 }

--- a/resources/js/form/components/use-field-commit.ts
+++ b/resources/js/form/components/use-field-commit.ts
@@ -1,3 +1,4 @@
+import { useFieldScope } from "./field-scope";
 import { useFormContext } from "./context";
 import { useSetFormValue } from "./values";
 
@@ -14,27 +15,41 @@ export type FieldCommit = {
  * The shared field-mutation contract every form field uses to write its value
  * and drive precognition. Fields that validate on change call `commit`; fields
  * that validate on blur/close (rich editor, select) call `change` then `blur`.
+ *
+ * When called inside a `FieldScopeProvider`, writes go through the scope's
+ * `setValue` and error paths use the scoped dot-key; outside a scope the
+ * behavior is identical to before.
  */
 export function useFieldCommit(): FieldCommit {
   const { clearErrors, precognitive, validate } = useFormContext();
-  const setValue = useSetFormValue();
+  const setGlobal = useSetFormValue();
+  const scope = useFieldScope();
+
+  const write = (name: string, value: unknown): void => {
+    if (scope) {
+      scope.setValue(name, value);
+    } else {
+      setGlobal(name, value);
+    }
+  };
+  const errorPath = (name: string): string => (scope ? scope.errorKey(name) : name);
 
   return {
     commit(name, value) {
-      setValue(name, value);
+      write(name, value);
       if (precognitive) {
-        validate(name);
+        validate(errorPath(name));
       } else {
-        clearErrors(name);
+        clearErrors(errorPath(name));
       }
     },
     change(name, value) {
-      setValue(name, value);
-      clearErrors(name);
+      write(name, value);
+      clearErrors(errorPath(name));
     },
     blur(name) {
       if (precognitive) {
-        validate(name);
+        validate(errorPath(name));
       }
     },
   };

--- a/resources/js/form/components/values.tsx
+++ b/resources/js/form/components/values.tsx
@@ -19,10 +19,17 @@ export function FormValuesProvider({
 }) {
   const [values, setValues] = useState<Record<string, unknown>>(initial);
 
+  // A function `value` is applied as an updater against the field's previous
+  // value, letting callers mutate without capturing the current value in a closure.
   const setValue = useCallback((name: string, value: unknown) => {
-    setValues((current) =>
-      Object.is(current[name], value) ? current : { ...current, [name]: value },
-    );
+    setValues((current) => {
+      const next =
+        typeof value === "function"
+          ? (value as (previous: unknown) => unknown)(current[name])
+          : value;
+
+      return Object.is(current[name], next) ? current : { ...current, [name]: next };
+    });
   }, []);
 
   const contextValue = useMemo(() => ({ values, setValue }), [values, setValue]);

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -10,6 +10,7 @@ type FormComponentName =
   | "HiddenInputComponent"
   | "NumberInputComponent"
   | "PasswordInputComponent"
+  | "RepeaterComponent"
   | "SelectComponent"
   | "TextareaComponent"
   | "TextInputComponent";
@@ -39,6 +40,7 @@ export const formComponents = createPlugin({
     "form.hidden-input": lazyComponent(loadFormComponent("HiddenInputComponent")),
     "form.number-input": lazyComponent(loadFormComponent("NumberInputComponent")),
     "form.password-input": lazyComponent(loadFormComponent("PasswordInputComponent")),
+    "form.repeater": lazyComponent(loadFormComponent("RepeaterComponent")),
     // Loaded from its own module so TipTap is split into a separate chunk,
     // only fetched on pages that actually render a rich editor.
     "form.rich-editor": lazyComponent<"form.rich-editor">(async () => {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -342,6 +342,11 @@ export type FormFieldNode =
       props: PasswordInput;
     }
   | {
+      type: "form.repeater";
+      key?: string;
+      props: Repeater;
+    }
+  | {
       type: "form.rich-editor";
       key?: string;
       props: RichEditor;
@@ -564,6 +569,30 @@ export type ReloadComponentEffect = {
   readonly component: string;
 };
 export type ReloadPageEffect = object;
+export type Repeater = {
+  addLabel: string | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  defaultItems: number;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  itemLabel: string | null;
+  label: string | null;
+  maxItems: number | null;
+  minItems: number | null;
+  name: string;
+  readOnly: boolean | null;
+  reorderable: boolean;
+  required: boolean | null;
+  value: unknown;
+};
 export type ResetFormEffect = {
   readonly form: string | null;
 };

--- a/src/Core/Components/Concerns/HasChildSchema.php
+++ b/src/Core/Components/Concerns/HasChildSchema.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Lattice\Lattice\Core\Components\Concerns;
+
+use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Components\Component;
+use Lattice\Lattice\Core\Concerns\FiltersRenderableComponents;
+
+trait HasChildSchema
+{
+    use FiltersRenderableComponents;
+
+    /**
+     * @var array<int, Component>
+     */
+    protected array $children = [];
+
+    /**
+     * @param  array<int, Component>  $components
+     */
+    public function schema(array $components): static
+    {
+        $this->children = $components;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    protected function renderableChildren(): array
+    {
+        return $this->renderableComponents($this->children);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 300)]
+    protected function serialiseSchema(array $data): array
+    {
+        return [
+            ...$data,
+            'schema' => $this->renderableChildren(),
+        ];
+    }
+}

--- a/src/Core/Components/ContainerComponent.php
+++ b/src/Core/Components/ContainerComponent.php
@@ -2,35 +2,11 @@
 
 namespace Lattice\Lattice\Core\Components;
 
-use Lattice\Lattice\Attributes\SerializationHook;
-use Lattice\Lattice\Core\Concerns\FiltersRenderableComponents;
+use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
 
 abstract class ContainerComponent extends Component
 {
-    use FiltersRenderableComponents;
-
-    /**
-     * @var array<int, Component>
-     */
-    protected array $children = [];
-
-    /**
-     * @param  array<int, Component>  $components
-     */
-    public function schema(array $components): static
-    {
-        $this->children = $components;
-
-        return $this;
-    }
-
-    /**
-     * @return array<int, Component>
-     */
-    protected function renderableChildren(): array
-    {
-        return $this->renderableComponents($this->children);
-    }
+    use HasChildSchema;
 
     /**
      * @return array<int, Component>
@@ -48,18 +24,5 @@ abstract class ContainerComponent extends Component
         }
 
         return $result;
-    }
-
-    /**
-     * @param  array<string, mixed>  $data
-     * @return array<string, mixed>
-     */
-    #[SerializationHook(priority: 300)]
-    protected function serialiseSchema(array $data): array
-    {
-        return [
-            ...$data,
-            'schema' => $this->renderableChildren(),
-        ];
     }
 }

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -186,6 +186,19 @@ abstract class Field extends Component
     }
 
     /**
+     * Extra validation rule keys this field contributes beyond its own name
+     * (e.g. a Repeater's `items.*.child` per-row rules). Merged by FieldValidator.
+     *
+     * @internal
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function nestedRules(FormData $data, Request $request): array
+    {
+        return [];
+    }
+
+    /**
      * @param  string|array<int, string>  $attributes
      */
     public function dependsOn(string|array $attributes, mixed $operatorOrValue = null, mixed $value = null): static

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -186,6 +186,26 @@ abstract class Field extends Component
     }
 
     /**
+     * The field's resolved rules with a leading `required` when the field is
+     * required and doesn't already declare one. Shared by FieldValidator and by
+     * fields that build rules for nested children (e.g. Repeater rows).
+     *
+     * @internal
+     *
+     * @return array<int, mixed>
+     */
+    public function resolvedRulesWithRequired(FormData $data, Request $request): array
+    {
+        $rules = $this->resolveRules($data, $request);
+
+        if ($this->isRequired($data) && ! in_array('required', $rules, true)) {
+            array_unshift($rules, 'required');
+        }
+
+        return $rules;
+    }
+
+    /**
      * Extra validation rule keys this field contributes beyond its own name
      * (e.g. a Repeater's `items.*.child` per-row rules). Merged by FieldValidator.
      *

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Closure;
+use Lattice\Lattice\Attributes\Component;
+use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
+
+#[Component('form.repeater')]
+class Repeater extends Field
+{
+    use HasChildSchema;
+
+    public ?int $minItems = null;
+
+    public ?int $maxItems = null;
+
+    public bool $reorderable = true;
+
+    public ?string $addLabel = null;
+
+    public ?string $itemLabel = null;
+
+    public int $defaultItems = 1;
+
+    public function minItems(int $min): static
+    {
+        $this->minItems = $min;
+
+        return $this;
+    }
+
+    public function maxItems(int $max): static
+    {
+        $this->maxItems = $max;
+
+        return $this;
+    }
+
+    public function reorderable(bool $reorderable = true): static
+    {
+        $this->reorderable = $reorderable;
+
+        return $this;
+    }
+
+    public function addLabel(string $label): static
+    {
+        $this->addLabel = $label;
+
+        return $this;
+    }
+
+    /**
+     * Per-row heading. v1 serialises only the string form; the Closure form is
+     * accepted for forward-compatible API parity and resolved in a follow-up.
+     */
+    public function itemLabel(string|Closure $label): static
+    {
+        $this->itemLabel = $label instanceof Closure ? null : $label;
+
+        return $this;
+    }
+
+    public function defaultItems(int $count): static
+    {
+        $this->defaultItems = $count;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, Field>
+     */
+    public function childFields(): array
+    {
+        return array_values(array_filter(
+            $this->children,
+            static fn ($child): bool => $child instanceof Field,
+        ));
+    }
+}

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -3,8 +3,10 @@
 namespace Lattice\Lattice\Forms\Components;
 
 use Closure;
+use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
+use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.repeater')]
 class Repeater extends Field
@@ -78,5 +80,76 @@ class Repeater extends Field
             $this->children,
             static fn ($child): bool => $child instanceof Field,
         ));
+    }
+
+    /**
+     * The repeater value is always an array; array-level rules live here so they
+     * are not clobbered by the nested per-row rules (which use `items.*.x` keys).
+     *
+     * @return array<int, mixed>
+     */
+    public function resolveRules(FormData $data, Request $request): array
+    {
+        $rules = ['array'];
+
+        if ($this->minItems !== null) {
+            $rules[] = "min:{$this->minItems}";
+        }
+
+        if ($this->maxItems !== null) {
+            $rules[] = "max:{$this->maxItems}";
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Per-row rules: each child field's rules applied to every row via the
+     * `<name>.*.<child>` wildcard. Never emits the bare `<name>` key (that would
+     * overwrite resolveRules()'s array-level rules in FieldValidator).
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function nestedRules(FormData $data, Request $request): array
+    {
+        $rules = [];
+
+        foreach ($this->childFields() as $child) {
+            $childRules = $child->resolveRules($data, $request);
+
+            if ($child->isRequired($data) && ! in_array('required', $childRules, true)) {
+                array_unshift($childRules, 'required');
+            }
+
+            if ($childRules !== []) {
+                $rules["{$this->name}.*.{$child->name()}"] = $childRules;
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Normalise the validated value to a re-indexed list of rows, each row's
+     * cells cast through the matching child field's castValue().
+     */
+    public function castValue(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $children = $this->childFields();
+
+        return array_values(array_map(function ($row) use ($children): array {
+            $cast = [];
+
+            foreach ($children as $child) {
+                $name = $child->name();
+                $cast[$name] = $child->castValue(is_array($row) ? ($row[$name] ?? null) : null);
+            }
+
+            return $cast;
+        }, $value));
     }
 }

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -115,11 +115,7 @@ class Repeater extends Field
         $rules = [];
 
         foreach ($this->childFields() as $child) {
-            $childRules = $child->resolveRules($data, $request);
-
-            if ($child->isRequired($data) && ! in_array('required', $childRules, true)) {
-                array_unshift($childRules, 'required');
-            }
+            $childRules = $child->resolvedRulesWithRequired($data, $request);
 
             if ($childRules !== []) {
                 $rules["{$this->name}.*.{$child->name()}"] = $childRules;

--- a/src/Forms/FieldValidator.php
+++ b/src/Forms/FieldValidator.php
@@ -60,11 +60,7 @@ final class FieldValidator
                 continue;
             }
 
-            $fieldRules = $field->resolveRules($data, $request);
-
-            if ($field->isRequired($data) && ! in_array('required', $fieldRules, true)) {
-                array_unshift($fieldRules, 'required');
-            }
+            $fieldRules = $field->resolvedRulesWithRequired($data, $request);
 
             if ($fieldRules !== []) {
                 $rules[$name] = $fieldRules;

--- a/src/Forms/FieldValidator.php
+++ b/src/Forms/FieldValidator.php
@@ -70,6 +70,10 @@ final class FieldValidator
                 $rules[$name] = $fieldRules;
             }
 
+            foreach ($field->nestedRules($data, $request) as $ruleKey => $ruleSet) {
+                $rules[$ruleKey] = $ruleSet;
+            }
+
             foreach ($field->messages() as $rule => $message) {
                 $messages["{$name}.{$rule}"] = $message;
             }

--- a/tests/Browser/Forms/RepeaterTest.php
+++ b/tests/Browser/Forms/RepeaterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+it('renders the repeater with one default row', function (): void {
+    visit('/repeater')
+        ->assertSee('Repeater Demo')
+        ->assertSee('Line items')
+        ->assertPresent('[data-test="repeater-items-row-0"]')
+        ->assertPresent('input[name="items[0][name]"]')
+        ->assertPresent('input[name="items[0][qty]"]')
+        ->assertNoSmoke();
+});
+
+it('round-trips a nested repeater payload through submit', function (): void {
+    visit('/repeater')
+        ->assertSee('Repeater Demo')
+        ->fill('input[name="items[0][name]"]', 'Widget')
+        ->fill('input[name="items[0][qty]"]', '2')
+        ->click('@repeater-items-add')
+        ->assertPresent('[data-test="repeater-items-row-1"]')
+        ->fill('input[name="items[1][name]"]', 'Gadget')
+        ->fill('input[name="items[1][qty]"]', '5')
+        ->click('Save')
+        ->assertSee('Repeater Demo')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});
+
+it('reorders rows and submits successfully', function (): void {
+    visit('/repeater')
+        ->assertSee('Repeater Demo')
+        ->fill('input[name="items[0][name]"]', 'First')
+        ->fill('input[name="items[0][qty]"]', '1')
+        ->click('@repeater-items-add')
+        ->assertPresent('[data-test="repeater-items-row-1"]')
+        ->fill('input[name="items[1][name]"]', 'Second')
+        ->fill('input[name="items[1][qty]"]', '2')
+        ->click('@repeater-items-down-0')
+        ->click('Save')
+        ->assertSee('Repeater Demo')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});
+
+it('surfaces the per-row required validation error on submit', function (): void {
+    visit('/repeater')
+        ->assertSee('Repeater Demo')
+        ->click('Save')
+        ->assertSee('The items.0.name field is required.')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/FieldValidatorNestedRulesTest.php
+++ b/tests/Feature/FieldValidatorNestedRulesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\FieldValidator;
+use Lattice\Lattice\Forms\FormData;
+
+it('merges a field nestedRules into the validator and validates them', function (): void {
+    $field = new class extends Field
+    {
+        public function nestedRules(FormData $data, Request $request): array
+        {
+            return ['items.*.name' => ['required', 'string']];
+        }
+    };
+    $field->name = 'items';
+
+    $request = Request::create('/', 'POST', ['items' => [['name' => '']]]);
+
+    (new FieldValidator)->validate([$field], $request);
+})->throws(ValidationException::class);
+
+it('passes when nested rules are satisfied', function (): void {
+    $field = new class extends Field
+    {
+        public function nestedRules(FormData $data, Request $request): array
+        {
+            return ['items.*.name' => ['required', 'string']];
+        }
+    };
+    $field->name = 'items';
+
+    $request = Request::create('/', 'POST', ['items' => [['name' => 'ok']]]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'])->toBe([['name' => 'ok']]);
+});

--- a/tests/Feature/RepeaterValidationTest.php
+++ b/tests/Feature/RepeaterValidationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FieldValidator;
+
+function repeaterField(): Repeater
+{
+    return Repeater::make('items')
+        ->schema([TextInput::make('name')->required()])
+        ->minItems(1)
+        ->maxItems(2);
+}
+
+it('passes a valid row set and returns the array', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [['name' => 'A']]]);
+
+    $validated = (new FieldValidator)->validate([repeaterField()], $request);
+
+    expect($validated['items'])->toBe([['name' => 'A']]);
+});
+
+it('rejects a row missing a required child', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [['name' => '']]]);
+
+    (new FieldValidator)->validate([repeaterField()], $request);
+})->throws(ValidationException::class);
+
+it('rejects fewer rows than minItems', function (): void {
+    $request = Request::create('/', 'POST', ['items' => []]);
+
+    (new FieldValidator)->validate([repeaterField()], $request);
+})->throws(ValidationException::class);
+
+it('rejects more rows than maxItems', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [
+        ['name' => 'A'], ['name' => 'B'], ['name' => 'C'],
+    ]]);
+
+    (new FieldValidator)->validate([repeaterField()], $request);
+})->throws(ValidationException::class);
+
+it('casts each row through child field casts', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [['name' => 'A'], ['name' => 'B']]]);
+
+    $validated = (new FieldValidator)->validate([repeaterField()], $request);
+
+    expect($validated['items'])->toBe([['name' => 'A'], ['name' => 'B']]);
+});

--- a/tests/Feature/RepeaterWireShapeTest.php
+++ b/tests/Feature/RepeaterWireShapeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+it('serialises a repeater with its row-template schema and props', function (): void {
+    $repeater = Repeater::make('items', 'Line items')
+        ->schema([TextInput::make('name', 'Name')])
+        ->minItems(1)
+        ->maxItems(5)
+        ->addLabel('Add line')
+        ->itemLabel('Line')
+        ->defaultItems(2);
+
+    $wire = json_decode(json_encode($repeater), true);
+
+    expect($wire['type'])->toBe('form.repeater')
+        ->and($wire['props']['name'])->toBe('items')
+        ->and($wire['props']['label'])->toBe('Line items')
+        ->and($wire['props']['minItems'])->toBe(1)
+        ->and($wire['props']['maxItems'])->toBe(5)
+        ->and($wire['props']['reorderable'])->toBeTrue()
+        ->and($wire['props']['addLabel'])->toBe('Add line')
+        ->and($wire['props']['itemLabel'])->toBe('Line')
+        ->and($wire['props']['defaultItems'])->toBe(2)
+        ->and($wire['schema'])->toHaveCount(1)
+        ->and($wire['schema'][0]['type'])->toBe('form.text-input')
+        ->and($wire['schema'][0]['props']['name'])->toBe('name');
+});
+
+it('defaults reorderable on and defaultItems to 1', function (): void {
+    $wire = json_decode(json_encode(Repeater::make('items')->schema([TextInput::make('name')])), true);
+
+    expect($wire['props']['reorderable'])->toBeTrue()
+        ->and($wire['props']['defaultItems'])->toBe(1);
+});

--- a/tests/Unit/RepeaterDocsTest.php
+++ b/tests/Unit/RepeaterDocsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+describe('docs fixtures', function (): void {
+    it('dumps the repeater example', function (): void {
+        dumpFixture('repeater.basic', [
+            Repeater::make('items', 'Line items')
+                ->schema([
+                    TextInput::make('name', 'Name')->required(),
+                    TextInput::make('qty', 'Qty')->rules(['numeric']),
+                ])
+                ->minItems(1)
+                ->maxItems(5)
+                ->reorderable()
+                ->addLabel('Add line')
+                ->defaultItems(1),
+        ]);
+
+        expect('docs/fixtures/repeater.basic.json')->toBeReadableFile();
+    });
+});

--- a/workbench/app/Forms/RepeaterDemoForm.php
+++ b/workbench/app/Forms/RepeaterDemoForm.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Forms;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Core\Components\Card;
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Form('workbench.repeater.form')]
+class RepeaterDemoForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form
+            ->precognitive(300)
+            ->schema([
+                Card::make('Line items')->schema([
+                    Repeater::make('items', 'Line items')
+                        ->schema([
+                            TextInput::make('name', 'Name')->required(),
+                            TextInput::make('qty', 'Qty')->rules(['numeric']),
+                        ])
+                        ->minItems(1)
+                        ->maxItems(3)
+                        ->addLabel('Add line')
+                        ->defaultItems(1),
+                ]),
+            ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $this->validate($request);
+
+        return redirect('/repeater');
+    }
+}

--- a/workbench/app/Pages/RepeaterDemoPage.php
+++ b/workbench/app/Pages/RepeaterDemoPage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Forms\Components\Form;
+use Workbench\App\Forms\RepeaterDemoForm;
+
+class RepeaterDemoPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Repeater Demo';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('repeater-demo-page')
+                ->gap(Gap::Large)
+                ->schema([
+                    Heading::make('Repeater Demo'),
+                    Form::use(RepeaterDemoForm::class)
+                        ->method(HttpMethod::Post)
+                        ->submitLabel('Save'),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -21,6 +21,7 @@ use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Forms\DependentDemoForm;
 use Workbench\App\Forms\ProductForm;
+use Workbench\App\Forms\RepeaterDemoForm;
 use Workbench\App\Forms\ShowcaseForm;
 use Workbench\App\Layouts\AppLayout;
 use Workbench\App\Support\BoostConfig;
@@ -123,6 +124,7 @@ class WorkbenchServiceProvider extends ServiceProvider
         Lattice::forms([
             DependentDemoForm::class,
             ProductForm::class,
+            RepeaterDemoForm::class,
             ShowcaseForm::class,
         ]);
 

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -8,6 +8,7 @@ use Workbench\App\Pages\HomePage;
 use Workbench\App\Pages\ProductCreatePage;
 use Workbench\App\Pages\ProductEditPage;
 use Workbench\App\Pages\ProductsPage;
+use Workbench\App\Pages\RepeaterDemoPage;
 use Workbench\App\Pages\ShowcasePage;
 use Workbench\App\Pages\TablesPage;
 use Workbench\App\Pages\TabsPage;
@@ -32,6 +33,9 @@ Route::latticePage('/products/{product}/edit', ProductEditPage::class)
 
 Route::latticePage('/dependent-demo', DependentDemoPage::class)
     ->name('dependent.demo');
+
+Route::latticePage('/repeater', RepeaterDemoPage::class)
+    ->name('repeater');
 
 Route::latticePage('/showcase', ShowcasePage::class)
     ->name('showcase');


### PR DESCRIPTION
## Summary

Adds a `Repeater` form field — a repeatable nested schema with **add / remove / reorder** that submits and validates an array of row objects. Closes the foundation item for HasMany/BelongsToMany editing (solo todo #116).

```php
Repeater::make('items', 'Line items')
    ->schema([
        TextInput::make('name', 'Name')->required(),
        TextInput::make('qty', 'Qty')->rules(['numeric']),
    ])
    ->minItems(1)->maxItems(5)
    ->reorderable()
    ->addLabel('Add line')
    ->defaultItems(1);
```

### How it works
- **PHP:** `Repeater extends Field` and holds a row-template schema via a new `HasChildSchema` trait (extracted from `ContainerComponent`). It stays a single top-level field (not flattened into the form's field list). A new `Field::nestedRules()` seam lets it contribute per-row `items.*.field` rules; array-level `min`/`max` live on the field's own rules (separate keyspace, no clobber). `castValue()` normalises to a re-indexed list of cast rows.
- **React:** the Repeater owns one array value in the flat store. A `FieldScope` context redirects the shared field hooks (`useControlledField` / `useFieldCommit`) and `Select` to read/write a row slice and emit bracket DOM names (`items[0][name]`). Existing field renderers work inside rows unchanged; non-repeater behaviour is byte-identical. Reorder is accessible up/down buttons (no drag dependency). A new internal `RenderNode` export renders the template per row.
- **Wire/TS:** `Repeater` prop type auto-generated; no transformer allow-list change needed.

### Test plan
- [x] PHP feature: wire shape, per-row required, array-level min/max, cast (`composer test` — 395 passed)
- [x] vitest: FieldScope adapter, row-array helpers, renderer add/remove/reorder, array-level error (236 passed)
- [x] Pest **browser**: proves the Inertia bracket→nested round-trip end-to-end + `items.0.name` per-row validation + reorder submit (45 passed)
- [x] lint / types / pint / docs build — all green

### Out of scope (follow-ups)
Nested repeaters · row-scoped conditions (`visibleWhen`/computed inside a row) · `->relationship()` HasMany auto-save (#115) · row `prefill` for server-resolved Selects on edit screens · true pointer-drag reorder.