### PR TITLE
refactor: manifest-based discovery

### DIFF
--- a/config/lattice.php
+++ b/config/lattice.php
@@ -32,10 +32,6 @@ return [
         'registered' => [],
     ],
 
-    'pages' => [
-        'registered' => [],
-    ],
-
     'actions' => [
         'endpoint' => 'lattice/actions/{action}',
         'middleware' => ['web'],

--- a/src/Console/Commands/DiscoverCacheCommand.php
+++ b/src/Console/Commands/DiscoverCacheCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Console\Commands;
 
 use Illuminate\Console\Command;
-use Lattice\Lattice\Core\Services\DefinitionDiscovery;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 
 final class DiscoverCacheCommand extends Command
 {
@@ -12,15 +12,11 @@ final class DiscoverCacheCommand extends Command
 
     protected $description = 'Cache discovered Lattice definitions for the configured discover paths';
 
-    public function handle(DefinitionDiscovery $discovery): int
+    public function handle(DiscoveryManifest $manifest): int
     {
-        $paths = array_keys(DefinitionDiscovery::configuredPaths());
+        $manifest->cache();
 
-        foreach ($paths as $path) {
-            $discovery->cache($path);
-        }
-
-        $this->components->info(sprintf('Cached definition discovery for %d path(s).', count($paths)));
+        $this->components->info('Cached the Lattice discovery manifest.');
 
         return self::SUCCESS;
     }

--- a/src/Console/Commands/DiscoverClearCommand.php
+++ b/src/Console/Commands/DiscoverClearCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Console\Commands;
 
 use Illuminate\Console\Command;
-use Lattice\Lattice\Core\Services\DefinitionDiscovery;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 
 final class DiscoverClearCommand extends Command
 {
@@ -12,15 +12,11 @@ final class DiscoverClearCommand extends Command
 
     protected $description = 'Clear the cached Lattice definition discovery';
 
-    public function handle(DefinitionDiscovery $discovery): int
+    public function handle(DiscoveryManifest $manifest): int
     {
-        $paths = array_keys(DefinitionDiscovery::configuredPaths());
+        $manifest->clear();
 
-        foreach ($paths as $path) {
-            $discovery->forget($path);
-        }
-
-        $this->components->info(sprintf('Cleared definition discovery cache for %d path(s).', count($paths)));
+        $this->components->info('Cleared the Lattice discovery manifest.');
 
         return self::SUCCESS;
     }

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Lattice\Lattice\Attributes\ComponentAttribute;
 use Lattice\Lattice\Core\Contracts\DefinitionRegistry as DefinitionRegistryContract;
 use Lattice\Lattice\Core\Contracts\Discoverable;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
 use Spatie\Attributes\Attributes;
 
@@ -25,7 +26,23 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract, Discove
 
     private ?string $endpointTemplate = null;
 
-    public function __construct(protected readonly Container $container) {}
+    public function __construct(
+        protected readonly Container $container,
+        protected readonly DiscoveryManifest $manifest,
+    ) {}
+
+    /**
+     * Explicit registrations layered over the discovered manifest entries.
+     *
+     * @return array<string, class-string<TDefinition>>
+     */
+    protected function definitions(): array
+    {
+        /** @var array<string, class-string<TDefinition>> $discovered */
+        $discovered = $this->manifest->forGroup($this->group());
+
+        return array_merge($discovered, $this->definitions);
+    }
 
     /**
      * @param  class-string<TDefinition>|array<int, class-string<TDefinition>>  $definitions
@@ -54,11 +71,13 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract, Discove
      */
     public function resolve(string $key): Definition
     {
-        if (! array_key_exists($key, $this->definitions)) {
+        $definitions = $this->definitions();
+
+        if (! array_key_exists($key, $definitions)) {
             throw new UnknownLatticeComponent($this->name(), $key);
         }
 
-        return $this->make($this->definitions[$key]);
+        return $this->make($definitions[$key]);
     }
 
     public function endpointFor(string $key): string
@@ -79,7 +98,7 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract, Discove
     {
         $key = $this->keyFor($definition);
 
-        if (($this->definitions[$key] ?? null) !== $definition) {
+        if (($this->definitions()[$key] ?? null) !== $definition) {
             throw new InvalidArgumentException("Lattice {$this->name()} [{$definition}] is not registered.");
         }
 

--- a/src/Core/Discovery/DiscoveryKinds.php
+++ b/src/Core/Discovery/DiscoveryKinds.php
@@ -15,11 +15,7 @@ use Spatie\Attributes\Attributes;
 
 final class DiscoveryKinds
 {
-    /**
-     * Keyed component groups: group => component attribute class.
-     *
-     * @var array<string, class-string>
-     */
+    /** @var array<string, class-string> */
     public const COMPONENTS = [
         'forms' => Form::class,
         'tables' => Table::class,

--- a/src/Core/Discovery/DiscoveryKinds.php
+++ b/src/Core/Discovery/DiscoveryKinds.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Discovery;
+
+use Lattice\Lattice\Attributes\Action;
+use Lattice\Lattice\Attributes\BulkAction;
+use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Attributes\Fragment;
+use Lattice\Lattice\Attributes\Layout;
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Attributes\Table;
+use Spatie\Attributes\Attributes;
+
+final class DiscoveryKinds
+{
+    /**
+     * Keyed component groups: group => component attribute class.
+     *
+     * @var array<string, class-string>
+     */
+    public const COMPONENTS = [
+        'forms' => Form::class,
+        'tables' => Table::class,
+        'actions' => Action::class,
+        'bulk-actions' => BulkAction::class,
+        'fragments' => Fragment::class,
+        'layouts' => Layout::class,
+    ];
+
+    public const PAGE_ATTRIBUTE = Page::class;
+
+    /**
+     * @param  class-string  $class
+     * @param  class-string  $attributeClass
+     */
+    public static function keyOf(string $class, string $attributeClass): string
+    {
+        return Attributes::get($class, $attributeClass)->key;
+    }
+}

--- a/src/Core/Discovery/DiscoveryManifest.php
+++ b/src/Core/Discovery/DiscoveryManifest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Discovery;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Filesystem\Filesystem;
+use Lattice\Lattice\Core\Services\DefinitionDiscovery;
+use Lattice\Lattice\Http\PageMetadata;
+use Lattice\Lattice\Support\Discovery\ClassWalker;
+use ReflectionClass;
+use Spatie\Attributes\Attributes;
+
+final class DiscoveryManifest
+{
+    /** @var array<string, mixed>|null */
+    private ?array $resolved = null;
+
+    public function __construct(
+        private readonly Application $app,
+        private readonly Filesystem $files,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function resolve(): array
+    {
+        return $this->resolved ??= $this->isCached() ? require $this->path() : $this->build();
+    }
+
+    /** @return array<string, mixed> */
+    public function forGroup(string $group): array
+    {
+        return $this->resolve()[$group] ?? [];
+    }
+
+    /** @return list<array<string, mixed>> */
+    public function pageDescriptors(): array
+    {
+        /** @var list<array<string, mixed>> $pages */
+        $pages = $this->resolve()['pages'] ?? [];
+
+        return $pages;
+    }
+
+    /**
+     * @param  class-string  $class
+     * @return array<string, mixed>|null
+     */
+    public function descriptorFor(string $class): ?array
+    {
+        foreach ($this->pageDescriptors() as $descriptor) {
+            if ($descriptor['class'] === $class) {
+                return $descriptor;
+            }
+        }
+
+        return null;
+    }
+
+    public function isCached(): bool
+    {
+        return $this->files->exists($this->path());
+    }
+
+    public function path(): string
+    {
+        return $this->app->bootstrapPath('cache/lattice.php');
+    }
+
+    public function cache(): void
+    {
+        $manifest = $this->build();
+
+        $this->files->put($this->path(), '<?php return '.var_export($manifest, true).';'.PHP_EOL);
+
+        $this->resolved = $manifest;
+    }
+
+    public function clear(): void
+    {
+        if ($this->isCached()) {
+            $this->files->delete($this->path());
+        }
+
+        $this->resolved = null;
+    }
+
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $manifest = ['pages' => []];
+
+        foreach (array_keys(DiscoveryKinds::COMPONENTS) as $group) {
+            $manifest[$group] = [];
+        }
+
+        foreach (array_keys(DefinitionDiscovery::configuredPaths()) as $path) {
+            foreach (ClassWalker::classes($path) as $class) {
+                if ((new ReflectionClass($class))->isAbstract()) {
+                    continue;
+                }
+
+                foreach (DiscoveryKinds::COMPONENTS as $group => $attribute) {
+                    if (Attributes::has($class, $attribute)) {
+                        $manifest[$group][DiscoveryKinds::keyOf($class, $attribute)] = $class;
+                    }
+                }
+
+                if (Attributes::has($class, DiscoveryKinds::PAGE_ATTRIBUTE)) {
+                    $metadata = PageMetadata::reflect($class);
+
+                    if ($metadata->route !== null) {
+                        $manifest['pages'][] = $metadata->toArray();
+                    }
+                }
+            }
+        }
+
+        return $manifest;
+    }
+}

--- a/src/Core/Services/DefinitionDiscovery.php
+++ b/src/Core/Services/DefinitionDiscovery.php
@@ -57,7 +57,7 @@ final class DefinitionDiscovery implements DiscoversDefinitions
             return $definitions;
         }
 
-        foreach ($this->classesIn($path) as $class) {
+        foreach (ClassWalker::classes($path) as $class) {
             if ((new ReflectionClass($class))->isAbstract()) {
                 continue;
             }
@@ -70,13 +70,5 @@ final class DefinitionDiscovery implements DiscoversDefinitions
         }
 
         return $definitions;
-    }
-
-    /**
-     * @return list<class-string>
-     */
-    private function classesIn(string $path): array
-    {
-        return ClassWalker::classes($path);
     }
 }

--- a/src/Core/Services/DefinitionDiscovery.php
+++ b/src/Core/Services/DefinitionDiscovery.php
@@ -8,10 +8,6 @@ use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
 use Lattice\Lattice\Support\Discovery\ClassWalker;
 use ReflectionClass;
 use Spatie\Attributes\Attributes;
-use Spatie\StructureDiscoverer\Cache\DiscoverCacheDriver;
-use Spatie\StructureDiscoverer\Cache\LaravelDiscoverCacheDriver;
-use Spatie\StructureDiscoverer\Support\DiscoverCacheDriverFactory;
-use Throwable;
 
 final class DefinitionDiscovery implements DiscoversDefinitions
 {
@@ -76,61 +72,11 @@ final class DefinitionDiscovery implements DiscoversDefinitions
         return $definitions;
     }
 
-    public function cache(string $path): void
-    {
-        if (! is_dir($path)) {
-            return;
-        }
-
-        $this->cacheDriver()->put($this->cacheId($path), $this->freshClasses($path));
-    }
-
-    public function forget(string $path): void
-    {
-        $this->cacheDriver()->forget($this->cacheId($path));
-    }
-
     /**
-     * Returns the cached class list when the path has been warmed, otherwise a
-     * fresh walk. The cache is never written here, so an un-warmed app always
-     * sees current classes; warming happens explicitly via `lattice:discover-cache`.
-     *
      * @return list<class-string>
      */
     private function classesIn(string $path): array
     {
-        try {
-            $driver = $this->cacheDriver();
-            $id = $this->cacheId($path);
-
-            if ($driver->has($id)) {
-                return $driver->get($id);
-            }
-        } catch (Throwable) {
-            // The cache is an optimisation, never a dependency: an unavailable or
-            // unconfigured cache store must not break discovery. Fall back to a walk.
-        }
-
-        return $this->freshClasses($path);
-    }
-
-    /**
-     * @return list<class-string>
-     */
-    private function freshClasses(string $path): array
-    {
         return ClassWalker::classes($path);
-    }
-
-    private function cacheDriver(): DiscoverCacheDriver
-    {
-        return DiscoverCacheDriverFactory::create(
-            config('structure-discoverer.cache', ['driver' => LaravelDiscoverCacheDriver::class, 'store' => null]),
-        );
-    }
-
-    private function cacheId(string $path): string
-    {
-        return 'lattice-definitions-'.md5($path);
     }
 }

--- a/src/Http/PageMetadata.php
+++ b/src/Http/PageMetadata.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Http;
 
+use BackedEnum;
 use Lattice\Lattice\Attributes\Page as PageAttribute;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use ReflectionClass;
@@ -28,6 +30,23 @@ final class PageMetadata
     {
         $class = is_object($page) ? $page::class : $page;
 
+        $manifest = app(DiscoveryManifest::class);
+
+        if ($manifest->isCached()) {
+            $descriptor = $manifest->descriptorFor($class);
+
+            if ($descriptor !== null) {
+                return self::fromArray($descriptor);
+            }
+        }
+
+        return self::reflect($class);
+    }
+
+    public static function reflect(Page|string $page): self
+    {
+        $class = is_object($page) ? $page::class : $page;
+
         $own = self::attributeOn($class);
 
         return new self(
@@ -38,6 +57,41 @@ final class PageMetadata
             container: self::inherited($class, fn (PageAttribute $a) => $a->container) ?? PageContainer::Centered,
             middleware: (array) (self::inherited($class, fn (PageAttribute $a) => $a->middleware) ?? []),
         );
+    }
+
+    /**
+     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>, layout: string, container: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'class' => $this->class,
+            'route' => $this->route,
+            'name' => $this->name,
+            'middleware' => $this->middleware,
+            'layout' => self::serialize($this->layout),
+            'container' => self::serialize($this->container),
+        ];
+    }
+
+    /**
+     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>, layout: string, container: string}  $descriptor
+     */
+    public static function fromArray(array $descriptor): self
+    {
+        return new self(
+            class: $descriptor['class'],
+            route: $descriptor['route'],
+            name: $descriptor['name'],
+            layout: $descriptor['layout'],
+            container: $descriptor['container'],
+            middleware: $descriptor['middleware'],
+        );
+    }
+
+    private static function serialize(PageLayout|PageContainer|string $value): string
+    {
+        return $value instanceof BackedEnum ? (string) $value->value : $value;
     }
 
     private static function attributeOn(string $class): ?PageAttribute

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -95,10 +95,6 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
         Lattice::registerConfiguredDefinitions();
 
-        foreach (DefinitionDiscovery::configuredPaths() as $path => $namespace) {
-            Lattice::discover($path, $namespace);
-        }
-
         // Deferred so pages registered by any provider's boot() (e.g. an app's
         // own `Lattice::pages([...])`) are collected before the routes are built.
         $this->app->booted(fn () => $this->bootPages());

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -17,6 +17,7 @@ use Lattice\Lattice\Console\Commands\MakeFieldCommand;
 use Lattice\Lattice\Console\Commands\TypeScriptCommand;
 use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
 use Lattice\Lattice\Core\Services\DefinitionDiscovery;
 use Lattice\Lattice\Facades\Lattice;
@@ -64,6 +65,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->singleton(ComponentReferenceSigner::class);
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);
         $this->app->singleton(LatticeRegistry::class);
+        $this->app->singleton(DiscoveryManifest::class);
 
         // Default role; the workbench rebinds this to BaseProfile.
         $this->app->bind(TypeScriptProfile::class, AugmentProfile::class);

--- a/src/Pages/PageRegistry.php
+++ b/src/Pages/PageRegistry.php
@@ -27,9 +27,6 @@ final class PageRegistry
     }
 
     /**
-     * Every routable page: discovered (from the manifest) plus explicitly
-     * registered, resolved to its metadata and de-duplicated by class.
-     *
      * @return array<int, PageMetadata>
      */
     public function all(): array

--- a/src/Pages/PageRegistry.php
+++ b/src/Pages/PageRegistry.php
@@ -4,27 +4,17 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Pages;
 
-use Lattice\Lattice\Attributes\Page as PageAttribute;
-use Lattice\Lattice\Core\Contracts\Discoverable;
-use Lattice\Lattice\Core\Contracts\DiscoversDefinitions;
-use Lattice\Lattice\Core\Services\DefinitionDiscovery;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Http\PageContract;
 use Lattice\Lattice\Http\PageMetadata;
 use ReflectionClass;
 
-/**
- * Collects page classes from explicit registration, configuration, and
- * discovery. It does not register routes itself — the service provider reads
- * `all()` and binds the routes, so the routing happens in one visible place.
- */
-final class PageRegistry implements Discoverable
+final class PageRegistry
 {
     /** @var array<class-string, class-string> */
     private array $registered = [];
 
-    private bool $sourcesLoaded = false;
-
-    public function __construct(private readonly DiscoversDefinitions $discovery) {}
+    public function __construct(private readonly DiscoveryManifest $manifest) {}
 
     /**
      * @param  class-string|array<int, class-string>  $pages
@@ -37,68 +27,35 @@ final class PageRegistry implements Discoverable
     }
 
     /**
-     * @param  array<int, class-string>  $definitions
-     */
-    public function registerDiscovered(array $definitions): void
-    {
-        $this->register($definitions);
-    }
-
-    public function attributeClass(): string
-    {
-        return PageAttribute::class;
-    }
-
-    public function group(): string
-    {
-        return 'pages';
-    }
-
-    /**
-     * Every routable page — explicitly registered, configured, and discovered
-     * under the configured paths — resolved to its route metadata. Discovery
-     * runs lazily the first time this is called.
+     * Every routable page: discovered (from the manifest) plus explicitly
+     * registered, resolved to its metadata and de-duplicated by class.
      *
      * @return array<int, PageMetadata>
      */
     public function all(): array
     {
-        $this->loadSources();
-
         $pages = [];
 
+        foreach ($this->manifest->pageDescriptors() as $descriptor) {
+            $pages[$descriptor['class']] = PageMetadata::fromArray($descriptor);
+        }
+
         foreach ($this->registered as $page) {
+            if (isset($pages[$page])) {
+                continue;
+            }
+
             if (! is_a($page, PageContract::class, true) || (new ReflectionClass($page))->isAbstract()) {
                 continue;
             }
 
-            $metadata = PageMetadata::for($page);
+            $metadata = PageMetadata::reflect($page);
 
             if ($metadata->route !== null) {
-                $pages[] = $metadata;
+                $pages[$page] = $metadata;
             }
         }
 
-        return $pages;
-    }
-
-    private function loadSources(): void
-    {
-        if ($this->sourcesLoaded) {
-            return;
-        }
-
-        $this->sourcesLoaded = true;
-
-        $configured = config('lattice.pages.registered', []);
-
-        if (is_array($configured)) {
-            $this->register($configured);
-        }
-
-        foreach (DefinitionDiscovery::configuredPaths() as $path => $namespace) {
-            $discovered = $this->discovery->discover($path, $namespace, [$this]);
-            $this->register($discovered[$this->group()] ?? []);
-        }
+        return array_values($pages);
     }
 }

--- a/tests/Feature/Console/DiscoverCacheCommandTest.php
+++ b/tests/Feature/Console/DiscoverCacheCommandTest.php
@@ -4,27 +4,17 @@ declare(strict_types=1);
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionRegistry;
 use Lattice\Lattice\Core\DefinitionRegistry;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Services\DefinitionDiscovery;
 use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Layouts\LayoutRegistry;
 use Lattice\Lattice\Tables\TableRegistry;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
-use Spatie\StructureDiscoverer\Cache\DiscoverCacheDriver;
-use Spatie\StructureDiscoverer\Cache\LaravelDiscoverCacheDriver;
-use Spatie\StructureDiscoverer\Support\DiscoverCacheDriverFactory;
 
 use function Pest\Laravel\artisan;
 
 $fixtures = dirname(__DIR__, 2).'/Fixtures/Discovery';
-$cacheId = 'lattice-definitions-'.md5($fixtures);
-
-function discoveryCacheDriver(): DiscoverCacheDriver
-{
-    return DiscoverCacheDriverFactory::create(
-        config('structure-discoverer.cache', ['driver' => LaravelDiscoverCacheDriver::class, 'store' => null]),
-    );
-}
 
 /** @return array<int, DefinitionRegistry<*>> */
 function discoveryRegistries(): array
@@ -39,30 +29,20 @@ function discoveryRegistries(): array
     ];
 }
 
-beforeEach(fn () => config()->set('cache.default', 'array'));
-
-afterEach(fn () => discoveryCacheDriver()->forget('lattice-definitions-'.md5(dirname(__DIR__, 2).'/Fixtures/Discovery')));
-
-it('caches and clears definition discovery for the configured paths', function () use ($fixtures, $cacheId) {
-    config()->set('lattice.discover', [$fixtures => 'Lattice\\Lattice\\Tests\\Fixtures\\Discovery']);
-
-    $driver = discoveryCacheDriver();
-    expect($driver->has($cacheId))->toBeFalse();
-
-    artisan('lattice:discover-cache')->assertSuccessful();
-    expect($driver->has($cacheId))->toBeTrue();
-
-    artisan('lattice:discover-clear')->assertSuccessful();
-    expect($driver->has($cacheId))->toBeFalse();
+afterEach(function () {
+    app(DiscoveryManifest::class)->clear();
 });
 
-it('reads discovered classes from the warmed cache instead of walking', function () use ($fixtures, $cacheId) {
-    discoveryCacheDriver()->put($cacheId, [DiscoveredProfileForm::class]);
+it('caches and clears the discovery manifest', function () {
+    $manifest = app(DiscoveryManifest::class);
 
-    $result = app(DefinitionDiscovery::class)->discover($fixtures, 'X', discoveryRegistries());
+    expect($manifest->isCached())->toBeFalse();
 
-    expect($result['forms'])->toBe([DiscoveredProfileForm::class])
-        ->and($result['tables'])->toBe([]);
+    artisan('lattice:discover-cache')->assertSuccessful();
+    expect($manifest->isCached())->toBeTrue();
+
+    artisan('lattice:discover-clear')->assertSuccessful();
+    expect($manifest->isCached())->toBeFalse();
 });
 
 it('walks fresh when the cache is cold', function () use ($fixtures) {

--- a/tests/Feature/DiscoveryManifestTest.php
+++ b/tests/Feature/DiscoveryManifestTest.php
@@ -10,6 +10,7 @@ use Lattice\Lattice\Attributes\Layout;
 use Lattice\Lattice\Attributes\Table;
 use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredDemoPage;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredUsersTable;
@@ -76,4 +77,12 @@ test('registries resolve discovered definitions from the manifest', function () 
     $form = wire(FormComponent::use(DiscoveredProfileForm::class));
 
     expect($form)->toMatchArray(['type' => 'form', 'id' => 'fixtures.profile']);
+});
+
+test('discovered pages are available through the page registry', function () {
+    discoverFixtures();
+
+    $classes = collect(Lattice::pages()->all())->pluck('class');
+
+    expect($classes)->toContain(DiscoveredDemoPage::class);
 });

--- a/tests/Feature/DiscoveryManifestTest.php
+++ b/tests/Feature/DiscoveryManifestTest.php
@@ -9,7 +9,10 @@ use Lattice\Lattice\Attributes\Fragment;
 use Lattice\Lattice\Attributes\Layout;
 use Lattice\Lattice\Attributes\Table;
 use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredDemoPage;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
+use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredUsersTable;
 
 test('discovery kinds map every component group to its attribute', function () {
     expect(DiscoveryKinds::COMPONENTS)->toMatchArray([
@@ -25,4 +28,39 @@ test('discovery kinds map every component group to its attribute', function () {
 test('discovery kinds extracts a component key from its attribute', function () {
     expect(DiscoveryKinds::keyOf(DiscoveredProfileForm::class, Form::class))
         ->toBe('fixtures.profile');
+});
+
+function discoverFixtures(): void
+{
+    config(['lattice.discover' => [
+        __DIR__.'/../Fixtures/Discovery' => 'Lattice\\Lattice\\Tests\\Fixtures\\Discovery',
+    ]]);
+}
+
+test('the manifest builds resolved entries for every kind', function () {
+    discoverFixtures();
+
+    $manifest = app(DiscoveryManifest::class);
+
+    expect($manifest->forGroup('forms'))->toMatchArray(['fixtures.profile' => DiscoveredProfileForm::class])
+        ->and($manifest->forGroup('tables'))->toMatchArray(['fixtures.users' => DiscoveredUsersTable::class])
+        ->and(collect($manifest->pageDescriptors())->firstWhere('class', DiscoveredDemoPage::class))
+        ->toMatchArray(['route' => '/discovered-demo', 'name' => 'discovered.demo', 'middleware' => ['web']]);
+});
+
+test('the manifest round-trips through the cached file', function () {
+    discoverFixtures();
+
+    $manifest = app(DiscoveryManifest::class);
+    $manifest->cache();
+
+    try {
+        expect($manifest->isCached())->toBeTrue();
+
+        $fresh = new DiscoveryManifest(app(), app('files'));
+        expect($fresh->forGroup('forms'))->toMatchArray(['fixtures.profile' => DiscoveredProfileForm::class]);
+    } finally {
+        $manifest->clear();
+        expect($manifest->isCached())->toBeFalse();
+    }
 });

--- a/tests/Feature/DiscoveryManifestTest.php
+++ b/tests/Feature/DiscoveryManifestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Attributes\Action;
+use Lattice\Lattice\Attributes\BulkAction;
+use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Attributes\Fragment;
+use Lattice\Lattice\Attributes\Layout;
+use Lattice\Lattice\Attributes\Table;
+use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
+use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
+
+test('discovery kinds map every component group to its attribute', function () {
+    expect(DiscoveryKinds::COMPONENTS)->toMatchArray([
+        'forms' => Form::class,
+        'tables' => Table::class,
+        'actions' => Action::class,
+        'bulk-actions' => BulkAction::class,
+        'fragments' => Fragment::class,
+        'layouts' => Layout::class,
+    ]);
+});
+
+test('discovery kinds extracts a component key from its attribute', function () {
+    expect(DiscoveryKinds::keyOf(DiscoveredProfileForm::class, Form::class))
+        ->toBe('fixtures.profile');
+});

--- a/tests/Feature/DiscoveryManifestTest.php
+++ b/tests/Feature/DiscoveryManifestTest.php
@@ -35,6 +35,8 @@ function discoverFixtures(): void
     config(['lattice.discover' => [
         __DIR__.'/../Fixtures/Discovery' => 'Lattice\\Lattice\\Tests\\Fixtures\\Discovery',
     ]]);
+
+    app(DiscoveryManifest::class)->clear();
 }
 
 test('the manifest builds resolved entries for every kind', function () {
@@ -63,4 +65,15 @@ test('the manifest round-trips through the cached file', function () {
         $manifest->clear();
         expect($manifest->isCached())->toBeFalse();
     }
+});
+
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
+
+test('registries resolve discovered definitions from the manifest', function () {
+    discoverFixtures();
+
+    // No explicit Lattice::forms([...]) — resolution comes from the manifest.
+    $form = wire(FormComponent::use(DiscoveredProfileForm::class));
+
+    expect($form)->toMatchArray(['type' => 'form', 'id' => 'fixtures.profile']);
 });

--- a/tests/Feature/PageMetadataTest.php
+++ b/tests/Feature/PageMetadataTest.php
@@ -3,10 +3,12 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Http\Page as BasePage;
 use Lattice\Lattice\Http\PageMetadata;
+use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredDemoPage;
 
 #[Page(layout: PageLayout::App, container: PageContainer::Default)]
 abstract class FixtureBasePage extends BasePage {}
@@ -55,4 +57,44 @@ test('a page without any attribute resolves to defaults', function () {
         ->and($meta->layout)->toBe(PageLayout::None)
         ->and($meta->container)->toBe(PageContainer::Centered)
         ->and($meta->middleware)->toBe([]);
+});
+
+test('page metadata round-trips through an array descriptor', function () {
+    $descriptor = PageMetadata::reflect(FixtureEditPage::class)->toArray();
+
+    expect($descriptor)->toMatchArray([
+        'class' => FixtureEditPage::class,
+        'route' => '/products/{product}/edit',
+        'name' => 'products.edit',
+        'layout' => 'app',
+        'container' => 'default',
+    ]);
+
+    $rebuilt = PageMetadata::fromArray($descriptor);
+
+    expect($rebuilt->class)->toBe(FixtureEditPage::class)
+        ->and($rebuilt->route)->toBe('/products/{product}/edit')
+        ->and($rebuilt->layout)->toBe('app')
+        ->and($rebuilt->container)->toBe('default');
+});
+
+test('for() prefers a manifest descriptor and falls back to reflection', function () {
+    config(['lattice.discover' => [
+        __DIR__.'/../Fixtures/Discovery' => 'Lattice\\Lattice\\Tests\\Fixtures\\Discovery',
+    ]]);
+
+    $manifest = app(DiscoveryManifest::class);
+    $manifest->cache();
+
+    try {
+        // DiscoveredDemoPage is in the cached manifest.
+        $fromManifest = PageMetadata::for(DiscoveredDemoPage::class);
+        expect($fromManifest->name)->toBe('discovered.demo');
+
+        // FixtureEditPage is NOT discovered (it lives in this test file) -> reflection fallback.
+        $fromReflection = PageMetadata::for(FixtureEditPage::class);
+        expect($fromReflection->name)->toBe('products.edit');
+    } finally {
+        $manifest->clear();
+    }
 });

--- a/tests/Fixtures/Discovery/DiscoveredDemoPage.php
+++ b/tests/Fixtures/Discovery/DiscoveredDemoPage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\Discovery;
+
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page as BasePage;
+
+#[Page(route: '/discovered-demo', name: 'discovered.demo', middleware: ['web'])]
+final class DiscoveredDemoPage extends BasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Discovered'));
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Workbench\App\Providers;
@@ -11,43 +12,11 @@ use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\SkillComposer;
 use Laravel\Boost\Support\Config;
 use Laravel\Roster\Roster;
-use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
-use Workbench\App\Actions\ArchiveProductAction;
-use Workbench\App\Actions\ArchiveSelectedProductsAction;
-use Workbench\App\Actions\EditProductAction;
-use Workbench\App\Actions\RejectProductAction;
-use Workbench\App\Actions\RejectSelectedProductsAction;
-use Workbench\App\Forms\BuilderDemoForm;
-use Workbench\App\Forms\BuilderTableDemoForm;
-use Workbench\App\Forms\DependentDemoForm;
-use Workbench\App\Forms\PricingBuilderDemoForm;
-use Workbench\App\Forms\ProductForm;
-use Workbench\App\Forms\RepeaterDemoForm;
-use Workbench\App\Forms\ShowcaseForm;
-use Workbench\App\Layouts\AppLayout;
-use Workbench\App\Pages\BuilderDemoPage;
-use Workbench\App\Pages\BuilderTableDemoPage;
-use Workbench\App\Pages\DependentDemoPage;
-use Workbench\App\Pages\HomePage;
-use Workbench\App\Pages\PricingBuilderDemoPage;
-use Workbench\App\Pages\ProductCreatePage;
-use Workbench\App\Pages\ProductEditPage;
-use Workbench\App\Pages\ProductsPage;
-use Workbench\App\Pages\RepeaterDemoPage;
-use Workbench\App\Pages\ShowcasePage;
-use Workbench\App\Pages\TablesPage;
-use Workbench\App\Pages\TabsPage;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
 use Workbench\App\Support\TypeScript\BaseProfile;
-use Workbench\App\Tables\ProductsTable;
-use Workbench\App\Tables\UsersInfiniteTable;
-use Workbench\App\Tables\UsersNoneTable;
-use Workbench\App\Tables\UsersSimpleTable;
-use Workbench\App\Tables\UsersTable;
-use Workbench\App\Tables\UsersTablePaginationTable;
 
 use function Orchestra\Testbench\package_path;
 
@@ -56,6 +25,10 @@ class WorkbenchServiceProvider extends ServiceProvider
     #[\Override]
     public function register(): void
     {
+        config(['lattice.discover' => [
+            package_path('workbench/app') => 'Workbench\\App',
+        ]]);
+
         // Rebind so lattice:typescript regenerates the package's own built-in types.
         $this->app->bind(TypeScriptProfile::class, BaseProfile::class);
         $this->useWorkbenchDatabase();
@@ -123,55 +96,6 @@ class WorkbenchServiceProvider extends ServiceProvider
         }
 
         $this->loadMigrationsFrom(package_path('workbench/database/migrations'));
-
-        Lattice::actions([
-            ArchiveProductAction::class,
-            EditProductAction::class,
-            RejectProductAction::class,
-        ]);
-
-        Lattice::bulkActions([
-            ArchiveSelectedProductsAction::class,
-            RejectSelectedProductsAction::class,
-        ]);
-
-        Lattice::forms([
-            BuilderDemoForm::class,
-            BuilderTableDemoForm::class,
-            DependentDemoForm::class,
-            PricingBuilderDemoForm::class,
-            ProductForm::class,
-            RepeaterDemoForm::class,
-            ShowcaseForm::class,
-        ]);
-
-        Lattice::tables([
-            ProductsTable::class,
-            UsersTable::class,
-            UsersNoneTable::class,
-            UsersSimpleTable::class,
-            UsersTablePaginationTable::class,
-            UsersInfiniteTable::class,
-        ]);
-
-        Lattice::layouts([
-            AppLayout::class,
-        ]);
-
-        Lattice::pages([
-            HomePage::class,
-            TablesPage::class,
-            TabsPage::class,
-            ProductsPage::class,
-            ProductCreatePage::class,
-            ProductEditPage::class,
-            DependentDemoPage::class,
-            RepeaterDemoPage::class,
-            BuilderDemoPage::class,
-            BuilderTableDemoPage::class,
-            PricingBuilderDemoPage::class,
-            ShowcasePage::class,
-        ]);
 
         $this->pointBoostAtPackageRoot();
         $this->redirectBoostSkillsToPackageRoot();


### PR DESCRIPTION
## What

Replaces per-path discovery + cache-*store* with a single discovery pass whose fully-resolved result is written to one PHP file (`bootstrap/cache/lattice.php`), the way Laravel caches config and packages.

- `DiscoveryManifest` owns the file and the live build; registries inject it and pull their resolved definitions via `forGroup()` / page descriptors.
- Pages fold into the same discovery + manifest: route/name/middleware **and** layout/container per page, so there's no page reflection in production (boot or render).
- `lattice:discover-cache` / `-clear` write/remove the file (still wired into `optimize`); never written automatically, so dev discovers live.
- Workbench is dogfooded onto discovery — explicit `Lattice::forms/tables/...([...])` registration dropped from the provider.

## Why

Old path still reflected every discovered class twice per boot and depended on a configured cache store. The manifest eliminates boot-time reflection in production, drops the cache-store dependency, and unifies pages with the rest.

## Notes

- Explicit registration (`Lattice::forms([...])`) still layers on top at runtime for consumers and test fixtures.
- Follow-up worth considering: the ad-hoc `Lattice::discover()` / `Discoverable` stack is now production-dead (test-only) and could be removed to consolidate discovery to a single mechanism.

488 passed, PHPStan clean, Pint clean.