### PR TITLE
feat: Builder field (polymorphic line-items)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig({
                 { label: "Hidden input", link: "/forms/fields/hidden-input/" },
                 { label: "Rich editor", link: "/forms/fields/rich-editor/" },
                 { label: "Repeater", link: "/forms/fields/repeater/" },
+                { label: "Builder", link: "/forms/fields/builder/" },
               ],
             },
             { label: "Validation", link: "/forms/validation/" },

--- a/docs/content/docs/forms/fields/builder.mdx
+++ b/docs/content/docs/forms/fields/builder.mdx
@@ -1,0 +1,112 @@
+---
+title: Builder
+description: A polymorphic repeatable field — rows of different consumer-defined block types, each with its own schema.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+The builder renders a repeatable list of rows where each row can be a different block type. You define
+the available block types up front, and every block carries its own schema of fields. A row records
+which block it is through an automatic hidden `type` discriminator, so the field submits an array of
+row objects — each tagged with its `type` and keyed by that block's field names. Create one with
+`Builder::make()` and list the blocks with `->blocks()`.
+
+<ComponentExample
+  php={`Builder::make('items', 'Line items')
+    ->blocks([
+        Block::make('text')->label('Text')->schema([
+            Textarea::make('content', 'Content')->required(),
+        ]),
+        Block::make('product')->label('Product line')->schema([
+            TextInput::make('product', 'Product')->required(),
+            TextInput::make('qty', 'Qty')->rules(['numeric']),
+            TextInput::make('price', 'Price')->rules(['numeric']),
+        ]),
+    ])
+    ->minItems(1)
+    ->addLabel('Add block')`}
+  fixture="builder.basic"
+  values={{ items: [] }}
+/>
+
+## Blocks
+
+`->blocks()` takes the list of block types the builder offers. Each is a `Block::make($type)` where
+`$type` is the discriminator stored on every row of that kind. Give it a human label with `->label()`
+and its row template with `->schema()`; the schema is a normal array of fields, so each child keeps its
+own label, placeholder, default value, and rules.
+
+```php
+Block::make('product')
+    ->label('Product line')
+    ->schema([
+        TextInput::make('product', 'Product')->required(),
+        TextInput::make('qty', 'Qty')->rules(['numeric']),
+    ]);
+```
+
+The example above submits as an array of typed rows:
+
+```php
+['items' => [
+    ['type' => 'text', 'content' => 'Thanks for your order.'],
+    ['type' => 'product', 'product' => 'Widget', 'qty' => '3', 'price' => '9.99'],
+]]
+```
+
+## Adding rows
+
+Each builder row is inserted through an add menu listing every block by its label. Picking a block
+appends an empty row of that type. `->addLabel()` sets the text on the button that opens the menu
+(default "Add").
+
+```php
+Builder::make('items', 'Line items')
+    ->blocks([Block::make('text')->schema([Textarea::make('content')])])
+    ->addLabel('Add block');
+```
+
+## Row counts
+
+`->minItems()` and `->maxItems()` bound how many rows the form accepts; both are enforced as
+array-level validation rules independent of which block each row is.
+
+```php
+Builder::make('items', 'Line items')
+    ->blocks([Block::make('text')->schema([Textarea::make('content')])])
+    ->minItems(1)
+    ->maxItems(20);
+```
+
+## Reordering
+
+Rows are reorderable by default through up/down controls. Pass `->reorderable(false)` to fix the
+order.
+
+```php
+Builder::make('items', 'Line items')
+    ->blocks([Block::make('text')->schema([Textarea::make('content')])])
+    ->reorderable(false);
+```
+
+## Validation
+
+Each row is validated against the schema of its own block: a child marked `->required()` is required
+only in rows of that block type, and an error points at the offending row. The hidden `type`
+discriminator is validated too — a row whose `type` is not one of the declared blocks is rejected. The
+array-level `minItems`/`maxItems` rules validate the number of rows independently of the per-row
+rules. See [Validation](/forms/validation/) for how field rules are resolved.
+
+## Not yet supported (v1)
+
+These are follow-ups, not part of the first release:
+
+- Built-in image and subtotal blocks.
+- Nested builders (a builder inside a builder row).
+- The table layout modifier and customer-aware price prefill — tracked as separate upcoming work.
+
+## Common options
+
+`Builder` shares label, required, disabled, read-only, and visibility options with every field — see
+[Fields](/forms/fields/overview/). For validation and conditional behavior, see
+[Validation](/forms/validation/) and [Conditional fields](/forms/conditional-fields/).

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -10,8 +10,8 @@ Fields are the building blocks of a form. Lattice ships
 [Select](/forms/fields/select/), [Choice](/forms/fields/choice/),
 [Checkbox](/forms/fields/checkbox/), [Date input](/forms/fields/date-input/),
 [Number input](/forms/fields/number-input/), [Password input](/forms/fields/password-input/),
-[Hidden input](/forms/fields/hidden-input/), [Rich editor](/forms/fields/rich-editor/), and
-[Repeater](/forms/fields/repeater/) — and you can add your own. Each field type has its own page for the options unique to it; this page covers the
+[Hidden input](/forms/fields/hidden-input/), [Rich editor](/forms/fields/rich-editor/),
+[Repeater](/forms/fields/repeater/), and [Builder](/forms/fields/builder/) — and you can add your own. Each field type has its own page for the options unique to it; this page covers the
 options every field shares.
 
 The submit button is not a field: the form renders it for you from `->submitLabel()`. See

--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -1,0 +1,120 @@
+[
+    {
+        "blocks": [
+            {
+                "label": "Text",
+                "schema": [
+                    {
+                        "props": {
+                            "autoFocus": null,
+                            "conditions": null,
+                            "dependsOnAny": null,
+                            "dependsOnKeys": null,
+                            "disabled": null,
+                            "helperText": null,
+                            "hidden": null,
+                            "label": "Content",
+                            "name": "content",
+                            "placeholder": null,
+                            "readOnly": null,
+                            "required": true,
+                            "rows": null,
+                            "tabIndex": null,
+                            "value": null
+                        },
+                        "type": "form.textarea"
+                    }
+                ],
+                "type": "text"
+            },
+            {
+                "label": "Product line",
+                "schema": [
+                    {
+                        "props": {
+                            "autoComplete": null,
+                            "autoFocus": null,
+                            "conditions": null,
+                            "dependsOnAny": null,
+                            "dependsOnKeys": null,
+                            "disabled": null,
+                            "helperText": null,
+                            "hidden": null,
+                            "label": "Product",
+                            "name": "product",
+                            "placeholder": null,
+                            "readOnly": null,
+                            "required": true,
+                            "tabIndex": null,
+                            "type": null,
+                            "value": null
+                        },
+                        "type": "form.text-input"
+                    },
+                    {
+                        "props": {
+                            "autoComplete": null,
+                            "autoFocus": null,
+                            "conditions": null,
+                            "dependsOnAny": null,
+                            "dependsOnKeys": null,
+                            "disabled": null,
+                            "helperText": null,
+                            "hidden": null,
+                            "label": "Qty",
+                            "name": "qty",
+                            "placeholder": null,
+                            "readOnly": null,
+                            "required": null,
+                            "tabIndex": null,
+                            "type": null,
+                            "value": null
+                        },
+                        "type": "form.text-input"
+                    },
+                    {
+                        "props": {
+                            "autoComplete": null,
+                            "autoFocus": null,
+                            "conditions": null,
+                            "dependsOnAny": null,
+                            "dependsOnKeys": null,
+                            "disabled": null,
+                            "helperText": null,
+                            "hidden": null,
+                            "label": "Price",
+                            "name": "price",
+                            "placeholder": null,
+                            "readOnly": null,
+                            "required": null,
+                            "tabIndex": null,
+                            "type": null,
+                            "value": null
+                        },
+                        "type": "form.text-input"
+                    }
+                ],
+                "type": "product"
+            }
+        ],
+        "props": {
+            "addLabel": "Add block",
+            "conditions": null,
+            "defaultItems": 0,
+            "dependsOnAny": null,
+            "dependsOnKeys": null,
+            "disabled": null,
+            "helperText": null,
+            "hidden": null,
+            "label": "Line items",
+            "maxItems": null,
+            "minItems": 1,
+            "name": "items",
+            "readOnly": null,
+            "reorderable": true,
+            "required": null,
+            "value": null
+        },
+        "type": "form.builder"
+    }
+]

--- a/resources/js/form/components/fields/block-add-menu.test.tsx
+++ b/resources/js/form/components/fields/block-add-menu.test.tsx
@@ -1,0 +1,22 @@
+import { expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BlockAddMenu } from "./block-add-menu";
+
+it("lists blocks and emits the chosen type", () => {
+  const onSelect = vi.fn<(type: string) => void>();
+  render(
+    <BlockAddMenu
+      addLabel="Add block"
+      blocks={[
+        { type: "text", label: "Text" },
+        { type: "product", label: "Product line" },
+      ]}
+      onSelect={onSelect}
+    />,
+  );
+
+  fireEvent.click(screen.getByText("Add block"));
+  fireEvent.click(screen.getByText("Product line"));
+
+  expect(onSelect).toHaveBeenCalledWith("product");
+});

--- a/resources/js/form/components/fields/block-add-menu.tsx
+++ b/resources/js/form/components/fields/block-add-menu.tsx
@@ -1,0 +1,54 @@
+import { Icon } from "@lattice/lattice/icons";
+import * as Popover from "@radix-ui/react-popover";
+import { useState } from "react";
+
+export type BlockOption = { type: string; label: string };
+
+export function BlockAddMenu({
+  addLabel,
+  blocks,
+  onSelect,
+}: {
+  addLabel: string;
+  blocks: BlockOption[];
+  onSelect: (type: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          data-test="builder-add"
+          className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
+        >
+          <Icon name="plus" />
+          {addLabel}
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 min-w-[12rem] overflow-hidden rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-md"
+        >
+          {blocks.map((block) => (
+            <button
+              key={block.type}
+              type="button"
+              data-test={`builder-add-${block.type}`}
+              className="flex w-full items-center rounded-lt-sm px-3 py-1.5 text-left text-sm hover:bg-lt-accent hover:text-lt-accent-fg"
+              onClick={() => {
+                onSelect(block.type);
+                setOpen(false);
+              }}
+            >
+              {block.label}
+            </button>
+          ))}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -91,3 +91,12 @@ it("renders an unknown-block placeholder", () => {
   wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, { items: [{ type: "video" }] });
   expect(screen.getByText(/Unknown block/i)).toBeInTheDocument();
 });
+
+it("can remove an unknown-block row", () => {
+  wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, {
+    items: [{ type: "video" }, { type: "text", content: "keep" }],
+  });
+  expect(screen.getByText(/Unknown block/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByTestId("repeater-items-remove-0"));
+  expect(screen.queryByText(/Unknown block/i)).not.toBeInTheDocument();
+});

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -1,0 +1,93 @@
+import { expect, it, vi, beforeAll, afterAll } from "vitest";
+import { configure, getConfig, fireEvent, render, screen } from "@testing-library/react";
+
+let prev: string;
+beforeAll(() => {
+  prev = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+afterAll(() => configure({ testIdAttribute: prev }));
+
+vi.mock("@lattice/lattice/core/renderer", async () => {
+  const { useFieldScope } = await import("../field-scope");
+  return {
+    RenderNode: ({ node }: { node: { props: { name: string } } }) => {
+      const scope = useFieldScope();
+      return (
+        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+      );
+    },
+  };
+});
+
+import { FormProvider } from "../context";
+import { FormValuesProvider } from "../values";
+import { BuilderComponent } from "./builder";
+
+const node = {
+  id: "b",
+  type: "form.builder",
+  props: {
+    name: "items",
+    reorderable: true,
+    defaultItems: 0,
+    addLabel: "Add block",
+    minItems: 0,
+    maxItems: 5,
+  },
+  blocks: [
+    {
+      type: "text",
+      label: "Text",
+      schema: [{ id: "t", type: "form.textarea", props: { name: "content" } }],
+    },
+    {
+      type: "product",
+      label: "Product line",
+      schema: [{ id: "p", type: "form.text-input", props: { name: "qty" } }],
+    },
+  ],
+} as never;
+
+function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
+  return render(
+    <FormProvider
+      value={{
+        action: "#",
+        clearErrors: () => {},
+        componentRef: "",
+        errors: {},
+        fieldLabels: {},
+        precognitive: false,
+        processing: false,
+        validate: () => {},
+      }}
+    >
+      <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>
+    </FormProvider>,
+  );
+}
+
+it("renders each row against its block template", () => {
+  wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, {
+    items: [
+      { type: "text", content: "hi" },
+      { type: "product", qty: "2" },
+    ],
+  });
+  const children = screen.getAllByTestId("child");
+  expect(children.map((c) => c.textContent)).toEqual(["items[0][content]", "items[1][qty]"]);
+});
+
+it("adds a row of the chosen block type", () => {
+  wrap(<BuilderComponent node={node}>{null}</BuilderComponent>);
+  fireEvent.click(screen.getByTestId("builder-add"));
+  fireEvent.click(screen.getByTestId("builder-add-product"));
+  const children = screen.getAllByTestId("child");
+  expect(children.map((c) => c.textContent)).toEqual(["items[0][qty]"]);
+});
+
+it("renders an unknown-block placeholder", () => {
+  wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, { items: [{ type: "video" }] });
+  expect(screen.getByText(/Unknown block/i)).toBeInTheDocument();
+});

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -8,13 +8,25 @@ beforeAll(() => {
 });
 afterAll(() => configure({ testIdAttribute: prev }));
 
+const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
+
 vi.mock("@lattice/lattice/core/renderer", async () => {
   const { useFieldScope } = await import("../field-scope");
   return {
     RenderNode: ({ node }: { node: { props: { name: string } } }) => {
       const scope = useFieldScope();
+      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
+      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
       return (
-        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+        <>
+          <span data-test="child">{key}</span>
+          <button
+            aria-label={`commit ${key}`}
+            data-test={`commit-${key}`}
+            type="button"
+            onClick={() => scope?.setValue(node.props.name, "x")}
+          />
+        </>
       );
     },
   };
@@ -99,4 +111,17 @@ it("can remove an unknown-block row", () => {
   expect(screen.getByText(/Unknown block/i)).toBeInTheDocument();
   fireEvent.click(screen.getByTestId("repeater-items-remove-0"));
   expect(screen.queryByText(/Unknown block/i)).not.toBeInTheDocument();
+});
+
+it("does not re-render sibling rows when one row changes", () => {
+  wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, {
+    items: [
+      { type: "product", qty: "1" },
+      { type: "product", qty: "2" },
+    ],
+  });
+  renderCounts.clear();
+  fireEvent.click(screen.getByTestId("commit-items[0][qty]"));
+  expect(renderCounts.get("items[0][qty]") ?? 0).toBeGreaterThanOrEqual(1);
+  expect(renderCounts.get("items[1][qty]") ?? 0).toBe(0);
 });

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -1,4 +1,5 @@
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import { Icon } from "@lattice/lattice/icons";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
@@ -47,9 +48,20 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
               <div
                 key={index}
                 data-test={`repeater-${name}-row-${index}`}
-                className="rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
+                className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
               >
-                Unknown block: {String(row.type)}
+                <span>Unknown block: {String(row.type)}</span>
+                {!atMin && (
+                  <button
+                    type="button"
+                    aria-label="Remove"
+                    data-test={`repeater-${name}-remove-${index}`}
+                    className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+                    onClick={() => onRemove(index)}
+                  >
+                    <Icon name="trash-2" />
+                  </button>
+                )}
               </div>
             );
           }

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -1,0 +1,86 @@
+import type { Node, RendererComponent } from "@lattice/lattice/core/types";
+import { FormFieldFrame } from "../base/field";
+import { useFormContext } from "../context";
+import { useDependentField } from "../use-dependent-field";
+import { BlockAddMenu, type BlockOption } from "./block-add-menu";
+import { RowItem } from "./row-item";
+import { useRowCollection } from "./use-row-collection";
+
+type Block = { type: string; label: string; schema: Node[] };
+
+const EMPTY_TEMPLATE: Node[] = [];
+
+export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) => {
+  const props = node.props;
+  const name = props.name;
+  const blocks = ((node as unknown as { blocks?: Block[] }).blocks ?? []) as Block[];
+  const { errors } = useFormContext();
+  const { hidden, required } = useDependentField(node);
+  const { rows, onField, onRemove, onMove, append } = useRowCollection(
+    name,
+    props.defaultItems ?? 0,
+  );
+  const atMax = props.maxItems != null && rows.length >= props.maxItems;
+  const atMin = props.minItems != null && rows.length <= props.minItems;
+
+  const blockFor = (type: unknown): Block | undefined => blocks.find((b) => b.type === type);
+  const options: BlockOption[] = blocks.map((b) => ({ type: b.type, label: b.label }));
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <FormFieldFrame
+      error={errors[name]}
+      helperText={props.helperText ?? undefined}
+      label={props.label ?? ""}
+      name={name}
+      required={required}
+    >
+      <div className="flex flex-col gap-3">
+        {rows.map((row, index) => {
+          const block = blockFor(row.type);
+
+          if (!block) {
+            return (
+              <div
+                key={index}
+                data-test={`repeater-${name}-row-${index}`}
+                className="rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
+              >
+                Unknown block: {String(row.type)}
+              </div>
+            );
+          }
+
+          return (
+            <RowItem
+              key={index}
+              base={name}
+              index={index}
+              row={row}
+              template={block.schema ?? EMPTY_TEMPLATE}
+              heading={block.label}
+              reorderable={props.reorderable ?? false}
+              isFirst={index === 0}
+              isLast={index === rows.length - 1}
+              removable={!atMin}
+              onField={onField}
+              onRemove={onRemove}
+              onMove={onMove}
+            />
+          );
+        })}
+
+        {!atMax && (
+          <BlockAddMenu
+            addLabel={props.addLabel ?? "Add"}
+            blocks={options}
+            onSelect={(type) => append({ type })}
+          />
+        )}
+      </div>
+    </FormFieldFrame>
+  );
+};

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -25,7 +25,10 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
   const atMin = props.minItems != null && rows.length <= props.minItems;
 
   const blockFor = (type: unknown): Block | undefined => blocks.find((b) => b.type === type);
-  const options: BlockOption[] = blocks.map((b) => ({ type: b.type, label: b.label }));
+  const options: BlockOption[] = blocks.map((b) => ({
+    type: b.type,
+    label: b.label,
+  }));
 
   if (hidden) {
     return null;
@@ -81,7 +84,9 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
               onField={onField}
               onRemove={onRemove}
               onMove={onMove}
-            />
+            >
+              <input name={`${name}[${index}][type]`} type="hidden" value={block.type} />
+            </RowItem>
           );
         })}
 

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { Icon } from "@lattice/lattice/icons";
 import { FormFieldFrame } from "../base/field";
@@ -46,47 +47,48 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
         {rows.map((row, index) => {
           const block = blockFor(row.type);
 
-          if (!block) {
-            return (
-              <div
-                key={index}
-                data-test={`repeater-${name}-row-${index}`}
-                className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
-              >
-                <span>Unknown block: {String(row.type)}</span>
-                {!atMin && (
-                  <button
-                    type="button"
-                    aria-label="Remove"
-                    data-test={`repeater-${name}-remove-${index}`}
-                    className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
-                    onClick={() => onRemove(index)}
-                  >
-                    <Icon name="trash-2" />
-                  </button>
-                )}
-              </div>
-            );
-          }
-
           return (
-            <RowItem
-              key={index}
-              base={name}
-              index={index}
-              row={row}
-              template={block.schema ?? EMPTY_TEMPLATE}
-              heading={block.label}
-              reorderable={props.reorderable ?? false}
-              isFirst={index === 0}
-              isLast={index === rows.length - 1}
-              removable={!atMin}
-              onField={onField}
-              onRemove={onRemove}
-              onMove={onMove}
-            >
-              <input name={`${name}[${index}][type]`} type="hidden" value={block.type} />
-            </RowItem>
+            <Fragment key={index}>
+              <input
+                type="hidden"
+                name={`${name}[${index}][type]`}
+                value={String(row.type ?? "")}
+              />
+              {block ? (
+                <RowItem
+                  base={name}
+                  index={index}
+                  row={row}
+                  template={block.schema ?? EMPTY_TEMPLATE}
+                  heading={block.label}
+                  reorderable={props.reorderable ?? false}
+                  isFirst={index === 0}
+                  isLast={index === rows.length - 1}
+                  removable={!atMin}
+                  onField={onField}
+                  onRemove={onRemove}
+                  onMove={onMove}
+                />
+              ) : (
+                <div
+                  data-test={`repeater-${name}-row-${index}`}
+                  className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
+                >
+                  <span>Unknown block: {String(row.type)}</span>
+                  {!atMin && (
+                    <button
+                      type="button"
+                      aria-label="Remove"
+                      data-test={`repeater-${name}-remove-${index}`}
+                      className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+                      onClick={() => onRemove(index)}
+                    >
+                      <Icon name="trash-2" />
+                    </button>
+                  )}
+                </div>
+              )}
+            </Fragment>
           );
         })}
 

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -1,168 +1,25 @@
 import { Icon } from "@lattice/lattice/icons";
-import type { ReactNode } from "react";
-import { memo, useCallback } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
-import { RenderNode } from "@lattice/lattice/core/renderer";
 import { FormFieldFrame } from "../base/field";
-import { FieldScopeProvider } from "../field-scope";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
-import { useFormValue, useSetFormValue } from "../values";
-import { addRow, moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+import { RowItem } from "./row-item";
+import { useRowCollection } from "./use-row-collection";
 
 const EMPTY_TEMPLATE: Node[] = [];
-
-function RowButton({
-  label,
-  testId,
-  onClick,
-  children,
-}: {
-  label: string;
-  testId: string;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      data-test={testId}
-      className="text-lt-muted-fg hover:text-lt-fg"
-      onClick={onClick}
-    >
-      {children}
-    </button>
-  );
-}
-
-type RepeaterRowProps = {
-  base: string;
-  index: number;
-  row: RepeaterRow;
-  template: Node[];
-  reorderable: boolean;
-  isFirst: boolean;
-  isLast: boolean;
-  removable: boolean;
-  itemLabel: string | null;
-  onField: (index: number, field: string, value: unknown) => void;
-  onRemove: (index: number) => void;
-  onMove: (index: number, delta: number) => void;
-};
-
-// Memoised so editing one row doesn't re-render its siblings. Its props are kept
-// referentially stable by the parent: `row` survives untouched via functional
-// store updates, and the handlers are `useCallback`-stable.
-const RepeaterRowItem = memo(function RepeaterRowItem({
-  base,
-  index,
-  row,
-  template,
-  reorderable,
-  isFirst,
-  isLast,
-  removable,
-  itemLabel,
-  onField,
-  onRemove,
-  onMove,
-}: RepeaterRowProps) {
-  return (
-    <div
-      data-test={`repeater-${base}-row-${index}`}
-      className="rounded-lt border border-lt-border bg-lt-surface p-4"
-    >
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-sm font-medium text-lt-muted-fg">
-          {itemLabel ? `${itemLabel} ${index + 1}` : `#${index + 1}`}
-        </span>
-        <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
-          {reorderable && !isFirst && (
-            <RowButton
-              label="Move up"
-              testId={`repeater-${base}-up-${index}`}
-              onClick={() => onMove(index, -1)}
-            >
-              <Icon name="arrow-up" />
-            </RowButton>
-          )}
-          {reorderable && !isLast && (
-            <RowButton
-              label="Move down"
-              testId={`repeater-${base}-down-${index}`}
-              onClick={() => onMove(index, 1)}
-            >
-              <Icon name="arrow-down" />
-            </RowButton>
-          )}
-          {removable && (
-            <RowButton
-              label="Remove"
-              testId={`repeater-${base}-remove-${index}`}
-              onClick={() => onRemove(index)}
-            >
-              <Icon name="trash-2" />
-            </RowButton>
-          )}
-        </div>
-      </div>
-
-      <FieldScopeProvider
-        base={base}
-        index={index}
-        row={row}
-        onChange={(field, value) => onField(index, field, value)}
-      >
-        <div className="flex flex-col gap-4">
-          {template.map((child) => (
-            <RenderNode key={child.key ?? child.id} node={child} />
-          ))}
-        </div>
-      </FieldScopeProvider>
-    </div>
-  );
-});
 
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
   const name = props.name;
-  const defaultItems = props.defaultItems ?? 1;
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
-  const setValue = useSetFormValue();
-  const stored = useFormValue(name);
-  const rows: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
+  const { rows, onField, onRemove, onMove, append } = useRowCollection(
+    name,
+    props.defaultItems ?? 1,
+  );
   const template = node.schema ?? EMPTY_TEMPLATE;
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
-
-  // Functional store updates preserve the identity of untouched rows, which lets
-  // the memoised RepeaterRowItem skip re-rendering siblings on a single-row edit.
-  const mutate = useCallback(
-    (fn: (rows: RepeaterRow[]) => RepeaterRow[]): void => {
-      setValue(name, (prev: unknown) =>
-        fn(Array.isArray(prev) ? (prev as RepeaterRow[]) : seedRows(prev, defaultItems)),
-      );
-    },
-    [setValue, name, defaultItems],
-  );
-  const onField = useCallback(
-    (index: number, field: string, value: unknown): void => {
-      mutate((current) => current.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
-    },
-    [mutate],
-  );
-  const onRemove = useCallback(
-    (index: number): void => mutate((current) => removeRow(current, index)),
-    [mutate],
-  );
-  const onMove = useCallback(
-    (index: number, delta: number): void =>
-      mutate((current) => moveRow(current, index, index + delta)),
-    [mutate],
-  );
-  const onAdd = useCallback((): void => mutate(addRow), [mutate]);
 
   if (hidden) {
     return null;
@@ -178,17 +35,17 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
     >
       <div className="flex flex-col gap-3">
         {rows.map((row, index) => (
-          <RepeaterRowItem
+          <RowItem
             key={index}
             base={name}
             index={index}
             row={row}
             template={template}
+            heading={props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
             reorderable={props.reorderable ?? false}
             isFirst={index === 0}
             isLast={index === rows.length - 1}
             removable={!atMin}
-            itemLabel={props.itemLabel ?? null}
             onField={onField}
             onRemove={onRemove}
             onMove={onMove}
@@ -200,7 +57,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             type="button"
             data-test={`repeater-${name}-add`}
             className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
-            onClick={onAdd}
+            onClick={() => append({})}
           >
             <Icon name="plus" />
             {props.addLabel ?? "Add"}

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -43,7 +43,6 @@ export type RowItemProps = {
   onField: (index: number, field: string, value: unknown) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, delta: number) => void;
-  children?: ReactNode;
 };
 
 // Memoised so editing one row doesn't re-render its siblings. Its props are kept
@@ -62,7 +61,6 @@ export const RowItem = memo(function RowItem({
   onField,
   onRemove,
   onMove,
-  children,
 }: RowItemProps) {
   return (
     <div
@@ -108,7 +106,6 @@ export const RowItem = memo(function RowItem({
         row={row}
         onChange={(field, value) => onField(index, field, value)}
       >
-        {children}
         <div className="flex flex-col gap-4">
           {template.map((child) => (
             <RenderNode key={child.key ?? child.id} node={child} />

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -1,0 +1,117 @@
+import { Icon } from "@lattice/lattice/icons";
+import type { ReactNode } from "react";
+import { memo } from "react";
+import type { Node } from "@lattice/lattice/core/types";
+import { RenderNode } from "@lattice/lattice/core/renderer";
+import { FieldScopeProvider } from "../field-scope";
+import type { RepeaterRow } from "./repeater-rows";
+
+function RowButton({
+  label,
+  testId,
+  onClick,
+  children,
+}: {
+  label: string;
+  testId: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      data-test={testId}
+      className="text-lt-muted-fg hover:text-lt-fg"
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+export type RowItemProps = {
+  base: string;
+  index: number;
+  row: RepeaterRow;
+  template: Node[];
+  heading: string;
+  reorderable: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  removable: boolean;
+  onField: (index: number, field: string, value: unknown) => void;
+  onRemove: (index: number) => void;
+  onMove: (index: number, delta: number) => void;
+};
+
+// Memoised so editing one row doesn't re-render its siblings. Its props are kept
+// referentially stable by the parent: `row` survives untouched via functional
+// store updates, and the handlers are `useCallback`-stable.
+export const RowItem = memo(function RowItem({
+  base,
+  index,
+  row,
+  template,
+  heading,
+  reorderable,
+  isFirst,
+  isLast,
+  removable,
+  onField,
+  onRemove,
+  onMove,
+}: RowItemProps) {
+  return (
+    <div
+      data-test={`repeater-${base}-row-${index}`}
+      className="rounded-lt border border-lt-border bg-lt-surface p-4"
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-lt-muted-fg">{heading}</span>
+        <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
+          {reorderable && !isFirst && (
+            <RowButton
+              label="Move up"
+              testId={`repeater-${base}-up-${index}`}
+              onClick={() => onMove(index, -1)}
+            >
+              <Icon name="arrow-up" />
+            </RowButton>
+          )}
+          {reorderable && !isLast && (
+            <RowButton
+              label="Move down"
+              testId={`repeater-${base}-down-${index}`}
+              onClick={() => onMove(index, 1)}
+            >
+              <Icon name="arrow-down" />
+            </RowButton>
+          )}
+          {removable && (
+            <RowButton
+              label="Remove"
+              testId={`repeater-${base}-remove-${index}`}
+              onClick={() => onRemove(index)}
+            >
+              <Icon name="trash-2" />
+            </RowButton>
+          )}
+        </div>
+      </div>
+
+      <FieldScopeProvider
+        base={base}
+        index={index}
+        row={row}
+        onChange={(field, value) => onField(index, field, value)}
+      >
+        <div className="flex flex-col gap-4">
+          {template.map((child) => (
+            <RenderNode key={child.key ?? child.id} node={child} />
+          ))}
+        </div>
+      </FieldScopeProvider>
+    </div>
+  );
+});

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -43,6 +43,7 @@ export type RowItemProps = {
   onField: (index: number, field: string, value: unknown) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, delta: number) => void;
+  children?: ReactNode;
 };
 
 // Memoised so editing one row doesn't re-render its siblings. Its props are kept
@@ -61,6 +62,7 @@ export const RowItem = memo(function RowItem({
   onField,
   onRemove,
   onMove,
+  children,
 }: RowItemProps) {
   return (
     <div
@@ -106,6 +108,7 @@ export const RowItem = memo(function RowItem({
         row={row}
         onChange={(field, value) => onField(index, field, value)}
       >
+        {children}
         <div className="flex flex-col gap-4">
           {template.map((child) => (
             <RenderNode key={child.key ?? child.id} node={child} />

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { useFormValue, useSetFormValue } from "../values";
+import { moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+
+export type RowCollection = {
+  rows: RepeaterRow[];
+  onField: (index: number, field: string, value: unknown) => void;
+  onRemove: (index: number) => void;
+  onMove: (index: number, delta: number) => void;
+  append: (row: RepeaterRow) => void;
+};
+
+export function useRowCollection(name: string, defaultItems: number): RowCollection {
+  const setValue = useSetFormValue();
+  const stored = useFormValue(name);
+  const rows: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
+
+  // Functional store updates preserve the identity of untouched rows, which lets
+  // the memoised RowItem skip re-rendering siblings on a single-row edit.
+  const mutate = useCallback(
+    (fn: (rows: RepeaterRow[]) => RepeaterRow[]): void => {
+      setValue(name, (prev: unknown) =>
+        fn(Array.isArray(prev) ? (prev as RepeaterRow[]) : seedRows(prev, defaultItems)),
+      );
+    },
+    [setValue, name, defaultItems],
+  );
+
+  const onField = useCallback(
+    (index: number, field: string, value: unknown): void =>
+      mutate((current) => current.map((r, i) => (i === index ? { ...r, [field]: value } : r))),
+    [mutate],
+  );
+  const onRemove = useCallback(
+    (index: number): void => mutate((current) => removeRow(current, index)),
+    [mutate],
+  );
+  const onMove = useCallback(
+    (index: number, delta: number): void =>
+      mutate((current) => moveRow(current, index, index + delta)),
+    [mutate],
+  );
+  const append = useCallback(
+    (row: RepeaterRow): void => mutate((current) => [...current, row]),
+    [mutate],
+  );
+
+  return { rows, onField, onRemove, onMove, append };
+}

--- a/resources/js/form/components/index.ts
+++ b/resources/js/form/components/index.ts
@@ -1,3 +1,4 @@
+export { BuilderComponent } from "./fields/builder";
 export { CheckboxComponent } from "./fields/checkbox";
 export { ChoiceComponent } from "./fields/choice";
 export { DateInputComponent } from "./fields/date-input";

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -3,6 +3,7 @@ import type { RendererComponent, RendererComponentModule } from "@lattice/lattic
 import { FormSkeletonComponent } from "./skeleton";
 
 type FormComponentName =
+  | "BuilderComponent"
   | "CheckboxComponent"
   | "ChoiceComponent"
   | "DateInputComponent"
@@ -34,6 +35,7 @@ export const formComponents = createPlugin({
     form: lazyComponent(loadFormComponent("FormComponent"), {
       fallback: FormSkeletonComponent,
     }),
+    "form.builder": lazyComponent(loadFormComponent("BuilderComponent")),
     "form.checkbox": lazyComponent(loadFormComponent("CheckboxComponent")),
     "form.choice": lazyComponent(loadFormComponent("ChoiceComponent")),
     "form.date-input": lazyComponent(loadFormComponent("DateInputComponent")),

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -41,6 +41,29 @@ export type Badge = {
 export type BadgeColumnProps = {
   readonly colors: Record<string | number, string> | null;
 };
+export type Builder = {
+  addLabel: string | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  defaultItems: number;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  maxItems: number | null;
+  minItems: number | null;
+  name: string;
+  readOnly: boolean | null;
+  reorderable: boolean;
+  required: boolean | null;
+  value: unknown;
+};
 export type BulkAction = {
   confirmation: Confirmation | null;
   effects: Effect[];
@@ -311,6 +334,11 @@ export type Form = {
   validationTimeout: number | null;
 };
 export type FormFieldNode =
+  | {
+      type: "form.builder";
+      key?: string;
+      props: Builder;
+    }
   | {
       type: "form.checkbox";
       key?: string;

--- a/src/Forms/Components/Block.php
+++ b/src/Forms/Components/Block.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Illuminate\Support\Str;
+use JsonSerializable;
+use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
+
+final class Block implements JsonSerializable
+{
+    use HasChildSchema;
+
+    private ?string $label = null;
+
+    private function __construct(public readonly string $type) {}
+
+    public static function make(string $type): self
+    {
+        return new self($type);
+    }
+
+    public function label(string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, Field>
+     */
+    public function fields(): array
+    {
+        return array_values(array_filter(
+            $this->children,
+            static fn ($child): bool => $child instanceof Field,
+        ));
+    }
+
+    /**
+     * @return array{type: string, label: string, schema: array<int, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->type,
+            'label' => $this->label ?? Str::headline($this->type),
+            'schema' => $this->renderableChildren(),
+        ];
+    }
+}

--- a/src/Forms/Components/Builder.php
+++ b/src/Forms/Components/Builder.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Component;
+use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
+use Lattice\Lattice\Forms\FormData;
+
+#[Component('form.builder')]
+class Builder extends Field
+{
+    use HandlesRowSchemas;
+
+    /**
+     * @var array<int, Block>
+     */
+    protected array $blocks = [];
+
+    public ?int $minItems = null;
+
+    public ?int $maxItems = null;
+
+    public bool $reorderable = true;
+
+    public ?string $addLabel = null;
+
+    public int $defaultItems = 0;
+
+    /**
+     * @param  array<int, Block>  $blocks
+     */
+    public function blocks(array $blocks): static
+    {
+        $this->blocks = $blocks;
+
+        return $this;
+    }
+
+    public function minItems(int $min): static
+    {
+        $this->minItems = $min;
+
+        return $this;
+    }
+
+    public function maxItems(int $max): static
+    {
+        $this->maxItems = $max;
+
+        return $this;
+    }
+
+    public function reorderable(bool $reorderable = true): static
+    {
+        $this->reorderable = $reorderable;
+
+        return $this;
+    }
+
+    public function addLabel(string $label): static
+    {
+        $this->addLabel = $label;
+
+        return $this;
+    }
+
+    /**
+     * The builder value is always an array; array-level rules live here so they
+     * are not clobbered by the nested per-row rules (which use per-index keys).
+     *
+     * @return array<int, mixed>
+     */
+    public function resolveRules(FormData $data, Request $request): array
+    {
+        $rules = ['array'];
+
+        if ($this->minItems !== null) {
+            $rules[] = "min:{$this->minItems}";
+        }
+
+        if ($this->maxItems !== null) {
+            $rules[] = "max:{$this->maxItems}";
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<int, Field>
+     */
+    protected function rowFields(array $row): array
+    {
+        $type = is_string($row['type'] ?? null) ? $row['type'] : null;
+
+        foreach ($this->blocks as $block) {
+            if ($block->type === $type) {
+                return $block->fields();
+            }
+        }
+
+        return [];
+    }
+
+    public function nestedRules(FormData $data, Request $request): array
+    {
+        $rows = $data->get($this->name);
+        $rows = is_array($rows) ? $rows : [];
+
+        $rules = $this->rowRules($this->name, $rows, $data, $request);
+
+        $types = array_map(static fn (Block $block): string => $block->type, $this->blocks);
+
+        foreach (array_keys($rows) as $index) {
+            $rules["{$this->name}.{$index}.type"] = ['required', 'in:'.implode(',', $types)];
+        }
+
+        return $rules;
+    }
+
+    public function castValue(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $cast = $this->castRows($value);
+        $rows = array_values($value);
+
+        return array_map(function ($castRow, $original) {
+            if (is_array($original) && isset($original['type'])) {
+                return ['type' => $original['type']] + $castRow;
+            }
+
+            return $castRow;
+        }, $cast, $rows);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 300)]
+    protected function serialiseBlocks(array $data): array
+    {
+        return [...$data, 'blocks' => $this->blocks];
+    }
+}

--- a/src/Forms/Components/Concerns/HandlesRowSchemas.php
+++ b/src/Forms/Components/Concerns/HandlesRowSchemas.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Lattice\Lattice\Forms\Components\Concerns;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\FormData;
+
+/**
+ * Per-row validation + casting for array-valued fields whose rows each render a
+ * schema of child Fields. Implementers supply the template for a given row.
+ */
+trait HandlesRowSchemas
+{
+    /**
+     * The child Fields that validate/cast the given submitted row. Repeater
+     * returns a fixed schema; Builder resolves the block matching the row's type.
+     *
+     * @param  array<string, mixed>  $row
+     * @return array<int, Field>
+     */
+    abstract protected function rowFields(array $row): array;
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<string, array<int, mixed>>
+     */
+    protected function rowRules(string $name, array $rows, FormData $data, Request $request): array
+    {
+        $rules = [];
+
+        foreach ($rows as $index => $row) {
+            $row = is_array($row) ? $row : [];
+
+            foreach ($this->rowFields($row) as $child) {
+                $childRules = $child->resolvedRulesWithRequired($data, $request);
+
+                if ($childRules !== []) {
+                    $rules["{$name}.{$index}.{$child->name()}"] = $childRules;
+                }
+            }
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function castRows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map(function ($row): array {
+            $row = is_array($row) ? $row : [];
+            $cast = [];
+
+            foreach ($this->rowFields($row) as $child) {
+                $name = $child->name();
+                $cast[$name] = $child->castValue($row[$name] ?? null);
+            }
+
+            return $cast;
+        }, $value));
+    }
+}

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -86,7 +86,7 @@ class Repeater extends Field
 
     /**
      * The repeater value is always an array; array-level rules live here so they
-     * are not clobbered by the nested per-row rules (which use `items.*.x` keys).
+     * are not clobbered by the nested per-row rules (which use per-index keys).
      *
      * @return array<int, mixed>
      */

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -6,11 +6,13 @@ use Closure;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
+use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.repeater')]
 class Repeater extends Field
 {
+    use HandlesRowSchemas;
     use HasChildSchema;
 
     public ?int $minItems = null;
@@ -104,48 +106,24 @@ class Repeater extends Field
     }
 
     /**
-     * Per-row rules: each child field's rules applied to every row via the
-     * `<name>.*.<child>` wildcard. Never emits the bare `<name>` key (that would
-     * overwrite resolveRules()'s array-level rules in FieldValidator).
-     *
-     * @return array<string, array<int, mixed>>
+     * @param  array<string, mixed>  $row
+     * @return array<int, Field>
      */
-    public function nestedRules(FormData $data, Request $request): array
+    protected function rowFields(array $row): array
     {
-        $rules = [];
-
-        foreach ($this->childFields() as $child) {
-            $childRules = $child->resolvedRulesWithRequired($data, $request);
-
-            if ($childRules !== []) {
-                $rules["{$this->name}.*.{$child->name()}"] = $childRules;
-            }
-        }
-
-        return $rules;
+        return $this->childFields();
     }
 
-    /**
-     * Normalise the validated value to a re-indexed list of rows, each row's
-     * cells cast through the matching child field's castValue().
-     */
+    public function nestedRules(FormData $data, Request $request): array
+    {
+        $rows = $data->get($this->name);
+        $rows = is_array($rows) ? $rows : [];
+
+        return $this->rowRules($this->name, $rows, $data, $request);
+    }
+
     public function castValue(mixed $value): mixed
     {
-        if (! is_array($value)) {
-            return [];
-        }
-
-        $children = $this->childFields();
-
-        return array_values(array_map(function ($row) use ($children): array {
-            $cast = [];
-
-            foreach ($children as $child) {
-                $name = $child->name();
-                $cast[$name] = $child->castValue(is_array($row) ? ($row[$name] ?? null) : null);
-            }
-
-            return $cast;
-        }, $value));
+        return $this->castRows($value);
     }
 }

--- a/tests/Browser/Forms/BuilderTest.php
+++ b/tests/Browser/Forms/BuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+it('adds heterogeneous blocks and submits a typed payload', function (): void {
+    visit('/builder')
+        ->assertSee('Builder Demo')
+        ->assertSee('Line items')
+        ->click('@builder-add')
+        ->click('@builder-add-text')
+        ->fill('textarea[name="items[0][content]"]', 'Intro line')
+        ->click('@builder-add')
+        ->click('@builder-add-product')
+        ->fill('input[name="items[1][product]"]', 'SKU-1')
+        ->fill('input[name="items[1][qty]"]', '3')
+        ->fill('input[name="items[1][price]"]', '9.50')
+        ->click('Save')
+        ->assertSee('Builder Demo')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});
+
+it('surfaces a per-row required error for the active block', function (): void {
+    visit('/builder')
+        ->assertSee('Builder Demo')
+        ->click('@builder-add')
+        ->click('@builder-add-product')
+        ->click('Save')
+        ->assertSee('The items.0.product field is required.')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/BlockWireShapeTest.php
+++ b/tests/Feature/BlockWireShapeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+it('serialises a block as type + label + schema', function (): void {
+    $wire = json_decode(json_encode(
+        Block::make('product')->label('Product line')->schema([TextInput::make('qty')])
+    ), true);
+
+    expect($wire['type'])->toBe('product')
+        ->and($wire['label'])->toBe('Product line')
+        ->and($wire['schema'])->toHaveCount(1)
+        ->and($wire['schema'][0]['type'])->toBe('form.text-input')
+        ->and($wire['schema'][0]['props']['name'])->toBe('qty');
+});
+
+it('defaults the label to a title-cased type', function (): void {
+    $wire = json_decode(json_encode(Block::make('product')->schema([])), true);
+
+    expect($wire['label'])->toBe('Product');
+});

--- a/tests/Feature/BuilderValidationTest.php
+++ b/tests/Feature/BuilderValidationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FieldValidator;
+
+function builderField(): Builder
+{
+    return Builder::make('items')
+        ->blocks([
+            Block::make('text')->schema([Textarea::make('content')->required()]),
+            Block::make('product')->schema([
+                TextInput::make('product')->required(),
+                TextInput::make('qty')->rules(['numeric']),
+            ]),
+        ])
+        ->minItems(1);
+}
+
+it('validates each row against its own block', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'text', 'content' => 'Intro'],
+        ['type' => 'product', 'product' => 'SKU-1', 'qty' => '2'],
+    ]]);
+
+    $validated = (new FieldValidator)->validate([builderField()], $request);
+
+    expect($validated['items'])->toBe([
+        ['type' => 'text', 'content' => 'Intro'],
+        ['type' => 'product', 'product' => 'SKU-1', 'qty' => '2'],
+    ]);
+});
+
+it('rejects a product row missing its required product', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'product', 'product' => '', 'qty' => '1'],
+    ]]);
+
+    (new FieldValidator)->validate([builderField()], $request);
+})->throws(ValidationException::class);
+
+it('rejects an unknown block type', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'video', 'src' => 'x'],
+    ]]);
+
+    (new FieldValidator)->validate([builderField()], $request);
+})->throws(ValidationException::class);
+
+it('does not require a text row to satisfy product rules', function (): void {
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'text', 'content' => 'Just text'],
+    ]]);
+
+    $validated = (new FieldValidator)->validate([builderField()], $request);
+
+    expect($validated['items'][0]['type'])->toBe('text');
+});

--- a/tests/Feature/BuilderWireShapeTest.php
+++ b/tests/Feature/BuilderWireShapeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+it('serialises a builder with its blocks and props', function (): void {
+    $wire = json_decode(json_encode(
+        Builder::make('items', 'Line items')
+            ->blocks([
+                Block::make('text')->label('Text')->schema([Textarea::make('content')]),
+                Block::make('product')->label('Product line')->schema([TextInput::make('qty')]),
+            ])
+            ->minItems(1)
+            ->maxItems(20)
+            ->addLabel('Add block')
+    ), true);
+
+    expect($wire['type'])->toBe('form.builder')
+        ->and($wire['props']['name'])->toBe('items')
+        ->and($wire['props']['minItems'])->toBe(1)
+        ->and($wire['props']['maxItems'])->toBe(20)
+        ->and($wire['props']['reorderable'])->toBeTrue()
+        ->and($wire['props']['addLabel'])->toBe('Add block')
+        ->and($wire['blocks'])->toHaveCount(2)
+        ->and($wire['blocks'][0]['type'])->toBe('text')
+        ->and($wire['blocks'][1]['type'])->toBe('product')
+        ->and($wire['blocks'][1]['schema'][0]['props']['name'])->toBe('qty');
+});

--- a/tests/Unit/BuilderDocsTest.php
+++ b/tests/Unit/BuilderDocsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+describe('docs fixtures', function (): void {
+    it('dumps the builder example', function (): void {
+        dumpFixture('builder.basic', [
+            Builder::make('items', 'Line items')
+                ->blocks([
+                    Block::make('text')->label('Text')->schema([
+                        Textarea::make('content', 'Content')->required(),
+                    ]),
+                    Block::make('product')->label('Product line')->schema([
+                        TextInput::make('product', 'Product')->required(),
+                        TextInput::make('qty', 'Qty')->rules(['numeric']),
+                        TextInput::make('price', 'Price')->rules(['numeric']),
+                    ]),
+                ])
+                ->minItems(1)
+                ->addLabel('Add block'),
+        ]);
+
+        expect('docs/fixtures/builder.basic.json')->toBeReadableFile();
+    });
+});

--- a/workbench/app/Forms/BuilderDemoForm.php
+++ b/workbench/app/Forms/BuilderDemoForm.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Forms;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Core\Components\Card;
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Form('workbench.builder.form')]
+class BuilderDemoForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form
+            ->precognitive(300)
+            ->schema([
+                Card::make('Line items')->schema([
+                    Builder::make('items', 'Line items')
+                        ->blocks([
+                            Block::make('text')->label('Text')->schema([
+                                Textarea::make('content', 'Content')->required(),
+                            ]),
+                            Block::make('product')->label('Product line')->schema([
+                                TextInput::make('product', 'Product')->required(),
+                                TextInput::make('qty', 'Qty')->rules(['numeric']),
+                                TextInput::make('price', 'Price')->rules(['numeric']),
+                            ]),
+                        ])
+                        ->minItems(1)
+                        ->addLabel('Add block'),
+                ]),
+            ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $this->validate($request);
+
+        return redirect('/builder');
+    }
+}

--- a/workbench/app/Pages/BuilderDemoPage.php
+++ b/workbench/app/Pages/BuilderDemoPage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Forms\Components\Form;
+use Workbench\App\Forms\BuilderDemoForm;
+
+class BuilderDemoPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Builder Demo';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('builder-demo-page')
+                ->gap(Gap::Large)
+                ->schema([
+                    Heading::make('Builder Demo'),
+                    Form::use(BuilderDemoForm::class)
+                        ->method(HttpMethod::Post)
+                        ->submitLabel('Save'),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -19,6 +19,7 @@ use Workbench\App\Actions\ArchiveSelectedProductsAction;
 use Workbench\App\Actions\EditProductAction;
 use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
+use Workbench\App\Forms\BuilderDemoForm;
 use Workbench\App\Forms\DependentDemoForm;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Forms\RepeaterDemoForm;
@@ -122,6 +123,7 @@ class WorkbenchServiceProvider extends ServiceProvider
         ]);
 
         Lattice::forms([
+            BuilderDemoForm::class,
             DependentDemoForm::class,
             ProductForm::class,
             RepeaterDemoForm::class,

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Workbench\App\Pages\BuilderDemoPage;
 use Workbench\App\Pages\DependentDemoPage;
 use Workbench\App\Pages\HomePage;
 use Workbench\App\Pages\ProductCreatePage;
@@ -36,6 +37,9 @@ Route::latticePage('/dependent-demo', DependentDemoPage::class)
 
 Route::latticePage('/repeater', RepeaterDemoPage::class)
     ->name('repeater');
+
+Route::latticePage('/builder', BuilderDemoPage::class)
+    ->name('builder');
 
 Route::latticePage('/showcase', ShowcasePage::class)
     ->name('showcase');


### PR DESCRIPTION
## Summary

A `Builder` form field — a **polymorphic repeater** whose rows can each be a different consumer-defined **block type**, each with its own schema and an automatic, hidden `type` discriminator. Foundation for line-items / page-builder editors.

```php
Builder::make('items', 'Line items')
    ->blocks([
        Block::make('text')->label('Text')->schema([
            Textarea::make('content', 'Content')->required(),
        ]),
        Block::make('product')->label('Product line')->schema([
            Select::make('product')->searchable(...)->required(),
            TextInput::make('qty')->rules(['numeric']),
            TextInput::make('price')->rules(['numeric']),
        ]),
    ])
    ->minItems(1)
    ->addLabel('Add block');
```

## How it works

- **Reuse over duplication.** The Repeater's per-row mechanics were extracted into a shared `HandlesRowSchemas` PHP concern and a shared `useRowCollection` hook + memoised `RowItem` React component. The Builder is a thin polymorphic layer on top — it only adds "pick the row template by `type`" + an add-menu. The Repeater is unchanged (its suites, incl. the sibling-render memo test, stay green).
- **Blocks.** `Block::make(type)->label()->schema([...])` serialises as `{type, label, schema}` under a `blocks` wire key. An add-menu (Radix popover) inserts a blank row carrying just the `type`.
- **Hidden discriminator.** `type` is never a rendered field; it's injected on add and submitted via a hidden `items[i][type]` input (rendered as a *sibling* of the memoised row so the per-row re-render optimization holds).
- **Per-type validation.** Each submitted row is validated against the block matching its `type` (per-index `items.{i}.{field}` rules); unknown/forged types are rejected. Casting preserves `type`.
- **Robustness.** Unknown-block rows (a type removed from config) render a placeholder with a working remove button.

## Test plan

- [x] PHP feature: Block + Builder wire shape; heterogeneous per-row validation (text vs product at correct indices, unknown-type rejected, no cross-type contamination) — `composer test` 403 passed
- [x] vitest: per-type template render, add-of-chosen-type, unknown-block placeholder + removal, Builder sibling-render memo guard — 243 passed
- [x] Pest **browser**: heterogeneous `{type,…}` rows round-trip through Inertia + per-type server validation (`items.0.product` error) — 47 passed
- [x] lint / types / format / pint — all clean

## Not in this PR (next, by design)

The **table layout modifier** (columnar rows + shared header from the primary block, full-width spanning rows for other block types, reorder on the left, a remove action / ⋯-menu on the right), the **FLIP reorder slide animation** (+ stable row keys, which also fixes the pre-existing `key={index}` state-migration footgun), and the **customer-aware price prefill** (the `resolvePrefill` editable-computed-default capability) are deliberately deferred to follow-up work.