### PR TITLE
Fix user menu placement (open upward; align when collapsed)

### DIFF
--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -81,6 +81,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
         as={method === "get" ? undefined : "button"}
         className={cn(
           rowClass,
+          "w-full",
           collapsed && "group relative justify-center",
           active && "bg-lt-muted font-medium",
         )}

--- a/resources/js/layout/menu.test.tsx
+++ b/resources/js/layout/menu.test.tsx
@@ -168,5 +168,6 @@ describe("Menu", () => {
     const link = screen.getByRole("link", { name: "Log out" });
     expect(link).toHaveAttribute("data-method", "post");
     expect(link).toHaveAttribute("data-as", "button");
+    expect(link).toHaveClass("w-full");
   });
 });

--- a/resources/js/layout/popover.test.tsx
+++ b/resources/js/layout/popover.test.tsx
@@ -27,4 +27,28 @@ describe("Popover", () => {
     fireEvent.click(overlay as Element);
     expect(screen.queryByRole("link", { name: "Item" })).not.toBeInTheDocument();
   });
+
+  it("opens upward for a top placement", () => {
+    render(
+      <Popover trigger={<span>Open</span>} placement="top" testId="pop">
+        <a href="/x">Item</a>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByText("Open"));
+
+    expect(screen.getByRole("menu").style.transform).toBe("translate(0, -100%)");
+  });
+
+  it("opens to the side without a transform for a right placement", () => {
+    render(
+      <Popover trigger={<span>Open</span>} placement="right" testId="pop">
+        <a href="/x">Item</a>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByText("Open"));
+
+    expect(screen.getByRole("menu").style.transform).toBe("");
+  });
 });

--- a/resources/js/layout/popover.tsx
+++ b/resources/js/layout/popover.tsx
@@ -18,7 +18,7 @@ export function Popover({
   align?: "start" | "end";
   children: ReactNode;
   className?: string;
-  placement?: "bottom" | "right";
+  placement?: "bottom" | "right" | "top";
   testId?: string;
   trigger: ReactNode;
   triggerClassName?: string;
@@ -37,7 +37,10 @@ export function Popover({
       setPosition(
         placement === "right"
           ? { left: rect.right + 4, top: rect.top }
-          : { left: align === "end" ? rect.right : rect.left, top: rect.bottom + 4 },
+          : {
+              left: align === "end" ? rect.right : rect.left,
+              top: placement === "top" ? rect.top - 4 : rect.bottom + 4,
+            },
       );
     }
     setOpen((value) => !value);
@@ -79,7 +82,9 @@ export function Popover({
                   left: position.left,
                   top: position.top,
                   transform:
-                    placement === "bottom" && align === "end" ? "translateX(-100%)" : undefined,
+                    placement === "right"
+                      ? undefined
+                      : `translate(${align === "end" ? "-100%" : "0"}, ${placement === "top" ? "-100%" : "0"})`,
                 }}
               >
                 <SidebarCollapsedContext.Provider value={false}>

--- a/resources/js/layout/user-menu.test.tsx
+++ b/resources/js/layout/user-menu.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
 import { Renderer } from "@lattice/lattice/core/renderer";
 import type { Node } from "@lattice/lattice/core/types";
+import { SidebarCollapsedContext } from "./context";
 import MenuItemComponent from "./menu-item";
 import UserMenuComponent from "./user-menu";
 
@@ -52,5 +53,27 @@ describe("UserMenu", () => {
     fireEvent.click(screen.getByRole("button"));
 
     expect(screen.getByRole("link", { name: "Log out" })).toHaveAttribute("href", "/logout");
+  });
+
+  it("centers the trigger when the sidebar is collapsed", () => {
+    render(
+      <SidebarCollapsedContext.Provider value={true}>
+        <Renderer
+          nodes={[
+            {
+              id: "u1",
+              type: "user-menu",
+              props: { name: "Ada Lovelace" },
+              schema: [
+                { id: "i", props: { href: "/logout", label: "Log out" }, type: "menu-item" },
+              ],
+            },
+          ]}
+          registry={registry}
+        />
+      </SidebarCollapsedContext.Provider>,
+    );
+
+    expect(screen.getByText("AL").parentElement).toHaveClass("justify-center");
   });
 });

--- a/resources/js/layout/user-menu.tsx
+++ b/resources/js/layout/user-menu.tsx
@@ -18,10 +18,16 @@ const UserMenuComponent: RendererComponent<"user-menu"> = ({ children, node }) =
 
   return (
     <Popover
-      align="end"
+      align="start"
+      placement={collapsed ? "right" : "top"}
       testId="user-menu"
       trigger={
-        <span className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-lt-muted">
+        <span
+          className={cn(
+            "flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-lt-muted",
+            collapsed && "justify-center",
+          )}
+        >
           {avatar ? (
             <img alt={name} className="size-8 shrink-0 rounded-md object-cover" src={avatar} />
           ) : (


### PR DESCRIPTION
The user menu sits at the bottom of a full-height sidebar (`Stack->height(Height::Screen)`), so its dropdown opened **downward** and fell off-screen. When the rail was collapsed the trigger was also left-aligned, out of step with the centered icon column.

- `Popover` gains a `top` placement (opens above the trigger; composes with `align` via a single `translate(x, y)`).
- `UserMenu` opens `top` when expanded and `right` when collapsed (matching the collapsed group flyout), and centers its trigger (`justify-center`) when collapsed.

## Tests
Vitest: added `Popover` cases for the `top` (upward) and `right` (no-transform) placements, and a `UserMenu` collapsed-centering case. `npm run check` green (284 tests, lint/format/typecheck/build).