### PR TITLE
feat: line-items table layout, reorder animation, and row actions

### DIFF
--- a/docs/content/docs/forms/fields/builder.mdx
+++ b/docs/content/docs/forms/fields/builder.mdx
@@ -89,6 +89,33 @@ Builder::make('items', 'Line items')
     ->reorderable(false);
 ```
 
+## Table layout
+
+Rows stack by default — each row is a full block of stacked fields. Call `->table()` to lay rows out
+as a table instead. The columns come from the first block's schema, a shared header of those field
+labels sits above the rows, and each cell renders the input alone (the field's own label moves up into
+the header). A row of any other block type spans the full width below the header rather than fitting
+the columns.
+
+```php
+Builder::make('items', 'Line items')
+    ->blocks([
+        Block::make('product')->label('Product line')->schema([
+            TextInput::make('product', 'Product'),
+            TextInput::make('qty', 'Qty')->rules(['numeric']),
+        ]),
+        Block::make('text')->label('Text')->schema([
+            Textarea::make('content', 'Content'),
+        ]),
+    ])
+    ->table();
+```
+
+Reorder controls (↑↓) sit on the left of each row and the remove action on the right; once a row
+carries more than one action they collapse into a ⋯ menu. Reordering slides each row to its new
+position, and the table scrolls horizontally on narrow screens. The slide animation is skipped when
+the viewer prefers reduced motion.
+
 ## Validation
 
 Each row is validated against the schema of its own block: a child marked `->required()` is required
@@ -103,7 +130,7 @@ These are follow-ups, not part of the first release:
 
 - Built-in image and subtotal blocks.
 - Nested builders (a builder inside a builder row).
-- The table layout modifier and customer-aware price prefill — tracked as separate upcoming work.
+- Customer-aware price prefill — tracked as separate upcoming work.
 
 ## Common options
 

--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -58,6 +58,26 @@ Repeater::make('items', 'Line items')
     ->reorderable(false);
 ```
 
+## Table layout
+
+Rows stack by default — each row is a full block of stacked fields. Call `->table()` to lay rows out
+as a table instead: the schema fields become columns, a shared header of the field labels sits above
+the rows, and each cell renders the input alone (the field's own label moves up into the header).
+
+```php
+Repeater::make('items', 'Line items')
+    ->schema([
+        TextInput::make('name', 'Name'),
+        TextInput::make('qty', 'Qty')->rules(['numeric']),
+    ])
+    ->table();
+```
+
+Reorder controls (↑↓) sit on the left of each row and the remove action on the right; once a row
+carries more than one action they collapse into a ⋯ menu. Reordering slides each row to its new
+position, and the table scrolls horizontally on narrow screens. The slide animation is skipped when
+the viewer prefers reduced motion.
+
 ## Labels
 
 `->addLabel()` sets the text on the button that appends a row (default "Add"). `->itemLabel()` sets a

--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -107,6 +107,7 @@
             "helperText": null,
             "hidden": null,
             "label": "Line items",
+            "layout": "stack",
             "maxItems": null,
             "minItems": 1,
             "name": "items",

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -11,6 +11,7 @@
             "hidden": null,
             "itemLabel": null,
             "label": "Line items",
+            "layout": "stack",
             "maxItems": 5,
             "minItems": 1,
             "name": "items",

--- a/resources/js/form/components/base/field.test.tsx
+++ b/resources/js/form/components/base/field.test.tsx
@@ -13,14 +13,19 @@ it("renders the label and error in normal (stack) context", () => {
   expect(screen.getByText("bad")).toBeInTheDocument();
 });
 
-it("omits the label but keeps the error inside a table cell", () => {
+it("keeps a visually-hidden accessible label inside a table cell", () => {
   render(
     <TableCellProvider>
       <FormFieldFrame label="Qty" name="qty" error="bad">
-        <input aria-label="qty" />
+        {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+        <input id="qty" />
       </FormFieldFrame>
     </TableCellProvider>,
   );
-  expect(screen.queryByText("Qty")).not.toBeInTheDocument();
+  // input is accessibly labeled via the sr-only <label for="qty">
+  expect(screen.getByLabelText("Qty")).toBeInTheDocument();
+  // the error still renders
   expect(screen.getByText("bad")).toBeInTheDocument();
+  // the label is visually hidden
+  expect(screen.getByText("Qty")).toHaveClass("sr-only");
 });

--- a/resources/js/form/components/base/field.test.tsx
+++ b/resources/js/form/components/base/field.test.tsx
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormFieldFrame } from "./field";
+import { TableCellProvider } from "../row-layout-context";
+
+it("renders the label and error in normal (stack) context", () => {
+  render(
+    <FormFieldFrame label="Qty" name="qty" error="bad">
+      <input aria-label="qty" />
+    </FormFieldFrame>,
+  );
+  expect(screen.getByText("Qty")).toBeInTheDocument();
+  expect(screen.getByText("bad")).toBeInTheDocument();
+});
+
+it("omits the label but keeps the error inside a table cell", () => {
+  render(
+    <TableCellProvider>
+      <FormFieldFrame label="Qty" name="qty" error="bad">
+        <input aria-label="qty" />
+      </FormFieldFrame>
+    </TableCellProvider>,
+  );
+  expect(screen.queryByText("Qty")).not.toBeInTheDocument();
+  expect(screen.getByText("bad")).toBeInTheDocument();
+});

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -26,6 +26,9 @@ export function FormFieldFrame({
   if (bare) {
     return (
       <div className="grid gap-1">
+        <Label htmlFor={name} className="sr-only">
+          {label}
+        </Label>
         {children}
         <InputError message={error} />
       </div>

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -1,6 +1,7 @@
 import InputError from "@lattice/lattice/form/components/base/input-error";
 import { TextLink } from "@lattice/lattice/core/components/link";
 import { Label } from "@lattice/lattice/form/components/base/label";
+import { useInTableCell } from "../row-layout-context";
 import type { FormLabelAction } from "../types";
 
 export function FormFieldFrame({
@@ -20,6 +21,17 @@ export function FormFieldFrame({
   name: string;
   required?: boolean;
 }) {
+  const bare = useInTableCell();
+
+  if (bare) {
+    return (
+      <div className="grid gap-1">
+        {children}
+        <InputError message={error} />
+      </div>
+    );
+  }
+
   return (
     <div className="grid gap-2">
       <div className="flex min-h-5 items-center">

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -113,6 +113,50 @@ it("can remove an unknown-block row", () => {
   expect(screen.queryByText(/Unknown block/i)).not.toBeInTheDocument();
 });
 
+it("renders the table layout: primary columns, spanning non-primary rows", () => {
+  const node = {
+    id: "b",
+    type: "form.builder",
+    props: {
+      name: "items",
+      layout: "table",
+      reorderable: true,
+      defaultItems: 0,
+      addLabel: "Add block",
+      minItems: 0,
+      maxItems: 9,
+    },
+    blocks: [
+      {
+        type: "product",
+        label: "Product",
+        schema: [
+          { id: "p", type: "form.text-input", props: { name: "product", label: "Product" } },
+          { id: "q", type: "form.text-input", props: { name: "qty", label: "Qty" } },
+        ],
+      },
+      {
+        type: "text",
+        label: "Text",
+        schema: [{ id: "c", type: "form.textarea", props: { name: "content", label: "Content" } }],
+      },
+    ],
+  } as never;
+  wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, {
+    items: [
+      { type: "product", product: "SKU", qty: "2" },
+      { type: "text", content: "note" },
+    ],
+  });
+  expect(screen.getByText("Product")).toBeInTheDocument();
+  expect(screen.getByText("Qty")).toBeInTheDocument();
+  const texts = screen.getAllByTestId("child").map((c) => c.textContent);
+  expect(texts).toContain("items[0][product]");
+  expect(texts).toContain("items[0][qty]");
+  expect(texts).toContain("items[1][content]");
+  expect(screen.getByTestId("table-row-items-1-span")).toBeInTheDocument();
+});
+
 it("does not re-render sibling rows when one row changes", () => {
   wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, {
     items: [

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -6,13 +6,11 @@ import { useDependentField } from "../use-dependent-field";
 import { BlockAddMenu, type BlockOption } from "./block-add-menu";
 import { ROW_ID_KEY } from "./repeater-rows";
 import { RowItem } from "./row-item";
-import { TableRows } from "./table-rows";
+import { columnsFromSchema, TableRows } from "./table-rows";
 import { useFlipReorder } from "./use-flip-reorder";
 import { useRowCollection } from "./use-row-collection";
 
 type Block = { type: string; label: string; schema: Node[] };
-
-type FieldProps = { name: string; label?: string };
 
 const EMPTY_TEMPLATE: Node[] = [];
 
@@ -51,56 +49,18 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
     />
   ));
 
-  if (isTable) {
-    const primary = blocks[0];
-    const columns = (primary?.schema ?? []).map((field) => {
-      const fieldProps = field.props as FieldProps;
-      return { name: String(fieldProps.name), label: String(fieldProps.label ?? fieldProps.name) };
-    });
-    const tableRows = rows.map((row, index) => {
-      const block = blockFor(row.type);
-      const isPrimary = !!block && !!primary && block.type === primary.type;
-      return {
-        key: String(row[ROW_ID_KEY] ?? index),
-        index,
-        row,
-        template: block?.schema ?? EMPTY_TEMPLATE,
-        span: !isPrimary,
-      };
-    });
-
-    return (
-      <FormFieldFrame
-        error={errors[name]}
-        helperText={props.helperText ?? undefined}
-        label={props.label ?? ""}
-        name={name}
-        required={required}
-      >
-        <div className="flex flex-col gap-3">
-          {hiddenTypeInputs}
-          <TableRows
-            base={name}
-            columns={columns}
-            rows={tableRows}
-            reorderable={props.reorderable ?? false}
-            removable={() => !atMin}
-            onField={onField}
-            onMove={onMove}
-            onRemove={onRemove}
-            registerRow={registerRow}
-          />
-          {!atMax && (
-            <BlockAddMenu
-              addLabel={props.addLabel ?? "Add"}
-              blocks={options}
-              onSelect={(type) => append({ type })}
-            />
-          )}
-        </div>
-      </FormFieldFrame>
-    );
-  }
+  const primary = blocks[0];
+  const tableRows = rows.map((row, index) => {
+    const block = blockFor(row.type);
+    const isPrimary = !!block && !!primary && block.type === primary.type;
+    return {
+      key: String(row[ROW_ID_KEY] ?? index),
+      index,
+      row,
+      template: block?.schema ?? EMPTY_TEMPLATE,
+      span: !isPrimary,
+    };
+  });
 
   return (
     <FormFieldFrame
@@ -111,54 +71,71 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
       required={required}
     >
       <div className="flex flex-col gap-3">
-        {rows.map((row, index) => {
-          const block = blockFor(row.type);
-          const key = String(row[ROW_ID_KEY] ?? index);
+        {isTable ? (
+          <>
+            {hiddenTypeInputs}
+            <TableRows
+              base={name}
+              columns={columnsFromSchema(primary?.schema ?? [])}
+              rows={tableRows}
+              reorderable={props.reorderable ?? false}
+              removable={() => !atMin}
+              onField={onField}
+              onMove={onMove}
+              onRemove={onRemove}
+              registerRow={registerRow}
+            />
+          </>
+        ) : (
+          rows.map((row, index) => {
+            const block = blockFor(row.type);
+            const key = String(row[ROW_ID_KEY] ?? index);
 
-          return (
-            <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
-              <input
-                type="hidden"
-                name={`${name}[${index}][type]`}
-                value={String(row.type ?? "")}
-              />
-              {block ? (
-                <RowItem
-                  base={name}
-                  index={index}
-                  row={row}
-                  template={block.schema ?? EMPTY_TEMPLATE}
-                  heading={block.label}
-                  reorderable={props.reorderable ?? false}
-                  isFirst={index === 0}
-                  isLast={index === rows.length - 1}
-                  removable={!atMin}
-                  onField={onField}
-                  onRemove={onRemove}
-                  onMove={onMove}
+            return (
+              <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
+                <input
+                  type="hidden"
+                  name={`${name}[${index}][type]`}
+                  value={String(row.type ?? "")}
                 />
-              ) : (
-                <div
-                  data-test={`repeater-${name}-row-${index}`}
-                  className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
-                >
-                  <span>Unknown block: {String(row.type)}</span>
-                  {!atMin && (
-                    <button
-                      type="button"
-                      aria-label="Remove"
-                      data-test={`repeater-${name}-remove-${index}`}
-                      className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
-                      onClick={() => onRemove(index)}
-                    >
-                      <Icon name="trash-2" />
-                    </button>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
+                {block ? (
+                  <RowItem
+                    base={name}
+                    index={index}
+                    row={row}
+                    template={block.schema ?? EMPTY_TEMPLATE}
+                    heading={block.label}
+                    reorderable={props.reorderable ?? false}
+                    isFirst={index === 0}
+                    isLast={index === rows.length - 1}
+                    removable={!atMin}
+                    onField={onField}
+                    onRemove={onRemove}
+                    onMove={onMove}
+                  />
+                ) : (
+                  <div
+                    data-test={`repeater-${name}-row-${index}`}
+                    className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
+                  >
+                    <span>Unknown block: {String(row.type)}</span>
+                    {!atMin && (
+                      <button
+                        type="button"
+                        aria-label="Remove"
+                        data-test={`repeater-${name}-remove-${index}`}
+                        className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+                        onClick={() => onRemove(index)}
+                      >
+                        <Icon name="trash-2" />
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
 
         {!atMax && (
           <BlockAddMenu

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -1,11 +1,12 @@
-import { Fragment } from "react";
 import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { Icon } from "@lattice/lattice/icons";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { BlockAddMenu, type BlockOption } from "./block-add-menu";
+import { ROW_ID_KEY } from "./repeater-rows";
 import { RowItem } from "./row-item";
+import { useFlipReorder } from "./use-flip-reorder";
 import { useRowCollection } from "./use-row-collection";
 
 type Block = { type: string; label: string; schema: Node[] };
@@ -22,6 +23,8 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
     name,
     props.defaultItems ?? 0,
   );
+  const orderSignature = rows.map((r) => String(r[ROW_ID_KEY] ?? "")).join(",");
+  const registerRow = useFlipReorder(orderSignature);
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
 
@@ -46,9 +49,10 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
       <div className="flex flex-col gap-3">
         {rows.map((row, index) => {
           const block = blockFor(row.type);
+          const key = String(row[ROW_ID_KEY] ?? index);
 
           return (
-            <Fragment key={index}>
+            <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
               <input
                 type="hidden"
                 name={`${name}[${index}][type]`}
@@ -88,7 +92,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
                   )}
                 </div>
               )}
-            </Fragment>
+            </div>
           );
         })}
 

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -6,10 +6,13 @@ import { useDependentField } from "../use-dependent-field";
 import { BlockAddMenu, type BlockOption } from "./block-add-menu";
 import { ROW_ID_KEY } from "./repeater-rows";
 import { RowItem } from "./row-item";
+import { TableRows } from "./table-rows";
 import { useFlipReorder } from "./use-flip-reorder";
 import { useRowCollection } from "./use-row-collection";
 
 type Block = { type: string; label: string; schema: Node[] };
+
+type FieldProps = { name: string; label?: string };
 
 const EMPTY_TEMPLATE: Node[] = [];
 
@@ -27,6 +30,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
   const registerRow = useFlipReorder(orderSignature);
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
+  const isTable = props.layout === "table";
 
   const blockFor = (type: unknown): Block | undefined => blocks.find((b) => b.type === type);
   const options: BlockOption[] = blocks.map((b) => ({
@@ -36,6 +40,66 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
 
   if (hidden) {
     return null;
+  }
+
+  const hiddenTypeInputs = rows.map((row, index) => (
+    <input
+      key={String(row[ROW_ID_KEY] ?? index)}
+      type="hidden"
+      name={`${name}[${index}][type]`}
+      value={String(row.type ?? "")}
+    />
+  ));
+
+  if (isTable) {
+    const primary = blocks[0];
+    const columns = (primary?.schema ?? []).map((field) => {
+      const fieldProps = field.props as FieldProps;
+      return { name: String(fieldProps.name), label: String(fieldProps.label ?? fieldProps.name) };
+    });
+    const tableRows = rows.map((row, index) => {
+      const block = blockFor(row.type);
+      const isPrimary = !!block && !!primary && block.type === primary.type;
+      return {
+        key: String(row[ROW_ID_KEY] ?? index),
+        index,
+        row,
+        template: block?.schema ?? EMPTY_TEMPLATE,
+        span: !isPrimary,
+      };
+    });
+
+    return (
+      <FormFieldFrame
+        error={errors[name]}
+        helperText={props.helperText ?? undefined}
+        label={props.label ?? ""}
+        name={name}
+        required={required}
+      >
+        <div className="flex flex-col gap-3">
+          {hiddenTypeInputs}
+          <TableRows
+            base={name}
+            columns={columns}
+            rows={tableRows}
+            reorderable={props.reorderable ?? false}
+            removable={() => !atMin}
+            onField={onField}
+            onMove={onMove}
+            onRemove={onRemove}
+            registerRow={registerRow}
+          />
+          {!atMax && (
+            <BlockAddMenu
+              addLabel={props.addLabel ?? "Add"}
+              blocks={options}
+              onSelect={(type) => append({ type })}
+            />
+          )}
+        </div>
+      </FormFieldFrame>
+    );
   }
 
   return (

--- a/resources/js/form/components/fields/repeater-rows.test.ts
+++ b/resources/js/form/components/fields/repeater-rows.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { addRow, moveRow, removeRow, seedRows } from "./repeater-rows";
+import { ensureRowIds, ROW_ID_KEY, withRowId } from "./repeater-rows";
 
 it("seeds rows from an existing value", () => {
   expect(seedRows([{ name: "a" }], 3)).toEqual([{ name: "a" }]);
@@ -41,4 +42,29 @@ it("does not mutate the input array", () => {
   removeRow(rows, 0);
   moveRow(rows, 0, 1);
   expect(rows).toEqual([{ n: 0 }, { n: 1 }]);
+});
+
+it("stamps a unique stable id via withRowId", () => {
+  const a = withRowId({ name: "x" });
+  const b = withRowId({ name: "y" });
+  expect(typeof a[ROW_ID_KEY]).toBe("string");
+  expect(a[ROW_ID_KEY]).not.toBe(b[ROW_ID_KEY]);
+  expect(a.name).toBe("x");
+});
+
+it("withRowId is a no-op when the row already has an id", () => {
+  const a = withRowId({ name: "x" });
+  expect(withRowId(a)).toBe(a);
+});
+
+it("ensureRowIds adds ids only to rows missing one, preserving existing ids + identity", () => {
+  const withId = withRowId({ name: "keep" });
+  const out = ensureRowIds([withId, { name: "fresh" }]);
+  expect(out[0]).toBe(withId);
+  expect(typeof out[1][ROW_ID_KEY]).toBe("string");
+});
+
+it("ensureRowIds returns the same array reference when all rows already have ids", () => {
+  const rows = [withRowId({}), withRowId({})];
+  expect(ensureRowIds(rows)).toBe(rows);
 });

--- a/resources/js/form/components/fields/repeater-rows.ts
+++ b/resources/js/form/components/fields/repeater-rows.ts
@@ -1,5 +1,22 @@
 export type RepeaterRow = Record<string, unknown>;
 
+export const ROW_ID_KEY = "__rowId";
+
+let rowIdCounter = 0;
+
+/** Stamp a stable client-only id on a row (no-op if it already has one). */
+export function withRowId(row: RepeaterRow): RepeaterRow {
+  return row[ROW_ID_KEY] ? row : { ...row, [ROW_ID_KEY]: `r${rowIdCounter++}` };
+}
+
+/** Ensure every row has a stable id; returns the SAME array reference if none were missing. */
+export function ensureRowIds(rows: RepeaterRow[]): RepeaterRow[] {
+  if (rows.every((row) => Boolean(row[ROW_ID_KEY]))) {
+    return rows;
+  }
+  return rows.map(withRowId);
+}
+
 /** Seed the row list from a stored value, falling back to `defaultItems` blank rows. */
 export function seedRows(value: unknown, defaultItems: number): RepeaterRow[] {
   if (Array.isArray(value) && value.length > 0) {

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -113,6 +113,33 @@ it("shows the array-level error for the repeater field", () => {
   expect(screen.getByText("Must have at least 1 item")).toBeInTheDocument();
 });
 
+it("renders the table layout with a header from the schema", () => {
+  const node = {
+    id: "r",
+    type: "form.repeater",
+    props: {
+      name: "items",
+      layout: "table",
+      reorderable: true,
+      defaultItems: 0,
+      minItems: 0,
+      maxItems: 5,
+      addLabel: "Add",
+    },
+    schema: [
+      { id: "q", type: "form.text-input", props: { name: "qty", label: "Qty" } },
+      { id: "p", type: "form.text-input", props: { name: "price", label: "Price" } },
+    ],
+  } as never;
+  wrap(<RepeaterComponent node={node}>{null}</RepeaterComponent>, {
+    items: [{ qty: "1", price: "2" }],
+  });
+  expect(screen.getByText("Qty")).toBeInTheDocument();
+  expect(screen.getByText("Price")).toBeInTheDocument();
+  const children = screen.getAllByTestId("child").map((c) => c.textContent);
+  expect(children).toEqual(["items[0][qty]", "items[0][price]"]);
+});
+
 it("does not re-render sibling rows when one row changes", () => {
   wrap(<RepeaterComponent node={repeaterNode}>{null}</RepeaterComponent>, {
     items: [{ name: "a" }, { name: "b" }],

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -5,13 +5,11 @@ import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { ROW_ID_KEY } from "./repeater-rows";
 import { RowItem } from "./row-item";
-import { TableRows } from "./table-rows";
+import { columnsFromSchema, TableRows } from "./table-rows";
 import { useFlipReorder } from "./use-flip-reorder";
 import { useRowCollection } from "./use-row-collection";
 
 const EMPTY_TEMPLATE: Node[] = [];
-
-type FieldProps = { name: string; label?: string };
 
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
@@ -33,56 +31,13 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
     return null;
   }
 
-  const addButton = !atMax && (
-    <button
-      type="button"
-      data-test={`repeater-${name}-add`}
-      className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
-      onClick={() => append({})}
-    >
-      <Icon name="plus" />
-      {props.addLabel ?? "Add"}
-    </button>
-  );
-
-  if (isTable) {
-    const columns = template.map((field) => {
-      const fieldProps = field.props as FieldProps;
-      return { name: String(fieldProps.name), label: String(fieldProps.label ?? fieldProps.name) };
-    });
-    const tableRows = rows.map((row, index) => ({
-      key: String(row[ROW_ID_KEY] ?? index),
-      index,
-      row,
-      template,
-      span: false,
-    }));
-
-    return (
-      <FormFieldFrame
-        error={errors[name]}
-        helperText={props.helperText ?? undefined}
-        label={props.label ?? ""}
-        name={name}
-        required={required}
-      >
-        <div className="flex flex-col gap-3">
-          <TableRows
-            base={name}
-            columns={columns}
-            rows={tableRows}
-            reorderable={props.reorderable ?? false}
-            removable={() => !atMin}
-            onField={onField}
-            onMove={onMove}
-            onRemove={onRemove}
-            registerRow={registerRow}
-          />
-          {addButton}
-        </div>
-      </FormFieldFrame>
-    );
-  }
+  const tableRows = rows.map((row, index) => ({
+    key: String(row[ROW_ID_KEY] ?? index),
+    index,
+    row,
+    template,
+    span: false,
+  }));
 
   return (
     <FormFieldFrame
@@ -93,29 +48,53 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
       required={required}
     >
       <div className="flex flex-col gap-3">
-        {rows.map((row, index) => {
-          const key = String(row[ROW_ID_KEY] ?? index);
-          return (
-            <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
-              <RowItem
-                base={name}
-                index={index}
-                row={row}
-                template={template}
-                heading={props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
-                reorderable={props.reorderable ?? false}
-                isFirst={index === 0}
-                isLast={index === rows.length - 1}
-                removable={!atMin}
-                onField={onField}
-                onRemove={onRemove}
-                onMove={onMove}
-              />
-            </div>
-          );
-        })}
+        {isTable ? (
+          <TableRows
+            base={name}
+            columns={columnsFromSchema(template)}
+            rows={tableRows}
+            reorderable={props.reorderable ?? false}
+            removable={() => !atMin}
+            onField={onField}
+            onMove={onMove}
+            onRemove={onRemove}
+            registerRow={registerRow}
+          />
+        ) : (
+          rows.map((row, index) => {
+            const key = String(row[ROW_ID_KEY] ?? index);
+            return (
+              <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
+                <RowItem
+                  base={name}
+                  index={index}
+                  row={row}
+                  template={template}
+                  heading={props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
+                  reorderable={props.reorderable ?? false}
+                  isFirst={index === 0}
+                  isLast={index === rows.length - 1}
+                  removable={!atMin}
+                  onField={onField}
+                  onRemove={onRemove}
+                  onMove={onMove}
+                />
+              </div>
+            );
+          })
+        )}
 
-        {addButton}
+        {!atMax && (
+          <button
+            type="button"
+            data-test={`repeater-${name}-add`}
+            className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
+            onClick={() => append({})}
+          >
+            <Icon name="plus" />
+            {props.addLabel ?? "Add"}
+          </button>
+        )}
       </div>
     </FormFieldFrame>
   );

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -3,7 +3,9 @@ import type { Node, RendererComponent } from "@lattice/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
+import { ROW_ID_KEY } from "./repeater-rows";
 import { RowItem } from "./row-item";
+import { useFlipReorder } from "./use-flip-reorder";
 import { useRowCollection } from "./use-row-collection";
 
 const EMPTY_TEMPLATE: Node[] = [];
@@ -18,6 +20,8 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
     props.defaultItems ?? 1,
   );
   const template = node.schema ?? EMPTY_TEMPLATE;
+  const orderSignature = rows.map((r) => String(r[ROW_ID_KEY] ?? "")).join(",");
+  const registerRow = useFlipReorder(orderSignature);
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
 
@@ -34,23 +38,27 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
       required={required}
     >
       <div className="flex flex-col gap-3">
-        {rows.map((row, index) => (
-          <RowItem
-            key={index}
-            base={name}
-            index={index}
-            row={row}
-            template={template}
-            heading={props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
-            reorderable={props.reorderable ?? false}
-            isFirst={index === 0}
-            isLast={index === rows.length - 1}
-            removable={!atMin}
-            onField={onField}
-            onRemove={onRemove}
-            onMove={onMove}
-          />
-        ))}
+        {rows.map((row, index) => {
+          const key = String(row[ROW_ID_KEY] ?? index);
+          return (
+            <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
+              <RowItem
+                base={name}
+                index={index}
+                row={row}
+                template={template}
+                heading={props.itemLabel ? `${props.itemLabel} ${index + 1}` : `#${index + 1}`}
+                reorderable={props.reorderable ?? false}
+                isFirst={index === 0}
+                isLast={index === rows.length - 1}
+                removable={!atMin}
+                onField={onField}
+                onRemove={onRemove}
+                onMove={onMove}
+              />
+            </div>
+          );
+        })}
 
         {!atMax && (
           <button

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -5,10 +5,13 @@ import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { ROW_ID_KEY } from "./repeater-rows";
 import { RowItem } from "./row-item";
+import { TableRows } from "./table-rows";
 import { useFlipReorder } from "./use-flip-reorder";
 import { useRowCollection } from "./use-row-collection";
 
 const EMPTY_TEMPLATE: Node[] = [];
+
+type FieldProps = { name: string; label?: string };
 
 export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) => {
   const props = node.props;
@@ -24,9 +27,61 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
   const registerRow = useFlipReorder(orderSignature);
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
+  const isTable = props.layout === "table";
 
   if (hidden) {
     return null;
+  }
+
+  const addButton = !atMax && (
+    <button
+      type="button"
+      data-test={`repeater-${name}-add`}
+      className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
+      onClick={() => append({})}
+    >
+      <Icon name="plus" />
+      {props.addLabel ?? "Add"}
+    </button>
+  );
+
+  if (isTable) {
+    const columns = template.map((field) => {
+      const fieldProps = field.props as FieldProps;
+      return { name: String(fieldProps.name), label: String(fieldProps.label ?? fieldProps.name) };
+    });
+    const tableRows = rows.map((row, index) => ({
+      key: String(row[ROW_ID_KEY] ?? index),
+      index,
+      row,
+      template,
+      span: false,
+    }));
+
+    return (
+      <FormFieldFrame
+        error={errors[name]}
+        helperText={props.helperText ?? undefined}
+        label={props.label ?? ""}
+        name={name}
+        required={required}
+      >
+        <div className="flex flex-col gap-3">
+          <TableRows
+            base={name}
+            columns={columns}
+            rows={tableRows}
+            reorderable={props.reorderable ?? false}
+            removable={() => !atMin}
+            onField={onField}
+            onMove={onMove}
+            onRemove={onRemove}
+            registerRow={registerRow}
+          />
+          {addButton}
+        </div>
+      </FormFieldFrame>
+    );
   }
 
   return (
@@ -60,17 +115,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
           );
         })}
 
-        {!atMax && (
-          <button
-            type="button"
-            data-test={`repeater-${name}-add`}
-            className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
-            onClick={() => append({})}
-          >
-            <Icon name="plus" />
-            {props.addLabel ?? "Add"}
-          </button>
-        )}
+        {addButton}
       </div>
     </FormFieldFrame>
   );

--- a/resources/js/form/components/fields/row-actions.test.tsx
+++ b/resources/js/form/components/fields/row-actions.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it, vi, beforeAll, afterAll } from "vitest";
+import { configure, getConfig, fireEvent, render, screen } from "@testing-library/react";
+
+let prevTestIdAttribute: string;
+beforeAll(() => {
+  prevTestIdAttribute = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+afterAll(() => {
+  configure({ testIdAttribute: prevTestIdAttribute });
+});
+
+import { RowActions } from "./row-actions";
+
+it("renders a single action inline (no menu)", () => {
+  const onClick = vi.fn<() => void>();
+  render(<RowActions actions={[{ key: "remove", label: "Remove", icon: "trash-2", onClick }]} />);
+  fireEvent.click(screen.getByTestId("row-action-remove"));
+  expect(onClick).toHaveBeenCalled();
+  expect(screen.queryByTestId("row-actions-menu")).not.toBeInTheDocument();
+});
+
+it("collapses 2+ actions into a kebab menu", () => {
+  const dup = vi.fn<() => void>();
+  render(
+    <RowActions
+      actions={[
+        { key: "remove", label: "Remove", icon: "trash-2", onClick: () => {} },
+        { key: "duplicate", label: "Duplicate", icon: "copy", onClick: dup },
+      ]}
+    />,
+  );
+  fireEvent.click(screen.getByTestId("row-actions-menu"));
+  fireEvent.click(screen.getByText("Duplicate"));
+  expect(dup).toHaveBeenCalled();
+});
+
+it("renders nothing for an empty action list", () => {
+  const { container } = render(<RowActions actions={[]} />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/resources/js/form/components/fields/row-actions.tsx
+++ b/resources/js/form/components/fields/row-actions.tsx
@@ -1,0 +1,72 @@
+import { Icon } from "@lattice/lattice/icons";
+import * as Popover from "@radix-ui/react-popover";
+import { useState } from "react";
+
+export type RowAction = {
+  key: string;
+  label: string;
+  icon: string;
+  onClick: () => void;
+  destructive?: boolean;
+};
+
+export function RowActions({ actions }: { actions: RowAction[] }) {
+  const [open, setOpen] = useState(false);
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  if (actions.length === 1) {
+    const action = actions[0];
+    return (
+      <button
+        type="button"
+        aria-label={action.label}
+        data-test={`row-action-${action.key}`}
+        className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+        onClick={action.onClick}
+      >
+        <Icon name={action.icon} />
+      </button>
+    );
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          aria-label="Actions"
+          data-test="row-actions-menu"
+          className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+        >
+          <Icon name="more-horizontal" />
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={4}
+          className="z-50 min-w-[10rem] overflow-hidden rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-md"
+        >
+          {actions.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              data-test={`row-action-${action.key}`}
+              className="flex w-full items-center gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm hover:bg-lt-accent hover:text-lt-accent-fg [&_svg]:size-lt-icon-sm"
+              onClick={() => {
+                action.onClick();
+                setOpen(false);
+              }}
+            >
+              <Icon name={action.icon} />
+              {action.label}
+            </button>
+          ))}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -6,7 +6,7 @@ import { RenderNode } from "@lattice/lattice/core/renderer";
 import { FieldScopeProvider } from "../field-scope";
 import type { RepeaterRow } from "./repeater-rows";
 
-function RowButton({
+export function RowButton({
   label,
   testId,
   onClick,

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -83,3 +83,21 @@ it("shows a remove action when removable", () => {
   );
   expect(screen.getByTestId("row-action-remove")).toBeInTheDocument();
 });
+
+it("registers each row element for FLIP", () => {
+  const calls: Array<[string, HTMLElement | null]> = [];
+  render(
+    <TableRows
+      base="items"
+      columns={columns}
+      rows={[{ key: "a", index: 0, row: {}, template: [qtyNode], span: false }]}
+      reorderable={true}
+      removable={() => true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+      registerRow={(k, el) => calls.push([k, el])}
+    />,
+  );
+  expect(calls.some(([k, el]) => k === "a" && el !== null)).toBe(true);
+});

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -1,0 +1,85 @@
+import { expect, it, vi, beforeAll, afterAll } from "vitest";
+import { configure, getConfig, render, screen } from "@testing-library/react";
+
+let prev: string;
+beforeAll(() => {
+  prev = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+afterAll(() => configure({ testIdAttribute: prev }));
+
+vi.mock("@lattice/lattice/core/renderer", async () => {
+  const { useFieldScope } = await import("../field-scope");
+  return {
+    RenderNode: ({ node }: { node: { props: { name: string } } }) => {
+      const scope = useFieldScope();
+      return (
+        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+      );
+    },
+  };
+});
+
+import { TableRows } from "./table-rows";
+
+const columns = [
+  { name: "qty", label: "Qty" },
+  { name: "price", label: "Price" },
+];
+const qtyNode = { id: "q", type: "form.text-input", props: { name: "qty" } } as never;
+const priceNode = { id: "p", type: "form.text-input", props: { name: "price" } } as never;
+const contentNode = { id: "c", type: "form.textarea", props: { name: "content" } } as never;
+
+function noop() {}
+
+it("renders the header columns once and a columnar row's scoped cells", () => {
+  render(
+    <TableRows
+      base="items"
+      columns={columns}
+      rows={[{ key: "a", index: 0, row: {}, template: [qtyNode, priceNode], span: false }]}
+      reorderable={true}
+      removable={() => true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+    />,
+  );
+  expect(screen.getByText("Qty")).toBeInTheDocument();
+  expect(screen.getByText("Price")).toBeInTheDocument();
+  const children = screen.getAllByTestId("child").map((c) => c.textContent);
+  expect(children).toEqual(["items[0][qty]", "items[0][price]"]);
+});
+
+it("renders a spanning row in a single full-width cell", () => {
+  render(
+    <TableRows
+      base="items"
+      columns={columns}
+      rows={[{ key: "b", index: 0, row: {}, template: [contentNode], span: true }]}
+      reorderable={true}
+      removable={() => true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+    />,
+  );
+  expect(screen.getByTestId("table-row-items-0-span")).toBeInTheDocument();
+  expect(screen.getByTestId("child").textContent).toBe("items[0][content]");
+});
+
+it("shows a remove action when removable", () => {
+  render(
+    <TableRows
+      base="items"
+      columns={columns}
+      rows={[{ key: "a", index: 0, row: {}, template: [qtyNode], span: false }]}
+      reorderable={true}
+      removable={() => true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+    />,
+  );
+  expect(screen.getByTestId("row-action-remove")).toBeInTheDocument();
+});

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -1,5 +1,5 @@
 import { expect, it, vi, beforeAll, afterAll } from "vitest";
-import { configure, getConfig, render, screen } from "@testing-library/react";
+import { configure, fireEvent, getConfig, render, screen } from "@testing-library/react";
 
 let prev: string;
 beforeAll(() => {
@@ -8,18 +8,33 @@ beforeAll(() => {
 });
 afterAll(() => configure({ testIdAttribute: prev }));
 
+const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
+
 vi.mock("@lattice/lattice/core/renderer", async () => {
   const { useFieldScope } = await import("../field-scope");
   return {
     RenderNode: ({ node }: { node: { props: { name: string } } }) => {
       const scope = useFieldScope();
+      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
+      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
       return (
-        <span data-test="child">{scope ? scope.scopedName(node.props.name) : "no-scope"}</span>
+        <>
+          <span data-test="child">{key}</span>
+          <button
+            aria-label={`commit ${key}`}
+            data-test={`commit-${key}`}
+            type="button"
+            onClick={() => scope?.setValue(node.props.name, "x")}
+          />
+        </>
       );
     },
   };
 });
 
+import { FormProvider } from "../context";
+import { FormValuesProvider } from "../values";
+import { RepeaterComponent } from "./repeater";
 import { TableRows } from "./table-rows";
 
 const columns = [
@@ -100,4 +115,49 @@ it("registers each row element for FLIP", () => {
     />,
   );
   expect(calls.some(([k, el]) => k === "a" && el !== null)).toBe(true);
+});
+
+function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
+  return render(
+    <FormProvider
+      value={{
+        action: "#",
+        clearErrors: () => {},
+        componentRef: "",
+        errors: {},
+        fieldLabels: {},
+        precognitive: false,
+        processing: false,
+        validate: () => {},
+      }}
+    >
+      <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>
+    </FormProvider>,
+  );
+}
+
+const tableNode = {
+  id: "r",
+  type: "form.repeater",
+  props: {
+    name: "items",
+    layout: "table",
+    reorderable: true,
+    defaultItems: 0,
+    minItems: 0,
+    maxItems: 5,
+  },
+  schema: [{ id: "q", type: "form.text-input", props: { name: "qty", label: "Qty" } }],
+} as never;
+
+it("does not re-render sibling table rows when one row changes", () => {
+  wrap(<RepeaterComponent node={tableNode}>{null}</RepeaterComponent>, {
+    items: [{ qty: "1" }, { qty: "2" }],
+  });
+
+  renderCounts.clear();
+  fireEvent.click(screen.getByTestId("commit-items[0][qty]"));
+
+  expect(renderCounts.get("items[0][qty]") ?? 0).toBeGreaterThanOrEqual(1);
+  expect(renderCounts.get("items[1][qty]") ?? 0).toBe(0);
 });

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -1,0 +1,158 @@
+import type { Node } from "@lattice/lattice/core/types";
+import { Icon } from "@lattice/lattice/icons";
+import { RenderNode } from "@lattice/lattice/core/renderer";
+import { FieldScopeProvider } from "../field-scope";
+import { TableCellProvider } from "../row-layout-context";
+import { RowActions } from "./row-actions";
+import type { RepeaterRow } from "./repeater-rows";
+
+export type TableColumn = { name: string; label: string };
+
+export type TableRowModel = {
+  key: string;
+  index: number;
+  row: RepeaterRow;
+  template: Node[];
+  span: boolean;
+};
+
+function ReorderButton({
+  label,
+  testId,
+  onClick,
+  icon,
+}: {
+  label: string;
+  testId: string;
+  onClick: () => void;
+  icon: string;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      data-test={testId}
+      className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+      onClick={onClick}
+    >
+      <Icon name={icon} />
+    </button>
+  );
+}
+
+export function TableRows({
+  base,
+  columns,
+  rows,
+  reorderable,
+  removable,
+  onField,
+  onMove,
+  onRemove,
+}: {
+  base: string;
+  columns: TableColumn[];
+  rows: TableRowModel[];
+  reorderable: boolean;
+  removable: (index: number) => boolean;
+  onField: (index: number, field: string, value: unknown) => void;
+  onMove: (index: number, delta: number) => void;
+  onRemove: (index: number) => void;
+}) {
+  const gridTemplateColumns = `auto repeat(${columns.length}, minmax(0, 1fr)) auto`;
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex min-w-max flex-col gap-2">
+        <div className="grid items-center gap-x-3" style={{ gridTemplateColumns }}>
+          <div />
+          {columns.map((column) => (
+            <div key={column.name} className="text-xs font-medium text-lt-muted-fg">
+              {column.label}
+            </div>
+          ))}
+          <div />
+        </div>
+
+        {rows.map((row) => {
+          const isFirst = row.index === 0;
+          const isLast = row.index === rows.length - 1;
+
+          return (
+            <div
+              key={row.key}
+              data-flip-key={row.key}
+              data-test={`table-row-${base}-${row.index}`}
+              className="grid items-start gap-x-3"
+              style={{ gridTemplateColumns }}
+            >
+              <div className="flex items-center gap-1">
+                {reorderable && !isFirst && (
+                  <ReorderButton
+                    label="Move up"
+                    testId={`table-${base}-up-${row.index}`}
+                    onClick={() => onMove(row.index, -1)}
+                    icon="arrow-up"
+                  />
+                )}
+                {reorderable && !isLast && (
+                  <ReorderButton
+                    label="Move down"
+                    testId={`table-${base}-down-${row.index}`}
+                    onClick={() => onMove(row.index, 1)}
+                    icon="arrow-down"
+                  />
+                )}
+              </div>
+
+              <FieldScopeProvider
+                base={base}
+                index={row.index}
+                row={row.row}
+                onChange={(field, value) => onField(row.index, field, value)}
+              >
+                <TableCellProvider>
+                  {row.span ? (
+                    <div
+                      data-test={`table-row-${base}-${row.index}-span`}
+                      className="flex flex-col gap-2"
+                      style={{ gridColumn: `span ${columns.length}` }}
+                    >
+                      {row.template.map((child) => (
+                        <RenderNode key={child.key ?? child.id} node={child} />
+                      ))}
+                    </div>
+                  ) : (
+                    row.template.map((child) => (
+                      <div key={child.key ?? child.id}>
+                        <RenderNode node={child} />
+                      </div>
+                    ))
+                  )}
+                </TableCellProvider>
+              </FieldScopeProvider>
+
+              <div className="flex items-center">
+                <RowActions
+                  actions={
+                    removable(row.index)
+                      ? [
+                          {
+                            key: "remove",
+                            label: "Remove",
+                            icon: "trash-2",
+                            onClick: () => onRemove(row.index),
+                            destructive: true,
+                          },
+                        ]
+                      : []
+                  }
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -49,6 +49,7 @@ export function TableRows({
   onField,
   onMove,
   onRemove,
+  registerRow,
 }: {
   base: string;
   columns: TableColumn[];
@@ -58,7 +59,10 @@ export function TableRows({
   onField: (index: number, field: string, value: unknown) => void;
   onMove: (index: number, delta: number) => void;
   onRemove: (index: number) => void;
+  registerRow?: (key: string, el: HTMLElement | null) => void;
 }) {
+  // For columnar (non-span) rows, template node order must match columns order,
+  // as cells are placed by grid position.
   const gridTemplateColumns = `auto repeat(${columns.length}, minmax(0, 1fr)) auto`;
 
   return (
@@ -81,6 +85,7 @@ export function TableRows({
           return (
             <div
               key={row.key}
+              ref={(el) => registerRow?.(row.key, el)}
               data-flip-key={row.key}
               data-test={`table-row-${base}-${row.index}`}
               className="grid items-start gap-x-3"

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -1,9 +1,11 @@
 import type { Node } from "@lattice/lattice/core/types";
 import { Icon } from "@lattice/lattice/icons";
+import { memo } from "react";
 import { RenderNode } from "@lattice/lattice/core/renderer";
 import { FieldScopeProvider } from "../field-scope";
 import { TableCellProvider } from "../row-layout-context";
 import { RowActions } from "./row-actions";
+import { RowButton } from "./row-item";
 import type { RepeaterRow } from "./repeater-rows";
 
 export type TableColumn = { name: string; label: string };
@@ -16,29 +18,126 @@ export type TableRowModel = {
   span: boolean;
 };
 
-function ReorderButton({
-  label,
-  testId,
-  onClick,
-  icon,
-}: {
-  label: string;
-  testId: string;
-  onClick: () => void;
-  icon: string;
-}) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      data-test={testId}
-      className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
-      onClick={onClick}
-    >
-      <Icon name={icon} />
-    </button>
-  );
+export function columnsFromSchema(nodes: Node[]): TableColumn[] {
+  return nodes.map((node) => {
+    const props = node.props as { name: unknown; label?: unknown };
+    return { name: String(props.name), label: String(props.label ?? props.name) };
+  });
 }
+
+type TableRowItemProps = {
+  base: string;
+  index: number;
+  row: RepeaterRow;
+  template: Node[];
+  span: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  columnCount: number;
+  gridTemplateColumns: string;
+  flipKey: string;
+  reorderable: boolean;
+  removable: boolean;
+  onField: (index: number, field: string, value: unknown) => void;
+  onMove: (index: number, delta: number) => void;
+  onRemove: (index: number) => void;
+  registerRow?: (key: string, el: HTMLElement | null) => void;
+};
+
+const TableRowItem = memo(function TableRowItem({
+  base,
+  index,
+  row,
+  template,
+  span,
+  isFirst,
+  isLast,
+  columnCount,
+  gridTemplateColumns,
+  flipKey,
+  reorderable,
+  removable,
+  onField,
+  onMove,
+  onRemove,
+  registerRow,
+}: TableRowItemProps) {
+  return (
+    <div
+      ref={(el) => registerRow?.(flipKey, el)}
+      data-flip-key={flipKey}
+      data-test={`table-row-${base}-${index}`}
+      className="grid items-start gap-x-3"
+      style={{ gridTemplateColumns }}
+    >
+      <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
+        {reorderable && !isFirst && (
+          <RowButton
+            label="Move up"
+            testId={`table-${base}-up-${index}`}
+            onClick={() => onMove(index, -1)}
+          >
+            <Icon name="arrow-up" />
+          </RowButton>
+        )}
+        {reorderable && !isLast && (
+          <RowButton
+            label="Move down"
+            testId={`table-${base}-down-${index}`}
+            onClick={() => onMove(index, 1)}
+          >
+            <Icon name="arrow-down" />
+          </RowButton>
+        )}
+      </div>
+
+      <FieldScopeProvider
+        base={base}
+        index={index}
+        row={row}
+        onChange={(field, value) => onField(index, field, value)}
+      >
+        <TableCellProvider>
+          {span ? (
+            <div
+              data-test={`table-row-${base}-${index}-span`}
+              className="flex flex-col gap-2"
+              style={{ gridColumn: `span ${columnCount}` }}
+            >
+              {template.map((child) => (
+                <RenderNode key={child.key ?? child.id} node={child} />
+              ))}
+            </div>
+          ) : (
+            template.map((child) => (
+              <div key={child.key ?? child.id}>
+                <RenderNode node={child} />
+              </div>
+            ))
+          )}
+        </TableCellProvider>
+      </FieldScopeProvider>
+
+      <div className="flex items-center">
+        <RowActions
+          actions={
+            removable
+              ? [
+                  {
+                    key: "remove",
+                    label: "Remove",
+                    icon: "trash-2",
+                    onClick: () => onRemove(index),
+                    destructive: true,
+                  },
+                ]
+              : []
+          }
+        />
+      </div>
+    </div>
+  );
+});
 
 export function TableRows({
   base,
@@ -78,85 +177,27 @@ export function TableRows({
           <div />
         </div>
 
-        {rows.map((row) => {
-          const isFirst = row.index === 0;
-          const isLast = row.index === rows.length - 1;
-
-          return (
-            <div
-              key={row.key}
-              ref={(el) => registerRow?.(row.key, el)}
-              data-flip-key={row.key}
-              data-test={`table-row-${base}-${row.index}`}
-              className="grid items-start gap-x-3"
-              style={{ gridTemplateColumns }}
-            >
-              <div className="flex items-center gap-1">
-                {reorderable && !isFirst && (
-                  <ReorderButton
-                    label="Move up"
-                    testId={`table-${base}-up-${row.index}`}
-                    onClick={() => onMove(row.index, -1)}
-                    icon="arrow-up"
-                  />
-                )}
-                {reorderable && !isLast && (
-                  <ReorderButton
-                    label="Move down"
-                    testId={`table-${base}-down-${row.index}`}
-                    onClick={() => onMove(row.index, 1)}
-                    icon="arrow-down"
-                  />
-                )}
-              </div>
-
-              <FieldScopeProvider
-                base={base}
-                index={row.index}
-                row={row.row}
-                onChange={(field, value) => onField(row.index, field, value)}
-              >
-                <TableCellProvider>
-                  {row.span ? (
-                    <div
-                      data-test={`table-row-${base}-${row.index}-span`}
-                      className="flex flex-col gap-2"
-                      style={{ gridColumn: `span ${columns.length}` }}
-                    >
-                      {row.template.map((child) => (
-                        <RenderNode key={child.key ?? child.id} node={child} />
-                      ))}
-                    </div>
-                  ) : (
-                    row.template.map((child) => (
-                      <div key={child.key ?? child.id}>
-                        <RenderNode node={child} />
-                      </div>
-                    ))
-                  )}
-                </TableCellProvider>
-              </FieldScopeProvider>
-
-              <div className="flex items-center">
-                <RowActions
-                  actions={
-                    removable(row.index)
-                      ? [
-                          {
-                            key: "remove",
-                            label: "Remove",
-                            icon: "trash-2",
-                            onClick: () => onRemove(row.index),
-                            destructive: true,
-                          },
-                        ]
-                      : []
-                  }
-                />
-              </div>
-            </div>
-          );
-        })}
+        {rows.map((row) => (
+          <TableRowItem
+            key={row.key}
+            base={base}
+            index={row.index}
+            row={row.row}
+            template={row.template}
+            span={row.span}
+            isFirst={row.index === 0}
+            isLast={row.index === rows.length - 1}
+            columnCount={columns.length}
+            gridTemplateColumns={gridTemplateColumns}
+            flipKey={row.key}
+            reorderable={reorderable}
+            removable={removable(row.index)}
+            onField={onField}
+            onMove={onMove}
+            onRemove={onRemove}
+            registerRow={registerRow}
+          />
+        ))}
       </div>
     </div>
   );

--- a/resources/js/form/components/fields/use-flip-reorder.test.tsx
+++ b/resources/js/form/components/fields/use-flip-reorder.test.tsx
@@ -1,0 +1,48 @@
+import { expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { useFlipReorder } from "./use-flip-reorder";
+
+it("returns a register callback and survives an order change without throwing", () => {
+  const seen: Array<HTMLElement | null> = [];
+  function Probe({ order }: { order: string }) {
+    const register = useFlipReorder(order);
+    return (
+      <div>
+        {order.split(",").map((k) => (
+          <div
+            key={k}
+            data-flip-key={k}
+            ref={(el) => {
+              register(k, el);
+              seen.push(el);
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+  const { rerender } = render(<Probe order="a,b" />);
+  rerender(<Probe order="b,a" />);
+  expect(seen.length).toBeGreaterThan(0);
+});
+
+it("no-ops under prefers-reduced-motion", () => {
+  vi.stubGlobal("matchMedia", (q: string) => ({
+    matches: true,
+    media: q,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    onchange: null,
+    dispatchEvent() {
+      return false;
+    },
+  }));
+  function Probe() {
+    const register = useFlipReorder("a");
+    return <div ref={(el) => register("a", el)} />;
+  }
+  expect(() => render(<Probe />)).not.toThrow();
+  vi.unstubAllGlobals();
+});

--- a/resources/js/form/components/fields/use-flip-reorder.ts
+++ b/resources/js/form/components/fields/use-flip-reorder.ts
@@ -17,6 +17,7 @@ export function useFlipReorder(
   const elements = useRef(new Map<string, HTMLElement>());
   const previous = useRef(new Map<string, DOMRect>());
 
+  // register is the FLIP measurement target; the element must be a zero-overhead positioning wrapper (no padding/margin) for the delta to match the visible row.
   const register = (key: string, el: HTMLElement | null): void => {
     if (el) {
       elements.current.set(key, el);
@@ -26,6 +27,7 @@ export function useFlipReorder(
   };
 
   useLayoutEffect(() => {
+    const handles: number[] = [];
     const next = new Map<string, DOMRect>();
     elements.current.forEach((el, key) => {
       el.style.transition = "";
@@ -41,16 +43,24 @@ export function useFlipReorder(
           const dy = before.top - after.top;
           if (dy) {
             el.style.transform = `translateY(${dy}px)`;
-            requestAnimationFrame(() => {
-              el.style.transition = `transform ${DURATION_MS}ms ease-out`;
-              el.style.transform = "";
-            });
+            handles.push(
+              requestAnimationFrame(() => {
+                el.style.transition = `transform ${DURATION_MS}ms ease-out`;
+                el.style.transform = "";
+              }),
+            );
           }
         }
       });
     }
 
     previous.current = next;
+
+    return () => {
+      for (const handle of handles) {
+        cancelAnimationFrame(handle);
+      }
+    };
   }, [orderSignature]);
 
   return register;

--- a/resources/js/form/components/fields/use-flip-reorder.ts
+++ b/resources/js/form/components/fields/use-flip-reorder.ts
@@ -1,0 +1,57 @@
+import { useLayoutEffect, useRef } from "react";
+
+const DURATION_MS = 180;
+
+function prefersReducedMotion(): boolean {
+  return typeof matchMedia === "function" && matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * FLIP reorder: animates registered elements from their previous to current
+ * position whenever `orderSignature` changes. Imperative style writes only, so
+ * it does not affect React render or the memoised rows.
+ */
+export function useFlipReorder(
+  orderSignature: string,
+): (key: string, el: HTMLElement | null) => void {
+  const elements = useRef(new Map<string, HTMLElement>());
+  const previous = useRef(new Map<string, DOMRect>());
+
+  const register = (key: string, el: HTMLElement | null): void => {
+    if (el) {
+      elements.current.set(key, el);
+    } else {
+      elements.current.delete(key);
+    }
+  };
+
+  useLayoutEffect(() => {
+    const next = new Map<string, DOMRect>();
+    elements.current.forEach((el, key) => {
+      el.style.transition = "";
+      el.style.transform = "";
+      next.set(key, el.getBoundingClientRect());
+    });
+
+    if (!prefersReducedMotion()) {
+      elements.current.forEach((el, key) => {
+        const before = previous.current.get(key);
+        const after = next.get(key);
+        if (before && after) {
+          const dy = before.top - after.top;
+          if (dy) {
+            el.style.transform = `translateY(${dy}px)`;
+            requestAnimationFrame(() => {
+              el.style.transition = `transform ${DURATION_MS}ms ease-out`;
+              el.style.transform = "";
+            });
+          }
+        }
+      });
+    }
+
+    previous.current = next;
+  }, [orderSignature]);
+
+  return register;
+}

--- a/resources/js/form/components/fields/use-flip-reorder.ts
+++ b/resources/js/form/components/fields/use-flip-reorder.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react";
+import { useCallback, useLayoutEffect, useRef } from "react";
 
 const DURATION_MS = 180;
 
@@ -18,13 +18,13 @@ export function useFlipReorder(
   const previous = useRef(new Map<string, DOMRect>());
 
   // register is the FLIP measurement target; the element must be a zero-overhead positioning wrapper (no padding/margin) for the delta to match the visible row.
-  const register = (key: string, el: HTMLElement | null): void => {
+  const register = useCallback((key: string, el: HTMLElement | null): void => {
     if (el) {
       elements.current.set(key, el);
     } else {
       elements.current.delete(key);
     }
-  };
+  }, []);
 
   useLayoutEffect(() => {
     const handles: number[] = [];

--- a/resources/js/form/components/fields/use-row-collection.test.tsx
+++ b/resources/js/form/components/fields/use-row-collection.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "vitest";
+import { act, render } from "@testing-library/react";
+import { FormValuesProvider } from "../values";
+import { ROW_ID_KEY } from "./repeater-rows";
+import { useRowCollection } from "./use-row-collection";
+
+function harness(onReady: (c: ReturnType<typeof useRowCollection>) => void) {
+  function Probe() {
+    onReady(useRowCollection("items", 0));
+    return null;
+  }
+  return render(
+    <FormValuesProvider initial={{ items: [{ a: "1" }, { a: "2" }] }}>
+      <Probe />
+    </FormValuesProvider>,
+  );
+}
+
+it("assigns stable ids and preserves them across edit + reorder", () => {
+  let c!: ReturnType<typeof useRowCollection>;
+  harness((latest) => (c = latest));
+
+  const id0 = c.rows[0][ROW_ID_KEY];
+  const id1 = c.rows[1][ROW_ID_KEY];
+  expect(id0).toBeTruthy();
+  expect(id1).toBeTruthy();
+  expect(id0).not.toBe(id1);
+
+  act(() => c.onField(0, "a", "edited"));
+  expect(c.rows[0][ROW_ID_KEY]).toBe(id0);
+  expect(c.rows[1][ROW_ID_KEY]).toBe(id1);
+
+  act(() => c.onMove(0, 1));
+  expect(c.rows[1][ROW_ID_KEY]).toBe(id0);
+  expect(c.rows[0][ROW_ID_KEY]).toBe(id1);
+});
+
+it("stamps an id on an appended row", () => {
+  let c!: ReturnType<typeof useRowCollection>;
+  harness((latest) => (c = latest));
+  act(() => c.append({ a: "3" }));
+  expect(c.rows[2][ROW_ID_KEY]).toBeTruthy();
+});

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,6 +1,13 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useFormValue, useSetFormValue } from "../values";
-import { moveRow, removeRow, seedRows, type RepeaterRow } from "./repeater-rows";
+import {
+  ensureRowIds,
+  moveRow,
+  removeRow,
+  seedRows,
+  withRowId,
+  type RepeaterRow,
+} from "./repeater-rows";
 
 export type RowCollection = {
   rows: RepeaterRow[];
@@ -13,7 +20,14 @@ export type RowCollection = {
 export function useRowCollection(name: string, defaultItems: number): RowCollection {
   const setValue = useSetFormValue();
   const stored = useFormValue(name);
-  const rows: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
+  const raw: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
+  const rows = ensureRowIds(raw);
+
+  useEffect(() => {
+    if (rows !== raw) {
+      setValue(name, rows);
+    }
+  }, [raw, rows, setValue, name]);
 
   // Functional store updates preserve the identity of untouched rows, which lets
   // the memoised RowItem skip re-rendering siblings on a single-row edit.
@@ -41,7 +55,7 @@ export function useRowCollection(name: string, defaultItems: number): RowCollect
     [mutate],
   );
   const append = useCallback(
-    (row: RepeaterRow): void => mutate((current) => [...current, row]),
+    (row: RepeaterRow): void => mutate((current) => [...current, withRowId(row)]),
     [mutate],
   );
 

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useLayoutEffect } from "react";
 import { useFormValue, useSetFormValue } from "../values";
 import {
   ensureRowIds,
@@ -23,7 +23,7 @@ export function useRowCollection(name: string, defaultItems: number): RowCollect
   const raw: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
   const rows = ensureRowIds(raw);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (rows !== raw) {
       setValue(name, rows);
     }

--- a/resources/js/form/components/row-layout-context.tsx
+++ b/resources/js/form/components/row-layout-context.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from "react";
+
+const TableCellContext = createContext(false);
+
+export function TableCellProvider({ children }: { children: React.ReactNode }) {
+  return <TableCellContext.Provider value={true}>{children}</TableCellContext.Provider>;
+}
+
+/** True when a field is being rendered inside a table-layout cell (no own label). */
+export function useInTableCell(): boolean {
+  return useContext(TableCellContext);
+}

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -57,6 +57,7 @@ export type Builder = {
   helperText: string | null;
   hidden: boolean | null;
   label: string | null;
+  layout: string;
   maxItems: number | null;
   minItems: number | null;
   name: string;
@@ -636,6 +637,7 @@ export type Repeater = {
   hidden: boolean | null;
   itemLabel: string | null;
   label: string | null;
+  layout: string;
   maxItems: number | null;
   minItems: number | null;
   name: string;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -57,7 +57,7 @@ export type Builder = {
   helperText: string | null;
   hidden: boolean | null;
   label: string | null;
-  layout: string;
+  layout: RowLayout;
   maxItems: number | null;
   minItems: number | null;
   name: string;
@@ -637,7 +637,7 @@ export type Repeater = {
   hidden: boolean | null;
   itemLabel: string | null;
   label: string | null;
-  layout: string;
+  layout: RowLayout;
   maxItems: number | null;
   minItems: number | null;
   name: string;
@@ -668,6 +668,7 @@ export type RichEditor = {
   required: boolean | null;
   value: unknown;
 };
+export type RowLayout = "stack" | "table";
 export type Section = {
   collapsed: boolean;
   collapsible: boolean;

--- a/src/Core/Enums/RowLayout.php
+++ b/src/Core/Enums/RowLayout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lattice\Lattice\Core\Enums;
 
 use Lattice\Lattice\Attributes\TypeScript;

--- a/src/Core/Enums/RowLayout.php
+++ b/src/Core/Enums/RowLayout.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Lattice\Lattice\Core\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum RowLayout: string
+{
+    case Stack = 'stack';
+    case Table = 'table';
+}

--- a/src/Forms/Components/Builder.php
+++ b/src/Forms/Components/Builder.php
@@ -7,12 +7,14 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
+use Lattice\Lattice\Forms\Components\Concerns\HasRowLayout;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.builder')]
 class Builder extends Field
 {
     use HandlesRowSchemas;
+    use HasRowLayout;
 
     /**
      * @var array<int, Block>

--- a/src/Forms/Components/Concerns/HasRowLayout.php
+++ b/src/Forms/Components/Concerns/HasRowLayout.php
@@ -2,13 +2,15 @@
 
 namespace Lattice\Lattice\Forms\Components\Concerns;
 
+use Lattice\Lattice\Core\Enums\RowLayout;
+
 trait HasRowLayout
 {
-    public string $layout = 'stack';
+    public RowLayout $layout = RowLayout::Stack;
 
     public function table(): static
     {
-        $this->layout = 'table';
+        $this->layout = RowLayout::Table;
 
         return $this;
     }

--- a/src/Forms/Components/Concerns/HasRowLayout.php
+++ b/src/Forms/Components/Concerns/HasRowLayout.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Lattice\Lattice\Forms\Components\Concerns;
+
+trait HasRowLayout
+{
+    public string $layout = 'stack';
+
+    public function table(): static
+    {
+        $this->layout = 'table';
+
+        return $this;
+    }
+}

--- a/src/Forms/Components/Concerns/HasRowLayout.php
+++ b/src/Forms/Components/Concerns/HasRowLayout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lattice\Lattice\Forms\Components\Concerns;
 
 use Lattice\Lattice\Core\Enums\RowLayout;

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
 use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
+use Lattice\Lattice\Forms\Components\Concerns\HasRowLayout;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.repeater')]
@@ -15,6 +16,7 @@ class Repeater extends Field
 {
     use HandlesRowSchemas;
     use HasChildSchema;
+    use HasRowLayout;
 
     public ?int $minItems = null;
 

--- a/tests/Browser/Forms/TableLayoutTest.php
+++ b/tests/Browser/Forms/TableLayoutTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+it('renders the table layout with a shared header and round-trips a typed payload', function (): void {
+    $page = visit('/builder-table');
+
+    $page->assertSee('Line items')->assertNoSmoke()
+        ->assertSee('Product')->assertSee('Qty')->assertSee('Price');
+
+    $page->click('@builder-add')->click('@builder-add-product')
+        ->fill('input[name="items[0][product]"]', 'SKU-9')
+        ->fill('input[name="items[0][qty]"]', '4')
+        ->fill('input[name="items[0][price]"]', '2.50')
+        ->click('@builder-add')->click('@builder-add-text')
+        ->fill('textarea[name="items[1][content]"]', 'Note row')
+        ->assertNoJavaScriptErrors();
+
+    $page->click('Submit')
+        ->assertSee('Builder Table Demo')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/RowLayoutTest.php
+++ b/tests/Feature/RowLayoutTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Repeater;

--- a/tests/Feature/RowLayoutTest.php
+++ b/tests/Feature/RowLayoutTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+it('defaults to the stack layout', function (): void {
+    $wire = json_decode(json_encode(Repeater::make('items')->schema([TextInput::make('a')])), true);
+    expect($wire['props']['layout'])->toBe('stack');
+});
+
+it('opts into the table layout via table()', function (): void {
+    $repeater = json_decode(json_encode(Repeater::make('items')->table()->schema([TextInput::make('a')])), true);
+    $builder = json_decode(json_encode(Builder::make('items')->table()), true);
+
+    expect($repeater['props']['layout'])->toBe('table')
+        ->and($builder['props']['layout'])->toBe('table');
+});

--- a/workbench/app/Forms/BuilderTableDemoForm.php
+++ b/workbench/app/Forms/BuilderTableDemoForm.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Forms;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Core\Components\Card;
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
+use Lattice\Lattice\Forms\Components\Textarea;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Form('workbench.builder-table.form')]
+class BuilderTableDemoForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form
+            ->precognitive(300)
+            ->schema([
+                Card::make('Line items')->schema([
+                    Builder::make('items', 'Line items')
+                        ->table()
+                        ->blocks([
+                            Block::make('product')->label('Product line')->schema([
+                                TextInput::make('product', 'Product')->required(),
+                                TextInput::make('qty', 'Qty')->rules(['numeric']),
+                                TextInput::make('price', 'Price')->rules(['numeric']),
+                            ]),
+                            Block::make('text')->label('Text')->schema([
+                                Textarea::make('content', 'Content')->required(),
+                            ]),
+                        ])
+                        ->minItems(1)
+                        ->addLabel('Add block'),
+                ]),
+            ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $this->validate($request);
+
+        return redirect('/builder-table');
+    }
+}

--- a/workbench/app/Pages/BuilderTableDemoPage.php
+++ b/workbench/app/Pages/BuilderTableDemoPage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Forms\Components\Form;
+use Workbench\App\Forms\BuilderTableDemoForm;
+
+class BuilderTableDemoPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Builder Table Demo';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('builder-table-demo-page')
+                ->gap(Gap::Large)
+                ->schema([
+                    Heading::make('Builder Table Demo'),
+                    Form::use(BuilderTableDemoForm::class)
+                        ->method(HttpMethod::Post)
+                        ->submitLabel('Submit'),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -19,6 +19,7 @@ use Workbench\App\Actions\EditProductAction;
 use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Forms\BuilderDemoForm;
+use Workbench\App\Forms\BuilderTableDemoForm;
 use Workbench\App\Forms\DependentDemoForm;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Forms\RepeaterDemoForm;
@@ -123,6 +124,7 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         Lattice::forms([
             BuilderDemoForm::class,
+            BuilderTableDemoForm::class,
             DependentDemoForm::class,
             ProductForm::class,
             RepeaterDemoForm::class,

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use Workbench\App\Pages\BuilderDemoPage;
+use Workbench\App\Pages\BuilderTableDemoPage;
 use Workbench\App\Pages\DependentDemoPage;
 use Workbench\App\Pages\HomePage;
 use Workbench\App\Pages\ProductCreatePage;
@@ -39,6 +40,9 @@ Route::latticePage('/repeater', RepeaterDemoPage::class)
 
 Route::latticePage('/builder', BuilderDemoPage::class)
     ->name('builder');
+
+Route::latticePage('/builder-table', BuilderTableDemoPage::class)
+    ->name('builder-table');
 
 Route::latticePage('/showcase', ShowcasePage::class)
     ->name('showcase');


### PR DESCRIPTION
## Summary

Three additions to the line-items fields (Repeater + Builder), built on the merged Builder (#71):

1. **Stable row identity + FLIP reorder animation** — rows now slide to their new position on sort ↑↓ (~180ms ease-out, `prefers-reduced-motion`-aware) instead of jumping. This required giving each row a persistent client-only `__rowId` (never submitted), which also **fixes the pre-existing `key={index}` footgun** where a stateful child (e.g. a rich editor) could keep the wrong row's state after a reorder/remove.
2. **An opt-in `->table()` layout** — rows render as a table: a shared header (column labels from the schema / the Builder's first block), horizontal fields in **bare** cells (the label becomes the column header; an `sr-only` label keeps it accessible), reorder ↑↓ on the left, a row-actions area on the right. Builder rows whose block isn't the primary one render as **full-width spanning rows**. Horizontal scroll on narrow screens.
3. **A row-actions mechanism** — a single action renders inline; two or more collapse into a ⋯ menu. v1 wires only `remove`; the mechanism is ready for more.

```php
Builder::make('items', 'Line items')
    ->table()
    ->blocks([
        Block::make('product')->label('Product line')->schema([
            TextInput::make('product')->required(),
            TextInput::make('qty')->rules(['numeric']),
            TextInput::make('price')->rules(['numeric']),
        ]),
        Block::make('text')->label('Text')->schema([Textarea::make('content')->required()]),
    ]);
```

## How it's built (reuse-first)

- **B1 (layout-agnostic):** `withRowId`/`ensureRowIds` + id persistence in `useRowCollection` (via `useLayoutEffect`, so ids are stable before paint and the memo still bails); a small imperative `use-flip-reorder` hook (measure→invert→play, cancels pending frames on rapid reorder/unmount). Wired into both renderers; the row element is the single FLIP target (no double-wrap).
- **B2:** a shared `HasRowLayout` PHP trait (`->table()` + `layout` prop); a `RowLayoutContext` so `FormFieldFrame` renders bare-but-accessible in a cell; a `TableRows` component using **per-row grids that share one `gridTemplateColumns`** (columns align across header + rows *and* each row stays an animatable box — a single grid with `display:contents` rows can't be FLIP'd); a `RowActions` component. The renderers branch on `layout`; the stack layout is byte-unchanged.

## Test plan

- [x] PHP: `->table()` wire shape (`composer test` — 404 passed)
- [x] vitest: id stability + memo preserved, FLIP hook, bare/accessible cell, RowActions inline/kebab, TableRows alignment/spanning/registerRow, both renderer table branches (272 passed)
- [x] Pest **browser**: a `->table()` Builder renders a shared header, columnar product rows + a spanning text row, and the heterogeneous `{type,…}` payload round-trips + validates per-type (50 passed, incl. `TableLayoutTest`)
- [x] lint / types / format / pint — clean

## Notes / deferred

Mobile stack-to-cards fallback (horizontal scroll only for now), drag-and-drop reorder (still ↑↓ + the slide), per-row custom/consumer-defined actions (mechanism only — v1 wires `remove`), and column-width config are out of scope. Each task was reviewed (spec + quality) during implementation; reviews caught and fixed real issues (memo-safe id persistence, FLIP frame cancellation, cell a11y, single FLIP target).