### PR TITLE
Row-scoped conditions and stable prefill overrides

### DIFF
--- a/resources/js/form/components/field-scope.test.tsx
+++ b/resources/js/form/components/field-scope.test.tsx
@@ -9,13 +9,21 @@ function Probe() {
       <span data-testid="dom">{scope?.scopedName("name")}</span>
       <span data-testid="err">{scope?.errorKey("name")}</span>
       <span data-testid="val">{String(scope?.getValue("name"))}</span>
+      <span data-testid="row-id">{String(scope?.rowId)}</span>
+      <span data-testid="override">{scope?.overrideKey("price")}</span>
+      <span data-testid="row-sku">{String(scope?.row.sku)}</span>
     </div>
   );
 }
 
 it("derives scoped DOM name, error key, and row value", () => {
   render(
-    <FieldScopeProvider base="items" index={2} row={{ name: "hi" }} onChange={() => {}}>
+    <FieldScopeProvider
+      base="items"
+      index={2}
+      row={{ __rowId: "row-7", name: "hi", sku: "A-1" }}
+      onChange={() => {}}
+    >
       <Probe />
     </FieldScopeProvider>,
   );
@@ -23,6 +31,9 @@ it("derives scoped DOM name, error key, and row value", () => {
   expect(screen.getByTestId("dom").textContent).toBe("items[2][name]");
   expect(screen.getByTestId("err").textContent).toBe("items.2.name");
   expect(screen.getByTestId("val").textContent).toBe("hi");
+  expect(screen.getByTestId("row-id").textContent).toBe("row-7");
+  expect(screen.getByTestId("override").textContent).toBe("items.row-7.price");
+  expect(screen.getByTestId("row-sku").textContent).toBe("A-1");
 });
 
 it("returns null scope outside a provider", () => {

--- a/resources/js/form/components/field-scope.tsx
+++ b/resources/js/form/components/field-scope.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo } from "react";
-import { ROW_ID_KEY } from "./fields/repeater-rows";
+import { buildOverrideKey, rowIdFrom } from "./override-keys";
 
 export type FieldScopeValue = {
   row: Record<string, unknown>;
@@ -27,7 +27,7 @@ export function FieldScopeProvider({
   children: React.ReactNode;
 }) {
   const value = useMemo<FieldScopeValue>(() => {
-    const rowId = typeof row[ROW_ID_KEY] === "string" ? row[ROW_ID_KEY] : null;
+    const rowId = rowIdFrom(row);
 
     return {
       row,
@@ -36,13 +36,14 @@ export function FieldScopeProvider({
       setValue: onChange,
       scopedName: (name) => `${base}[${index}][${name}]`,
       errorKey: (name) => `${base}.${index}.${name}`,
-      overrideKey: (name) => (rowId ? `${base}.${rowId}.${name}` : `${base}.${index}.${name}`),
+      overrideKey: (name) => buildOverrideKey(base, rowId, index, name),
     };
   }, [base, index, row, onChange]);
 
   return <FieldScopeContext.Provider value={value}>{children}</FieldScopeContext.Provider>;
 }
 
+/** Null outside a row so callers can preserve top-level behavior without a wrapper. */
 export function useFieldScope(): FieldScopeValue | null {
   return useContext(FieldScopeContext);
 }

--- a/resources/js/form/components/field-scope.tsx
+++ b/resources/js/form/components/field-scope.tsx
@@ -1,10 +1,14 @@
 import { createContext, useContext, useMemo } from "react";
+import { ROW_ID_KEY } from "./fields/repeater-rows";
 
 export type FieldScopeValue = {
+  row: Record<string, unknown>;
+  rowId: string | null;
   getValue: (name: string) => unknown;
   setValue: (name: string, value: unknown) => void;
   scopedName: (name: string) => string;
   errorKey: (name: string) => string;
+  overrideKey: (name: string) => string;
 };
 
 const FieldScopeContext = createContext<FieldScopeValue | null>(null);
@@ -22,20 +26,23 @@ export function FieldScopeProvider({
   onChange: (name: string, value: unknown) => void;
   children: React.ReactNode;
 }) {
-  const value = useMemo<FieldScopeValue>(
-    () => ({
+  const value = useMemo<FieldScopeValue>(() => {
+    const rowId = typeof row[ROW_ID_KEY] === "string" ? row[ROW_ID_KEY] : null;
+
+    return {
+      row,
+      rowId,
       getValue: (name) => row[name],
       setValue: onChange,
       scopedName: (name) => `${base}[${index}][${name}]`,
       errorKey: (name) => `${base}.${index}.${name}`,
-    }),
-    [base, index, row, onChange],
-  );
+      overrideKey: (name) => (rowId ? `${base}.${rowId}.${name}` : `${base}.${index}.${name}`),
+    };
+  }, [base, index, row, onChange]);
 
   return <FieldScopeContext.Provider value={value}>{children}</FieldScopeContext.Provider>;
 }
 
-/** Null when not inside a repeater row — callers fall back to the global flat store. */
 export function useFieldScope(): FieldScopeValue | null {
   return useContext(FieldScopeContext);
 }

--- a/resources/js/form/components/override-keys.ts
+++ b/resources/js/form/components/override-keys.ts
@@ -1,0 +1,14 @@
+import { ROW_ID_KEY } from "./fields/repeater-rows";
+
+export function rowIdFrom(row: Record<string, unknown>): string | null {
+  return typeof row[ROW_ID_KEY] === "string" ? row[ROW_ID_KEY] : null;
+}
+
+export function buildOverrideKey(
+  base: string,
+  rowId: string | null,
+  index: number,
+  name: string,
+): string {
+  return `${base}.${rowId ?? String(index)}.${name}`;
+}

--- a/resources/js/form/components/prefill-context.ts
+++ b/resources/js/form/components/prefill-context.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 
 export type PrefillController = {
-  markUserEdit: (path: string) => void;
+  markUserEdit: (overrideKey: string) => void;
 };
 
 const PrefillContext = createContext<PrefillController | null>(null);

--- a/resources/js/form/components/prefill-targets.test.ts
+++ b/resources/js/form/components/prefill-targets.test.ts
@@ -7,7 +7,6 @@ import {
   pathsToClear,
   pruneOverrides,
   seededOverrides,
-  targetByPath,
 } from "./prefill-targets";
 
 function priceField(): Node {
@@ -102,8 +101,10 @@ it("clears targets whose resetOn dependency changed", () => {
   const prev = { items: [{ product: "a" }] };
   const next = { items: [{ product: "b" }] };
 
-  expect(pathsToClear(targets, prev, targets, next)).toEqual(["items.r-a.price"]);
-  expect(pathsToClear(targets, prev, targets, prev)).toEqual([]);
+  expect(pathsToClear({ targets, values: prev }, { targets, values: next })).toEqual([
+    "items.r-a.price",
+  ]);
+  expect(pathsToClear({ targets, values: prev }, { targets, values: prev })).toEqual([]);
 });
 
 it("keeps reset comparisons attached to the same row after reindexing", () => {
@@ -132,19 +133,27 @@ it("keeps reset comparisons attached to the same row after reindexing", () => {
 
   expect(
     pathsToClear(
-      previousTargets,
-      { items: [{ product: "alpha" }, { product: "beta" }] },
-      currentTargets,
-      { items: [{ product: "beta" }] },
+      {
+        targets: previousTargets,
+        values: { items: [{ product: "alpha" }, { product: "beta" }] },
+      },
+      {
+        targets: currentTargets,
+        values: { items: [{ product: "beta" }] },
+      },
     ),
   ).toEqual([]);
 
   expect(
     pathsToClear(
-      previousTargets,
-      { items: [{ product: "alpha" }, { product: "beta" }] },
-      currentTargets,
-      { items: [{ product: "gamma" }] },
+      {
+        targets: previousTargets,
+        values: { items: [{ product: "alpha" }, { product: "beta" }] },
+      },
+      {
+        targets: currentTargets,
+        values: { items: [{ product: "gamma" }] },
+      },
     ),
   ).toEqual(["items.r-b.price"]);
 });
@@ -159,12 +168,11 @@ it("seeds overrides for targets that already hold a stored value", () => {
   expect(seededOverrides(targets, values)).toEqual(["items.r-a.price"]);
 });
 
-it("indexes targets by positional path while pruning by override key", () => {
+it("prunes stale override keys", () => {
   const targets = [
     { path: "items.0.price", overrideKey: "items.r-b.price", resetOn: [], refreshOn: [] },
   ];
 
-  expect(targetByPath(targets).get("items.0.price")?.overrideKey).toBe("items.r-b.price");
   expect(pruneOverrides(new Set(["items.r-b.price", "items.r-z.price"]), targets)).toEqual(
     new Set(["items.r-b.price"]),
   );

--- a/resources/js/form/components/prefill-targets.test.ts
+++ b/resources/js/form/components/prefill-targets.test.ts
@@ -5,7 +5,9 @@ import {
   collectPrefillTargets,
   getPath,
   pathsToClear,
+  pruneOverrides,
   seededOverrides,
+  targetByPath,
 } from "./prefill-targets";
 
 function priceField(): Node {
@@ -31,12 +33,27 @@ function builderNode(): Node {
 }
 
 it("collects a concrete target per row, mapping bare and @ deps", () => {
-  const values = { items: [{ type: "product" }, { type: "product" }] };
+  const values = {
+    items: [
+      { __rowId: "r-a", type: "product" },
+      { __rowId: "r-b", type: "product" },
+    ],
+  };
   const targets = collectPrefillTargets([builderNode()], values);
 
   expect(targets).toEqual([
-    { path: "items.0.price", resetOn: ["items.0.product"], refreshOn: ["customer"] },
-    { path: "items.1.price", resetOn: ["items.1.product"], refreshOn: ["customer"] },
+    {
+      path: "items.0.price",
+      overrideKey: "items.r-a.price",
+      resetOn: ["items.0.product"],
+      refreshOn: ["customer"],
+    },
+    {
+      path: "items.1.price",
+      overrideKey: "items.r-b.price",
+      resetOn: ["items.1.product"],
+      refreshOn: ["customer"],
+    },
   ]);
 });
 
@@ -48,7 +65,7 @@ it("collects a top-level target with form-level deps", () => {
   } as unknown as Node;
 
   expect(collectPrefillTargets([node], {})).toEqual([
-    { path: "total", resetOn: [], refreshOn: ["customer"] },
+    { path: "total", overrideKey: "total", resetOn: [], refreshOn: ["customer"] },
   ]);
 });
 
@@ -74,20 +91,81 @@ it("reads and applies nested row paths", () => {
 });
 
 it("clears targets whose resetOn dependency changed", () => {
-  const targets = [{ path: "items.0.price", resetOn: ["items.0.product"], refreshOn: [] }];
+  const targets = [
+    {
+      path: "items.0.price",
+      overrideKey: "items.r-a.price",
+      resetOn: ["items.0.product"],
+      refreshOn: [],
+    },
+  ];
   const prev = { items: [{ product: "a" }] };
   const next = { items: [{ product: "b" }] };
 
-  expect(pathsToClear(targets, prev, next)).toEqual(["items.0.price"]);
-  expect(pathsToClear(targets, prev, prev)).toEqual([]);
+  expect(pathsToClear(targets, prev, targets, next)).toEqual(["items.r-a.price"]);
+  expect(pathsToClear(targets, prev, targets, prev)).toEqual([]);
+});
+
+it("keeps reset comparisons attached to the same row after reindexing", () => {
+  const previousTargets = [
+    {
+      path: "items.0.price",
+      overrideKey: "items.r-a.price",
+      resetOn: ["items.0.product"],
+      refreshOn: [],
+    },
+    {
+      path: "items.1.price",
+      overrideKey: "items.r-b.price",
+      resetOn: ["items.1.product"],
+      refreshOn: [],
+    },
+  ];
+  const currentTargets = [
+    {
+      path: "items.0.price",
+      overrideKey: "items.r-b.price",
+      resetOn: ["items.0.product"],
+      refreshOn: [],
+    },
+  ];
+
+  expect(
+    pathsToClear(
+      previousTargets,
+      { items: [{ product: "alpha" }, { product: "beta" }] },
+      currentTargets,
+      { items: [{ product: "beta" }] },
+    ),
+  ).toEqual([]);
+
+  expect(
+    pathsToClear(
+      previousTargets,
+      { items: [{ product: "alpha" }, { product: "beta" }] },
+      currentTargets,
+      { items: [{ product: "gamma" }] },
+    ),
+  ).toEqual(["items.r-b.price"]);
 });
 
 it("seeds overrides for targets that already hold a stored value", () => {
   const targets = [
-    { path: "items.0.price", resetOn: [], refreshOn: [] },
-    { path: "items.1.price", resetOn: [], refreshOn: [] },
+    { path: "items.0.price", overrideKey: "items.r-a.price", resetOn: [], refreshOn: [] },
+    { path: "items.1.price", overrideKey: "items.r-b.price", resetOn: [], refreshOn: [] },
   ];
   const values = { items: [{ price: 12 }, {}] };
 
-  expect(seededOverrides(targets, values)).toEqual(["items.0.price"]);
+  expect(seededOverrides(targets, values)).toEqual(["items.r-a.price"]);
+});
+
+it("indexes targets by positional path while pruning by override key", () => {
+  const targets = [
+    { path: "items.0.price", overrideKey: "items.r-b.price", resetOn: [], refreshOn: [] },
+  ];
+
+  expect(targetByPath(targets).get("items.0.price")?.overrideKey).toBe("items.r-b.price");
+  expect(pruneOverrides(new Set(["items.r-b.price", "items.r-z.price"]), targets)).toEqual(
+    new Set(["items.r-b.price"]),
+  );
 });

--- a/resources/js/form/components/prefill-targets.ts
+++ b/resources/js/form/components/prefill-targets.ts
@@ -1,8 +1,10 @@
 import type { Node } from "@lattice/lattice/core/types";
 import { fieldProps } from "./field-props";
+import { ROW_ID_KEY } from "./fields/repeater-rows";
 
 export type PrefillTarget = {
   path: string;
+  overrideKey: string;
   resetOn: string[];
   refreshOn: string[];
 };
@@ -19,15 +21,23 @@ function mapDep(dep: string, base: string | null, index: number): string {
   return base === null ? dep : `${base}.${index}.${dep}`;
 }
 
-function targetFor(node: Node, base: string | null, index = 0): PrefillTarget | null {
+function targetFor(
+  node: Node,
+  base: string | null,
+  index = 0,
+  row: Record<string, unknown> = {},
+): PrefillTarget | null {
   const props = fieldProps(node);
 
   if (!props.prefill || !props.name) {
     return null;
   }
 
+  const rowId = typeof row[ROW_ID_KEY] === "string" ? row[ROW_ID_KEY] : String(index);
+
   return {
     path: base === null ? props.name : `${base}.${index}.${props.name}`,
+    overrideKey: base === null ? props.name : `${base}.${rowId}.${props.name}`,
     resetOn: (props.prefillResetOn ?? []).map((dep) => mapDep(dep, base, index)),
     refreshOn: (props.prefillRefreshOn ?? []).map((dep) => mapDep(dep, base, index)),
   };
@@ -55,7 +65,7 @@ export function collectPrefillTargets(
               : (node.schema ?? []);
 
             for (const child of template) {
-              const target = targetFor(child, name, index);
+              const target = targetFor(child, name, index, row);
               if (target) {
                 targets.push(target);
               }
@@ -122,18 +132,28 @@ export function applyPrefillValue(
 }
 
 export function pathsToClear(
-  targets: PrefillTarget[],
+  previousTargets: PrefillTarget[],
   previous: Record<string, unknown>,
+  targets: PrefillTarget[],
   next: Record<string, unknown>,
 ): string[] {
+  const previousByKey = new Map(
+    previousTargets.map((target) => [target.overrideKey, target] as const),
+  );
+
   return targets
-    .filter((target) =>
-      target.resetOn.some((dep) => !Object.is(getPath(previous, dep), getPath(next, dep))),
-    )
-    .map((target) => target.path);
+    .filter((target) => {
+      const previousTarget = previousByKey.get(target.overrideKey);
+
+      return target.resetOn.some((dep, index) => {
+        const previousDep = previousTarget?.resetOn[index] ?? dep;
+
+        return !Object.is(getPath(previous, previousDep), getPath(next, dep));
+      });
+    })
+    .map((target) => target.overrideKey);
 }
 
-// Seeded as overrides so the first resolve response doesn't clobber values an edit screen loaded.
 export function seededOverrides(
   targets: PrefillTarget[],
   values: Record<string, unknown>,
@@ -144,5 +164,15 @@ export function seededOverrides(
 
       return value !== undefined && value !== null && value !== "";
     })
-    .map((target) => target.path);
+    .map((target) => target.overrideKey);
+}
+
+export function pruneOverrides(overrides: Set<string>, targets: PrefillTarget[]): Set<string> {
+  const liveKeys = new Set(targets.map((target) => target.overrideKey));
+
+  return new Set([...overrides].filter((key) => liveKeys.has(key)));
+}
+
+export function targetByPath(targets: PrefillTarget[]): Map<string, PrefillTarget> {
+  return new Map(targets.map((target) => [target.path, target]));
 }

--- a/resources/js/form/components/prefill-targets.ts
+++ b/resources/js/form/components/prefill-targets.ts
@@ -1,12 +1,17 @@
 import type { Node } from "@lattice/lattice/core/types";
 import { fieldProps } from "./field-props";
-import { ROW_ID_KEY } from "./fields/repeater-rows";
+import { buildOverrideKey, rowIdFrom } from "./override-keys";
 
 export type PrefillTarget = {
   path: string;
   overrideKey: string;
   resetOn: string[];
   refreshOn: string[];
+};
+
+type PrefillSnapshot = {
+  targets: PrefillTarget[];
+  values: Record<string, unknown>;
 };
 
 type Block = { type: string; label: string; schema: Node[] };
@@ -33,11 +38,11 @@ function targetFor(
     return null;
   }
 
-  const rowId = typeof row[ROW_ID_KEY] === "string" ? row[ROW_ID_KEY] : String(index);
+  const rowId = rowIdFrom(row);
 
   return {
     path: base === null ? props.name : `${base}.${index}.${props.name}`,
-    overrideKey: base === null ? props.name : `${base}.${rowId}.${props.name}`,
+    overrideKey: base === null ? props.name : buildOverrideKey(base, rowId, index, props.name),
     resetOn: (props.prefillResetOn ?? []).map((dep) => mapDep(dep, base, index)),
     refreshOn: (props.prefillRefreshOn ?? []).map((dep) => mapDep(dep, base, index)),
   };
@@ -131,24 +136,19 @@ export function applyPrefillValue(
   });
 }
 
-export function pathsToClear(
-  previousTargets: PrefillTarget[],
-  previous: Record<string, unknown>,
-  targets: PrefillTarget[],
-  next: Record<string, unknown>,
-): string[] {
+export function pathsToClear(previous: PrefillSnapshot, next: PrefillSnapshot): string[] {
   const previousByKey = new Map(
-    previousTargets.map((target) => [target.overrideKey, target] as const),
+    previous.targets.map((target) => [target.overrideKey, target] as const),
   );
 
-  return targets
+  return next.targets
     .filter((target) => {
       const previousTarget = previousByKey.get(target.overrideKey);
 
       return target.resetOn.some((dep, index) => {
         const previousDep = previousTarget?.resetOn[index] ?? dep;
 
-        return !Object.is(getPath(previous, previousDep), getPath(next, dep));
+        return !Object.is(getPath(previous.values, previousDep), getPath(next.values, dep));
       });
     })
     .map((target) => target.overrideKey);
@@ -171,8 +171,4 @@ export function pruneOverrides(overrides: Set<string>, targets: PrefillTarget[])
   const liveKeys = new Set(targets.map((target) => target.overrideKey));
 
   return new Set([...overrides].filter((key) => liveKeys.has(key)));
-}
-
-export function targetByPath(targets: PrefillTarget[]): Map<string, PrefillTarget> {
-  return new Map(targets.map((target) => [target.path, target]));
 }

--- a/resources/js/form/components/use-dependent-field.test.tsx
+++ b/resources/js/form/components/use-dependent-field.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice/lattice/core/types";
+import { fakeNode } from "@lattice/lattice/test-support";
+import { FieldScopeProvider } from "./field-scope";
+import { useDependentField } from "./use-dependent-field";
+import { FormValuesProvider } from "./values";
+
+function conditionNode(field: string, value: string): Node {
+  return fakeNode({
+    type: "form.text-input",
+    props: {
+      name: "discount",
+      conditions: { visible: [{ field, operator: "eq", value }] },
+    },
+  });
+}
+
+function renderScopedField({
+  global,
+  node = conditionNode("product", "sku-1"),
+  row,
+}: {
+  global: Record<string, unknown>;
+  node?: Node;
+  row?: Record<string, unknown>;
+}) {
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    const content = row ? (
+      <FieldScopeProvider base="items" index={0} row={row} onChange={() => {}}>
+        {children}
+      </FieldScopeProvider>
+    ) : (
+      children
+    );
+
+    return <FormValuesProvider initial={global}>{content}</FormValuesProvider>;
+  };
+
+  return renderHook(() => useDependentField(node), { wrapper });
+}
+
+describe("useDependentField", () => {
+  it("evaluates row conditions against same-row siblings", () => {
+    const { result } = renderScopedField({
+      global: { product: "global" },
+      row: { __rowId: "r1", product: "sku-1" },
+    });
+
+    expect(result.current.hidden).toBe(false);
+  });
+
+  it("lets row values shadow same-named global values", () => {
+    const { result } = renderScopedField({
+      global: { product: "sku-1" },
+      row: { __rowId: "r1", product: "other" },
+    });
+
+    expect(result.current.hidden).toBe(true);
+  });
+
+  it("falls back to form-level values from inside a row", () => {
+    const { result } = renderScopedField({
+      global: { customer: "vip" },
+      node: conditionNode("customer", "vip"),
+      row: { __rowId: "r1" },
+    });
+
+    expect(result.current.hidden).toBe(false);
+  });
+});

--- a/resources/js/form/components/use-dependent-field.ts
+++ b/resources/js/form/components/use-dependent-field.ts
@@ -8,6 +8,7 @@ export function useDependentField(node: Node): FieldState {
   const values = useFormValues();
   const scope = useFieldScope();
   const props = fieldProps(node);
+  // Bare condition names resolve to row siblings first; form values remain the fallback.
   const conditionValues = scope ? { ...values, ...scope.row } : values;
 
   return evaluateConditions(props.conditions ?? undefined, conditionValues, {

--- a/resources/js/form/components/use-dependent-field.ts
+++ b/resources/js/form/components/use-dependent-field.ts
@@ -1,13 +1,16 @@
 import type { Node } from "@lattice/lattice/core/types";
 import { type FieldState, evaluateConditions } from "./conditions";
 import { fieldProps } from "./field-props";
+import { useFieldScope } from "./field-scope";
 import { useFormValues } from "./values";
 
 export function useDependentField(node: Node): FieldState {
   const values = useFormValues();
+  const scope = useFieldScope();
   const props = fieldProps(node);
+  const conditionValues = scope ? { ...values, ...scope.row } : values;
 
-  return evaluateConditions(props.conditions ?? undefined, values, {
+  return evaluateConditions(props.conditions ?? undefined, conditionValues, {
     hidden: props.hidden ?? false,
     required: props.required ?? false,
     readOnly: props.readOnly ?? false,

--- a/resources/js/form/components/use-field-commit.ts
+++ b/resources/js/form/components/use-field-commit.ts
@@ -33,7 +33,7 @@ export function useFieldCommit(): FieldCommit {
     } else {
       setGlobal(name, value);
     }
-    prefill?.markUserEdit(scope ? scope.errorKey(name) : name);
+    prefill?.markUserEdit(scope ? scope.overrideKey(name) : name);
   };
   const errorPath = (name: string): string => (scope ? scope.errorKey(name) : name);
 

--- a/resources/js/form/components/use-form-resolver.test.tsx
+++ b/resources/js/form/components/use-form-resolver.test.tsx
@@ -1,0 +1,94 @@
+import { act, render, screen } from "@testing-library/react";
+import { useLayoutEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Node } from "@lattice/lattice/core/types";
+import { fakeNode } from "@lattice/lattice/test-support";
+import { FORM_DEBOUNCE_MS } from "./form-transport";
+import { useFormResolver } from "./use-form-resolver";
+import { FormValuesProvider, useFormValues, useSetFormValue } from "./values";
+
+function priceField(): Node {
+  return fakeNode({
+    type: "form.text-input",
+    props: {
+      name: "price",
+      prefill: true,
+      prefillRefreshOn: ["@customer"],
+      prefillResetOn: ["product"],
+    },
+  });
+}
+
+function builderNode(): Node {
+  return {
+    id: "builder",
+    type: "form.builder",
+    props: { name: "items" },
+    blocks: [{ type: "product", label: "Product", schema: [priceField()] }],
+  } as unknown as Node;
+}
+
+function StampRowId() {
+  const values = useFormValues();
+  const setValue = useSetFormValue();
+
+  useLayoutEffect(() => {
+    const items = values.items;
+
+    if (!Array.isArray(items) || items[0]?.__rowId) {
+      return;
+    }
+
+    setValue("items", [{ ...items[0], __rowId: "r-stable" }]);
+  }, [setValue, values]);
+
+  return null;
+}
+
+function ResolverHarness() {
+  useFormResolver("/resolve", "component-ref", [builderNode()]);
+  const values = useFormValues();
+  const items = Array.isArray(values.items) ? values.items : [];
+  const price = items[0]?.price;
+
+  return <output data-testid="price">{String(price ?? "")}</output>;
+}
+
+describe("useFormResolver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps seeded row overrides after client row ids are attached", async () => {
+    const fetchMock = vi.fn<() => Promise<Response>>(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ prefill: { "items.0.price": "999" } }), { status: 200 }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <FormValuesProvider
+        initial={{
+          customer: "acme",
+          items: [{ type: "product", product: "alpha", price: "1.00" }],
+        }}
+      >
+        <ResolverHarness />
+        <StampRowId />
+      </FormValuesProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(FORM_DEBOUNCE_MS);
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(screen.getByTestId("price").textContent).toBe("1.00");
+  });
+});

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Node } from "@lattice/lattice/core/types";
 import { walkFields } from "./field-props";
 import { FORM_DEBOUNCE_MS, postFormAction } from "./form-transport";
@@ -7,7 +7,9 @@ import {
   collectPrefillTargets,
   getPath,
   pathsToClear,
+  pruneOverrides,
   seededOverrides,
+  targetByPath,
 } from "./prefill-targets";
 import type { PrefillController } from "./prefill-context";
 import { useFormValues, useSetFormValue } from "./values";
@@ -35,8 +37,9 @@ export function useFormResolver(
   const targets = useMemo(() => collectPrefillTargets(nodes, values), [nodes, values]);
 
   const overrides = useRef<Set<string>>(new Set());
-  const seeded = useRef(false);
+  const seededOverrideKeys = useRef<Set<string>>(new Set());
   const previousValues = useRef<Record<string, unknown>>(values);
+  const previousTargets = useRef(targets);
 
   // Read targets via a ref inside the effect: `targets` changes identity on every
   // value change, but the effect must fire only when `watchSignature` changes
@@ -45,10 +48,19 @@ export function useFormResolver(
   const targetsRef = useRef(targets);
   targetsRef.current = targets;
 
-  if (!seeded.current) {
-    seeded.current = true;
-    overrides.current = new Set(seededOverrides(targets, values));
-  }
+  useLayoutEffect(() => {
+    const freshTargets = targets.filter(
+      (target) => !seededOverrideKeys.current.has(target.overrideKey),
+    );
+
+    for (const overrideKey of seededOverrides(freshTargets, values)) {
+      overrides.current.add(overrideKey);
+    }
+
+    for (const target of freshTargets) {
+      seededOverrideKeys.current.add(target.overrideKey);
+    }
+  }, [targets, values]);
 
   const markUserEdit = useCallback((path: string) => {
     overrides.current.add(path);
@@ -101,21 +113,17 @@ export function useFormResolver(
     // `resetOn` deps unlock a path (a fresh product gives a fresh price); `refreshOn`
     // deps only re-ask the server and never clear an override (a customer change
     // re-prices untouched rows but leaves user-edited ones alone).
-    for (const path of pathsToClear(targetsRef.current, previous, values)) {
-      overrides.current.delete(path);
+    for (const overrideKey of pathsToClear(
+      previousTargets.current,
+      previous,
+      targetsRef.current,
+      values,
+    )) {
+      overrides.current.delete(overrideKey);
     }
+    previousTargets.current = targetsRef.current;
 
-    // Drop overrides whose path no longer maps to a live target so the set can't
-    // grow without bound as rows come and go. NOTE: override paths are positional
-    // (`items.2.price`); removing or reordering a mid-list row reindexes siblings,
-    // so an override can be misattributed to whichever row now holds that index.
-    // Acceptable for v1 (append-mostly editing); a stable-id keying is follow-up.
-    const livePaths = new Set(targetsRef.current.map((target) => target.path));
-    for (const path of overrides.current) {
-      if (!livePaths.has(path)) {
-        overrides.current.delete(path);
-      }
-    }
+    overrides.current = pruneOverrides(overrides.current, targetsRef.current);
 
     const controller = new AbortController();
 
@@ -133,8 +141,11 @@ export function useFormResolver(
           for (const [name, value] of Object.entries(response.values ?? {})) {
             setValue(name, value);
           }
+          const targetsByPath = targetByPath(targetsRef.current);
           for (const [path, value] of Object.entries(response.prefill ?? {})) {
-            if (!overrides.current.has(path)) {
+            const target = targetsByPath.get(path);
+
+            if (target && !overrides.current.has(target.overrideKey)) {
               applyPrefillValue(setValue, path, value);
             }
           }

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -9,7 +9,6 @@ import {
   pathsToClear,
   pruneOverrides,
   seededOverrides,
-  targetByPath,
 } from "./prefill-targets";
 import type { PrefillController } from "./prefill-context";
 import { useFormValues, useSetFormValue } from "./values";
@@ -49,10 +48,15 @@ export function useFormResolver(
   targetsRef.current = targets;
 
   useLayoutEffect(() => {
+    const liveOverrideKeys = new Set(targets.map((target) => target.overrideKey));
+    seededOverrideKeys.current = new Set(
+      [...seededOverrideKeys.current].filter((overrideKey) => liveOverrideKeys.has(overrideKey)),
+    );
     const freshTargets = targets.filter(
       (target) => !seededOverrideKeys.current.has(target.overrideKey),
     );
 
+    // Layout ordering seeds loaded values before the first resolve effect can apply prefill.
     for (const overrideKey of seededOverrides(freshTargets, values)) {
       overrides.current.add(overrideKey);
     }
@@ -62,8 +66,8 @@ export function useFormResolver(
     }
   }, [targets, values]);
 
-  const markUserEdit = useCallback((path: string) => {
-    overrides.current.add(path);
+  const markUserEdit = useCallback((overrideKey: string) => {
+    overrides.current.add(overrideKey);
   }, []);
 
   const watch = useMemo(() => {
@@ -114,15 +118,14 @@ export function useFormResolver(
     // deps only re-ask the server and never clear an override (a customer change
     // re-prices untouched rows but leaves user-edited ones alone).
     for (const overrideKey of pathsToClear(
-      previousTargets.current,
-      previous,
-      targetsRef.current,
-      values,
+      { targets: previousTargets.current, values: previous },
+      { targets: targetsRef.current, values },
     )) {
       overrides.current.delete(overrideKey);
     }
     previousTargets.current = targetsRef.current;
 
+    // Override ownership is row-id keyed, so pruning removes departed rows without reindex drift.
     overrides.current = pruneOverrides(overrides.current, targetsRef.current);
 
     const controller = new AbortController();
@@ -141,7 +144,9 @@ export function useFormResolver(
           for (const [name, value] of Object.entries(response.values ?? {})) {
             setValue(name, value);
           }
-          const targetsByPath = targetByPath(targetsRef.current);
+          const targetsByPath = new Map(
+            targetsRef.current.map((target) => [target.path, target] as const),
+          );
           for (const [path, value] of Object.entries(response.prefill ?? {})) {
             const target = targetsByPath.get(path);
 

--- a/tests/Browser/Forms/PricingBuilderTest.php
+++ b/tests/Browser/Forms/PricingBuilderTest.php
@@ -6,9 +6,12 @@ use Workbench\App\Models\Product;
 it('prefills computed prices, keeps manual edits, and re-prices untouched rows', function (): void {
     Product::factory()->create(['name' => 'Alpha Chair', 'price' => 100.00]);
     Product::factory()->create(['name' => 'Beta Table', 'price' => 200.00]);
+    Product::factory()->create(['name' => 'Gamma Shelf', 'price' => 300.00]);
 
     visit('/builder-pricing')
         ->assertSee('Pricing Builder Demo')
+        ->click('@builder-add')
+        ->click('@builder-add-product')
         ->click('@builder-add')
         ->click('@builder-add-product')
         ->click('@builder-add')
@@ -17,15 +20,19 @@ it('prefills computed prices, keeps manual edits, and re-prices untouched rows',
         ->click('Alpha Chair')
         ->click('[data-test="repeater-items-row-1"] [data-test="select-product"]')
         ->click('Beta Table')
+        ->click('[data-test="repeater-items-row-2"] [data-test="select-product"]')
+        ->click('Gamma Shelf')
         ->wait(1)
         ->assertValue('input[name="items[0][price]"]', '100')
         ->assertValue('input[name="items[1][price]"]', '200')
-        ->fill('input[name="items[0][price]"]', '1.00')
+        ->assertValue('input[name="items[2][price]"]', '300')
+        ->fill('input[name="items[1][price]"]', '1.00')
+        ->click('@repeater-items-remove-0')
         ->click('[data-test="select-customer"]')
         ->click('@select-customer-option-initech')
         ->wait(1)
         ->assertValue('input[name="items[0][price]"]', '1.00')
-        ->assertValue('input[name="items[1][price]"]', '150')
+        ->assertValue('input[name="items[1][price]"]', '225')
         ->assertNoSmoke()
         ->assertNoJavaScriptErrors();
 });

--- a/tests/Browser/Forms/PricingBuilderTest.php
+++ b/tests/Browser/Forms/PricingBuilderTest.php
@@ -29,3 +29,22 @@ it('prefills computed prices, keeps manual edits, and re-prices untouched rows',
         ->assertNoSmoke()
         ->assertNoJavaScriptErrors();
 });
+
+it('evaluates row field visibility against same-row siblings', function (): void {
+    Product::factory()->create(['name' => 'Alpha Chair', 'price' => 100.00]);
+
+    visit('/builder-pricing')
+        ->assertSee('Pricing Builder Demo')
+        ->click('@builder-add')
+        ->click('@builder-add-product')
+        ->click('@builder-add')
+        ->click('@builder-add-product')
+        ->assertNotPresent('input[name="items[0][discount_note]"]')
+        ->assertNotPresent('input[name="items[1][discount_note]"]')
+        ->click('[data-test="repeater-items-row-1"] [data-test="select-product"]')
+        ->click('Alpha Chair')
+        ->assertNotPresent('input[name="items[0][discount_note]"]')
+        ->assertPresent('input[name="items[1][discount_note]"]')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});

--- a/workbench/app/Forms/PricingBuilderDemoForm.php
+++ b/workbench/app/Forms/PricingBuilderDemoForm.php
@@ -58,6 +58,8 @@ class PricingBuilderDemoForm extends FormDefinition
                                     resetOn: ['product'],
                                     refreshOn: ['@customer'],
                                 ),
+                                TextInput::make('discount_note', 'Discount note')
+                                    ->visibleWhen('product', '!=', ''),
                             ]),
                         ])
                         ->minItems(1)


### PR DESCRIPTION
## Summary
- Expose row data and stable row override keys from `FieldScope`.
- Evaluate client conditions inside rows against same-row sibling values, with form-level fallback.
- Key client prefill overrides by stable row IDs while keeping server prefill paths positional.

## Validation
- `composer test`
- `vendor/bin/pint --dirty --format agent`
- `npm run format:check`
- `npm run lint:github`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `composer test:browser`
- `npm run build:lib`