### PR TITLE
perf: memoize repeater rows (skip sibling re-renders)

### DIFF
--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -11,15 +11,29 @@ afterAll(() => {
   configure({ testIdAttribute: prevTestIdAttribute });
 });
 
+// Per-scoped-key render counter, shared with the mock factory below.
+const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
+
 // Mock the child-node renderer so the test doesn't need the full registry.
-// The stub reads the FieldScope to prove each row scopes its children.
+// The stub reads the FieldScope to prove each row scopes its children, counts
+// its own renders, and exposes a button that commits a value into its row.
 vi.mock("@lattice/lattice/core/renderer", async () => {
   const { useFieldScope } = await import("../field-scope");
   return {
     RenderNode: ({ node }: { node: { props: { name: string } } }) => {
       const scope = useFieldScope();
+      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
+      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
       return (
-        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+        <>
+          <span data-test="child">{key}</span>
+          <button
+            aria-label={`commit ${key}`}
+            data-test={`commit-${key}`}
+            type="button"
+            onClick={() => scope?.setValue(node.props.name, "x")}
+          />
+        </>
       );
     },
   };
@@ -97,4 +111,16 @@ it("shows the array-level error for the repeater field", () => {
     { items: "Must have at least 1 item" },
   );
   expect(screen.getByText("Must have at least 1 item")).toBeInTheDocument();
+});
+
+it("does not re-render sibling rows when one row changes", () => {
+  wrap(<RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>, {
+    items: [{ name: "a" }, { name: "b" }],
+  });
+
+  renderCounts.clear();
+  fireEvent.click(screen.getByTestId("commit-items[0][name]"));
+
+  expect(renderCounts.get("items[0][name]") ?? 0).toBeGreaterThanOrEqual(1);
+  expect(renderCounts.get("items[1][name]") ?? 0).toBe(0);
 });

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@lattice/lattice/icons";
 import type { ReactNode } from "react";
+import { memo, useCallback } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { RenderNode } from "@lattice/lattice/core/renderer";
 import { FormFieldFrame } from "../base/field";
@@ -8,6 +9,8 @@ import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { useFormValue, useSetFormValue } from "../values";
 import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+
+const EMPTY_TEMPLATE: Node[] = [];
 
 function RowButton({
   label,
@@ -33,19 +36,133 @@ function RowButton({
   );
 }
 
+type RepeaterRowProps = {
+  base: string;
+  index: number;
+  row: RepeaterRow;
+  template: Node[];
+  reorderable: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  removable: boolean;
+  itemLabel: string | null;
+  onField: (index: number, field: string, value: unknown) => void;
+  onRemove: (index: number) => void;
+  onMove: (index: number, delta: number) => void;
+};
+
+// Memoised so editing one row doesn't re-render its siblings. Its props are kept
+// referentially stable by the parent: `row` survives untouched via functional
+// store updates, and the handlers are `useCallback`-stable.
+const RepeaterRowItem = memo(function RepeaterRowItem({
+  base,
+  index,
+  row,
+  template,
+  reorderable,
+  isFirst,
+  isLast,
+  removable,
+  itemLabel,
+  onField,
+  onRemove,
+  onMove,
+}: RepeaterRowProps) {
+  return (
+    <div
+      data-test={`repeater-${base}-row-${index}`}
+      className="rounded-lt border border-lt-border bg-lt-surface p-4"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-lt-muted-fg">
+          {itemLabel ? `${itemLabel} ${index + 1}` : `#${index + 1}`}
+        </span>
+        <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
+          {reorderable && !isFirst && (
+            <RowButton
+              label="Move up"
+              testId={`repeater-${base}-up-${index}`}
+              onClick={() => onMove(index, -1)}
+            >
+              <Icon name="arrow-up" />
+            </RowButton>
+          )}
+          {reorderable && !isLast && (
+            <RowButton
+              label="Move down"
+              testId={`repeater-${base}-down-${index}`}
+              onClick={() => onMove(index, 1)}
+            >
+              <Icon name="arrow-down" />
+            </RowButton>
+          )}
+          {removable && (
+            <RowButton
+              label="Remove"
+              testId={`repeater-${base}-remove-${index}`}
+              onClick={() => onRemove(index)}
+            >
+              <Icon name="trash-2" />
+            </RowButton>
+          )}
+        </div>
+      </div>
+
+      <FieldScopeProvider
+        base={base}
+        index={index}
+        row={row}
+        onChange={(field, value) => onField(index, field, value)}
+      >
+        <div className="flex flex-col gap-4">
+          {template.map((child) => (
+            <RenderNode key={child.key ?? child.id} node={child} />
+          ))}
+        </div>
+      </FieldScopeProvider>
+    </div>
+  );
+});
+
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
   const name = props.name;
+  const defaultItems = props.defaultItems ?? 1;
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
   const setValue = useSetFormValue();
   const stored = useFormValue(name);
-  const rows = seedRows(stored, props.defaultItems ?? 1);
-  const template: Node[] = node.schema ?? [];
+  const rows: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
+  const template = node.schema ?? EMPTY_TEMPLATE;
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
 
-  const writeRows = (next: RepeaterRow[]): void => setValue(name, next);
+  // Functional store updates preserve the identity of untouched rows, which lets
+  // the memoised RepeaterRowItem skip re-rendering siblings on a single-row edit.
+  const mutate = useCallback(
+    (fn: (rows: RepeaterRow[]) => RepeaterRow[]): void => {
+      setValue(name, (prev: unknown) =>
+        fn(Array.isArray(prev) ? (prev as RepeaterRow[]) : seedRows(prev, defaultItems)),
+      );
+    },
+    [setValue, name, defaultItems],
+  );
+  const onField = useCallback(
+    (index: number, field: string, value: unknown): void => {
+      mutate((current) => current.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+    },
+    [mutate],
+  );
+  const onRemove = useCallback(
+    (index: number): void => mutate((current) => removeRow(current, index)),
+    [mutate],
+  );
+  const onMove = useCallback(
+    (index: number, delta: number): void =>
+      mutate((current) => moveRow(current, index, index + delta)),
+    [mutate],
+  );
+  const onAdd = useCallback((): void => mutate(addRow), [mutate]);
 
   if (hidden) {
     return null;
@@ -61,61 +178,21 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
     >
       <div className="flex flex-col gap-3">
         {rows.map((row, index) => (
-          <div
+          <RepeaterRowItem
             key={index}
-            data-test={`repeater-${name}-row-${index}`}
-            className="rounded-lt border border-lt-border bg-lt-surface p-4"
-          >
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-sm font-medium text-lt-muted-fg">
-                {props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
-              </span>
-              <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
-                {props.reorderable && index > 0 && (
-                  <RowButton
-                    label="Move up"
-                    testId={`repeater-${name}-up-${index}`}
-                    onClick={() => writeRows(moveRow(rows, index, index - 1))}
-                  >
-                    <Icon name="arrow-up" />
-                  </RowButton>
-                )}
-                {props.reorderable && index < rows.length - 1 && (
-                  <RowButton
-                    label="Move down"
-                    testId={`repeater-${name}-down-${index}`}
-                    onClick={() => writeRows(moveRow(rows, index, index + 1))}
-                  >
-                    <Icon name="arrow-down" />
-                  </RowButton>
-                )}
-                {!atMin && (
-                  <RowButton
-                    label="Remove"
-                    testId={`repeater-${name}-remove-${index}`}
-                    onClick={() => writeRows(removeRow(rows, index))}
-                  >
-                    <Icon name="trash-2" />
-                  </RowButton>
-                )}
-              </div>
-            </div>
-
-            <FieldScopeProvider
-              base={name}
-              index={index}
-              row={row}
-              onChange={(field, value) =>
-                writeRows(rows.map((r, i) => (i === index ? { ...r, [field]: value } : r)))
-              }
-            >
-              <div className="flex flex-col gap-4">
-                {template.map((child) => (
-                  <RenderNode key={child.key ?? child.id} node={child} />
-                ))}
-              </div>
-            </FieldScopeProvider>
-          </div>
+            base={name}
+            index={index}
+            row={row}
+            template={template}
+            reorderable={props.reorderable ?? false}
+            isFirst={index === 0}
+            isLast={index === rows.length - 1}
+            removable={!atMin}
+            itemLabel={props.itemLabel ?? null}
+            onField={onField}
+            onRemove={onRemove}
+            onMove={onMove}
+          />
         ))}
 
         {!atMax && (
@@ -123,7 +200,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             type="button"
             data-test={`repeater-${name}-add`}
             className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
-            onClick={() => writeRows(addRow(rows))}
+            onClick={onAdd}
           >
             <Icon name="plus" />
             {props.addLabel ?? "Add"}

--- a/resources/js/form/components/values.tsx
+++ b/resources/js/form/components/values.tsx
@@ -19,10 +19,17 @@ export function FormValuesProvider({
 }) {
   const [values, setValues] = useState<Record<string, unknown>>(initial);
 
+  // A function `value` is applied as an updater against the field's previous
+  // value, letting callers mutate without capturing the current value in a closure.
   const setValue = useCallback((name: string, value: unknown) => {
-    setValues((current) =>
-      Object.is(current[name], value) ? current : { ...current, [name]: value },
-    );
+    setValues((current) => {
+      const next =
+        typeof value === "function"
+          ? (value as (previous: unknown) => unknown)(current[name])
+          : value;
+
+      return Object.is(current[name], next) ? current : { ...current, [name]: next };
+    });
   }, []);
 
   const contextValue = useMemo(() => ({ values, setValue }), [values, setValue]);


### PR DESCRIPTION
**Stacked on #65** (`feat/repeater-field`) — review/merge that first.

## Why
Today, editing one repeater row re-renders **every** row: a field commit replaces `values["items"]` wholesale, `RepeaterComponent` re-renders, and each row's `FieldScopeProvider` gets a fresh `onChange` closure + freshly-cloned `row`, so its memo busts. Invisible for a few text inputs; visible jank once rows hold expensive fields (rich editors, searchable/relationship selects, uploads — all on the roadmap).

## What
Makes a single-row edit re-render only that row, via three coordinated changes:

1. **Functional store updates** (`values.tsx`) — `setValue(name, prev => …)` applies an updater against the previous value, so handlers don't capture the live `rows` array.
2. **Identity-preserving rows** (`repeater.tsx`) — the read path uses the stored array directly (instead of re-cloning via `seedRows` every render), and updates rebuild only the touched row (`map(i === index ? {…} : r)`), so untouched rows keep their reference.
3. **Memoized `RepeaterRowItem`** with `useCallback`-stable `onField`/`onRemove`/`onMove` dispatchers — unchanged rows shallow-compare equal and bail out of rendering.

No API or behavior change; the wire payload, validation, and DOM are identical.

## Test
Adds a render-counter test (`does not re-render sibling rows when one row changes`) that commits a value into row 0 and asserts row 1's child renders **0** times. Verified it **fails** on the pre-memo code (sibling re-renders) and passes here — a genuine regression guard.

- [x] vitest 114 passed (incl. new sibling-render test + the functional-update store test)
- [x] Pest browser 4/4 (add/remove/reorder/submit/validation unchanged)
- [x] lint / types / format clean