### PR TITLE
feat(theme): teal brand identity + sizing defaults

### DIFF
--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196 48" role="img" aria-label="Lattice">
-  <rect x="0" y="0" width="48" height="48" rx="12" fill="#6366f1"/>
+  <rect x="0" y="0" width="48" height="48" rx="12" fill="#009585"/>
   <g fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round">
     <path d="M16 12v24"/>
     <path d="M24 12v24"/>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196 48" role="img" aria-label="Lattice">
-  <rect x="0" y="0" width="48" height="48" rx="12" fill="#6366f1"/>
+  <rect x="0" y="0" width="48" height="48" rx="12" fill="#009585"/>
   <g fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round">
     <path d="M16 12v24"/>
     <path d="M24 12v24"/>
@@ -15,5 +15,5 @@
     <circle cx="16" cy="32" r="2.4"/>
     <circle cx="32" cy="32" r="2.4"/>
   </g>
-  <text x="62" y="33" fill="#1e1b4b" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" font-weight="700" letter-spacing="-0.5">Lattice</text>
+  <text x="62" y="33" fill="#0b3d38" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="24" font-weight="700" letter-spacing="-0.5">Lattice</text>
 </svg>

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -17,15 +17,15 @@
   --sl-font: Inter, ui-sans-serif, system-ui, sans-serif;
   --sl-font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 
-  --sl-color-accent-low: #1e1b4b;
-  --sl-color-accent: #6366f1;
-  --sl-color-accent-high: #c7d2fe;
+  --sl-color-accent-low: #04302c;
+  --sl-color-accent: #14b8a6;
+  --sl-color-accent-high: #99f6e4;
 }
 
 :root[data-theme="light"] {
-  --sl-color-accent-low: #e0e7ff;
-  --sl-color-accent: #4f46e5;
-  --sl-color-accent-high: #312e81;
+  --sl-color-accent-low: #ccfbf1;
+  --sl-color-accent: #0d9488;
+  --sl-color-accent-high: #0a3d38;
 }
 
 @media (min-width: 50rem) {

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -6,23 +6,24 @@
   --lt-surface-fg: var(--card-foreground, oklch(0.145 0 0));
   --lt-popover: var(--popover, oklch(1 0 0));
   --lt-popover-fg: var(--popover-foreground, oklch(0.145 0 0));
-  --lt-primary: var(--primary, oklch(0.205 0 0));
+  --lt-primary: var(--primary, oklch(0.48 0.092 182));
   --lt-primary-fg: var(--primary-foreground, oklch(0.985 0 0));
   --lt-secondary: var(--secondary, oklch(0.97 0 0));
   --lt-secondary-fg: var(--secondary-foreground, oklch(0.205 0 0));
   --lt-muted: var(--muted, oklch(0.97 0 0));
   --lt-muted-fg: var(--muted-foreground, oklch(0.556 0 0));
-  --lt-accent: var(--accent, oklch(0.97 0 0));
-  --lt-accent-fg: var(--accent-foreground, oklch(0.205 0 0));
-  --lt-danger: var(--destructive, oklch(0.577 0.245 27.325));
+  --lt-accent: var(--accent, oklch(0.965 0.013 182));
+  --lt-accent-fg: var(--accent-foreground, oklch(0.4 0.07 182));
+  --lt-danger: var(--destructive, oklch(0.585 0.21 27.3));
   --lt-danger-fg: var(--destructive-foreground, oklch(0.985 0 0));
   --lt-border: var(--border, oklch(0.922 0 0));
   --lt-input: var(--input, oklch(0.922 0 0));
-  --lt-ring: var(--ring, oklch(0.87 0 0));
-  --lt-warning: var(--warning, oklch(0.852 0.156 91));
-  --lt-success: var(--success, oklch(0.596 0.145 163));
+  --lt-ring: var(--ring, oklch(0.72 0.075 182));
+  --lt-overlay: var(--overlay, oklch(0 0 0 / 0.5));
+  --lt-warning: var(--warning, oklch(0.84 0.14 88));
+  --lt-success: var(--success, oklch(0.62 0.125 160));
   --lt-success-fg: var(--success-foreground, oklch(0.985 0 0));
-  --lt-info: var(--info, oklch(0.588 0.158 241));
+  --lt-info: var(--info, oklch(0.62 0.14 240));
   --lt-info-fg: var(--info-foreground, oklch(0.985 0 0));
   --lt-radius: var(--radius, 0.625rem);
   --lt-radius-sm: calc(var(--lt-radius) - 2px);
@@ -45,23 +46,24 @@
   --lt-surface-fg: var(--card-foreground, oklch(0.985 0 0));
   --lt-popover: var(--popover, oklch(0.145 0 0));
   --lt-popover-fg: var(--popover-foreground, oklch(0.985 0 0));
-  --lt-primary: var(--primary, oklch(0.985 0 0));
-  --lt-primary-fg: var(--primary-foreground, oklch(0.205 0 0));
+  --lt-primary: var(--primary, oklch(0.74 0.105 182));
+  --lt-primary-fg: var(--primary-foreground, oklch(0.2 0.025 182));
   --lt-secondary: var(--secondary, oklch(0.269 0 0));
   --lt-secondary-fg: var(--secondary-foreground, oklch(0.985 0 0));
   --lt-muted: var(--muted, oklch(0.269 0 0));
   --lt-muted-fg: var(--muted-foreground, oklch(0.708 0 0));
-  --lt-accent: var(--accent, oklch(0.269 0 0));
+  --lt-accent: var(--accent, oklch(0.278 0.018 182));
   --lt-accent-fg: var(--accent-foreground, oklch(0.985 0 0));
-  --lt-danger: var(--destructive, oklch(0.396 0.141 25.723));
+  --lt-danger: var(--destructive, oklch(0.42 0.13 26));
   --lt-danger-fg: var(--destructive-foreground, oklch(0.985 0 0));
   --lt-border: var(--border, oklch(0.269 0 0));
   --lt-input: var(--input, oklch(0.269 0 0));
-  --lt-ring: var(--ring, oklch(0.439 0 0));
-  --lt-warning: var(--warning, oklch(0.68 0.14 75));
-  --lt-success: var(--success, oklch(0.696 0.17 162));
+  --lt-ring: var(--ring, oklch(0.55 0.08 182));
+  --lt-overlay: var(--overlay, oklch(0 0 0 / 0.6));
+  --lt-warning: var(--warning, oklch(0.7 0.13 78));
+  --lt-success: var(--success, oklch(0.7 0.15 162));
   --lt-success-fg: var(--success-foreground, oklch(0.205 0 0));
-  --lt-info: var(--info, oklch(0.685 0.15 238));
+  --lt-info: var(--info, oklch(0.7 0.14 240));
   --lt-info-fg: var(--info-foreground, oklch(0.205 0 0));
 
   color-scheme: dark;
@@ -87,6 +89,7 @@
   --color-lt-border: var(--lt-border);
   --color-lt-input: var(--lt-input);
   --color-lt-ring: var(--lt-ring);
+  --color-lt-overlay: var(--lt-overlay);
   --color-lt-warning: var(--lt-warning);
   --color-lt-success: var(--lt-success);
   --color-lt-success-fg: var(--lt-success-fg);
@@ -102,6 +105,36 @@
   --spacing-lt-icon-xl: var(--lt-icon-xl);
   --animate-lt-toast-in: lt-toast-in 160ms ease-out;
   --animate-lt-toast-out: lt-toast-out 120ms ease-in;
+}
+
+@theme {
+  --font-sans:
+    "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
+
+  --text-xs: 0.625rem;
+  --text-xs--line-height: 1.6;
+  --text-sm: 0.6875rem;
+  --text-sm--line-height: 1.82;
+  --text-base: 0.75rem;
+  --text-base--line-height: 1.5;
+  --text-lg: 0.875rem;
+  --text-lg--line-height: 1.4286;
+  --text-xl: 1rem;
+  --text-xl--line-height: 1.5;
+  --text-2xl: 1.125rem;
+  --text-2xl--line-height: 1.2;
+  --text-3xl: 1.25rem;
+  --text-3xl--line-height: 1.2;
+  --text-4xl: 1.5rem;
+  --text-4xl--line-height: 1.2;
+  --text-5xl: 1.875rem;
+  --text-5xl--line-height: 1;
+  --text-6xl: 2.25rem;
+  --text-6xl--line-height: 1;
+  --text-7xl: 3rem;
+  --text-7xl--line-height: 1;
 }
 
 @keyframes lt-toast-in {

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -315,7 +315,7 @@ export function ActionForm({ description, formNode, onClose, title, ...rest }: A
       }}
     >
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-lt-overlay" />
         <Dialog.Content
           {...(description ? {} : { "aria-describedby": undefined })}
           className="fixed left-1/2 top-1/2 z-50 max-h-[min(680px,calc(100vh-2rem))] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"

--- a/resources/js/core/components/confirm-dialog.tsx
+++ b/resources/js/core/components/confirm-dialog.tsx
@@ -40,7 +40,7 @@ export function ConfirmDialog({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-lt-overlay" />
         <Dialog.Content
           {...(description ? {} : { "aria-describedby": undefined })}
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"

--- a/resources/js/core/components/modal.tsx
+++ b/resources/js/core/components/modal.tsx
@@ -46,7 +46,7 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-lt-overlay" />
         <Dialog.Content
           {...(description ? {} : { "aria-describedby": undefined })}
           className="fixed left-1/2 top-1/2 z-50 max-h-[min(680px,calc(100vh-2rem))] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg"

--- a/resources/js/form/components/base/input-error.tsx
+++ b/resources/js/form/components/base/input-error.tsx
@@ -7,7 +7,7 @@ export default function InputError({
   ...props
 }: HTMLAttributes<HTMLParagraphElement> & { message?: string }) {
   return message ? (
-    <p {...props} className={cn("text-sm text-red-600 dark:text-red-400", className)}>
+    <p {...props} className={cn("text-sm text-lt-danger", className)}>
       {message}
     </p>
   ) : null;

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -139,9 +139,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
           <FormResetListener componentId={node.id} reset={reset} />
 
           {props.status && (
-            <div className="text-center text-sm font-medium text-lt-success">
-              {props.status}
-            </div>
+            <div className="text-center text-sm font-medium text-lt-success">{props.status}</div>
           )}
 
           <FormValuesProvider initial={initialValues}>

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -139,7 +139,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
           <FormResetListener componentId={node.id} reset={reset} />
 
           {props.status && (
-            <div className="text-center text-sm font-medium text-green-600 dark:text-green-400">
+            <div className="text-center text-sm font-medium text-lt-success">
               {props.status}
             </div>
           )}

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -78,7 +78,7 @@ export function ColumnFilterControl({
           >
             <Icon name="filter" aria-hidden="true" className="size-lt-icon-md" />
             {clauses.length > 0 && (
-              <span className="absolute -right-1.5 -top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-lt-primary text-[10px] font-medium text-lt-primary-fg">
+              <span className="absolute -right-1.5 -top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-lt-primary text-xs font-medium text-lt-primary-fg">
                 {clauses.length}
               </span>
             )}

--- a/workbench/resources/css/app.css
+++ b/workbench/resources/css/app.css
@@ -10,7 +10,7 @@
 
 @theme {
   --font-sans:
-    "Instrument Sans", ui-sans-serif, system-ui, sans-serif,
+    "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
   --radius-lg: var(--radius);
@@ -45,19 +45,19 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  --primary: oklch(0.48 0.092 182);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
+  --accent: oklch(0.965 0.013 182);
+  --accent-foreground: oklch(0.4 0.07 182);
+  --destructive: oklch(0.585 0.21 27.3);
   --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.87 0 0);
+  --ring: oklch(0.72 0.075 182);
   --radius: 0.625rem;
 }
 
@@ -68,19 +68,19 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.145 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
+  --primary: oklch(0.74 0.105 182);
+  --primary-foreground: oklch(0.2 0.025 182);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.278 0.018 182);
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
+  --destructive: oklch(0.42 0.13 26);
   --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
+  --ring: oklch(0.55 0.08 182);
 }
 
 @layer base {


### PR DESCRIPTION
## What

Gives the Lattice theme its own visual identity and a set of sensible sizing defaults, plus tidies up a few components that bypassed the design tokens.

### Theme identity (`resources/css/lattice.css`)
- **Teal/emerald brand** anchored on the logo hue (~182°): `--lt-primary`, `--lt-ring`, and a faint `--lt-accent` wash, for both light and dark. Was fully achromatic before (pure gray primary).
- **Pastel status tones** — softened chroma on danger/warning/success/info while keeping hue separation from the brand.
- **`--lt-overlay`** token for dialog scrims (light `black/50`, dark `black/60`).

### Sizing defaults
- Compact type scale (`--text-xs` … `--text-7xl`, **base = 12px**) with per-step line-heights — the dense admin-panel feel.
- **Inter** as the default `--font-sans`.

### Brand surfaces
- Logo mark + wordmark recolored to teal (`docs/assets/logo*.svg`).
- Docs Starlight accent (light + dark) moved from indigo to teal.
- Workbench demo (`workbench/resources/css/app.css`) mirrors the teal tokens + Inter so the identity is visible in the playground.

### Token cleanup (`refactor` commit)
Components that missed the token convention:
- Error/status text used raw `text-red-600`/`text-green-600` → `text-lt-danger` / `text-lt-success` (already dark-mode aware, matching the sibling field-error).
- Filter badge `text-[10px]` → `text-xs` (now exactly 10px under the compact scale).
- Dialog overlays `bg-black/50` ×3 → `bg-lt-overlay`.

## Notes
- The compact type scale is the biggest visual change: every `text-sm`/`text-base` across the package (and consumers) gets smaller. Easy to dial back per-step if it's too tight.
- All tokens keep the `var(--consumer, fallback)` pattern, so consuming apps can still override.
- One known item left out by request: z-index values are still hardcoded (`z-50` overlays vs `z-[100]` toast) — no `--z-*` scale yet.

## Verification
- `npm run build` ✓
- `npm run lint` ✓
- `npm run typecheck` ✓