### PR TITLE
feat: #[Page] attribute replacing the latticePage route macro

### DIFF
--- a/config/lattice.php
+++ b/config/lattice.php
@@ -32,6 +32,10 @@ return [
         'registered' => [],
     ],
 
+    'pages' => [
+        'registered' => [],
+    ],
+
     'actions' => [
         'endpoint' => 'lattice/actions/{action}',
         'middleware' => ['web'],

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -3,7 +3,7 @@ title: Pages
 description: The entry point of a Lattice screen — a PHP class that builds a component tree and renders through Inertia.
 ---
 
-A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render(PageSchema $schema)`. You route a URI to it with the `Route::latticePage()` macro; Lattice renders it through Inertia with no controller or Inertia page component of your own. Pages also carry their layout, container, breadcrumbs, and menus.
+A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render(PageSchema $schema)`. You annotate the class with `#[Page(route: '…')]`; Lattice discovers it and registers the route automatically (or you can register pages explicitly with `Lattice::pages([...])`), rendering through Inertia with no controller or Inertia page component of your own. Layout, container, and middleware are declared in the `#[Page]` attribute and can be inherited from a shared base page. Pages also carry their breadcrumbs and menus.
 
 See [Getting Started](/introduction/getting-started/) for a working example.
 

--- a/docs/content/docs/introduction/core-concepts.md
+++ b/docs/content/docs/introduction/core-concepts.md
@@ -26,7 +26,7 @@ The same flow powers interactive pieces: a form submit, a table page change, or 
 
 ### Pages
 
-A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. You point a URI at it with the `Route::latticePage()` macro — no Inertia page component or controller to write by hand. A page also carries its layout, container, breadcrumbs, and menus.
+A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. You annotate it with `#[Page(route: '…')]`; Lattice discovers the page and registers its route — no Inertia page component or controller to write by hand. A page also carries its layout, container, breadcrumbs, and menus.
 
 [Learn more →](/core/pages/)
 
@@ -56,7 +56,7 @@ Actions run on the server in response to a click — a single row action or a bu
 
 ### Navigation
 
-Menus and the sidebar are defined in PHP — most simply by adding `->sidebar()` to a `latticePage` route — and surfaced to the React shell, so navigation stays in sync with the pages it points at.
+Menus and the sidebar are composed from `Menu` and `Sidebar` layout components in PHP and surfaced to the React shell, so navigation stays in sync with the pages it points at.
 
 [Learn more →](/core/navigation/)
 

--- a/docs/content/docs/introduction/getting-started.md
+++ b/docs/content/docs/introduction/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 description: Build your first server-driven page with Lattice and route it.
 ---
 
-This guide builds a single page from PHP, registers a route for it, and adds it to the sidebar. It assumes you have completed [Installation](/introduction/installation/).
+This guide builds a single page from PHP and registers a route for it. It assumes you have completed [Installation](/introduction/installation/).
 
 ## Define a page
 
@@ -14,16 +14,19 @@ A page extends `Lattice\Lattice\Http\Page`. It returns a `title()` and builds it
 
 namespace App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Card;
 use Lattice\Lattice\Core\Components\Grid;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\Gap;
-use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page as BasePage;
 
-final class DashboardPage extends Page
+#[Page(route: '/dashboard', layout: PageLayout::App, middleware: ['web'])]
+final class DashboardPage extends BasePage
 {
     public function title(): string
     {
@@ -52,18 +55,33 @@ final class DashboardPage extends Page
 
 ## Route the page
 
-Lattice registers a `latticePage` route macro. Point a URI at your page class, and optionally add it to the sidebar with a label and an icon:
+There is no route file entry to write. Lattice scans the paths in `lattice.discover` (`app/` by default), finds every class carrying a `#[Page]` attribute, and registers a route for it automatically. The route name auto-derives from the URI (`/dashboard` → `dashboard`); supply `name:` in the attribute to override it.
+
+Visit `/dashboard` and the page renders through Inertia — no route file entry, no controller, and no Inertia page component to write by hand.
+
+### Sharing layout and middleware across pages
+
+Rather than repeating `layout:` and `middleware:` on every page, declare a shared base page and inherit from it:
 
 ```php
-use App\Pages\DashboardPage;
-use Lattice\Lattice\Core\Enums\Icon;
-use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Http\Page as BasePage;
 
-Route::latticePage('/dashboard', DashboardPage::class)
-    ->sidebar('Dashboard', Icon::LayoutDashboard);
+#[Page(layout: PageLayout::App, middleware: ['web'])]
+abstract class AppPage extends BasePage {}
+
+#[Page(route: '/dashboard')] // inherits layout + web middleware
+final class DashboardPage extends AppPage { /* title(), render() */ }
 ```
 
-Visit `/dashboard` and the page renders through Inertia — no Inertia page component or controller to write by hand.
+Pages need the `web` middleware group for sessions, CSRF, and route-model binding. Setting it once on the shared base keeps individual pages clean.
+
+To register pages explicitly — for example from a package — call `Lattice::pages([DashboardPage::class])` in a service provider instead of relying on discovery.
+
+## Navigation
+
+Navigation (sidebar and menus) is built from `Menu` and `Sidebar` layout components in PHP. See [Navigation](/core/navigation/) for details.
 
 ## Where to go next
 

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -9,19 +9,21 @@ Lattice (`lattice-php/lattice`) is a server-driven UI layer for Laravel apps run
 
 ### Building a page
 
-A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. Route it with the `Route::latticePage()` macro — no controller or Inertia page component to write by hand.
+A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. Annotate it with `#[Page(route: '…')]`; Lattice discovers the page and registers its route automatically — no controller, route file entry, or Inertia page component to write by hand.
 
 @verbatim
 <code-snippet name="A page and its route" lang="php">
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
-use Lattice\Lattice\Core\Enums\Icon;
+use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Http\Page as BasePage;
 use Lattice\Lattice\Tables\Components\Table;
 
-final class ProductsPage extends Page
+#[Page(route: '/products', layout: PageLayout::App, middleware: ['web'])]
+final class ProductsPage extends BasePage
 {
     public function title(): string
     {
@@ -39,9 +41,8 @@ final class ProductsPage extends Page
     }
 }
 
-// routes/web.php
-Route::latticePage('/products', ProductsPage::class)
-    ->sidebar('Products', Icon::LayoutDashboard);
+// Discovered automatically; or register explicitly:
+// Lattice::pages([ProductsPage::class]);
 </code-snippet>
 @endverbatim
 
@@ -53,7 +54,7 @@ Drop a form or a table into the tree with `Form::use(MyForm::class)` and `Table:
 - **Forms** — `FormDefinition` classes with fields + server-side (and live, Precognition) validation. **Reach for the `lattice-forms` skill.**
 - **Tables** — `EloquentTableDefinition` classes with columns, sorting, filtering, pagination, and row/bulk actions. **Reach for the `lattice-tables` skill.**
 - **Actions** — `ActionDefinition` / `BulkActionDefinition` that run on the server and return effects (toast, redirect, refresh, modal) via `ActionResult`. **Reach for the `lattice-actions` skill.**
-- **Navigation** — add `->sidebar('Label', Icon::Name)` to a `latticePage` route.
+- **Navigation** — compose `Menu`/`Sidebar` components inside a layout (there is no route-level sidebar helper).
 
 ### Conventions
 

--- a/src/Attributes/Page.php
+++ b/src/Attributes/Page.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Attributes;
+
+use Attribute;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Page
+{
+    /**
+     * @param  array<int, string>|string|null  $middleware
+     */
+    public function __construct(
+        public readonly ?string $route = null,
+        public readonly ?string $name = null,
+        public readonly PageLayout|string|null $layout = null,
+        public readonly PageContainer|string|null $container = null,
+        public readonly array|string|null $middleware = null,
+    ) {}
+}

--- a/src/Core/Contracts/Discoverable.php
+++ b/src/Core/Contracts/Discoverable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Contracts;
+
+interface Discoverable
+{
+    /** @return class-string */
+    public function attributeClass(): string;
+
+    public function group(): string;
+
+    /** @param array<int, class-string> $definitions */
+    public function registerDiscovered(array $definitions): void;
+}

--- a/src/Core/Contracts/DiscoversDefinitions.php
+++ b/src/Core/Contracts/DiscoversDefinitions.php
@@ -3,12 +3,10 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Contracts;
 
-use Lattice\Lattice\Core\DefinitionRegistry;
-
 interface DiscoversDefinitions
 {
     /**
-     * @param  array<int, DefinitionRegistry<*>>  $registries
+     * @param  array<int, Discoverable>  $registries
      * @return array<string, array<int, class-string>>
      */
     public function discover(string $path, string $namespace, array $registries): array;

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use Lattice\Lattice\Attributes\ComponentAttribute;
 use Lattice\Lattice\Core\Contracts\DefinitionRegistry as DefinitionRegistryContract;
+use Lattice\Lattice\Core\Contracts\Discoverable;
 use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
 use Spatie\Attributes\Attributes;
 
@@ -15,7 +16,7 @@ use Spatie\Attributes\Attributes;
  *
  * @implements DefinitionRegistryContract<TDefinition>
  */
-abstract class DefinitionRegistry implements DefinitionRegistryContract
+abstract class DefinitionRegistry implements DefinitionRegistryContract, Discoverable
 {
     /**
      * @var array<string, class-string<TDefinition>>

--- a/src/Core/Services/DefinitionDiscovery.php
+++ b/src/Core/Services/DefinitionDiscovery.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Services;
 
+use Lattice\Lattice\Core\Contracts\Discoverable;
 use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
-use Lattice\Lattice\Core\DefinitionRegistry;
 use Lattice\Lattice\Support\Discovery\ClassWalker;
 use ReflectionClass;
 use Spatie\Attributes\Attributes;
@@ -46,7 +46,7 @@ final class DefinitionDiscovery implements DiscoversDefinitions
     }
 
     /**
-     * @param  array<int, DefinitionRegistry<*>>  $registries
+     * @param  array<int, Discoverable>  $registries
      * @return array<string, array<int, class-string>>
      */
     public function discover(string $path, string $namespace, array $registries): array

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -14,11 +14,9 @@ use Lattice\Lattice\LatticeRegistry;
  * @method static \Lattice\Lattice\Layouts\LayoutRegistry layoutRegistry()
  * @method static void actions(class-string<\Lattice\Lattice\Actions\ActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\ActionDefinition>> $actions)
  * @method static void bulkActions(class-string<\Lattice\Lattice\Actions\BulkActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\BulkActionDefinition>> $bulkActions)
- * @method static void pages(class-string|array<int, class-string> $pages)
+ * @method static \Lattice\Lattice\Pages\PageRegistry pages(class-string|array<int, class-string> $pages = [])
  * @method static void registerConfiguredDefinitions()
- * @method static void registerConfiguredPages()
  * @method static void discover(string $path, string $namespace)
- * @method static void discoverPages(string $path, string $namespace)
  *
  * @see LatticeRegistry
  */

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -16,7 +16,9 @@ use Lattice\Lattice\LatticeRegistry;
  * @method static void bulkActions(class-string<\Lattice\Lattice\Actions\BulkActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\BulkActionDefinition>> $bulkActions)
  * @method static void pages(class-string|array<int, class-string> $pages)
  * @method static void registerConfiguredDefinitions()
+ * @method static void registerConfiguredPages()
  * @method static void discover(string $path, string $namespace)
+ * @method static void discoverPages(string $path, string $namespace)
  *
  * @see LatticeRegistry
  */

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -17,7 +17,6 @@ use Lattice\Lattice\LatticeRegistry;
  * @method static void pages(class-string|array<int, class-string> $pages)
  * @method static void registerConfiguredDefinitions()
  * @method static void discover(string $path, string $namespace)
- * @method static \Illuminate\Routing\Route page(string $uri, string $page)
  *
  * @see LatticeRegistry
  */

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -14,6 +14,7 @@ use Lattice\Lattice\LatticeRegistry;
  * @method static \Lattice\Lattice\Layouts\LayoutRegistry layoutRegistry()
  * @method static void actions(class-string<\Lattice\Lattice\Actions\ActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\ActionDefinition>> $actions)
  * @method static void bulkActions(class-string<\Lattice\Lattice\Actions\BulkActionDefinition>|array<int, class-string<\Lattice\Lattice\Actions\BulkActionDefinition>> $bulkActions)
+ * @method static void pages(class-string|array<int, class-string> $pages)
  * @method static void registerConfiguredDefinitions()
  * @method static void discover(string $path, string $namespace)
  * @method static \Illuminate\Routing\Route page(string $uri, string $page)

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -8,7 +8,6 @@ use BadMethodCallException;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
@@ -19,16 +18,6 @@ abstract class Page implements PageContract
     public function title(): ?string
     {
         return null;
-    }
-
-    public function layout(): PageLayout|string
-    {
-        return PageLayout::None;
-    }
-
-    public function container(): PageContainer|string
-    {
-        return PageContainer::Centered;
     }
 
     /**
@@ -83,10 +72,12 @@ abstract class Page implements PageContract
      */
     public function toArray(PageSchema $schema, Request $request): array
     {
+        $metadata = PageMetadata::for($this);
+
         return [
             'title' => $this->title(),
-            'layout' => $this->resolveLayout($request),
-            'container' => $this->serializePageMetadata($this->container()),
+            'layout' => $this->resolveLayout($metadata, $request),
+            'container' => $this->serializePageMetadata($metadata->container),
             'breadcrumbs' => $this->breadcrumbs(),
             'schema' => $this->serializeSchema($schema),
             'i18n' => $this->i18nConfig(),
@@ -101,9 +92,9 @@ abstract class Page implements PageContract
      *
      * @return array{key: string, schema: array<int, array<string, mixed>>}|null
      */
-    private function resolveLayout(Request $request): ?array
+    private function resolveLayout(PageMetadata $metadata, Request $request): ?array
     {
-        $key = $this->serializePageMetadata($this->layout());
+        $key = $this->serializePageMetadata($metadata->layout);
 
         if ($key === '' || $key === PageLayout::None->value) {
             return null;

--- a/src/Http/PageMetadata.php
+++ b/src/Http/PageMetadata.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http;
+
+use Lattice\Lattice\Attributes\Page as PageAttribute;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use ReflectionClass;
+
+final class PageMetadata
+{
+    /**
+     * @param  array<int, string>  $middleware
+     */
+    private function __construct(
+        public readonly ?string $route,
+        public readonly string $name,
+        public readonly PageLayout|string $layout,
+        public readonly PageContainer|string $container,
+        public readonly array $middleware,
+    ) {}
+
+    public static function for(Page|string $page): self
+    {
+        $class = is_object($page) ? $page::class : $page;
+
+        $own = self::attributeOn($class);
+
+        return new self(
+            route: $own?->route,
+            name: self::resolveName($class, $own),
+            layout: self::inherited($class, fn (PageAttribute $a) => $a->layout) ?? PageLayout::None,
+            container: self::inherited($class, fn (PageAttribute $a) => $a->container) ?? PageContainer::Centered,
+            middleware: (array) (self::inherited($class, fn (PageAttribute $a) => $a->middleware) ?? []),
+        );
+    }
+
+    private static function attributeOn(string $class): ?PageAttribute
+    {
+        $attributes = (new ReflectionClass($class))->getAttributes(PageAttribute::class);
+
+        return $attributes === [] ? null : $attributes[0]->newInstance();
+    }
+
+    /**
+     * @param  callable(PageAttribute): (PageLayout|PageContainer|array<int,string>|string|null)  $value
+     */
+    private static function inherited(string $class, callable $value): mixed
+    {
+        for ($current = $class; $current !== false; $current = get_parent_class($current)) {
+            $attribute = self::attributeOn($current);
+
+            if ($attribute !== null && ($resolved = $value($attribute)) !== null) {
+                return $resolved;
+            }
+        }
+
+        return null;
+    }
+
+    private static function resolveName(string $class, ?PageAttribute $own): string
+    {
+        if ($own?->name !== null) {
+            return $own->name;
+        }
+
+        $segments = array_filter(
+            explode('/', (string) ($own?->route ?? '')),
+            static fn (string $segment): bool => $segment !== '' && ! str_starts_with($segment, '{'),
+        );
+
+        if ($segments !== []) {
+            return implode('.', $segments);
+        }
+
+        return str(class_basename($class))->beforeLast('Page')->kebab()->toString();
+    }
+}

--- a/src/Http/PageMetadata.php
+++ b/src/Http/PageMetadata.php
@@ -66,8 +66,10 @@ final class PageMetadata
             return $own->name;
         }
 
+        $route = $own !== null ? ($own->route ?? '') : '';
+
         $segments = array_filter(
-            explode('/', (string) ($own?->route ?? '')),
+            explode('/', $route),
             static fn (string $segment): bool => $segment !== '' && ! str_starts_with($segment, '{'),
         );
 

--- a/src/Http/PageMetadata.php
+++ b/src/Http/PageMetadata.php
@@ -12,9 +12,11 @@ use ReflectionClass;
 final class PageMetadata
 {
     /**
+     * @param  class-string  $class
      * @param  array<int, string>  $middleware
      */
     private function __construct(
+        public readonly string $class,
         public readonly ?string $route,
         public readonly string $name,
         public readonly PageLayout|string $layout,
@@ -29,6 +31,7 @@ final class PageMetadata
         $own = self::attributeOn($class);
 
         return new self(
+            class: $class,
             route: $own?->route,
             name: self::resolveName($class, $own),
             layout: self::inherited($class, fn (PageAttribute $a) => $a->layout) ?? PageLayout::None,

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -10,6 +10,7 @@ use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionDefinition;
 use Lattice\Lattice\Actions\BulkActionRegistry;
+use Lattice\Lattice\Core\Contracts\Discoverable;
 use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
 use Lattice\Lattice\Core\DefinitionRegistry;
 use Lattice\Lattice\Forms\FormDefinition;
@@ -19,6 +20,7 @@ use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Http\PageContract;
 use Lattice\Lattice\Layouts\LayoutDefinition;
 use Lattice\Lattice\Layouts\LayoutRegistry;
+use Lattice\Lattice\Pages\PageRegistry;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableRegistry;
 
@@ -31,6 +33,7 @@ final class LatticeRegistry
         private readonly FormRegistry $forms,
         private readonly FragmentRegistry $fragments,
         private readonly LayoutRegistry $layouts,
+        private readonly PageRegistry $pages,
         private readonly Router $router,
         private readonly TableRegistry $tables,
     ) {}
@@ -83,6 +86,14 @@ final class LatticeRegistry
         $this->layouts->register($layouts);
     }
 
+    /**
+     * @param  class-string|array<int, class-string>  $pages
+     */
+    public function pages(string|array $pages): void
+    {
+        $this->pages->register($pages);
+    }
+
     public function layoutRegistry(): LayoutRegistry
     {
         return $this->layouts;
@@ -97,11 +108,22 @@ final class LatticeRegistry
                 $registry->register($configured);
             }
         }
+
+        $configuredPages = config('lattice.pages.registered', []);
+
+        if (is_array($configuredPages) && $configuredPages !== []) {
+            $this->pages->register($configuredPages);
+        }
     }
 
     public function discover(string $path, string $namespace): void
     {
-        $registries = $this->discoverableRegistries();
+        /** @var array<string, Discoverable> $registries */
+        $registries = array_merge(
+            $this->discoverableRegistries(),
+            ['pages' => $this->pages],
+        );
+
         $definitions = $this->discovery->discover($path, $namespace, array_values($registries));
 
         foreach ($definitions as $group => $classes) {

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -83,9 +83,19 @@ final class LatticeRegistry
     /**
      * @param  class-string|array<int, class-string>  $pages
      */
-    public function pages(string|array $pages): void
+    /**
+     * Register pages and/or return the page registry. Call without arguments to
+     * read every routable page via `Lattice::pages()->all()`.
+     *
+     * @param  class-string|array<int, class-string>  $pages
+     */
+    public function pages(string|array $pages = []): PageRegistry
     {
-        $this->pages->register($pages);
+        if ($pages !== []) {
+            $this->pages->register($pages);
+        }
+
+        return $this->pages;
     }
 
     public function layoutRegistry(): LayoutRegistry
@@ -104,15 +114,6 @@ final class LatticeRegistry
         }
     }
 
-    public function registerConfiguredPages(): void
-    {
-        $configured = config('lattice.pages.registered', []);
-
-        if (is_array($configured) && $configured !== []) {
-            $this->pages->register($configured);
-        }
-    }
-
     public function discover(string $path, string $namespace): void
     {
         $registries = $this->discoverableRegistries();
@@ -124,18 +125,6 @@ final class LatticeRegistry
                 $registries[$group]->registerDiscovered($classes);
             }
         }
-    }
-
-    /**
-     * Discover `#[Page]` classes under a path and register their routes. Kept
-     * separate from definition discovery so the service provider can skip it
-     * when the router is serving a cached route table.
-     */
-    public function discoverPages(string $path, string $namespace): void
-    {
-        $discovered = $this->discovery->discover($path, $namespace, [$this->pages]);
-
-        $this->pages->registerDiscovered($discovered[$this->pages->group()] ?? []);
     }
 
     /**

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -7,7 +7,6 @@ use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionDefinition;
 use Lattice\Lattice\Actions\BulkActionRegistry;
-use Lattice\Lattice\Core\Contracts\Discoverable;
 use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
 use Lattice\Lattice\Core\DefinitionRegistry;
 use Lattice\Lattice\Forms\FormDefinition;
@@ -103,21 +102,20 @@ final class LatticeRegistry
                 $registry->register($configured);
             }
         }
+    }
 
-        $configuredPages = config('lattice.pages.registered', []);
+    public function registerConfiguredPages(): void
+    {
+        $configured = config('lattice.pages.registered', []);
 
-        if (is_array($configuredPages) && $configuredPages !== []) {
-            $this->pages->register($configuredPages);
+        if (is_array($configured) && $configured !== []) {
+            $this->pages->register($configured);
         }
     }
 
     public function discover(string $path, string $namespace): void
     {
-        /** @var array<string, Discoverable> $registries */
-        $registries = array_merge(
-            $this->discoverableRegistries(),
-            ['pages' => $this->pages],
-        );
+        $registries = $this->discoverableRegistries();
 
         $definitions = $this->discovery->discover($path, $namespace, array_values($registries));
 
@@ -126,6 +124,18 @@ final class LatticeRegistry
                 $registries[$group]->registerDiscovered($classes);
             }
         }
+    }
+
+    /**
+     * Discover `#[Page]` classes under a path and register their routes. Kept
+     * separate from definition discovery so the service provider can skip it
+     * when the router is serving a cached route table.
+     */
+    public function discoverPages(string $path, string $namespace): void
+    {
+        $discovered = $this->discovery->discover($path, $namespace, [$this->pages]);
+
+        $this->pages->registerDiscovered($discovered[$this->pages->group()] ?? []);
     }
 
     /**

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -3,9 +3,6 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice;
 
-use Illuminate\Routing\Route;
-use Illuminate\Routing\Router;
-use InvalidArgumentException;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionDefinition;
@@ -17,7 +14,6 @@ use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\FragmentDefinition;
 use Lattice\Lattice\Fragments\FragmentRegistry;
-use Lattice\Lattice\Http\PageContract;
 use Lattice\Lattice\Layouts\LayoutDefinition;
 use Lattice\Lattice\Layouts\LayoutRegistry;
 use Lattice\Lattice\Pages\PageRegistry;
@@ -34,7 +30,6 @@ final class LatticeRegistry
         private readonly FragmentRegistry $fragments,
         private readonly LayoutRegistry $layouts,
         private readonly PageRegistry $pages,
-        private readonly Router $router,
         private readonly TableRegistry $tables,
     ) {}
 
@@ -144,21 +139,5 @@ final class LatticeRegistry
             array_map(static fn (DefinitionRegistry $registry): string => $registry->group(), $registries),
             $registries,
         );
-    }
-
-    /**
-     * @param  class-string  $page
-     */
-    public function page(string $uri, string $page): Route
-    {
-        if (! is_a($page, PageContract::class, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'Lattice page [%s] must implement [%s].',
-                $page,
-                PageContract::class,
-            ));
-        }
-
-        return $this->router->get($uri, [$page, 'render']);
     }
 }

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice;
 
 use BackedEnum;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Route;
 use Inertia\ResponseFactory;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionRegistry;
@@ -96,11 +97,13 @@ final class LatticeServiceProvider extends PackageServiceProvider
             Lattice::discover($path, $namespace);
         }
 
-        $this->bootPages();
+        // Deferred so pages registered by any provider's boot() (e.g. an app's
+        // own `Lattice::pages([...])`) are collected before the routes are built.
+        $this->app->booted(fn () => $this->bootPages());
     }
 
     /**
-     * Register page routes from configuration and discovery — but only when the
+     * Build a route for every discovered and registered page — but only when the
      * router is not serving a cached route table. With `route:cache` active,
      * Laravel loads the routes from the cache, so re-scanning the filesystem and
      * re-registering them here on every request would be redundant work.
@@ -111,10 +114,12 @@ final class LatticeServiceProvider extends PackageServiceProvider
             return;
         }
 
-        Lattice::registerConfiguredPages();
-
-        foreach (DefinitionDiscovery::configuredPaths() as $path => $namespace) {
-            Lattice::discoverPages($path, $namespace);
+        foreach (Lattice::pages()->all() as $page) {
+            Route::get($page->route, [$page->class, 'render'])
+                ->name($page->name)
+                ->middleware($page->middleware);
         }
+
+        Route::getRoutes()->refreshNameLookups();
     }
 }

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -95,5 +95,26 @@ final class LatticeServiceProvider extends PackageServiceProvider
         foreach (DefinitionDiscovery::configuredPaths() as $path => $namespace) {
             Lattice::discover($path, $namespace);
         }
+
+        $this->bootPages();
+    }
+
+    /**
+     * Register page routes from configuration and discovery — but only when the
+     * router is not serving a cached route table. With `route:cache` active,
+     * Laravel loads the routes from the cache, so re-scanning the filesystem and
+     * re-registering them here on every request would be redundant work.
+     */
+    public function bootPages(): void
+    {
+        if ($this->app->routesAreCached()) {
+            return;
+        }
+
+        Lattice::registerConfiguredPages();
+
+        foreach (DefinitionDiscovery::configuredPaths() as $path => $namespace) {
+            Lattice::discoverPages($path, $namespace);
+        }
     }
 }

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -24,6 +24,7 @@ use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Layouts\LayoutRegistry;
+use Lattice\Lattice\Pages\PageRegistry;
 use Lattice\Lattice\Support\TypeScript\AugmentProfile;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Lattice\Lattice\Tables\TableRegistry;
@@ -58,6 +59,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->singleton(LayoutRegistry::class);
         $this->app->singleton(ActionRegistry::class);
         $this->app->singleton(BulkActionRegistry::class);
+        $this->app->singleton(PageRegistry::class);
         $this->app->singleton(DefinitionDiscovery::class);
         $this->app->alias(DefinitionDiscovery::class, DiscoversDefinitions::class);
         $this->app->singleton(ComponentReferenceSigner::class);

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -5,8 +5,6 @@ namespace Lattice\Lattice;
 
 use BackedEnum;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Routing\Route;
-use Illuminate\Routing\Router;
 use Inertia\ResponseFactory;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionRegistry;
@@ -68,10 +66,6 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
         // Default role; the workbench rebinds this to BaseProfile.
         $this->app->bind(TypeScriptProfile::class, AugmentProfile::class);
-
-        if (! Router::hasMacro('latticePage')) {
-            Router::macro('latticePage', fn (string $uri, string $page): Route => Lattice::page($uri, $page));
-        }
 
         if (! ResponseFactory::hasMacro('toRoute')) {
             ResponseFactory::macro(

--- a/src/Pages/PageRegistry.php
+++ b/src/Pages/PageRegistry.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Pages;
+
+use Illuminate\Routing\Router;
+use Lattice\Lattice\Attributes\Page as PageAttribute;
+use Lattice\Lattice\Core\Contracts\Discoverable;
+use Lattice\Lattice\Http\PageContract;
+use Lattice\Lattice\Http\PageMetadata;
+use ReflectionClass;
+
+final class PageRegistry implements Discoverable
+{
+    public function __construct(private readonly Router $router) {}
+
+    /**
+     * @param  class-string|array<int, class-string>  $pages
+     */
+    public function register(string|array $pages): void
+    {
+        foreach ((array) $pages as $page) {
+            $this->registerRoute($page);
+        }
+    }
+
+    /**
+     * @param  array<int, class-string>  $definitions
+     */
+    public function registerDiscovered(array $definitions): void
+    {
+        foreach ($definitions as $definition) {
+            $this->registerRoute($definition);
+        }
+    }
+
+    public function attributeClass(): string
+    {
+        return PageAttribute::class;
+    }
+
+    public function group(): string
+    {
+        return 'pages';
+    }
+
+    /**
+     * @param  class-string  $page
+     */
+    private function registerRoute(string $page): void
+    {
+        if (! is_a($page, PageContract::class, true) || (new ReflectionClass($page))->isAbstract()) {
+            return;
+        }
+
+        $metadata = PageMetadata::for($page);
+
+        if ($metadata->route === null) {
+            return;
+        }
+
+        $route = $this->router->get($metadata->route, [$page, 'render']);
+        $route->name($metadata->name);
+
+        if ($metadata->middleware !== []) {
+            $route->middleware($metadata->middleware);
+        }
+
+        $this->router->getRoutes()->refreshNameLookups();
+    }
+}

--- a/src/Pages/PageRegistry.php
+++ b/src/Pages/PageRegistry.php
@@ -4,16 +4,27 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Pages;
 
-use Illuminate\Routing\Router;
 use Lattice\Lattice\Attributes\Page as PageAttribute;
 use Lattice\Lattice\Core\Contracts\Discoverable;
+use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
+use Lattice\Lattice\Core\Services\DefinitionDiscovery;
 use Lattice\Lattice\Http\PageContract;
 use Lattice\Lattice\Http\PageMetadata;
 use ReflectionClass;
 
+/**
+ * Collects page classes from explicit registration, configuration, and
+ * discovery. It does not register routes itself — the service provider reads
+ * `all()` and binds the routes, so the routing happens in one visible place.
+ */
 final class PageRegistry implements Discoverable
 {
-    public function __construct(private readonly Router $router) {}
+    /** @var array<class-string, class-string> */
+    private array $registered = [];
+
+    private bool $sourcesLoaded = false;
+
+    public function __construct(private readonly DiscoversDefinitions $discovery) {}
 
     /**
      * @param  class-string|array<int, class-string>  $pages
@@ -21,7 +32,7 @@ final class PageRegistry implements Discoverable
     public function register(string|array $pages): void
     {
         foreach ((array) $pages as $page) {
-            $this->registerRoute($page);
+            $this->registered[$page] = $page;
         }
     }
 
@@ -30,9 +41,7 @@ final class PageRegistry implements Discoverable
      */
     public function registerDiscovered(array $definitions): void
     {
-        foreach ($definitions as $definition) {
-            $this->registerRoute($definition);
-        }
+        $this->register($definitions);
     }
 
     public function attributeClass(): string
@@ -46,27 +55,50 @@ final class PageRegistry implements Discoverable
     }
 
     /**
-     * @param  class-string  $page
+     * Every routable page — explicitly registered, configured, and discovered
+     * under the configured paths — resolved to its route metadata. Discovery
+     * runs lazily the first time this is called.
+     *
+     * @return array<int, PageMetadata>
      */
-    private function registerRoute(string $page): void
+    public function all(): array
     {
-        if (! is_a($page, PageContract::class, true) || (new ReflectionClass($page))->isAbstract()) {
+        $this->loadSources();
+
+        $pages = [];
+
+        foreach ($this->registered as $page) {
+            if (! is_a($page, PageContract::class, true) || (new ReflectionClass($page))->isAbstract()) {
+                continue;
+            }
+
+            $metadata = PageMetadata::for($page);
+
+            if ($metadata->route !== null) {
+                $pages[] = $metadata;
+            }
+        }
+
+        return $pages;
+    }
+
+    private function loadSources(): void
+    {
+        if ($this->sourcesLoaded) {
             return;
         }
 
-        $metadata = PageMetadata::for($page);
+        $this->sourcesLoaded = true;
 
-        if ($metadata->route === null) {
-            return;
+        $configured = config('lattice.pages.registered', []);
+
+        if (is_array($configured)) {
+            $this->register($configured);
         }
 
-        $route = $this->router->get($metadata->route, [$page, 'render']);
-        $route->name($metadata->name);
-
-        if ($metadata->middleware !== []) {
-            $route->middleware($metadata->middleware);
+        foreach (DefinitionDiscovery::configuredPaths() as $path => $namespace) {
+            $discovered = $this->discovery->discover($path, $namespace, [$this]);
+            $this->register($discovered[$this->group()] ?? []);
         }
-
-        $this->router->getRoutes()->refreshNameLookups();
     }
 }

--- a/tests/Feature/LatticeLayoutTest.php
+++ b/tests/Feature/LatticeLayoutTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Layout;
+use Lattice\Lattice\Attributes\Page as PageAttr;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
-use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
@@ -29,13 +29,9 @@ final class WorkbenchAppLayout extends LayoutDefinition
     }
 }
 
+#[PageAttr(layout: 'app')]
 final class WorkbenchLayoutPage extends Page
 {
-    public function layout(): string
-    {
-        return 'app';
-    }
-
     public function render(PageSchema $schema): PageSchema
     {
         return $schema->component(Text::make('Page body'));
@@ -95,11 +91,6 @@ test('a page without a layout serializes a null layout', function () {
 test('the none layout sentinel serializes a null layout', function () {
     $page = new class extends Page
     {
-        public function layout(): PageLayout
-        {
-            return PageLayout::None;
-        }
-
         public function render(PageSchema $schema): PageSchema
         {
             return $schema->component(Text::make('body'));

--- a/tests/Feature/LatticeMenuTest.php
+++ b/tests/Feature/LatticeMenuTest.php
@@ -74,7 +74,7 @@ test('a menu item includes unset optional props as null on the wire', function (
 });
 
 test('fromPage resolves the href and a default label from the page route', function () {
-    Route::latticePage('/menu-products', MenuProductsPage::class);
+    Route::get('/menu-products', [MenuProductsPage::class, 'render']);
 
     $wire = wire(MenuItem::fromPage(MenuProductsPage::class));
 
@@ -85,7 +85,7 @@ test('fromPage resolves the href and a default label from the page route', funct
 });
 
 test('fromPage substitutes route parameters into the href', function () {
-    Route::latticePage('/menu-products/{product}', MenuProductsPage::class);
+    Route::get('/menu-products/{product}', [MenuProductsPage::class, 'render']);
 
     $wire = wire(MenuItem::fromPage(MenuProductsPage::class, ['product' => 7]));
 
@@ -93,7 +93,7 @@ test('fromPage substitutes route parameters into the href', function () {
 });
 
 test('fromPage label can be overridden fluently', function () {
-    Route::latticePage('/menu-products', MenuProductsPage::class);
+    Route::get('/menu-products', [MenuProductsPage::class, 'render']);
 
     $wire = wire(MenuItem::fromPage(MenuProductsPage::class)->label('Catalog'));
 

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -1470,7 +1470,7 @@ test('tabs ignore hidden tab children when resolving their active value', functi
 });
 
 test('tabs hydrate their active value from the request query string', function () {
-    Route::latticePage('query-tabs', WorkbenchTabsPage::class)->middleware('web')->name('query-tabs.show');
+    Route::get('query-tabs', [WorkbenchTabsPage::class, 'render'])->middleware('web')->name('query-tabs.show');
 
     withoutVite();
 
@@ -1510,7 +1510,7 @@ test('confirmed inactive tabs serialize only their tab metadata', function () {
 });
 
 test('confirmed active tabs redirect to password confirmation when the password is not confirmed', function () {
-    Route::latticePage('confirmed-tabs', WorkbenchConfirmedTabsPage::class)->middleware('web')->name('confirmed-tabs.show');
+    Route::get('confirmed-tabs', [WorkbenchConfirmedTabsPage::class, 'render'])->middleware('web')->name('confirmed-tabs.show');
     config(['session.driver' => 'array']);
 
     get('/confirmed-tabs?tabs=security')
@@ -1520,7 +1520,7 @@ test('confirmed active tabs redirect to password confirmation when the password 
 });
 
 test('confirmed active tabs serialize their children after password confirmation', function () {
-    Route::latticePage('confirmed-tabs', WorkbenchConfirmedTabsPage::class)->middleware('web')->name('confirmed-tabs.show');
+    Route::get('confirmed-tabs', [WorkbenchConfirmedTabsPage::class, 'render'])->middleware('web')->name('confirmed-tabs.show');
 
     withoutVite();
     config(['session.driver' => 'array']);
@@ -1549,7 +1549,7 @@ test('pages use laravel controller resolution for constructor dependencies rende
         'name' => 'Route Bound User',
     ]);
 
-    Route::latticePage('page-injection/{user}/{label}', WorkbenchInjectedPage::class)
+    Route::get('page-injection/{user}/{label}', [WorkbenchInjectedPage::class, 'render'])
         ->middleware('web')
         ->name('page-injection.show');
 
@@ -1564,7 +1564,7 @@ test('pages use laravel controller resolution for constructor dependencies rende
 });
 
 test('pages can authorize requests before rendering', function () {
-    Route::latticePage('authorized-page', WorkbenchAuthorizedPage::class)
+    Route::get('authorized-page', [WorkbenchAuthorizedPage::class, 'render'])
         ->middleware('web')
         ->name('authorized-page.show');
 

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -40,6 +40,7 @@ use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\ToastVariant;
 use Lattice\Lattice\Core\Enums\Width;
 use Lattice\Lattice\Core\PageSchema;
@@ -1589,13 +1590,8 @@ test('pages serialize layout and container metadata', function () {
         }
     };
 
-    $configuredPage = new class extends Page
+    $configuredPage = new #[\Lattice\Lattice\Attributes\Page(container: PageContainer::Default)] class extends Page
     {
-        public function container(): string
-        {
-            return 'default';
-        }
-
         public function render(PageSchema $schema): PageSchema
         {
             return $schema->component(Text::make('Configured page'));
@@ -1603,15 +1599,9 @@ test('pages serialize layout and container metadata', function () {
     };
 
     expect($defaultPage->toArray($defaultPage->render(PageSchema::make()), new Request))
-        ->toMatchArray([
-            'layout' => null,
-            'container' => 'centered',
-        ])
+        ->toMatchArray(['layout' => null, 'container' => 'centered'])
         ->and($configuredPage->toArray($configuredPage->render(PageSchema::make()), new Request))
-        ->toMatchArray([
-            'layout' => null,
-            'container' => 'default',
-        ]);
+        ->toMatchArray(['layout' => null, 'container' => 'default']);
 });
 
 test('pages serialize breadcrumb metadata', function () {

--- a/tests/Feature/PageAttributeTest.php
+++ b/tests/Feature/PageAttributeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+
+test('page attribute stores route metadata', function () {
+    $attribute = new Page(
+        route: '/products/{product}/edit',
+        name: 'products.edit',
+        layout: PageLayout::App,
+        container: PageContainer::Default,
+        middleware: ['can:manage'],
+    );
+
+    expect($attribute->route)->toBe('/products/{product}/edit')
+        ->and($attribute->name)->toBe('products.edit')
+        ->and($attribute->layout)->toBe(PageLayout::App)
+        ->and($attribute->container)->toBe(PageContainer::Default)
+        ->and($attribute->middleware)->toBe(['can:manage']);
+});
+
+test('page attribute defaults every argument to null', function () {
+    $attribute = new Page;
+
+    expect($attribute->route)->toBeNull()
+        ->and($attribute->name)->toBeNull()
+        ->and($attribute->layout)->toBeNull()
+        ->and($attribute->container)->toBeNull()
+        ->and($attribute->middleware)->toBeNull();
+});

--- a/tests/Feature/PageMetadataTest.php
+++ b/tests/Feature/PageMetadataTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Http\Page as BasePage;
+use Lattice\Lattice\Http\PageMetadata;
+
+#[Page(layout: PageLayout::App, container: PageContainer::Default)]
+abstract class FixtureBasePage extends BasePage {}
+
+#[Page(route: '/products', name: 'products.index')]
+final class FixtureProductsPage extends FixtureBasePage {}
+
+#[Page(route: '/products/{product}/edit')]
+final class FixtureEditPage extends FixtureBasePage {}
+
+#[Page(route: '/', middleware: 'web')]
+final class FixtureHomePage extends FixtureBasePage {}
+
+#[Page(route: '/standalone', container: PageContainer::Centered)]
+final class FixtureStandalonePage extends FixtureBasePage {}
+
+test('metadata inherits layout and container from a base page attribute', function () {
+    $meta = PageMetadata::for(FixtureProductsPage::class);
+
+    expect($meta->route)->toBe('/products')
+        ->and($meta->name)->toBe('products.index')
+        ->and($meta->layout)->toBe(PageLayout::App)
+        ->and($meta->container)->toBe(PageContainer::Default)
+        ->and($meta->middleware)->toBe([]);
+});
+
+test('metadata derives the route name when none is given', function () {
+    expect(PageMetadata::for(FixtureEditPage::class)->name)->toBe('products.edit');
+});
+
+test('metadata falls back to the class name for the root route', function () {
+    expect(PageMetadata::for(FixtureHomePage::class)->name)->toBe('fixture-home')
+        ->and(PageMetadata::for(FixtureHomePage::class)->middleware)->toBe(['web']);
+});
+
+test('a concrete page overrides an inherited container', function () {
+    expect(PageMetadata::for(FixtureStandalonePage::class)->container)->toBe(PageContainer::Centered);
+});
+
+test('a page without any attribute resolves to defaults', function () {
+    $page = new class extends BasePage {};
+
+    $meta = PageMetadata::for($page);
+
+    expect($meta->route)->toBeNull()
+        ->and($meta->layout)->toBe(PageLayout::None)
+        ->and($meta->container)->toBe(PageContainer::Centered)
+        ->and($meta->middleware)->toBe([]);
+});

--- a/tests/Feature/PageRouteRegistrationTest.php
+++ b/tests/Feature/PageRouteRegistrationTest.php
@@ -25,17 +25,26 @@ final class RegWidgetsPage extends RegBasePage
     }
 }
 
-#[Page(route: '/cache-guard', name: 'cache-guard.page')]
-final class RegCacheGuardPage extends BasePage
-{
-    public function render(PageSchema $schema): PageSchema
-    {
-        return $schema->component(Text::make('Cache guard'));
-    }
-}
+test('Lattice::pages()->all() resolves route metadata for registered pages', function () {
+    $widgets = collect(Lattice::pages([RegWidgetsPage::class])->all())
+        ->firstWhere('class', RegWidgetsPage::class);
 
-test('registering a page binds a named GET route to render', function () {
+    expect($widgets)->not->toBeNull()
+        ->and($widgets->route)->toBe('/widgets')
+        ->and($widgets->name)->toBe('widgets.index')
+        ->and($widgets->middleware)->toContain('web');
+});
+
+test('Lattice::pages()->all() excludes abstract base pages', function () {
+    $classes = collect(Lattice::pages([RegBasePage::class])->all())->pluck('class');
+
+    expect($classes)->not->toContain(RegBasePage::class);
+});
+
+test('the service provider builds a named GET route for each page', function () {
     Lattice::pages([RegWidgetsPage::class]);
+
+    (new LatticeServiceProvider(app()))->bootPages();
 
     $route = Route::getRoutes()->getByName('widgets.index');
 
@@ -45,26 +54,8 @@ test('registering a page binds a named GET route to render', function () {
         ->and($route->gatherMiddleware())->toContain('web');
 });
 
-test('an abstract base page is never registered as a route', function () {
-    Lattice::pages([RegBasePage::class]);
-
-    $names = collect(Route::getRoutes()->getRoutes())->map->getActionName();
-
-    expect($names)->not->toContain(RegBasePage::class.'@render');
-});
-
-test('configured page routes register when the route cache is inactive', function () {
-    config(['lattice.pages.registered' => [RegCacheGuardPage::class]]);
-
-    expect(app()->routesAreCached())->toBeFalse();
-
-    (new LatticeServiceProvider(app()))->bootPages();
-
-    expect(Route::getRoutes()->getByName('cache-guard.page'))->not->toBeNull();
-});
-
-test('page route registration is skipped when the route cache is active', function () {
-    config(['lattice.pages.registered' => [RegCacheGuardPage::class]]);
+test('the service provider skips building routes when the route cache is active', function () {
+    Lattice::pages([RegWidgetsPage::class]);
 
     $cachedApp = new class extends Application
     {
@@ -78,5 +69,5 @@ test('page route registration is skipped when the route cache is active', functi
 
     (new LatticeServiceProvider($cachedApp))->bootPages();
 
-    expect(Route::getRoutes()->getByName('cache-guard.page'))->toBeNull();
+    expect(Route::getRoutes()->getByName('widgets.index'))->toBeNull();
 });

--- a/tests/Feature/PageRouteRegistrationTest.php
+++ b/tests/Feature/PageRouteRegistrationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Http\Page as BasePage;
+
+#[Page(layout: PageLayout::App, container: PageContainer::Default)]
+abstract class RegBasePage extends BasePage {}
+
+#[Page(route: '/widgets', name: 'widgets.index', middleware: 'web')]
+final class RegWidgetsPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Widgets'));
+    }
+}
+
+test('registering a page binds a named GET route to render', function () {
+    Lattice::pages([RegWidgetsPage::class]);
+
+    $route = Route::getRoutes()->getByName('widgets.index');
+
+    expect($route)->not->toBeNull()
+        ->and($route->uri())->toBe('widgets')
+        ->and($route->getActionName())->toBe(RegWidgetsPage::class.'@render')
+        ->and($route->gatherMiddleware())->toContain('web');
+});
+
+test('an abstract base page is never registered as a route', function () {
+    Lattice::pages([RegBasePage::class]);
+
+    $names = collect(Route::getRoutes()->getRoutes())->map->getActionName();
+
+    expect($names)->not->toContain(RegBasePage::class.'@render');
+});

--- a/tests/Feature/PageRouteRegistrationTest.php
+++ b/tests/Feature/PageRouteRegistrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Text;
@@ -10,6 +11,7 @@ use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Http\Page as BasePage;
+use Lattice\Lattice\LatticeServiceProvider;
 
 #[Page(layout: PageLayout::App, container: PageContainer::Default)]
 abstract class RegBasePage extends BasePage {}
@@ -20,6 +22,15 @@ final class RegWidgetsPage extends RegBasePage
     public function render(PageSchema $schema): PageSchema
     {
         return $schema->component(Text::make('Widgets'));
+    }
+}
+
+#[Page(route: '/cache-guard', name: 'cache-guard.page')]
+final class RegCacheGuardPage extends BasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Cache guard'));
     }
 }
 
@@ -40,4 +51,32 @@ test('an abstract base page is never registered as a route', function () {
     $names = collect(Route::getRoutes()->getRoutes())->map->getActionName();
 
     expect($names)->not->toContain(RegBasePage::class.'@render');
+});
+
+test('configured page routes register when the route cache is inactive', function () {
+    config(['lattice.pages.registered' => [RegCacheGuardPage::class]]);
+
+    expect(app()->routesAreCached())->toBeFalse();
+
+    (new LatticeServiceProvider(app()))->bootPages();
+
+    expect(Route::getRoutes()->getByName('cache-guard.page'))->not->toBeNull();
+});
+
+test('page route registration is skipped when the route cache is active', function () {
+    config(['lattice.pages.registered' => [RegCacheGuardPage::class]]);
+
+    $cachedApp = new class extends Application
+    {
+        public function __construct() {}
+
+        public function routesAreCached(): bool
+        {
+            return true;
+        }
+    };
+
+    (new LatticeServiceProvider($cachedApp))->bootPages();
+
+    expect(Route::getRoutes()->getByName('cache-guard.page'))->toBeNull();
 });

--- a/workbench/app/Pages/BuilderDemoPage.php
+++ b/workbench/app/Pages/BuilderDemoPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -11,6 +12,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\BuilderDemoForm;
 
+#[Page(route: '/builder')]
 class BuilderDemoPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/BuilderTableDemoPage.php
+++ b/workbench/app/Pages/BuilderTableDemoPage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -12,6 +13,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\BuilderTableDemoForm;
 
+#[Page(route: '/builder-table')]
 class BuilderTableDemoPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/DependentDemoPage.php
+++ b/workbench/app/Pages/DependentDemoPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -11,6 +12,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\DependentDemoForm;
 
+#[Page(route: '/dependent-demo', name: 'dependent.demo')]
 class DependentDemoPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/HomePage.php
+++ b/workbench/app/Pages/HomePage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Badge;
 use Lattice\Lattice\Core\Components\Button;
 use Lattice\Lattice\Core\Components\Card;
@@ -16,6 +17,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Tables\Components\Table;
 use Workbench\App\Tables\UsersTable;
 
+#[Page(route: '/')]
 final class HomePage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/ProductCreatePage.php
+++ b/workbench/app/Pages/ProductCreatePage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -11,6 +12,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\ProductForm;
 
+#[Page(route: '/products/create')]
 class ProductCreatePage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -12,6 +13,7 @@ use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\Product;
 
+#[Page(route: '/products/{product}/edit')]
 class ProductEditPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/ProductsPage.php
+++ b/workbench/app/Pages/ProductsPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Button;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
@@ -12,6 +13,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Tables\Components\Table;
 use Workbench\App\Tables\ProductsTable;
 
+#[Page(route: '/products', name: 'products.index')]
 class ProductsPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/RepeaterDemoPage.php
+++ b/workbench/app/Pages/RepeaterDemoPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -11,6 +12,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\RepeaterDemoForm;
 
+#[Page(route: '/repeater')]
 class RepeaterDemoPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/ShowcasePage.php
+++ b/workbench/app/Pages/ShowcasePage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -11,6 +12,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\ShowcaseForm;
 
+#[Page(route: '/showcase')]
 class ShowcasePage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/TablesPage.php
+++ b/workbench/app/Pages/TablesPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Badge;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
@@ -17,6 +18,7 @@ use Workbench\App\Tables\UsersNoneTable;
 use Workbench\App\Tables\UsersSimpleTable;
 use Workbench\App\Tables\UsersTablePaginationTable;
 
+#[Page(route: '/tables')]
 final class TablesPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/TabsPage.php
+++ b/workbench/app/Pages/TabsPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Tab;
@@ -12,6 +13,7 @@ use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\Orientation;
 use Lattice\Lattice\Core\PageSchema;
 
+#[Page(route: '/tabs')]
 final class TabsPage extends WorkbenchPage
 {
     public function title(): string

--- a/workbench/app/Pages/WorkbenchPage.php
+++ b/workbench/app/Pages/WorkbenchPage.php
@@ -3,19 +3,10 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages;
 
+use Lattice\Lattice\Attributes\Page;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
-use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Http\Page as BasePage;
 
-abstract class WorkbenchPage extends Page
-{
-    public function layout(): PageLayout
-    {
-        return PageLayout::App;
-    }
-
-    public function container(): PageContainer
-    {
-        return PageContainer::Default;
-    }
-}
+#[Page(layout: PageLayout::App, container: PageContainer::Default, middleware: ['web'])]
+abstract class WorkbenchPage extends BasePage {}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -25,6 +25,17 @@ use Workbench\App\Forms\ProductForm;
 use Workbench\App\Forms\RepeaterDemoForm;
 use Workbench\App\Forms\ShowcaseForm;
 use Workbench\App\Layouts\AppLayout;
+use Workbench\App\Pages\BuilderDemoPage;
+use Workbench\App\Pages\BuilderTableDemoPage;
+use Workbench\App\Pages\DependentDemoPage;
+use Workbench\App\Pages\HomePage;
+use Workbench\App\Pages\ProductCreatePage;
+use Workbench\App\Pages\ProductEditPage;
+use Workbench\App\Pages\ProductsPage;
+use Workbench\App\Pages\RepeaterDemoPage;
+use Workbench\App\Pages\ShowcasePage;
+use Workbench\App\Pages\TablesPage;
+use Workbench\App\Pages\TabsPage;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
@@ -142,6 +153,20 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         Lattice::layouts([
             AppLayout::class,
+        ]);
+
+        Lattice::pages([
+            HomePage::class,
+            TablesPage::class,
+            TabsPage::class,
+            ProductsPage::class,
+            ProductCreatePage::class,
+            ProductEditPage::class,
+            DependentDemoPage::class,
+            RepeaterDemoPage::class,
+            BuilderDemoPage::class,
+            BuilderTableDemoPage::class,
+            ShowcasePage::class,
         ]);
 
         $this->pointBoostAtPackageRoot();

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -1,51 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Workbench\App\Pages\BuilderDemoPage;
-use Workbench\App\Pages\BuilderTableDemoPage;
-use Workbench\App\Pages\DependentDemoPage;
-use Workbench\App\Pages\HomePage;
-use Workbench\App\Pages\ProductCreatePage;
-use Workbench\App\Pages\ProductEditPage;
-use Workbench\App\Pages\ProductsPage;
-use Workbench\App\Pages\RepeaterDemoPage;
-use Workbench\App\Pages\ShowcasePage;
-use Workbench\App\Pages\TablesPage;
-use Workbench\App\Pages\TabsPage;
-
-Route::latticePage('/', HomePage::class)
-    ->name('home');
-
-Route::latticePage('/tables', TablesPage::class)
-    ->name('tables');
-
-Route::latticePage('/tabs', TabsPage::class)
-    ->name('tabs');
-
-Route::latticePage('/products', ProductsPage::class)
-    ->name('products.index');
-
-Route::latticePage('/products/create', ProductCreatePage::class)
-    ->name('products.create');
-
-Route::latticePage('/products/{product}/edit', ProductEditPage::class)
-    ->name('products.edit');
-
-Route::latticePage('/dependent-demo', DependentDemoPage::class)
-    ->name('dependent.demo');
-
-Route::latticePage('/repeater', RepeaterDemoPage::class)
-    ->name('repeater');
-
-Route::latticePage('/builder', BuilderDemoPage::class)
-    ->name('builder');
-
-Route::latticePage('/builder-table', BuilderTableDemoPage::class)
-    ->name('builder-table');
-
-Route::latticePage('/showcase', ShowcasePage::class)
-    ->name('showcase');
 
 Route::get('/dashboard', fn (): string => 'Dashboard')->name('dashboard');
 Route::get('/login', fn (): string => 'Login')->name('login');


### PR DESCRIPTION
## Summary

Replaces the `Route::latticePage($uri, $page)` macro with a `#[Page]` class attribute that declares a page's **route, name, layout, container, and middleware**. Pages are registered automatically — discovered under `lattice.discover` (your `app/` by default) or explicitly via `Lattice::pages([...])` — so there's no route-file boilerplate and no macro.

```php
#[Page(route: '/products/{product}/edit', layout: PageLayout::App, middleware: ['web'])]
final class ProductEditPage extends AppPage { /* render(PageSchema, Product $product) */ }
```

## Design

- **Auto-derived route name** from the URI (`/products` → `products`, `/products/{product}/edit` → `products.edit`, `/` → kebab class basename); `name:` overrides.
- **Attribute-only layout/container** — the `layout()`/`container()` methods are removed from `Http\Page`; values come from the attribute and are **inherited up the class hierarchy** (a base page can carry `#[Page(layout: App, middleware: ['web'])]` with no route; concrete pages inherit it). `route`/`name` are taken from the concrete class only.
- New `PageRegistry` participates in the existing discovery scan via a small `Discoverable` contract — pages are routes, not signed component definitions, so they don't go through `DefinitionRegistry`.

## Migration included

- 9 workbench pages annotated; routes moved from `workbench/routes/web.php` to `Lattice::pages([...])` in `WorkbenchServiceProvider`.
- Test fixtures that registered ad-hoc page routes switched to the macro-equivalent `Route::get($uri, [Page::class, 'render'])`.
- Docs (`getting-started`, `pages`, `core-concepts`) and the shipped Boost guideline updated; the non-existent `->sidebar()` examples corrected (navigation is built from `Menu`/`Sidebar` layout components).

## Heads-up for reviewers

- ⚠️ **Needs a rebase onto current `main`.** This branch was cut before #71/#72 merged; `main` still contains the macro and adds `BuilderDemoPage` (which uses `latticePage`). Rebasing will conflict in `LatticePageTest`, `WorkbenchServiceProvider`, and `workbench/routes/web.php`, and `BuilderDemoPage` will need a `#[Page]` attribute.
- **Pages need the `web` middleware group** (sessions/CSRF/route-model-binding) now that they aren't inside a `web` route group. Set `middleware: ['web']` on the page or a shared base page (as the workbench does). Open question worth deciding: should page routes default to `web`, or stay explicit?

## Verification

Pest **449 passed**, `composer analyse` clean, `npm run typecheck` ✓, `npm run build:lib` ✓, `docs:build` Complete!, generated TS types unchanged.