### PR TITLE
Fix package/docs drift and local source-link workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require lattice-php/lattice
 npm install @lattice-php/lattice
 ```
 
-See [Installation](https://latticephp.com/getting-started/installation/) and [Frontend Setup](https://latticephp.com/getting-started/frontend-setup/) for the full setup.
+See [Installation](https://latticephp.com/introduction/installation/) for the full setup.
 
 ## Documentation
 

--- a/docs/content/docs/contributing/local-development.md
+++ b/docs/content/docs/contributing/local-development.md
@@ -3,11 +3,46 @@ title: Local Development
 description: Consume Lattice from a local Composer checkout instead of the published packages.
 ---
 
-When you work on Lattice itself — or need to try an unreleased change in a real application — you consume the package straight from a local checkout rather than from Packagist and npm. The PHP side comes from a Composer path repository, and the React renderer is aliased to the package's source (`resources/js`) instead of installed from npm.
+There are two supported local-development loops:
 
-This is the workflow the Testbench app in the repository uses; `workbench/resources/js/app.tsx` and `workbench/resources/css/app.css` are the canonical, working reference.
+- **Workbench development** — the default loop for changing Lattice itself.
+- **External app source-linking** — an integration loop for testing an unreleased checkout inside a real Laravel app with Vite HMR.
 
-## Point Composer at your checkout
+Use package-linking only when you want publish-like verification. It exercises the built `dist` package and therefore requires rebuilding after JavaScript changes.
+
+## Workbench development
+
+The repository ships with an Orchestra Testbench workbench app. This is the default way to develop Lattice because PHP, routes, fixtures, Vite, Tailwind, icons, and the React renderer are already wired together.
+
+Install dependencies once:
+
+```bash
+composer install
+npm install
+```
+
+Serve the workbench:
+
+```bash
+composer serve
+npm run dev
+```
+
+The workbench compiles Lattice directly from `resources/js` and imports the stylesheet directly from `resources/css/lattice.css`, so frontend changes are picked up by Vite without running the package build.
+
+The canonical references are:
+
+- `workbench/resources/js/app.tsx`
+- `workbench/resources/css/app.css`
+- `vite.config.ts`
+
+## External app source-linking
+
+Use this when you need to try local Lattice changes inside an existing Laravel + Inertia React application. The PHP side is linked with Composer, and the React renderer is compiled from source by the consuming app's Vite dev server.
+
+This mode gives you HMR for Lattice's TypeScript and CSS without running `npm run build:lib`.
+
+### Link PHP with Composer
 
 In the consuming app's `composer.json`, add a path repository and require the dev version:
 
@@ -16,91 +51,118 @@ In the consuming app's `composer.json`, add a path repository and require the de
   "repositories": [
     {
       "type": "path",
-      "url": "../lattice-package"
+      "url": "../lattice",
+      "options": {
+        "symlink": true
+      }
     }
-  ],
-  "require": {
-    "lattice-php/lattice": "*@dev"
-  }
+  ]
 }
 ```
 
 ```bash
-composer update lattice-php/lattice
+composer require lattice-php/lattice:"*@dev" -W
 ```
 
-Composer symlinks your checkout into `vendor/lattice-php/lattice`, so PHP changes are picked up immediately.
+Composer symlinks your checkout into `vendor/lattice-php/lattice`, so PHP changes are picked up by the app immediately.
 
-## Install the renderer's JavaScript dependencies
-
-The published npm package declares these for you, but when you consume the source through an alias your app's `node_modules` must provide them itself:
+### Keep the public npm package installed
 
 ```bash
-npm install \
-  @inertiajs/react \
-  react \
-  react-dom \
-  lucide-react \
-  class-variance-authority \
-  clsx \
-  tailwind-merge \
-  @radix-ui/react-checkbox \
-  @radix-ui/react-label \
-  @radix-ui/react-slot \
-  @tiptap/react \
-  @tiptap/pm \
-  @tiptap/starter-kit \
-  @tiptap/extension-details \
-  @tiptap/extension-highlight \
-  @tiptap/extension-link \
-  @tiptap/extension-table \
-  @tiptap/extension-text-align
-npm install -D tailwindcss @tailwindcss/vite tw-animate-css
+npm install @lattice-php/lattice
 ```
 
-## Alias the renderer source
+Keep application imports on the public package name:
 
-Point `@lattice/lattice` at the symlinked source in your Vite config:
+```tsx
+import LatticePage from "@lattice-php/lattice/page";
+import { Provider, registry } from "@lattice-php/lattice";
+```
+
+Do not import from `@lattice/lattice` in application code. That name is an internal source alias used by the package itself.
+
+### Alias the renderer source
+
+Add an opt-in source alias to the consuming app's `vite.config.ts`:
 
 ```ts
-// vite.config.ts
-resolve: {
-  alias: {
-    "@lattice/lattice": path.resolve(
-      __dirname,
-      "vendor/lattice-php/lattice/resources/js",
-    ),
+import path from "node:path";
+import { defineConfig, searchForWorkspaceRoot } from "vite";
+
+const latticeRoot = path.resolve(__dirname, "vendor/lattice-php/lattice");
+const latticeSource = path.resolve(latticeRoot, "resources/js");
+const useLocalLattice = process.env.LATTICE_SOURCE === "1";
+
+export default defineConfig({
+  resolve: {
+    alias: useLocalLattice
+      ? {
+          "@lattice-php/lattice/css": path.resolve(latticeRoot, "resources/css/lattice.css"),
+          "@lattice-php/lattice": latticeSource,
+          "@lattice/lattice": latticeSource,
+        }
+      : {},
+    dedupe: ["react", "react-dom", "@inertiajs/react"],
   },
-},
+  server: useLocalLattice
+    ? {
+        fs: {
+          allow: [searchForWorkspaceRoot(process.cwd()), latticeRoot],
+        },
+      }
+    : undefined,
+});
 ```
 
-Mirror it in `tsconfig.json` so your editor and `tsc` resolve the same imports:
+This keeps normal development on the installed npm package, while `LATTICE_SOURCE=1` switches Vite to the checkout under `vendor/lattice-php/lattice`.
+
+If your editor or `tsc` does not follow Vite aliases, mirror the public package name in `tsconfig.json`:
 
 ```json
 {
   "compilerOptions": {
     "paths": {
-      "@lattice/lattice": ["./vendor/lattice-php/lattice/resources/js/index.ts"],
-      "@lattice/lattice/*": ["./vendor/lattice-php/lattice/resources/js/*"]
+      "@lattice-php/lattice": ["./vendor/lattice-php/lattice/resources/js/index.ts"],
+      "@lattice-php/lattice/*": ["./vendor/lattice-php/lattice/resources/js/*"]
     }
   }
 }
 ```
 
-## Import the stylesheet and register the renderer
+### Scan Lattice source with Tailwind
 
-Import the stylesheet from the source and register the page component exactly as in [Installation](/introduction/installation/), but resolve everything through the alias:
+Keep the regular stylesheet import, then add a Tailwind source path for the linked checkout:
 
 ```css
 /* resources/css/app.css */
 @import "tailwindcss";
 @import "tw-animate-css";
-@import "../../vendor/lattice-php/lattice/resources/css/lattice.css";
+@import "@lattice-php/lattice/css";
+
+@source "../../vendor/lattice-php/lattice/resources/js";
 ```
 
-```tsx
-import LatticePage from "@lattice/lattice/page";
+### Run the app in source mode
+
+```bash
+LATTICE_SOURCE=1 npm run dev
 ```
 
-Since your bundler compiles the package's TypeScript directly, edits to `resources/js` in your checkout are reflected on the next Vite reload.
-</content>
+Vite now compiles the linked checkout directly. TypeScript and CSS changes in Lattice update through the consuming app's dev server without a package build.
+
+## Package-link verification
+
+Use package-linking when you want to test the same surface that npm publishes:
+
+```bash
+npm install @lattice-php/lattice@file:../lattice
+```
+
+This mode reads the package exports and `dist` files. It is closer to a release, but it is not a live source workflow. Run the package build after renderer changes:
+
+```bash
+cd ../lattice
+npm run build:lib
+```
+
+Use source-linking for daily integration work, and package-linking for publish-like checks.

--- a/docs/content/docs/contributing/local-development.md
+++ b/docs/content/docs/contributing/local-development.md
@@ -150,6 +150,14 @@ LATTICE_SOURCE=1 npm run dev
 
 Vite now compiles the linked checkout directly. TypeScript and CSS changes in Lattice update through the consuming app's dev server without a package build.
 
+### Known issue: source-linked tests
+
+Source-linking is intended for browser development and HMR. It is not a reliable way to run the consuming app's Vitest suite against a full Lattice checkout.
+
+The checkout has its own `node_modules`, so React-based dependencies imported from Lattice source can resolve their own copy of React instead of the application's copy. In tests this can show up as React's "Invalid hook call" error. Browser dev and production builds dedupe correctly, but the test runner can still cross that dependency boundary.
+
+For green test verification, switch back to package-linking or the published npm package so the app tests the built package surface rather than the checkout's source tree.
+
 ## Package-link verification
 
 Use package-linking when you want to test the same surface that npm publishes:

--- a/docs/content/docs/extending/custom-columns.md
+++ b/docs/content/docs/extending/custom-columns.md
@@ -132,10 +132,10 @@ After running `lattice:typescript`, `column.props` is narrowed to the generated 
 The generator appended an entry to `resources/js/lattice/columns.ts`:
 
 ```ts
-import { createColumnPlugin } from "@lattice-php/lattice";
+import { createPlugin } from "@lattice-php/lattice";
 import { StatusBadgeCell } from "./columns/status-badge";
 
-export const appColumns = createColumnPlugin({
+export const appColumns = createPlugin({
   name: "app",
   columns: {
     "column.status-badge": StatusBadgeCell,
@@ -145,17 +145,17 @@ export const appColumns = createColumnPlugin({
 
 ## 6. Wire columns in app.tsx
 
-Create the column registry from your plugin and pass it to `Provider`:
+Extend the built-in registry with your column plugin and pass that registry to `Provider`:
 
 ```tsx
 import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
 import { createRoot } from "react-dom/client";
 import LatticePage from "@lattice-php/lattice/page";
-import { createColumnRegistry, Provider, registry } from "@lattice-php/lattice";
+import { extendRegistry, Provider, registry } from "@lattice-php/lattice";
 import { appColumns } from "./lattice/columns";
 
-const columns = createColumnRegistry(appColumns);
+const appRegistry = extendRegistry(registry, appColumns);
 
 createInertiaApp({
   resolve: (name) => {
@@ -166,7 +166,7 @@ createInertiaApp({
   setup({ el, App, props }) {
     if (!el) return;
     createRoot(el).render(
-      <Provider registry={registry} columns={columns}>
+      <Provider registry={appRegistry}>
         <App {...props} />
       </Provider>,
     );
@@ -174,7 +174,7 @@ createInertiaApp({
 });
 ```
 
-If you also have custom fields or components, pass both `registry={appRegistry}` (from `extendRegistry`) and `columns={columns}` to the same `Provider`.
+If you also have custom fields or components, pass all of those plugins to the same `extendRegistry(registry, ...)` call.
 
 ## 7. Generate TypeScript types
 

--- a/docs/content/docs/extending/registry-and-types.md
+++ b/docs/content/docs/extending/registry-and-types.md
@@ -27,15 +27,15 @@ The node registry maps type strings to `RendererComponent` functions. Imports co
 Creates a named plugin object that bundles one or more component registrations:
 
 ```ts
-import { createPlugin } from "@lattice-php/lattice";
+import { createPlugin, eagerComponent } from "@lattice-php/lattice";
 import { ColorPickerComponent } from "./fields/color-picker";
 import { RatingComponent } from "./components/rating";
 
 export const appPlugin = createPlugin({
   name: "app",
   components: {
-    "form.color-picker": ColorPickerComponent,
-    "rating": RatingComponent,
+    "form.color-picker": eagerComponent(ColorPickerComponent),
+    "rating": eagerComponent(RatingComponent),
   },
 });
 ```
@@ -68,30 +68,31 @@ const minimalRegistry = createRegistry(appPlugin);
 Components can be registered eagerly (imported at module load time) or lazily (code-split on first render):
 
 ```ts
-import { createPlugin, lazyComponent } from "@lattice-php/lattice";
+import { createPlugin, eagerComponent, lazyComponent } from "@lattice-php/lattice";
+import { RatingComponent } from "./components/rating";
 
 export const appPlugin = createPlugin({
   name: "app",
   components: {
     // Eager — bundled with the entry point.
-    "rating": RatingComponent,
+    "rating": eagerComponent(RatingComponent),
     // Lazy — splits into a separate chunk loaded on demand.
-    "form.color-picker": lazyComponent(() =>
-      import("./fields/color-picker").then((m) => m.ColorPickerComponent)
-    ),
+    "form.color-picker": lazyComponent(async () => ({
+      default: (await import("./fields/color-picker")).ColorPickerComponent,
+    })),
   },
 });
 ```
 
 ### Provider and useRegistry
 
-`Provider` supplies the registry (and optionally the column registry) to every Lattice component below it in the tree:
+`Provider` supplies the registry to every Lattice component below it in the tree:
 
 ```tsx
 import { Provider } from "@lattice-php/lattice";
 
 createRoot(el).render(
-  <Provider registry={appRegistry} columns={columns}>
+  <Provider registry={appRegistry}>
     <App {...props} />
   </Provider>,
 );
@@ -109,15 +110,15 @@ const registry = useRegistry();
 
 The column-cell registry maps type strings to `ColumnCellComponent` functions.
 
-### createColumnPlugin
+### Column plugins
 
-Creates a named plugin for column cell renderers:
+Column cell renderers use the same plugin object as components. Put them under the `columns` key:
 
 ```ts
-import { createColumnPlugin } from "@lattice-php/lattice";
+import { createPlugin } from "@lattice-php/lattice";
 import { StatusBadgeCell } from "./columns/status-badge";
 
-export const appColumns = createColumnPlugin({
+export const appColumns = createPlugin({
   name: "app",
   columns: {
     "column.status-badge": StatusBadgeCell,
@@ -125,25 +126,13 @@ export const appColumns = createColumnPlugin({
 });
 ```
 
-### createColumnRegistry
-
-Builds the registry object that `Provider` consumes:
+Merge column plugins into the same registry you pass to `Provider`:
 
 ```ts
-import { createColumnRegistry } from "@lattice-php/lattice";
+import { extendRegistry, registry } from "@lattice-php/lattice";
 import { appColumns } from "./lattice/columns";
 
-const columns = createColumnRegistry(appColumns);
-```
-
-### extendColumnRegistry
-
-Merges additional plugins into an existing column registry:
-
-```ts
-import { extendColumnRegistry } from "@lattice-php/lattice";
-
-const extended = extendColumnRegistry(columns, extraPlugin);
+const appRegistry = extendRegistry(registry, appColumns);
 ```
 
 ### useColumnRegistry

--- a/docs/content/docs/introduction/getting-started.md
+++ b/docs/content/docs/introduction/getting-started.md
@@ -25,7 +25,7 @@ use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Http\Page as BasePage;
 
-#[Page(route: '/dashboard', layout: PageLayout::App, middleware: ['web'])]
+#[Page(route: '/dashboard', layout: PageLayout::None, middleware: ['web'])]
 final class DashboardPage extends BasePage
 {
     public function title(): string
@@ -35,15 +35,15 @@ final class DashboardPage extends BasePage
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
+        return $schema->schema([
             Stack::make('dashboard')
                 ->gap(Gap::Large)
-                ->children([
+                ->schema([
                     Heading::make('Dashboard'),
                     Text::make('Everything below is described in PHP and rendered as React.'),
                     Grid::make('stats')
                         ->columns(2)
-                        ->children([
+                        ->schema([
                             Card::make('Orders', '128 this week.'),
                             Card::make('Revenue', '$4,210 this week.'),
                         ]),

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -50,7 +50,7 @@ The browser needs the Lattice React renderer to turn the server's component tree
 npm install @lattice-php/lattice
 ```
 
-The renderer's UI libraries (Radix, TipTap, Lucide, …) come with it. `react`, `react-dom`, and `@inertiajs/react` are peer dependencies you already have in a Laravel React app. Styling is driven by Tailwind CSS v4:
+The renderer's UI libraries (Radix, TipTap, i18n, and styling utilities) come with it. Only `react`, `react-dom`, and `@inertiajs/react` are peer dependencies you already have in a Laravel React app. Styling is driven by Tailwind CSS v4:
 
 ```bash
 npm install -D tailwindcss @tailwindcss/vite tw-animate-css
@@ -59,6 +59,12 @@ npm install -D tailwindcss @tailwindcss/vite tw-animate-css
 :::note
 Lattice targets React 19, Inertia v3, Tailwind 4, and TipTap 3. The npm package version always matches the `lattice-php/lattice` Composer version you installed — they ship from the same release.
 :::
+
+### Version compatibility
+
+Keep the Composer and npm package lines aligned. For pre-1.0 releases, install the same minor line on both sides, such as `lattice-php/lattice:^0.2` with `@lattice-php/lattice@^0.2`. From 1.0 onward, keep the major versions matched, such as `1.x` with `1.x` or `2.x` with `2.x`.
+
+The split is intentional: React, React DOM, and Inertia stay as peer dependencies so the application owns its SPA runtime, while Lattice bundles its renderer internals.
 
 ### Import the stylesheet
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "clsx": "^2.1.1",
         "i18next": "^26.3.1",
         "i18next-http-backend": "^4.0.0",
-        "react-i18next": "^17.0.8",
         "tailwind-merge": "^3.0.1"
       },
       "devDependencies": {
@@ -1382,6 +1381,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -8745,15 +8745,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
-      }
-    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -11600,33 +11591,6 @@
         "react": "^19.2.7"
       }
     },
-    "node_modules/react-i18next": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
-      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "html-parse-stringify": "^3.0.1",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "i18next": ">= 26.2.0",
-        "react": ">= 16.8.0",
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13581,15 +13545,6 @@
         "vite": {
           "optional": false
         }
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "clsx": "^2.1.1",
     "i18next": "^26.3.1",
     "i18next-http-backend": "^4.0.0",
-    "react-i18next": "^17.0.8",
     "tailwind-merge": "^3.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
       "types": "./dist/icons/index.d.ts",
       "import": "./dist/icons/index.js"
     },
-    "./menu": {
-      "types": "./dist/menu/index.d.ts",
-      "import": "./dist/menu/index.js"
+    "./layout": {
+      "types": "./dist/layout/index.d.ts",
+      "import": "./dist/layout/index.js"
     },
     "./table": {
       "types": "./dist/table/index.d.ts",

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -32,8 +32,8 @@ final class ProductsPage extends BasePage
 
     public function render(PageSchema $schema): PageSchema
     {
-        return $schema->components([
-            Stack::make('page')->gap(Gap::Large)->children([
+        return $schema->schema([
+            Stack::make('page')->gap(Gap::Large)->schema([
                 Heading::make('Products'),
                 Table::use(ProductsTable::class),
             ]),

--- a/resources/js/i18n/instance.test.tsx
+++ b/resources/js/i18n/instance.test.tsx
@@ -1,0 +1,40 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { i18n, translate, useT } from "./instance";
+
+const namespace = "test";
+
+function Greeting() {
+  const { t } = useT(namespace);
+
+  return <span>{t("greeting", "Hello")}</span>;
+}
+
+describe("i18n instance", () => {
+  beforeEach(() => {
+    if (i18n.isInitialized && i18n.hasResourceBundle("en", namespace)) {
+      i18n.removeResourceBundle("en", namespace);
+    }
+  });
+
+  it("returns inline defaults without the React i18next adapter", () => {
+    render(<Greeting />);
+
+    expect(screen.getByText("Hello")).toBeVisible();
+    expect(translate(namespace, "greeting", "Hello")).toBe("Hello");
+  });
+
+  it("rerenders hook consumers when resources change", async () => {
+    render(<Greeting />);
+
+    expect(screen.getByText("Hello")).toBeVisible();
+
+    await waitFor(() => expect(i18n.isInitialized).toBe(true));
+
+    act(() => {
+      i18n.addResourceBundle("en", namespace, { greeting: "Hallo" }, true, true);
+    });
+
+    expect(await screen.findByText("Hallo")).toBeVisible();
+  });
+});

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -1,7 +1,19 @@
 import i18next, { type i18n as I18nInstance, type InitOptions } from "i18next";
-import { initReactI18next, useTranslation } from "react-i18next";
+import { useCallback, useSyncExternalStore } from "react";
 
 const NAMESPACE = "lattice";
+
+type TranslationFunction = (
+  key: string,
+  defaultValue?: string,
+  options?: Record<string, unknown>,
+) => string;
+
+export type TranslationResult = {
+  t: TranslationFunction;
+  i18n: I18nInstance;
+  ready: boolean;
+};
 
 function detectLanguage(): string {
   if (typeof document !== "undefined" && document.documentElement.lang) {
@@ -11,10 +23,35 @@ function detectLanguage(): string {
   return "en";
 }
 
-/** Lattice's own i18next instance, isolated from the host app's. */
-export const i18n: I18nInstance = i18next.createInstance().use(initReactI18next);
+export const i18n: I18nInstance = i18next.createInstance();
 
 let initialization: Promise<unknown> | undefined;
+let revision = 0;
+
+function subscribe(onStoreChange: () => void): () => void {
+  const listener = () => {
+    revision += 1;
+    onStoreChange();
+  };
+
+  i18n.on("initialized", listener);
+  i18n.on("loaded", listener);
+  i18n.on("languageChanged", listener);
+  i18n.store?.on("added", listener);
+  i18n.store?.on("removed", listener);
+
+  return () => {
+    i18n.off("initialized", listener);
+    i18n.off("loaded", listener);
+    i18n.off("languageChanged", listener);
+    i18n.store?.off("added", listener);
+    i18n.store?.off("removed", listener);
+  };
+}
+
+function snapshot(): number {
+  return revision;
+}
 
 /**
  * Initialize the instance exactly once. The first caller wins — a rendered
@@ -29,7 +66,6 @@ export function ensureI18n(extend?: (base: InitOptions) => InitOptions): Promise
       ns: [NAMESPACE],
       defaultNS: NAMESPACE,
       interpolation: { escapeValue: false },
-      react: { useSuspense: false },
     };
 
     initialization = i18n.init(extend ? extend(base) : base);
@@ -38,14 +74,18 @@ export function ensureI18n(extend?: (base: InitOptions) => InitOptions): Promise
   return initialization;
 }
 
-/** Translation hook bound to Lattice's instance. The chrome passes `"lattice"`; consumers pass their own namespace. */
-export function useT(namespace: string) {
+export function useT(namespace: string): TranslationResult {
   ensureI18n();
+  useSyncExternalStore(subscribe, snapshot, snapshot);
 
-  return useTranslation(namespace, { i18n });
+  const t = useCallback<TranslationFunction>(
+    (key, defaultValue = key, options = {}) => translate(namespace, key, defaultValue, options),
+    [namespace],
+  );
+
+  return { t, i18n, ready: i18n.isInitialized };
 }
 
-/** Translate a key in the given namespace with an inline fallback, outside of a component. */
 export function translate(
   namespace: string,
   key: string,

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -36,6 +36,8 @@ final class ActionController
             return $this->validatePrecognitive($request, fn () => $definition->validate($request));
         }
 
+        $definition->validate($request);
+
         return response()->json(
             $definition->handle($request),
         );

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -40,6 +40,8 @@ final class FormController
             return $this->validatePrecognitive($request, fn () => $definition->validate($request));
         }
 
+        $definition->validate($request);
+
         return $definition->handle($request);
     }
 }

--- a/tests/Feature/ActionFormTest.php
+++ b/tests/Feature/ActionFormTest.php
@@ -89,6 +89,17 @@ it('rejects an invalid embedded form with a 422', function (): void {
         ->assertJsonValidationErrors('reason');
 });
 
+it('validates final embedded form submissions before handle is called', function (): void {
+    Lattice::actions([UnvalidatedRejectActionFixture::class]);
+    $ref = componentRef(wire(ActionComponent::use(UnvalidatedRejectActionFixture::class)));
+
+    postJson('/lattice/actions/test.unvalidated-reject', ['reason' => ''], latticeHeaders($ref))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('reason');
+
+    expect(session('handled-unvalidated-reject'))->toBeNull();
+});
+
 it('validates the embedded form precognitively without running handle', function (): void {
     Lattice::actions([RejectActionFixture::class]);
     $ref = componentRef(wire(ActionComponent::use(RejectActionFixture::class)));
@@ -166,5 +177,26 @@ class RejectActionFixture extends ActionDefinition
         $data = $this->validate($request);
 
         return ActionResult::success(['reason' => $data['reason']]);
+    }
+}
+
+#[Action('test.unvalidated-reject')]
+class UnvalidatedRejectActionFixture extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action
+            ->label('Reject')
+            ->method(HttpMethod::Post)
+            ->form([
+                Textarea::make('reason', 'Reason')->required(),
+            ]);
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $request->session()->put('handled-unvalidated-reject', true);
+
+        return ActionResult::success(['handled' => true]);
     }
 }

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -50,6 +50,7 @@ use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Choice;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\PasswordInput;
+use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Fragments\Components\Fragment as FragmentComponent;
 use Lattice\Lattice\Fragments\FragmentDefinition;
@@ -80,6 +81,7 @@ use Workbench\App\Tables\UsersTable as WorkbenchAppUsersTable;
 use function Pest\Laravel\get;
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\patch;
+use function Pest\Laravel\patchJson;
 use function Pest\Laravel\postJson;
 use function Pest\Laravel\withoutVite;
 use function Pest\Laravel\withSession;
@@ -528,6 +530,18 @@ test('registered form endpoints require a valid component reference', function (
         'name' => 'Taylor',
     ], latticeHeaders('tampered'))
         ->assertForbidden();
+});
+
+test('registered form submissions validate before handle is called', function () {
+    Lattice::forms([WorkbenchRequiredProfileForm::class]);
+
+    $ref = componentRef(wire(Form::use(WorkbenchRequiredProfileForm::class)));
+
+    patchJson('/lattice/forms/workbench.required-profile', [], latticeHeaders($ref))
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('name');
+
+    expect(session('handled-required-profile'))->toBeNull();
 });
 
 test('registered forms receive the current request while serializing definitions', function () {
@@ -1724,6 +1738,26 @@ class WorkbenchProfileForm extends FormDefinition
         $request->session()->put('handled-form-team', $this->context($request, 'team'));
 
         return redirect('/submitted');
+    }
+}
+
+#[FormAttribute('workbench.required-profile')]
+class WorkbenchRequiredProfileForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form
+            ->method(HttpMethod::Patch)
+            ->schema([
+                TextInput::make('name', 'Name')->required(),
+            ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->session()->put('handled-required-profile', true);
+
+        return response()->json(['handled' => true]);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the stale menu npm export and align docs with current schema/plugin APIs
- validate final form/action submissions before handlers run
- document local source-link HMR workflow and its test-runner limitation
- remove the react-i18next adapter in favor of a small internal i18n hook

## Verification
- vendor/bin/pint --dirty --format agent
- ./vendor/bin/pest tests/Feature/LatticePageTest.php tests/Feature/ActionFormTest.php --filter='registered form submissions validate before handle is called|validates final embedded form submissions before handle is called|validates submitted values against a lazy form schema|rejects an invalid embedded form with a 422|validates the embedded form and hands the data to handle'
- npm run test -- resources/js/i18n/instance.test.tsx
- npm run typecheck
- in ../starter-kit: LATTICE_SOURCE=1 npm run build
- in ../starter-kit: LATTICE_SOURCE=1 npm run dev -- --host 127.0.0.1

## Notes
- Source-linked starter-kit Vitest remains documented as unsupported because a full checkout can expose a second React through its own node_modules.
