### PR TITLE
docs: Boost AI guidelines & skills, Development-with-AI page, backend-first i18n

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig({
             { label: "Installation", link: "/introduction/installation/" },
             { label: "Getting Started", link: "/introduction/getting-started/" },
             { label: "Configuration", link: "/introduction/configuration/" },
+            { label: "Development with AI", link: "/introduction/development-with-ai/" },
           ],
         },
         {

--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -1,16 +1,48 @@
 ---
 title: Internationalization
-description: Translate Lattice's built-in UI strings, and reuse the same i18next instance in your own components.
+description: Translate everything with normal Laravel translations, and deliver the same strings to the client through an i18next backend.
 ---
 
-Lattice's built-in components — the rich-editor toolbar, table pagination, filter controls, the bulk
-bar, and the accessibility labels on menus, toasts, tabs, and selects — read their text through
-[i18next](https://www.i18next.com/), with the English baked into each call site as a fallback. The
-UI is fully readable with **zero configuration**, and you can translate it by pointing Lattice's
-i18next instance at a translation backend.
+Lattice apps are translated with **Laravel's normal translation system**. Because you describe your UI
+in PHP, almost everything a user reads — page titles and headings, field labels and helper text, table
+headers, action labels, validation messages — is produced on the server, so you translate it exactly
+like any Laravel app: `lang/` files and `__()` / `trans()`. There is no Lattice-specific layer to learn
+for it.
 
-The instance is isolated from your app's own i18next setup (if any), so wiring it up never touches
-your application's translations.
+A smaller set of strings renders in the **browser** — Lattice's built-in chrome (the rich-editor
+toolbar, table pagination, filter controls, the bulk bar, and the accessibility labels on menus,
+toasts, tabs, and selects) and any custom React components you write. Lattice delivers the *same*
+translations to the client through an [i18next](https://www.i18next.com/) backend, so you keep one set
+of files in `lang/` and never duplicate strings in JavaScript.
+
+Start in the backend; reach for the frontend bridge only for what actually renders in the browser.
+
+## Backend: translate in PHP
+
+Your definitions are PHP, so wrap the text you author in Laravel's translation helpers, exactly as you
+would anywhere else:
+
+```php
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+Heading::make(__('products.title'));
+
+TextInput::make('name', __('products.fields.name'))
+    ->helperText(__('products.fields.name_hint'))
+    ->rules(['required']); // validation messages come from Laravel's validation translations
+```
+
+These render on the server and ship already-translated in the Inertia payload — nothing here touches
+i18next. The active language is the app locale (`App::setLocale()`), the same as any Laravel request.
+
+## Frontend: the same translations, over i18next
+
+The strings that live in the browser read through i18next, with the English baked into each call site
+as a fallback — so the UI is fully readable with **zero configuration**. To replace that English with
+your translations, you point Lattice's i18next instance at a backend that serves your `lang/` files
+(below). The instance is isolated from your app's own i18next setup (if any), so wiring it up never
+touches your application's translations.
 
 ## The `lattice` namespace
 

--- a/docs/content/docs/introduction/development-with-ai.md
+++ b/docs/content/docs/introduction/development-with-ai.md
@@ -1,0 +1,54 @@
+---
+title: Development with AI
+description: Lattice ships Laravel Boost guidelines and skills so AI coding agents know how to build Lattice pages, forms, tables, and actions.
+---
+
+Lattice is a natural fit for AI-assisted development. Because the whole UI is described in PHP, an agent that knows Lattice's APIs can build entire screens — pages, forms, tables, actions — without anyone hand-writing the React. To make that reliable, Lattice ships first-class support for [Laravel Boost](https://github.com/laravel/boost), the toolkit that gives agents Laravel-aware context.
+
+## Laravel Boost
+
+[Laravel Boost](https://laravel.com/docs/boost) is an MCP server plus a bundle of AI guidelines and skills for coding agents. Install it in your application:
+
+```bash
+composer require laravel/boost --dev
+php artisan boost:install
+```
+
+`boost:install` registers the MCP server — so the agent can inspect your database, models, routes, and search the Laravel ecosystem docs — and writes guideline files (`CLAUDE.md`, `AGENTS.md`, …) and skills for the agents you select, scoped to the packages you actually have installed. Lattice is one of them.
+
+## What Lattice contributes
+
+When Boost runs in an app that has Lattice installed, it discovers the guidelines and skills Lattice ships, so your agent learns Lattice's conventions automatically:
+
+- **Core guideline** — always loaded. A compact overview of the server-driven model, how to build and route a page, the building blocks, the discovery and configuration conventions, and the `lattice:*` artisan commands.
+- **`lattice-forms` skill** — building [forms](/forms/overview/): fields, `Select`/`Choice` options, validation and live Precognition, conditional and computed fields, and the submit lifecycle.
+- **`lattice-tables` skill** — building [tables](/tables/overview/): columns, the Eloquent builder, sortable and filterable columns, custom data sources, and row & bulk actions.
+- **`lattice-actions` skill** — [actions](/actions/overview/) and bulk actions: `ActionResult` effects, confirmation and input-form modals, and authorization.
+
+Guidelines load up front so the agent always has the mental model; skills load on demand when the agent works in that area, which keeps its context focused. See [Guidelines vs. Skills](https://laravel.com/docs/boost#guidelines-vs-skills) in the Boost docs for the distinction.
+
+## Keeping them current
+
+Lattice's guidelines and skills are versioned with the package. After upgrading Lattice — or any ecosystem package — refresh the generated resources:
+
+```bash
+php artisan boost:update
+```
+
+Add `--discover` to let Boost scan for newly installed packages and offer to publish their guidelines and skills:
+
+```bash
+php artisan boost:update --discover
+```
+
+:::tip
+You can automate this by adding `@php artisan boost:update --ansi` to your `composer.json` `post-update-cmd` scripts, so the resources stay in sync whenever you update dependencies.
+:::
+
+## A habit worth keeping
+
+One Lattice-specific step the core guideline already teaches your agent — worth knowing yourself: after changing the PHP wire format (enums, value objects) or adding a custom component, field, or column, regenerate the TypeScript types so the React side stays in lockstep.
+
+```bash
+php artisan lattice:typescript
+```

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,75 @@
+## Lattice
+
+Lattice (`lattice-php/lattice`) is a server-driven UI layer for Laravel apps running Inertia + React. You describe pages, forms, tables, actions, and menus in **PHP**; Lattice serializes them to a typed component tree that real React components render. The server is the single source of truth — there is no hand-written API and no client-side routing, and the wire format is generated to TypeScript so the two sides cannot drift.
+
+### The model
+
+- A **page** is a PHP class that builds a tree of component definitions; one React component (`lattice/page`) renders it over Inertia by resolving each node against a registry.
+- **Forms, tables, actions, and fragments** are PHP classes tagged with an attribute (`#[Form]`, `#[Table]`, `#[Action]`, `#[BulkAction]`, `#[Fragment]`). Lattice **discovers** them under the paths in `config('lattice.discover')` (your `app/` directory by default) and exposes each at a stable, signed endpoint (e.g. `lattice/forms/{form}`, `lattice/tables/{table}`). The rendered components call back into those endpoints for submits, paging, and clicks.
+
+### Building a page
+
+A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. Route it with the `Route::latticePage()` macro — no controller or Inertia page component to write by hand.
+
+@verbatim
+<code-snippet name="A page and its route" lang="php">
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\Icon;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Tables\Components\Table;
+
+final class ProductsPage extends Page
+{
+    public function title(): string
+    {
+        return 'Products';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->components([
+            Stack::make('page')->gap(Gap::Large)->children([
+                Heading::make('Products'),
+                Table::use(ProductsTable::class),
+            ]),
+        ]);
+    }
+}
+
+// routes/web.php
+Route::latticePage('/products', ProductsPage::class)
+    ->sidebar('Products', Icon::LayoutDashboard);
+</code-snippet>
+@endverbatim
+
+Drop a form or a table into the tree with `Form::use(MyForm::class)` and `Table::use(MyTable::class)`.
+
+### Building blocks
+
+- **Components** — layout/visual builders in `Lattice\Lattice\Core\Components`: `Card`, `Grid`, `Stack`, `Heading`, `Text`, `Tabs`, `Badge`, `Link`, `Button`. Composed into the page tree.
+- **Forms** — `FormDefinition` classes with fields + server-side (and live, Precognition) validation. **Reach for the `lattice-forms` skill.**
+- **Tables** — `EloquentTableDefinition` classes with columns, sorting, filtering, pagination, and row/bulk actions. **Reach for the `lattice-tables` skill.**
+- **Actions** — `ActionDefinition` / `BulkActionDefinition` that run on the server and return effects (toast, redirect, refresh, modal) via `ActionResult`. **Reach for the `lattice-actions` skill.**
+- **Navigation** — add `->sidebar('Label', Icon::Name)` to a `latticePage` route.
+
+### Conventions
+
+- Definitions (forms, tables, actions, pages) live under a discover path (`app/` by default) and follow normal PSR-4 namespacing — e.g. `App\Forms\ProfileForm`, `App\Tables\ProductsTable`. Discovery scans recursively, so the sub-folder is your choice.
+- Always give a definition a **stable id** in its attribute: `#[Form('app.profile.form')]`. Endpoints and signed refs derive from it; changing it breaks existing references.
+- After changing the PHP wire format (enums / value objects) or adding custom components, regenerate the TypeScript types with `php artisan lattice:typescript`.
+- Scaffold custom UI with the `make` commands below — each generates a paired PHP builder and React `.tsx` component.
+- Use Boost's `search-docs` tool for Laravel/Inertia/Pest specifics.
+
+### Artisan commands
+
+| Command | Purpose |
+| --- | --- |
+| `php artisan lattice:component {name} {--type=}` | Scaffold a custom Lattice UI component (PHP + React). |
+| `php artisan lattice:field {name} {--type=}` | Scaffold a custom form field (PHP + React). |
+| `php artisan lattice:column {name} {--type=}` | Scaffold a custom table column (PHP + React). |
+| `php artisan lattice:typescript` | Generate Lattice TypeScript types for the current project. |
+| `php artisan lattice:discover-cache` | Cache discovered definitions for the configured discover paths. |
+| `php artisan lattice:discover-clear` | Clear the discovery cache. |

--- a/resources/boost/skills/lattice-actions/SKILL.md
+++ b/resources/boost/skills/lattice-actions/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: lattice-actions
+description: Use when building or editing Lattice actions — creating ActionDefinition or BulkActionDefinition classes, returning effects from an ActionResult (toast, redirect, reloadComponent, reloadPage, download, openModal, resetForm), adding confirmation modals or input forms to an action, grouping actions, authorizing them, or placing them on a page, a table row, or a table selection.
+---
+
+# Building Lattice actions
+
+An action runs on the server in response to a click and returns **effects** the client dispatches — a toast, a redirect, a component or page refresh, opening a modal. It can both change data and drive the UI that follows. Actions are a discovered definition type addressed at `lattice/actions/{action}` (bulk: `lattice/bulk-actions/{bulkAction}`).
+
+## Defining an action
+
+Extend `ActionDefinition` with `definition()` (describe the trigger) and `handle()` (do the work, return an `ActionResult`). The `#[Action('id')]` attribute gives it a stable id. Note the import alias — the attribute and the `Action` component share a name:
+
+```php
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\Action as ActionAttribute;
+use Lattice\Lattice\Core\Enums\ButtonVariant;
+use Lattice\Lattice\Core\Enums\ToastVariant;
+
+#[ActionAttribute('app.products.archive')]
+class ArchiveProductAction extends ActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action
+            ->label('Archive')
+            ->variant(ButtonVariant::Destructive)
+            ->confirm('Archive product?', 'This hides it from the catalogue.');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $product = $this->product($request);
+        $product->update(['status' => 'archived']);
+
+        return ActionResult::success()
+            ->toast(ToastVariant::Success, 'Product archived.')
+            ->reloadComponent('app.products');
+    }
+}
+```
+
+## The result and its effects
+
+`handle()` returns an `ActionResult`. Start from `ActionResult::success($data?)` or `ActionResult::failure($data?)`, then chain effects (each returns a new result, so they read as a pipeline) — the client runs them in order:
+
+| Effect | What it does |
+| --- | --- |
+| `->toast($message, $variant?)` | Show a toast (`ToastVariant::Success`/`Error`/`Warning`/`Info`; defaults to success; message and variant are order-insensitive). |
+| `->reloadComponent($id)` | Re-fetch one component — pass a `#[Table]`/component id so only it refreshes. |
+| `->reloadPage()` | Reload the current page's props. |
+| `->redirect($url)` | Navigate to a URL. |
+| `->download($url)` | Trigger a file download. |
+| `->openModal($id)` / `->closeModal($id?)` | Open/close a modal (`closeModal()` closes the current one). |
+| `->resetForm($id?)` | Reset a form to its initial values (`resetForm()` resets the current form). |
+
+```php
+return ActionResult::success()->toast('Saved.')->reloadComponent('app.products');
+```
+
+## Reading context
+
+Reference an action anywhere a component is accepted with `Action::use(...)`, passing per-record data with `->context()`:
+
+```php
+Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]);
+```
+
+`handle()` reads it back with `$this->context($request, 'product_id')`. The context is **signed** into the action's reference, so it cannot be tampered with on the way back. Group related triggers behind one button with `ActionGroup::make('row')->actions([...])` (`Lattice\Lattice\Actions\Components\ActionGroup`).
+
+## Confirmation and input forms
+
+- `->confirm($title, $description?, $confirmLabel?, $cancelLabel?)` shows a confirmation dialog before the action runs.
+- `->form([...])` renders a [form](#) in a modal first; its values post to the action endpoint, validate server-side (precognitive by default), and are read in `handle()` with `$this->validate($request)`. Use the same `Field` builders as any form. Use `->lazyForm()->form([...])` for a per-record form prefilled from the row when the modal opens.
+
+```php
+return $action
+    ->label('Reject')
+    ->variant(ButtonVariant::Destructive)
+    ->confirm('Reject product?', 'Tell the seller why.', 'Submit')
+    ->form([
+        Textarea::make('reason', 'Reason')->required()->rules(['string', 'max:255']),
+    ]);
+```
+
+## Authorization
+
+Override `authorize(Request $request): bool` to gate an action; the trusted context is already merged in. A denied action never reaches `handle()`.
+
+## Bulk actions
+
+A bulk action runs over a table selection. Extend `BulkActionDefinition`; `handle()` receives the selected models as a `Collection`. `definition()` returns the same `Action` component, so labels, variants, confirmation, and forms all apply.
+
+```php
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\BulkAction as BulkActionAttribute;
+
+#[BulkActionAttribute('app.products.archive-selected')]
+class ArchiveSelectedProductsAction extends BulkActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action->label('Archive selected')->variant(ButtonVariant::Destructive);
+    }
+
+    public function handle(Collection $records, Request $request): ActionResult
+    {
+        $records->each(fn (Product $product) => $product->update(['status' => 'archived']));
+
+        return ActionResult::success(['archived' => $records->count()])
+            ->toast(ToastVariant::Success, "Archived {$records->count()} products.")
+            ->reloadComponent('app.products');
+    }
+}
+```
+
+## Placing actions
+
+- **On a table row:** return them from the table's `actions(array $row)` — `Action::use(...)->context(['product_id' => $row['id']])` (and plain `Link::make('Edit')->href(...)`).
+- **On a table selection:** return `BulkAction::use(...)` (component `Lattice\Lattice\Actions\Components\BulkAction`) from the table's `bulkActions()`.
+- **Anywhere in a page tree:** `Action::use(...)` is a component like any other.
+
+See the **`lattice-tables`** skill for the table wiring.
+
+## Common mistakes
+
+- **Confusing the attribute and the component** — `#[Action]`/`#[BulkAction]` live in `Lattice\Lattice\Attributes` (alias them on import); `Action::use()`/`BulkAction::use()` are components in `Lattice\Lattice\Actions\Components`.
+- **`reloadComponent()` with the wrong id** — pass the target component's `#[Table]`/component id, not the action's id.
+- **Reading context off the raw request** — use `$this->context($request, $key)`; it is the signed, trusted copy.
+- **No `#[Action('id')]` / `#[BulkAction('id')]`** → the action is not discovered and has no endpoint.

--- a/resources/boost/skills/lattice-forms/SKILL.md
+++ b/resources/boost/skills/lattice-forms/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: lattice-forms
+description: Use when building or editing Lattice forms in a Laravel + Inertia app — creating FormDefinition classes, adding fields (TextInput, Select, Checkbox, Choice, DateInput, NumberInput, RichEditor, Repeater), writing server-side or live Precognition validation, conditional or computed fields, rendering a form on a page with Form::use(), or handling submissions.
+---
+
+# Building Lattice forms
+
+A Lattice form is a PHP class that declares its fields and handles its own submission. You define the schema once; Lattice renders the React inputs, posts to a dedicated **signed** endpoint, validates with Laravel (live, via Precognition), and runs your handler. Validation and conditions run on the server, so the client cannot bypass them.
+
+## Defining a form
+
+Extend `FormDefinition` and implement `definition()` (build the schema) and `handle()` (process a valid submit). The `#[Form('id')]` attribute gives a stable id so the form is discovered and addressed at `lattice/forms/{form}`.
+
+```php
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Form('app.profile.form')]
+class ProfileForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form->schema([
+            TextInput::make('name', 'Name')->rules(['required', 'string', 'max:255']),
+            TextInput::make('email', 'Email')->email()->rules(['required', 'email']),
+        ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $this->validate($request);
+        $request->user()->update($validated);
+
+        return redirect('/profile');
+    }
+}
+```
+
+The schema accepts fields and layout containers (`Card`, `Grid`, `Stack`) in any nesting.
+
+## Fields
+
+Built-in fields live in `Lattice\Lattice\Forms\Components`: `TextInput`, `Textarea`, `Select`, `Choice`, `Checkbox`, `DateInput`, `NumberInput`, `PasswordInput`, `HiddenInput`, `RichEditor`, `Repeater`. Create one with `Field::make('name', 'Label')` (label optional).
+
+Options shared by **every** field (they extend the base `Field`):
+
+| Method | Effect |
+| --- | --- |
+| `->value($v)` | Default value. A `fill()`ed / record value wins over it. |
+| `->helperText($t)` / `->hint($t)` | Muted help line below the input. |
+| `->required()` | Required indicator + `required` rule. |
+| `->rules([...])` | Laravel validation rules for this field. |
+| `->disabled()` | Non-interactive **and not submitted**. |
+| `->readOnly()` | Shown, not editable, **still submitted**. |
+| `->hidden()` / `->visible($bool)` | Remove / show the field. |
+
+### Select and Choice options
+
+`Select` (a dropdown) and `Choice` (inline radio-style, for a handful of options) are populated the same way — `->options([...])` of label/value pairs built with the field's own `option()` helper, or `->enum()` from a backed enum:
+
+```php
+use Lattice\Lattice\Forms\Components\Choice;
+use Lattice\Lattice\Forms\Components\Select;
+
+Select::make('status', 'Status')
+    ->placeholder('Pick a status')
+    ->options([
+        Select::option('Active', 'active'),
+        Select::option('Archived', 'archived'),
+    ]);
+
+Select::make('status', 'Status')->enum(Status::class);   // backed enum; labels from HasLabel or humanized case
+Select::make('languages', 'Languages')->multiple();      // submits an array
+
+Choice::make('plan', 'Plan')->options([
+    Choice::option('Free', 'free'),
+    Choice::option('Pro', 'pro'),
+]);
+```
+
+For large datasets make the select server-driven with `->searchable()`; the closure gets the query (plus `FormData` and `Request`) and returns options. On an edit form, add `->resolveSelectedUsing()` so the stored value(s) resolve back to labels:
+
+```php
+Select::make('author_id', 'Author')
+    ->searchable(fn (string $query) => User::query()
+        ->where('name', 'like', "%{$query}%")->limit(10)->get()
+        ->map(fn (User $u) => Select::option($u->name, (string) $u->id))->all())
+    ->resolveSelectedUsing(fn (array $values) => User::query()
+        ->whereIn('id', $values)->get()
+        ->map(fn (User $u) => Select::option($u->name, (string) $u->id))->all());
+```
+
+## Validation
+
+Attach Laravel rules per field with `->rules([...])` (or `->required()`). In `handle()`, call `$this->validate($request)` — it runs the field rules and returns the validated, cast data as an array (**visible-only**; hidden and disabled values are stripped).
+
+Turn on **live validation** by calling `->precognitive(500)` (debounce ms) in `definition()`. It validates as the user types using the exact same ruleset — nothing to keep in sync.
+
+```php
+return $form
+    ->precognitive(500)
+    ->schema([/* … */]);
+```
+
+Where a callback needs in-flight form state (dynamic rules, dependent fields), it receives a `FormData` object with typed accessors: `$data->string('name')`, `->boolean('subscribe')`, `->integer('qty')`, `->float('price')`, `->get('tags', [])`.
+
+## Conditional & computed fields
+
+Fields react to other fields. Each method names the field to watch, an optional operator, and the value to compare:
+
+```php
+TextInput::make('vat', 'VAT ID')->visibleWhen('type', 'business');
+TextInput::make('vat', 'VAT ID')->requiredWhen('country', 'DE');
+TextInput::make('coupon')->readOnlyWhen('plan', 'enterprise');
+TextInput::make('coupon')->disabledWhen('billing', 'invoice');
+```
+
+Pass an array to match any value (`->visibleWhen('country', ['DE', 'AT', 'CH'])`), or an operator string / `Lattice\Lattice\Core\Enums\Op` case as the middle argument (`->requiredWhen('age', '<', 18)`). Operators include `=`, `!=`, `>`, `<`, `contains`, `starts_with`, `in`, `empty`, `before`/`after`. Conditions are evaluated on the client **and** re-checked on the server.
+
+Compute a value from the form data instead of typing it:
+
+```php
+TextInput::make('total', 'Total')
+    ->value(fn (FormData $data) => $data->float('qty') * $data->float('price'));
+```
+
+To also change the field when its inputs change, name them with `->dependsOn()`:
+
+```php
+TextInput::make('total', 'Total')->dependsOn(
+    ['qty', 'price'],
+    fn (TextInput $field, FormData $data) => $field->value($data->float('qty') * $data->float('price')),
+);
+```
+
+## Rendering on a page
+
+Render with `Form::use(MyForm::class)` inside a page's component tree, configured fluently:
+
+```php
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Forms\Components\Form;
+
+Form::use(ProfileForm::class)
+    ->method(HttpMethod::Patch)   // post by default
+    ->submitLabel('Save changes')
+    ->fill(['name' => $user->name, 'email' => $user->email])  // seeds an edit form
+    ->context(['user_id' => $user->id]);                      // extra data handle() can read
+```
+
+The form renders its own submit button (disabled while submitting or while there are errors, with a spinner). To place it yourself, call `->withoutSubmitButton()` and add `Button::make('Save')->submit()` in the schema.
+
+## Submit lifecycle
+
+Every form posts to its signed endpoint; `FormController` routes the request: a searchable `Select` **search** returns options; a dependent-field **resolve** returns updated nodes/values; a **precognitive** request validates and returns `204`/`422` without running `handle()`; otherwise it validates and calls `handle()`. `handle()` may return any Laravel `Response`/`Responsable` — a redirect, JSON, or a toast effect via `ActionResult`.
+
+## Common mistakes
+
+- **No `#[Form('id')]` attribute** → the form is not discovered and has no endpoint.
+- **Validating only in `handle()`** instead of per-field `->rules()` → no live validation; the client can't reflect the rules.
+- **Expecting `disabled()` values in the validated data** — they are stripped. Use `->readOnly()` when the value must still be submitted.
+- **Relying on a conditionally hidden field's value** — a field hidden by `visibleWhen` (or `->hidden()`) is stripped from `validate()`'s result, so it is absent from the array. Default it in `handle()` if you still need a value.
+- **Changing a `#[Form]` id later** → breaks already-rendered references.
+
+Need an action behind a button, a row, or a selection? See the **`lattice-actions`** skill.

--- a/resources/boost/skills/lattice-tables/SKILL.md
+++ b/resources/boost/skills/lattice-tables/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: lattice-tables
+description: Use when building or editing Lattice tables — creating EloquentTableDefinition or TableDefinition classes, declaring columns (TextColumn, BadgeColumn, IconColumn, ImageColumn, StackColumn), making columns sortable or filterable, choosing pagination, backing a table with a custom data source, rendering a table on a page with Table::use(), or adding row and bulk actions.
+---
+
+# Building Lattice tables
+
+A Lattice table is a listing backed by a **data source**. You declare columns in PHP; Lattice renders the React table and handles sorting, filtering, and pagination, fetching rows from the table's **signed** endpoint (`lattice/tables/{table}`). An Eloquent source ships out of the box.
+
+## Defining a table
+
+For a database-backed table, extend `EloquentTableDefinition` and implement `columns()` + `builder()`. The `#[Table('id')]` attribute gives a stable id so the table is discovered and addressed by its endpoint.
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Attributes\Table;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\EloquentTableDefinition;
+use Lattice\Lattice\Tables\TableQuery;
+
+/** @extends EloquentTableDefinition<Product> */
+#[Table('app.products')]
+class ProductsTable extends EloquentTableDefinition
+{
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->sortable()->filterable(),
+            TextColumn::make('price')->numeric()->sortable()->filterable(),
+            TextColumn::make('updated_at')->date('Y-m-d')->sortable(),
+        ];
+    }
+
+    public function builder(TableQuery $query): Builder
+    {
+        return Product::query()->select(['id', 'name', 'price', 'updated_at']);
+    }
+}
+```
+
+`builder()` returns the **base query** — your own scoping only (a `select()`, eager loads, tenant constraints, a default order). Lattice applies the request's filters and sorts **on top** of it, driven by the columns' capabilities. The `TableQuery` argument is the read model of the current request (`->filters()`, `->sorts()`, page, size), so the builder can react — e.g. apply a default order only when `$query->sorts() === []`.
+
+`TableDefinition` hooks beyond `columns()`: `source()`, `perPage()` (default `25`), `pagination()`, `striped()`, `emptyLabel()`, `actionsLabel()`, `actions($row)`, `bulkActions()`.
+
+## Columns
+
+Columns live in `Lattice\Lattice\Tables\Columns`. `Column::make('key')` reads `$row['key']`; the label defaults to the humanized key (override with `->label()`).
+
+- **`TextColumn`** — `->numeric()` (right-aligns), `->boolean()` (check/cross), `->date('Y-m-d H:i')`, `->copyable()`, `->link('/products/{value}')` (`{value}` is substituted; pass `external: true` for outbound).
+- **`BadgeColumn`** — `->colors(['active' => 'green', 'invited' => 'yellow', 'archived' => 'gray'])`. Colors: `gray`, `red`, `green`, `yellow`, `blue`, `purple`, `orange` (unmapped → gray).
+- **`IconColumn`** — `->icon(Icon::Star)` for one icon, or `->icons(['1' => Icon::Check, '0' => Icon::Minus])`; add `->colors([...])` to tint.
+- **`ImageColumn`** — renders the value as an image URL: `->circular()`, `->size(40)`.
+- **`StackColumn`** — group child columns into one cell: `->columns([TextColumn::make('name'), TextColumn::make('email')])`.
+
+### Sortable & filterable
+
+`->sortable()` and `->filterable()` are **capabilities**, not display options: they add the header controls **and** tell the Eloquent source to apply the request's sort/filter for that column. Because both map to the column **key**, a sortable/filterable key must be a real DB column (or an aliased `select`). Keep computed/accessor columns display-only.
+
+```php
+TextColumn::make('name')->sortable()->filterable();
+```
+
+## Custom data sources
+
+For non-Eloquent data, extend `TableDefinition` and implement `source()` returning a `TableSource` — `query(TableQuery): TableResult`, `resolveMatching(TableQuery): Collection`, `resolveSelection(array $keys): Collection`. The quickest path is `CallbackTableSource`:
+
+```php
+public function source(): TableSource
+{
+    return new CallbackTableSource(
+        fn (TableQuery $query) => TableResult::fromItems($this->rows($query)),
+    );
+}
+```
+
+Build a `TableResult` from a paginator (`TableResult::fromPaginator()`, `fromSimplePaginator()`) or a collection (`fromItems()`).
+
+## Rendering on a page
+
+Render with `Table::use(ProductsTable::class)` inside a page's component tree. `Table::lazy(ProductsTable::class)` renders the same table but defers the first data load until the component mounts — useful inside a tab or an off-screen section.
+
+## Row & bulk actions
+
+A table only *attaches* actions and their context; the action classes themselves are defined separately — see the **`lattice-actions`** skill.
+
+- **Row actions** — return components from `actions(array $row)`: `Action::use(...)->context([...])` scoped to the record, plus plain `Link::make()->href(...)`.
+
+  ```php
+  use Lattice\Lattice\Actions\Components\Action;
+  use Lattice\Lattice\Core\Components\Link;
+
+  public function actions(array $row): array
+  {
+      return [
+          Link::make('Edit')->href('/products/'.$row['id'].'/edit'),
+          Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]),
+      ];
+  }
+  ```
+
+- **Bulk actions** — return `BulkAction::use(...)` from `bulkActions()`.
+
+  ```php
+  use Lattice\Lattice\Actions\Components\BulkAction;
+
+  public function bulkActions(): array
+  {
+      return [BulkAction::use(ArchiveSelectedProductsAction::class)];
+  }
+  ```
+
+  The bulk action's `handle(Collection $records, Request $request)` receives the selected **models** — with the Eloquent source, both explicit checks and "select all matching" (re-runs the current filters) are resolved for you, no extra code.
+
+## Common mistakes
+
+- **Making a computed/accessor column `sortable()`/`filterable()`** → it maps to a non-existent DB column. Keep it display-only or use a custom source.
+- **Filtering/sorting by hand in `builder()`** → Lattice already applies the request's filters and sorts; `builder()` is only the base query.
+- **No `#[Table('id')]` attribute** → the table is not discovered and has no endpoint.


### PR DESCRIPTION
## What

Ship Lattice's AI-tooling resources and improve two docs pages.

### Boost resources for consumers (`resources/boost/`)
Third-party [Laravel Boost](https://laravel.com/docs/boost#third-party-package-ai-guidelines) guidelines + skills that load automatically when an app using Lattice runs `boost:install` / `boost:update`:

- **`guidelines/core.blade.php`** — always-loaded overview: the server-driven model, building & routing a page, the building blocks, discovery/namespace/config conventions, and the `lattice:*` artisan commands.
- **`skills/lattice-forms`** — fields, `Select`/`Choice` options, validation + live Precognition, conditional/computed fields, submit lifecycle.
- **`skills/lattice-tables`** — columns, the Eloquent builder, sortable/filterable, custom sources, row & bulk actions.
- **`skills/lattice-actions`** — actions & bulk actions, `ActionResult` effects, confirmation & input-form modals, authorization.

All content is sourced from the existing docs site, so namespaces and signatures are accurate.

### Docs
- **New `introduction/development-with-ai` page** — laravel/boost setup and the guideline + skills the package ships, plus `boost:update` and `lattice:typescript` habits. Added to the Introduction sidebar.
- **`core/i18n` reframed backend-first** — leads with normal Laravel translations (`lang/`, `__()`) as the source of truth for everything server-rendered, then presents the i18next backend as the bridge that delivers those same files to client-rendered strings.

## Verification
- Skills GREEN-tested: a subagent given only these files built a full form + table + bulk action using exclusively real Lattice APIs (two rounds — the first surfaced gaps in `Select` options and action namespaces, which this PR fixes).
- `npm run docs:build` → Complete!, 48 pages, no broken links/MDX.