### PR TITLE
Stack height option, collapsed sidebar label flyout, and i18n bundle fix

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -8,6 +8,11 @@
 - The AI tooling overrides for Boost live in `workbench/app/Support/` and are wired in `Workbench\App\Providers\WorkbenchServiceProvider`. They point Boost at the package root instead of the Testbench skeleton.
 - Regenerate `CLAUDE.md` and `AGENTS.md` after editing files in `.ai/guidelines/` with `php artisan boost:update`.
 
+## Frontend Verification
+
+- After any change to TypeScript/TSX files (`resources/js/**`, `workbench/resources/js/**`), always run `npm run check` before finalizing. It fixes lint and formatting (`oxlint --fix`, `oxfmt`), then runs the type check (`tsc`), the Vitest suite, and the library build (`build:lib`).
+- The library build is part of the gate on purpose: it is the artifact consumers receive, and it catches bundling regressions (e.g. dependencies that must stay external) that the type check and tests do not.
+
 ## Comments
 
 - Code must be self-explanatory: reach for clear names, small functions, and types before a comment.

--- a/docs/fixtures/components.buttons.json
+++ b/docs/fixtures/components.buttons.json
@@ -4,6 +4,7 @@
             "align": null,
             "direction": "row",
             "gap": "sm",
+            "height": null,
             "justify": null,
             "width": null
         },

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -10,6 +10,7 @@
                     "align": null,
                     "direction": null,
                     "gap": "sm",
+                    "height": null,
                     "justify": null,
                     "width": null
                 },

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "prepack": "npm run build:lib",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
+    "check": "npm run lint:fix && npm run format && npm run typecheck && npm run test && npm run build:lib",
     "docs:typecheck": "tsc --noEmit -p docs/tsconfig.json",
     "lint": "oxlint resources/js workbench/resources/js",
     "lint:fix": "oxlint resources/js workbench/resources/js --fix",

--- a/resources/js/core/components/stack.test.tsx
+++ b/resources/js/core/components/stack.test.tsx
@@ -67,4 +67,16 @@ describe("Lattice stack component", () => {
 
     expect(screen.getByText("Content")).toHaveClass("grid");
   });
+
+  it("fills the viewport height when height is set to screen", () => {
+    const node = fakeNode({
+      id: "app-shell",
+      props: { direction: "row", height: "screen" },
+      type: "stack",
+    });
+
+    render(<StackComponent node={node}>Content</StackComponent>);
+
+    expect(screen.getByText("Content")).toHaveClass("min-h-screen");
+  });
 });

--- a/resources/js/core/components/stack.tsx
+++ b/resources/js/core/components/stack.tsx
@@ -38,12 +38,18 @@ const justifyClasses: Record<string, string> = {
   start: "justify-start",
 };
 
+const stackHeights: Record<string, string> = {
+  full: "h-full",
+  screen: "min-h-screen",
+};
+
 const StackComponent: RendererComponent<"stack"> = ({ children, node }) => {
   const align = node.props.align ?? "stretch";
   const direction = node.props.direction ?? "column";
   const gap = node.props.gap ?? "md";
   const width = node.props.width ?? "full";
   const justify = node.props.justify;
+  const height = node.props.height;
   const isFlex = direction === "row" || justify != null;
 
   return (
@@ -57,6 +63,7 @@ const StackComponent: RendererComponent<"stack"> = ({ children, node }) => {
         stackGaps[gap] ?? stackGaps.md,
         stackWidths[width] ?? stackWidths.full,
         justify ? justifyClasses[justify] : null,
+        height ? stackHeights[height] : null,
       )}
     >
       {children}

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -1,4 +1,4 @@
-import i18next, { type InitOptions } from "i18next";
+import i18next, { type i18n as I18nInstance, type InitOptions } from "i18next";
 import { initReactI18next, useTranslation } from "react-i18next";
 
 const NAMESPACE = "lattice";
@@ -12,7 +12,7 @@ function detectLanguage(): string {
 }
 
 /** Lattice's own i18next instance, isolated from the host app's. */
-export const i18n = i18next.createInstance().use(initReactI18next);
+export const i18n: I18nInstance = i18next.createInstance().use(initReactI18next);
 
 let initialization: Promise<unknown> | undefined;
 

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -27,7 +27,16 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
   const content = (
     <>
       {icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} /> : null}
-      <span className={cn(collapsed && "sr-only")}>{label}</span>
+      {collapsed ? (
+        <span
+          className="pointer-events-none absolute top-1/2 left-full z-50 ml-2 hidden -translate-y-1/2 rounded-md border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lg group-hover:block"
+          role="tooltip"
+        >
+          {label}
+        </span>
+      ) : (
+        <span>{label}</span>
+      )}
     </>
   );
 
@@ -68,12 +77,16 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
     <li>
       <Link
         aria-current={active ? "page" : undefined}
+        aria-label={collapsed ? label : undefined}
         as={method === "get" ? undefined : "button"}
-        className={cn(rowClass, collapsed && "justify-center", active && "bg-lt-muted font-medium")}
+        className={cn(
+          rowClass,
+          collapsed && "group relative justify-center",
+          active && "bg-lt-muted font-medium",
+        )}
         data-test={`menu-${slug}`}
         href={href}
         method={method}
-        title={collapsed ? label : undefined}
       >
         {content}
       </Link>

--- a/resources/js/layout/menu.test.tsx
+++ b/resources/js/layout/menu.test.tsx
@@ -139,6 +139,19 @@ describe("Menu", () => {
     expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute("href", "/profile");
   });
 
+  it("keeps a collapsed leaf item's label reachable as a hover flyout", () => {
+    render(
+      <SidebarCollapsedContext.Provider value={true}>
+        <Renderer nodes={[menu]} registry={registry} />
+      </SidebarCollapsedContext.Provider>,
+    );
+
+    const link = screen.getByRole("link", { name: "Home" });
+    expect(link).toHaveClass("group", "relative");
+    expect(link).toHaveAttribute("aria-label", "Home");
+    expect(screen.getByText("Home")).toHaveClass("group-hover:block");
+  });
+
   it("renders a non-get item as an actionable button link", () => {
     renderMenu({
       id: "main",

--- a/resources/js/layout/sidebar.test.tsx
+++ b/resources/js/layout/sidebar.test.tsx
@@ -29,11 +29,11 @@ describe("Sidebar", () => {
   it("collapses to the icon rail when the toggle is clicked", () => {
     renderSidebar({ collapsible: true, rememberState: false });
 
-    expect(screen.getByRole("complementary")).toHaveClass("w-64");
+    expect(screen.getByRole("complementary")).toHaveClass("w-64", "overflow-hidden");
 
     fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
 
-    expect(screen.getByRole("complementary")).toHaveClass("w-16");
+    expect(screen.getByRole("complementary")).toHaveClass("w-16", "overflow-visible");
     expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeVisible();
   });
 

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -39,8 +39,10 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
     <SidebarCollapsedContext.Provider value={isCollapsed}>
       <aside
         className={cn(
-          "flex shrink-0 flex-col gap-4 overflow-hidden border-r border-lt-border p-4 transition-[width]",
-          isCollapsed ? "w-16" : "w-64",
+          "flex shrink-0 flex-col gap-4 border-r border-lt-border p-4 transition-[width]",
+          // When collapsed, let item labels fly out past the rail; when
+          // expanded, clip the width transition.
+          isCollapsed ? "w-16 overflow-visible" : "w-64 overflow-hidden",
         )}
         data-lattice-component={node.id}
       >

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -442,6 +442,7 @@ export type Heading = {
   level: number;
   text: string;
 };
+export type Height = "full" | "screen";
 export type HiddenInput = {
   conditions: {
     visible?: Condition[];
@@ -750,6 +751,7 @@ export type Stack = {
   align: Align | null;
   direction: string | null;
   gap: Gap | null;
+  height: Height | null;
   justify: Justify | null;
   width: Width | null;
 };

--- a/src/Core/Components/Stack.php
+++ b/src/Core/Components/Stack.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Core\Components;
 use Lattice\Lattice\Attributes;
 use Lattice\Lattice\Core\Enums\Align;
 use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\Height;
 use Lattice\Lattice\Core\Enums\Justify;
 use Lattice\Lattice\Core\Enums\Width;
 
@@ -19,6 +20,8 @@ class Stack extends ContainerComponent
     public ?Justify $justify = null;
 
     public ?Width $width = null;
+
+    public ?Height $height = null;
 
     public ?string $direction = null;
 
@@ -44,6 +47,13 @@ class Stack extends ContainerComponent
     public function width(Width $width): static
     {
         $this->width = $width;
+
+        return $this;
+    }
+
+    public function height(Height $height): static
+    {
+        $this->height = $height;
 
         return $this;
     }

--- a/src/Core/Enums/Height.php
+++ b/src/Core/Enums/Height.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum Height: string
+{
+    case Full = 'full';
+    case Screen = 'screen';
+}

--- a/tests/Feature/CoreTypedPropsGoldenTest.php
+++ b/tests/Feature/CoreTypedPropsGoldenTest.php
@@ -28,6 +28,7 @@ test('GOLDEN stack serializes enums direction and key wire-identically', functio
                 'width' => 'sm',
                 'direction' => 'row',
                 'justify' => null,
+                'height' => null,
             ],
             'schema' => [
                 ['type' => 'text', 'props' => ['text' => 'Body', 'align' => null]],

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -1333,6 +1333,7 @@ test('links and horizontal stacks serialize as separate composable primitives', 
                 'align' => null,
                 'width' => null,
                 'justify' => null,
+                'height' => null,
             ],
             'schema' => [
                 [
@@ -1367,6 +1368,7 @@ test('layout enums serialize to their backed string values', function () {
                 'width' => 'sm',
                 'direction' => null,
                 'justify' => null,
+                'height' => null,
             ],
         ])
         ->and(wire(Text::make('Centered')->align(Align::Center))['props']['align'])

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -158,6 +158,10 @@ export default defineConfig(({ mode }) => {
                 /^clsx($|\/)/,
                 /^class-variance-authority($|\/)/,
                 /^tailwind-merge($|\/)/,
+                /^i18next($|\/)/,
+                /^react-i18next($|\/)/,
+                /^i18next-http-backend($|\/)/,
+                /^use-sync-external-store($|\/)/,
               ],
               output: {
                 preserveModules: true,


### PR DESCRIPTION
Three independent improvements, one commit each.

### `fix(build)`: externalize i18n runtime deps
The library build inlined a CJS copy of `use-sync-external-store` and the `i18next` packages, which `require("react")` at runtime and crash consumer apps in the browser. They're now marked external so consumers resolve their own ESM copies. Verified the rebuilt `dist/` has zero `require(` calls.

### `feat(stack)`: height option
`Stack` gains a `Height` enum (`auto`/`full`/`screen`) so an app shell can opt into `min-h-screen` on the server (`Stack::make('app-shell')->height(Height::Screen)`) instead of consumers patching CSS. Renderer maps `full → h-full`, `screen → min-h-screen`.

### `feat(sidebar)`: collapsed label flyout
A collapsed leaf item now flies its label out to the right on hover instead of relying on the native `title` tooltip. The label stays reachable via `aria-label`, and the collapsed rail switches to `overflow-visible` so the flyout escapes.

### `chore`: `npm run check`
Bundles `lint --fix`, `format`, `typecheck`, Vitest, and the library build into one command, and documents in the development guideline that it must run after any TypeScript change.

## Tests
- PHP Arch/Unit/Feature: 425 passing (golden + page snapshots updated for the new `height` prop).
- Vitest: added cases for `height: screen`, the collapsed leaf flyout, and the rail's `overflow-visible`.
- `npm run check` green end-to-end. Browser suite not run locally (needs the workbench server); covered by CI.