### PR TITLE
Collapsed-sidebar popovers: collapse-aware Dropdown + viewport clamping

### DIFF
--- a/resources/js/layout/dropdown.test.tsx
+++ b/resources/js/layout/dropdown.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice/lattice/core/registry";
 import { Renderer } from "@lattice/lattice/core/renderer";
 import type { Node } from "@lattice/lattice/core/types";
+import { SidebarCollapsedContext } from "./context";
 import DropdownComponent from "./dropdown";
 import MenuItemComponent from "./menu-item";
 
@@ -36,6 +37,23 @@ describe("Dropdown", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Account" }));
 
+    expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute("href", "/profile");
+  });
+
+  it("collapses to an icon-only trigger that keeps the label reachable", () => {
+    render(
+      <SidebarCollapsedContext.Provider value={true}>
+        <Renderer
+          nodes={[{ ...node, props: { label: "Account", icon: "panel-left" } }]}
+          registry={registry}
+        />
+      </SidebarCollapsedContext.Provider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Account" });
+    expect(screen.getByText("Account")).toHaveClass("sr-only");
+
+    fireEvent.click(trigger);
     expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute("href", "/profile");
   });
 });

--- a/resources/js/layout/dropdown.tsx
+++ b/resources/js/layout/dropdown.tsx
@@ -1,20 +1,32 @@
 import type { RendererComponent } from "@lattice/lattice/core/types";
 import { Icon, IconRenderer } from "@lattice/lattice/icons";
+import { cn } from "@lattice/lattice/lib/utils";
+import { useSidebarCollapsed } from "./context";
 import { Popover } from "./popover";
 
 const DropdownComponent: RendererComponent<"dropdown"> = ({ children, node }) => {
+  const collapsed = useSidebarCollapsed();
   const icon = node.props.icon;
   const label = node.props.label;
   const slug = label.toLowerCase().replace(/\s+/g, "-");
 
   return (
     <Popover
+      placement={collapsed ? "right" : "bottom"}
       testId={`dropdown-${slug}`}
+      triggerLabel={collapsed ? label : undefined}
       trigger={
-        <span className="flex items-center gap-2 rounded-md px-3 py-2 text-sm text-lt-fg hover:bg-lt-muted">
+        <span
+          className={cn(
+            "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-lt-fg hover:bg-lt-muted",
+            collapsed && "justify-center",
+          )}
+        >
           {icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} /> : null}
-          <span>{label}</span>
-          <Icon name="chevron-down" className="ml-auto size-lt-icon-md shrink-0" />
+          <span className={cn(collapsed && "sr-only")}>{label}</span>
+          {collapsed ? null : (
+            <Icon name="chevron-down" className="ml-auto size-lt-icon-md shrink-0" />
+          )}
         </span>
       }
     >

--- a/resources/js/layout/popover.tsx
+++ b/resources/js/layout/popover.tsx
@@ -1,5 +1,5 @@
 import { usePage } from "@inertiajs/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@lattice/lattice/lib/utils";
@@ -27,9 +27,46 @@ export function Popover({
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState({ left: 0, top: 0 });
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const url = usePage().url;
 
   useEffect(() => setOpen(false), [url]);
+
+  // Once open, nudge the menu back inside the viewport. A "right"-placed menu
+  // anchored to a trigger near the bottom (e.g. a sidebar user menu) would
+  // otherwise spill off-screen.
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!open || !menu) {
+      return;
+    }
+
+    const rect = menu.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      return;
+    }
+
+    const margin = 8;
+    let dx = 0;
+    let dy = 0;
+
+    if (rect.right > window.innerWidth - margin) {
+      dx = window.innerWidth - margin - rect.right;
+    }
+    if (rect.left + dx < margin) {
+      dx = margin - rect.left;
+    }
+    if (rect.bottom > window.innerHeight - margin) {
+      dy = window.innerHeight - margin - rect.bottom;
+    }
+    if (rect.top + dy < margin) {
+      dy = margin - rect.top;
+    }
+
+    if (dx !== 0 || dy !== 0) {
+      setPosition((current) => ({ left: current.left + dx, top: current.top + dy }));
+    }
+  }, [open]);
 
   function toggle(): void {
     const rect = triggerRef.current?.getBoundingClientRect();
@@ -77,6 +114,7 @@ export function Popover({
                   "fixed z-50 min-w-56 rounded-md border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-lg",
                   className,
                 )}
+                ref={menuRef}
                 role="menu"
                 style={{
                   left: position.left,


### PR DESCRIPTION
The `Dropdown` layout primitive always rendered its label + chevron, so it overflowed a collapsed sidebar rail and couldn't be used for things like a team switcher.

When the sidebar is collapsed, the trigger now:
- shows only its icon (label kept reachable via `aria-label`),
- centers the icon (`justify-center`),
- drops the chevron,
- opens to the **right** (like the collapsed group flyout) instead of downward.

Expanded behavior is unchanged. Outside a sidebar (no collapse context) it renders exactly as before.

## Tests
Vitest: added a collapsed case asserting the label is `sr-only` but still the accessible name, and the menu still opens. `npm run check` green (285 tests).