### PR TITLE
feat(testing): AssertsLatticeComponents test helper

### DIFF
--- a/.ai/guidelines/git.md
+++ b/.ai/guidelines/git.md
@@ -4,3 +4,4 @@
 - Make meaningful commits: one logical change per commit with a conventional-commit subject (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`). Squash throwaway "wip" commits before opening a PR.
 - Keep pull request descriptions compact and concise: what changed and why, in a few lines. No filler.
 - For visual changes, include screenshots or concrete before/after examples in the PR description.
+- Before pushing or opening a PR, run `composer check` (Pint, PHPStan, Pest) — it mirrors the CI PHP job. Never push on red. `composer test` alone is not enough; PHPStan and Pint run in CI too. For frontend changes also run `npm run lint && npm run format && npm run test`. CI additionally verifies that generated TypeScript types (`composer types`) and docs fixtures are up to date.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -125,6 +125,12 @@ export default defineConfig({
           ],
         },
         {
+          label: "Testing",
+          items: [
+            { label: "Overview", link: "/testing/overview/" },
+          ],
+        },
+        {
           label: "Contributing",
           items: [
             { label: "Local Development", link: "/contributing/local-development/" },

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "larastan/larastan": "^3.0",
         "laravel/boost": "^2.4",
         "laravel/pint": "^1.16",
+        "mrpunyapal/peststan": "^0.2.10",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-browser": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,11 @@
     },
     "scripts": {
         "analyse": "./vendor/bin/phpstan analyse",
+        "check": [
+            "@test:lint",
+            "@analyse",
+            "@test"
+        ],
         "lint": "./vendor/bin/pint",
         "test:lint": "./vendor/bin/pint --test",
         "rector": "./vendor/bin/rector process",

--- a/docs/content/docs/testing/overview.md
+++ b/docs/content/docs/testing/overview.md
@@ -1,0 +1,184 @@
+---
+title: Testing
+description: Assert against the components a Lattice page renders — forms, fields, tables, filters, and actions — with the AssertsLatticeComponents trait.
+---
+
+Lattice ships a testing trait, `AssertsLatticeComponents`, that lets you make readable
+assertions about the components your pages render: which forms, tables, and actions are
+visible, whether a field is shown or hidden, what initial value it carries, and which
+filters a table exposes. It asserts against the serialized wire tree — the exact payload
+that reaches the browser — so a passing test reflects what a user with the current request
+and authorization actually sees.
+
+It is inspired by Filament's test helpers, adapted to Lattice's stateless Inertia output.
+
+## Setup
+
+The trait adds methods to your test case. Apply it once in your base `TestCase`:
+
+```php
+use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
+
+abstract class TestCase extends \Tests\TestCase
+{
+    use AssertsLatticeComponents;
+}
+```
+
+…or per file in Pest:
+
+```php
+uses(Lattice\Lattice\Support\Testing\AssertsLatticeComponents::class);
+```
+
+## Two entry points
+
+Both produce the same fluent assertions; pick the one that fits the test.
+
+**Against a component you build in the test** — fast, no HTTP:
+
+```php
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\TextInput;
+
+$form = Form::make('product')->action('/products')->schema([
+    TextInput::make('name', 'Name'),
+]);
+
+$this->assertLatticeComponent($form)
+    ->assertHasForm('product');
+```
+
+**Against a rendered page** — reads the component tree from the Inertia response:
+
+```php
+$this->assertLatticePage($this->get('/products'))
+    ->assertRendered('table:products');
+```
+
+> Page tests render a real Inertia view. If your front-end assets aren't built in the test
+> environment, call `withoutVite()` first (`use function Pest\Laravel\withoutVite;`).
+
+## Navigating the tree
+
+From the root you navigate to a component, then assert on it. Pass a closure to scope a
+group of assertions and keep chaining from the root; omit it to get the node back directly.
+
+```php
+use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
+use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
+
+$this->assertLatticeComponent($form)
+    ->form('product', fn (FormAssertions $form) => $form
+        ->assertSubmitsTo('/products')
+        ->field('name', fn (FieldAssertions $field) => $field
+            ->assertVisible()
+            ->assertInitialValue('Desk Lamp')));
+```
+
+`form(?id)`, `table(?id)`, and `action(id)` find a component by type (and optional id). When
+the id is omitted, the first component of that type is used.
+
+## Asserting what is rendered
+
+A component is "rendered" when it survives `shouldRender()` and `authorize()` and appears in
+the tree. Use selectors of the form `type` or `type:id`:
+
+```php
+$this->assertLatticePage($this->get('/products'))
+    ->assertRendered('table:products')
+    ->assertRendered('action:create')
+    ->assertNotRendered('action:archive')   // hidden for this user
+    ->assertRenderedCount('action', 1);
+```
+
+This is the natural way to test authorization-driven visibility: gate an action behind a
+policy, act as a user who fails it, and assert `assertNotRendered('action:…')`.
+
+## Forms and fields
+
+```php
+$this->assertLatticeComponent($form)
+    ->form('product', fn (FormAssertions $form) => $form
+        ->assertSubmitsTo('/products')
+        ->assertHasField('name')
+        ->assertMissingField('secret')
+        ->field('name', fn (FieldAssertions $field) => $field
+            ->assertVisible()
+            ->assertRequired()
+            ->assertInitialValue('Desk Lamp')));
+```
+
+Field assertions: `assertVisible` / `assertHidden`, `assertVisibleWhen($state)` /
+`assertHiddenWhen($state)`, `assertRequired` / `assertOptional`, `assertDisabled` /
+`assertEnabled`, `assertReadOnly`, `assertInitialValue($value)`, and
+`assertHasCondition($type, $field, $operator, $value)`.
+
+`assertVisible` / `assertHidden` check whether a field is force-hidden via `->hidden()`. A
+field shown only by a condition (`->visibleWhen(...)`) is not statically hidden, so it passes
+`assertVisible`. To evaluate conditional visibility for a given form state, use
+`assertVisibleWhen` / `assertHiddenWhen`, which run the field's conditions against the state
+you pass:
+
+```php
+use Lattice\Lattice\Core\Enums\Op;
+
+$field = TextInput::make('sku')->visibleWhen('type', 'physical');
+
+$this->assertLatticeComponent($form)
+    ->form('product', fn (FormAssertions $form) => $form
+        ->field('sku', fn (FieldAssertions $field) => $field
+            ->assertVisibleWhen(['type' => 'physical'])
+            ->assertHiddenWhen(['type' => 'digital'])
+            ->assertHasCondition('visible', 'type', Op::Equals, 'physical')));
+```
+
+`assertInitialValue` resolves the value the field is seeded with: a `->fill()`ed form's state
+wins, otherwise the field's own `->value()` — matching the bound-edit runtime precedence.
+
+## Tables and filters
+
+```php
+use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Tables\Enums\FilterType;
+use Lattice\Lattice\Support\Testing\Assertions\TableAssertions;
+use Lattice\Lattice\Support\Testing\Assertions\FilterAssertions;
+
+$this->assertLatticePage($this->get('/products'))
+    ->table('products', fn (TableAssertions $table) => $table
+        ->assertHasColumn('name')
+        ->assertHasFilter('name')
+        ->assertMissingFilter('internal_notes')
+        ->assertHasBulkAction('archive')
+        ->filter('name', fn (FilterAssertions $filter) => $filter
+            ->assertType(FilterType::Text)
+            ->assertDefaultOperator(Op::Contains)
+            ->assertOperators([Op::Contains, Op::Equals])));
+```
+
+## Actions
+
+```php
+use Lattice\Lattice\Core\Enums\ButtonVariant;
+use Lattice\Lattice\Support\Testing\Assertions\ActionAssertions;
+
+$this->assertLatticeComponent($action)
+    ->action('archive', fn (ActionAssertions $action) => $action
+        ->assertLabel('Archive')
+        ->assertEndpoint('/lattice/actions/archive')
+        ->assertVariant(ButtonVariant::Destructive)
+        ->assertHasConfirmation()
+        ->assertConfirmationTitle('Archive product?')
+        ->assertHasForm());
+```
+
+## Helpful failures
+
+Every assertion fails with context. A missing field lists the available fields; an
+unrendered selector lists what was rendered; a missing filter lists the table's filters —
+so you spend less time printing the payload to find a typo.
+
+```
+Lattice form field [emial] not found at [page › form#product].
+Available fields: [name, sku, price].
+```

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - vendor/larastan/larastan/extension.neon
+    - vendor/mrpunyapal/peststan/extension.neon
 
 parameters:
     paths:

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1,876 +1,799 @@
 export type Action = {
-  confirmation: Confirmation | null;
-  effects: Effect[];
-  endpoint: string | null;
-  form: Form | null;
-  icon: string | null;
-  label: string | null;
-  lazyForm: boolean | null;
-  method: HttpMethod | null;
-  ref: string | null;
-  variant: ButtonVariant | null;
+confirmation: Confirmation | null,
+effects: Effect[],
+endpoint: string | null,
+form: Form | null,
+icon: string | null,
+label: string | null,
+lazyForm: boolean | null,
+method: HttpMethod | null,
+ref: string | null,
+variant: ButtonVariant | null,
 };
 export type ActionGroup = {
-  label: string;
-  ref: string | null;
+label: string,
+ref: string | null,
 };
-export type ActionNode =
-  | {
-      type: "action";
-      key?: string;
-      id?: string;
-      props: Action;
-    }
-  | {
-      type: "action.group";
-      key?: string;
-      id?: string;
-      props: ActionGroup;
-      schema?: Node[];
-    }
-  | {
-      type: "bulkAction";
-      key?: string;
-      id?: string;
-      props: BulkAction;
-    };
-export type Align = "center" | "left" | "start" | "stretch";
+export type ActionNode = {
+type: 'action',
+key?: string,
+id?: string,
+props: Action,
+} | {
+type: 'action.group',
+key?: string,
+id?: string,
+props: ActionGroup,
+schema?: Node[],
+} | {
+type: 'bulkAction',
+key?: string,
+id?: string,
+props: BulkAction,
+};
+export type Align = 'center' | 'left' | 'start' | 'stretch';
 export type Badge = {
-  label: string;
+label: string,
 };
 export type BadgeColumnProps = {
-  readonly colors: Record<string | number, string> | null;
+readonly colors: Record<string | number, string> | null,
 };
 export type Breadcrumbs = Record<string, never>;
 export type Builder = {
-  addLabel: string | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  defaultItems: number;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  layout: RowLayout;
-  maxItems: number | null;
-  minItems: number | null;
-  name: string;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  reorderable: boolean;
-  required: boolean | null;
-  value: unknown;
+addLabel: string | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+defaultItems: number,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+layout: RowLayout,
+maxItems: number | null,
+minItems: number | null,
+name: string,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+reorderable: boolean,
+required: boolean | null,
+value: unknown,
 };
 export type BulkAction = {
-  confirmation: Confirmation | null;
-  effects: Effect[];
-  endpoint: string | null;
-  form: Form | null;
-  icon: string | null;
-  label: string | null;
-  lazyForm: boolean | null;
-  method: HttpMethod | null;
-  ref: string | null;
-  variant: ButtonVariant | null;
+confirmation: Confirmation | null,
+effects: Effect[],
+endpoint: string | null,
+form: Form | null,
+icon: string | null,
+label: string | null,
+lazyForm: boolean | null,
+method: HttpMethod | null,
+ref: string | null,
+variant: ButtonVariant | null,
 };
 export type Button = {
-  buttonType: ButtonType;
-  href: string | null;
-  label: string;
-  variant: ButtonVariant | null;
+buttonType: ButtonType,
+href: string | null,
+label: string,
+variant: ButtonVariant | null,
 };
-export type ButtonType = "button" | "submit" | "reset";
-export type ButtonVariant =
-  | "default"
-  | "destructive"
-  | "ghost"
-  | "info"
-  | "link"
-  | "outline"
-  | "secondary"
-  | "success";
+export type ButtonType = 'button' | 'submit' | 'reset';
+export type ButtonVariant = 'default' | 'destructive' | 'ghost' | 'info' | 'link' | 'outline' | 'secondary' | 'success';
 export type Card = {
-  description: string | null;
-  title: string | null;
+description: string | null,
+title: string | null,
 };
 export type Checkbox = {
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  name: string;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  tabIndex: number | null;
-  value: unknown;
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+name: string,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+tabIndex: number | null,
+value: unknown,
 };
 export type Choice = {
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  name: string;
-  options: Option[];
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  tabIndex: number | null;
-  value: unknown;
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+name: string,
+options: Option[],
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+tabIndex: number | null,
+value: unknown,
 };
 export type CloseModalEffect = {
-  readonly modal: string | null;
+readonly modal: string | null,
 };
-export type Color = "muted" | "primary" | "success" | "info" | "warning" | "danger";
+export type Color = 'muted' | 'primary' | 'success' | 'info' | 'warning' | 'danger';
 export type ColumnData = {
-  readonly key: string;
-  readonly label: string;
-  readonly type: ColumnType | string;
-  readonly sortable: boolean | null;
-  readonly filter: ColumnFilter | null;
-  readonly columns: ColumnData[] | null;
-  readonly props: Record<string, unknown> | null;
+readonly key: string,
+readonly label: string,
+readonly type: ColumnType | string,
+readonly sortable: boolean | null,
+readonly filter: ColumnFilter | null,
+readonly columns: ColumnData[] | null,
+readonly props: Record<string, unknown> | null,
 };
 export type ColumnFilter = {
-  readonly enabled: boolean;
-  readonly type: FilterType;
-  readonly operators: Op[];
-  readonly defaultOperator: Op;
+readonly enabled: boolean,
+readonly type: FilterType,
+readonly operators: Op[],
+readonly defaultOperator: Op,
 };
 export type ColumnPropsMap = {
-  badge: BadgeColumnProps;
-  icon: IconColumnProps;
-  image: ImageColumnProps;
-  text: TextColumnProps;
+badge: BadgeColumnProps,
+icon: IconColumnProps,
+image: ImageColumnProps,
+text: TextColumnProps,
 };
-export type ColumnType = "text" | "stack" | "badge" | "icon" | "image";
+export type ColumnType = 'text' | 'stack' | 'badge' | 'icon' | 'image';
 export type Condition = {
-  readonly field: string;
-  readonly operator: Op;
-  readonly value: unknown;
+readonly field: string,
+readonly operator: Op,
+readonly value: unknown,
 };
 export type Confirmation = {
-  readonly title: string;
-  readonly description: string | null;
-  readonly confirmLabel: string | null;
-  readonly cancelLabel: string | null;
+readonly title: string,
+readonly description: string | null,
+readonly confirmLabel: string | null,
+readonly cancelLabel: string | null,
 };
-export type CoreNode =
-  | {
-      type: "badge";
-      key?: string;
-      props: Badge;
-    }
-  | {
-      type: "button";
-      key?: string;
-      props: Button;
-    }
-  | {
-      type: "card";
-      key?: string;
-      props: Card;
-      schema?: Node[];
-    }
-  | {
-      type: "grid";
-      key?: string;
-      props: Grid;
-      schema?: Node[];
-    }
-  | {
-      type: "heading";
-      key?: string;
-      props: Heading;
-    }
-  | {
-      type: "icon";
-      key?: string;
-      props: Icon;
-    }
-  | {
-      type: "link";
-      key?: string;
-      props: Link;
-    }
-  | {
-      type: "modal";
-      key?: string;
-      id?: string;
-      props: Modal;
-      schema?: Node[];
-    }
-  | {
-      type: "section";
-      key?: string;
-      props: Section;
-      schema?: Node[];
-    }
-  | {
-      type: "segmented-control";
-      key?: string;
-      props: SegmentedControl;
-    }
-  | {
-      type: "stack";
-      key?: string;
-      props: Stack;
-      schema?: Node[];
-    }
-  | {
-      type: "tab";
-      key?: string;
-      props: Tab;
-      schema?: Node[];
-    }
-  | {
-      type: "tabs";
-      key?: string;
-      props: Tabs;
-      schema?: Node[];
-    }
-  | {
-      type: "text";
-      key?: string;
-      props: Text;
-    };
+export type CoreNode = {
+type: 'badge',
+key?: string,
+props: Badge,
+} | {
+type: 'button',
+key?: string,
+props: Button,
+} | {
+type: 'card',
+key?: string,
+props: Card,
+schema?: Node[],
+} | {
+type: 'grid',
+key?: string,
+props: Grid,
+schema?: Node[],
+} | {
+type: 'heading',
+key?: string,
+props: Heading,
+} | {
+type: 'icon',
+key?: string,
+props: Icon,
+} | {
+type: 'link',
+key?: string,
+props: Link,
+} | {
+type: 'modal',
+key?: string,
+id?: string,
+props: Modal,
+schema?: Node[],
+} | {
+type: 'section',
+key?: string,
+props: Section,
+schema?: Node[],
+} | {
+type: 'segmented-control',
+key?: string,
+props: SegmentedControl,
+} | {
+type: 'stack',
+key?: string,
+props: Stack,
+schema?: Node[],
+} | {
+type: 'tab',
+key?: string,
+props: Tab,
+schema?: Node[],
+} | {
+type: 'tabs',
+key?: string,
+props: Tabs,
+schema?: Node[],
+} | {
+type: 'text',
+key?: string,
+props: Text,
+};
 export type DateInput = {
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  max: string | null;
-  min: string | null;
-  name: string;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  tabIndex: number | null;
-  value: unknown;
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+max: string | null,
+min: string | null,
+name: string,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+tabIndex: number | null,
+value: unknown,
 };
 export type DownloadEffect = {
-  readonly url: string;
+readonly url: string,
 };
 export type Dropdown = {
-  icon: string | null;
-  label: string;
+icon: string | null,
+label: string,
 };
-export type Effect =
-  | ({
-      type: "closeModal";
-    } & CloseModalEffect)
-  | ({
-      type: "download";
-    } & DownloadEffect)
-  | ({
-      type: "openModal";
-    } & OpenModalEffect)
-  | ({
-      type: "redirect";
-    } & RedirectEffect)
-  | ({
-      type: "reloadComponent";
-    } & ReloadComponentEffect)
-  | ({
-      type: "reloadPage";
-    } & ReloadPageEffect)
-  | ({
-      type: "resetForm";
-    } & ResetFormEffect)
-  | ({
-      type: "toast";
-    } & ToastEffect);
-export type EffectType =
-  | "toast"
-  | "reloadComponent"
-  | "reloadPage"
-  | "redirect"
-  | "download"
-  | "openModal"
-  | "closeModal"
-  | "resetForm";
+export type Effect = {
+type: 'closeModal',
+} & CloseModalEffect | {
+type: 'download',
+} & DownloadEffect | {
+type: 'openModal',
+} & OpenModalEffect | {
+type: 'redirect',
+} & RedirectEffect | {
+type: 'reloadComponent',
+} & ReloadComponentEffect | {
+type: 'reloadPage',
+} & ReloadPageEffect | {
+type: 'resetForm',
+} & ResetFormEffect | {
+type: 'toast',
+} & ToastEffect;
+export type EffectType = 'toast' | 'reloadComponent' | 'reloadPage' | 'redirect' | 'download' | 'openModal' | 'closeModal' | 'resetForm';
 export type FilterClause = {
-  readonly field: string;
-  readonly operator: string;
-  readonly value: string;
+readonly field: string,
+readonly operator: string,
+readonly value: string,
 };
-export type FilterType = "text" | "number" | "date" | "boolean";
+export type FilterType = 'text' | 'number' | 'date' | 'boolean';
 export type Form = {
-  action: string | null;
-  errorBag: string | null;
-  method: HttpMethod | null;
-  precognitive: boolean | null;
-  ref: string | null;
-  resetOnError: string[] | boolean | null;
-  resetOnSuccess: string[] | boolean | null;
-  state: Record<string, unknown>;
-  status: string | null;
-  submitButton: boolean | null;
-  submitLabel: string | null;
-  validationSummaryLabel: string;
-  validationTimeout: number | null;
+action: string | null,
+errorBag: string | null,
+method: HttpMethod | null,
+precognitive: boolean | null,
+ref: string | null,
+resetOnError: string[] | boolean | null,
+resetOnSuccess: string[] | boolean | null,
+state: Record<string, unknown>,
+status: string | null,
+submitButton: boolean | null,
+submitLabel: string | null,
+validationSummaryLabel: string,
+validationTimeout: number | null,
 };
-export type FormFieldNode =
-  | {
-      type: "form.builder";
-      key?: string;
-      props: Builder;
-    }
-  | {
-      type: "form.checkbox";
-      key?: string;
-      props: Checkbox;
-    }
-  | {
-      type: "form.choice";
-      key?: string;
-      props: Choice;
-    }
-  | {
-      type: "form.date-input";
-      key?: string;
-      props: DateInput;
-    }
-  | {
-      type: "form.hidden-input";
-      key?: string;
-      props: HiddenInput;
-    }
-  | {
-      type: "form.number-input";
-      key?: string;
-      props: NumberInput;
-    }
-  | {
-      type: "form.password-input";
-      key?: string;
-      props: PasswordInput;
-    }
-  | {
-      type: "form.repeater";
-      key?: string;
-      props: Repeater;
-    }
-  | {
-      type: "form.rich-editor";
-      key?: string;
-      props: RichEditor;
-    }
-  | {
-      type: "form.select";
-      key?: string;
-      props: Select;
-    }
-  | {
-      type: "form.text-input";
-      key?: string;
-      props: TextInput;
-    }
-  | {
-      type: "form.textarea";
-      key?: string;
-      props: Textarea;
-    };
-export type FormNode =
-  | FormFieldNode
-  | {
-      type: "form";
-      key?: string;
-      id?: string;
-      props: Form;
-      schema?: Node[];
-    };
-export type FormNodeType = FormNode["type"];
+export type FormFieldNode = {
+type: 'form.builder',
+key?: string,
+props: Builder,
+} | {
+type: 'form.checkbox',
+key?: string,
+props: Checkbox,
+} | {
+type: 'form.choice',
+key?: string,
+props: Choice,
+} | {
+type: 'form.date-input',
+key?: string,
+props: DateInput,
+} | {
+type: 'form.hidden-input',
+key?: string,
+props: HiddenInput,
+} | {
+type: 'form.number-input',
+key?: string,
+props: NumberInput,
+} | {
+type: 'form.password-input',
+key?: string,
+props: PasswordInput,
+} | {
+type: 'form.repeater',
+key?: string,
+props: Repeater,
+} | {
+type: 'form.rich-editor',
+key?: string,
+props: RichEditor,
+} | {
+type: 'form.select',
+key?: string,
+props: Select,
+} | {
+type: 'form.text-input',
+key?: string,
+props: TextInput,
+} | {
+type: 'form.textarea',
+key?: string,
+props: Textarea,
+};
+export type FormNode = FormFieldNode | {
+type: 'form',
+key?: string,
+id?: string,
+props: Form,
+schema?: Node[],
+};
+export type FormNodeType = FormNode['type'];
 export type Fragment = {
-  endpoint: string | null;
-  lazy: boolean | null;
-  ref: string | null;
+endpoint: string | null,
+lazy: boolean | null,
+ref: string | null,
 };
 export type FragmentNode = {
-  type: "fragment";
-  key?: string;
-  id?: string;
-  props: Fragment;
-  schema?: Node[];
+type: 'fragment',
+key?: string,
+id?: string,
+props: Fragment,
+schema?: Node[],
 };
-export type Gap = "xs" | "sm" | "md" | "lg" | "xl";
+export type Gap = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type Grid = {
-  columns: number | null;
+columns: number | null,
 };
 export type Heading = {
-  level: number;
-  text: string;
+level: number,
+text: string,
 };
-export type Height = "full" | "screen";
+export type Height = 'full' | 'screen';
 export type HiddenInput = {
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  name: string;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  value: unknown;
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+name: string,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+value: unknown,
 };
 export type HttpMethod = import("@inertiajs/core").Method;
 export type Icon = {
-  class: string | null;
-  color: Color | null;
-  name: string;
-  size: Size;
+class: string | null,
+color: Color | null,
+name: string,
+size: Size,
 };
 export type IconColumnProps = {
-  readonly icon: string | null;
-  readonly icons: Record<string | number, string> | null;
-  readonly colors: Record<string | number, string> | null;
+readonly icon: string | null,
+readonly icons: Record<string | number, string> | null,
+readonly colors: Record<string | number, string> | null,
 };
 export type ImageColumnProps = {
-  readonly circular: boolean;
-  readonly size: number | null;
+readonly circular: boolean,
+readonly size: number | null,
 };
-export type Justify = "start" | "center" | "end" | "between" | "around" | "evenly";
-export type LayoutNode =
-  | {
-      type: "breadcrumbs";
-      key?: string;
-      props: Breadcrumbs;
-    }
-  | {
-      type: "dropdown";
-      key?: string;
-      props: Dropdown;
-      schema?: Node[];
-    }
-  | {
-      type: "menu";
-      key?: string;
-      props: Menu;
-      schema?: Node[];
-    }
-  | {
-      type: "menu-item";
-      key?: string;
-      props: MenuItem;
-      schema?: Node[];
-    }
-  | {
-      type: "outlet";
-      key?: string;
-      props: Outlet;
-    }
-  | {
-      type: "sidebar";
-      key?: string;
-      props: Sidebar;
-      schema?: Node[];
-    }
-  | {
-      type: "user-menu";
-      key?: string;
-      props: UserMenu;
-      schema?: Node[];
-    };
+export type Justify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
+export type LayoutNode = {
+type: 'breadcrumbs',
+key?: string,
+props: Breadcrumbs,
+} | {
+type: 'dropdown',
+key?: string,
+props: Dropdown,
+schema?: Node[],
+} | {
+type: 'menu',
+key?: string,
+props: Menu,
+schema?: Node[],
+} | {
+type: 'menu-item',
+key?: string,
+props: MenuItem,
+schema?: Node[],
+} | {
+type: 'outlet',
+key?: string,
+props: Outlet,
+} | {
+type: 'sidebar',
+key?: string,
+props: Sidebar,
+schema?: Node[],
+} | {
+type: 'user-menu',
+key?: string,
+props: UserMenu,
+schema?: Node[],
+};
 export type Link = {
-  href: string | null;
-  label: string;
-  method: HttpMethod | null;
-  tabIndex: number | null;
+href: string | null,
+label: string,
+method: HttpMethod | null,
+tabIndex: number | null,
 };
 export type Menu = Record<string, never>;
 export type MenuItem = {
-  href: string | null;
-  icon: string | null;
-  label: string;
-  method: HttpMethod | null;
+href: string | null,
+icon: string | null,
+label: string,
+method: HttpMethod | null,
 };
 export type Modal = {
-  closeLabel: string;
-  description: string | null;
-  open: boolean | null;
-  ref: string | null;
-  title: string | null;
+closeLabel: string,
+description: string | null,
+open: boolean | null,
+ref: string | null,
+title: string | null,
 };
 export type Node = FormNode | CoreNode | ActionNode | FragmentNode | TableNode | LayoutNode;
-export type NodeType = Node["type"];
+export type NodeType = Node['type'];
 export type NumberInput = {
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  max: number | null;
-  min: number | null;
-  name: string;
-  placeholder: string | null;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  slider: boolean | null;
-  step: number | null;
-  tabIndex: number | null;
-  value: unknown;
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+max: number | null,
+min: number | null,
+name: string,
+placeholder: string | null,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+slider: boolean | null,
+step: number | null,
+tabIndex: number | null,
+value: unknown,
 };
-export type Op =
-  | "contains"
-  | "starts_with"
-  | "ends_with"
-  | "eq"
-  | "neq"
-  | "gt"
-  | "gte"
-  | "lt"
-  | "lte"
-  | "in"
-  | "not_in"
-  | "before"
-  | "after"
-  | "empty"
-  | "filled";
+export type Op = 'contains' | 'starts_with' | 'ends_with' | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'not_in' | 'before' | 'after' | 'empty' | 'filled';
 export type OpenModalEffect = {
-  readonly modal: string;
+readonly modal: string,
 };
 export type Option = {
-  readonly label: string;
-  readonly value: string;
+readonly label: string,
+readonly value: string,
 };
-export type Orientation = "horizontal" | "vertical";
+export type Orientation = 'horizontal' | 'vertical';
 export type Outlet = Record<string, never>;
-export type PageContainer = "centered" | "default";
-export type PageLayout = "app" | "auth" | "none";
-export type PaginationType = "none" | "simple" | "table" | "infinite";
+export type PageContainer = 'centered' | 'default';
+export type PageLayout = 'app' | 'auth' | 'none';
+export type PaginationType = 'none' | 'simple' | 'table' | 'infinite';
 export type PasswordInput = {
-  autoComplete: string | null;
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  confirmation: {
-    label: string;
-    name: string;
-    placeholder: string;
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  labelAction: {
-    href: string;
-    label: string;
-    tabIndex?: number;
-  } | null;
-  name: string;
-  passwordRules: string | null;
-  placeholder: string | null;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  tabIndex: number | null;
-  value: unknown;
+autoComplete: string | null,
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+confirmation: {
+label: string,
+name: string,
+placeholder: string,
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+labelAction: {
+href: string,
+label: string,
+tabIndex?: number,
+} | null,
+name: string,
+passwordRules: string | null,
+placeholder: string | null,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+tabIndex: number | null,
+value: unknown,
 };
 export type RedirectEffect = {
-  readonly url: string;
+readonly url: string,
 };
 export type ReloadComponentEffect = {
-  readonly component: string;
+readonly component: string,
 };
 export type ReloadPageEffect = object;
 export type Repeater = {
-  addLabel: string | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  defaultItems: number;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  itemLabel: string | null;
-  label: string | null;
-  layout: RowLayout;
-  maxItems: number | null;
-  minItems: number | null;
-  name: string;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  reorderable: boolean;
-  required: boolean | null;
-  value: unknown;
+addLabel: string | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+defaultItems: number,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+itemLabel: string | null,
+label: string | null,
+layout: RowLayout,
+maxItems: number | null,
+minItems: number | null,
+name: string,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+reorderable: boolean,
+required: boolean | null,
+value: unknown,
 };
 export type ResetFormEffect = {
-  readonly form: string | null;
+readonly form: string | null,
 };
 export type RichEditor = {
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  name: string;
-  placeholder: string | null;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  value: unknown;
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+name: string,
+placeholder: string | null,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+value: unknown,
 };
-export type RowLayout = "stack" | "table";
+export type RowLayout = 'stack' | 'table';
 export type Section = {
-  collapsed: boolean;
-  collapsible: boolean;
-  description: string | null;
-  headerActions: undefined[];
-  rememberState: boolean;
-  title: string | null;
+collapsed: boolean,
+collapsible: boolean,
+description: string | null,
+headerActions: undefined[],
+rememberState: boolean,
+title: string | null,
 };
 export type SegmentedControl = {
-  emits: string | null;
-  label: string | null;
-  name: string;
-  options: Option[];
-  value: string | null;
+emits: string | null,
+label: string | null,
+name: string,
+options: Option[],
+value: string | null,
 };
 export type Select = {
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  emptyLabel: string;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  multiple: boolean | null;
-  name: string;
-  options: Option[];
-  placeholder: string | null;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  searchPlaceholder: string;
-  searchable: boolean | null;
-  tabIndex: number | null;
-  value: unknown;
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+emptyLabel: string,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+multiple: boolean | null,
+name: string,
+options: Option[],
+placeholder: string | null,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+searchPlaceholder: string,
+searchable: boolean | null,
+tabIndex: number | null,
+value: unknown,
 };
 export type Sidebar = {
-  collapsible: boolean;
-  rememberState: boolean;
+collapsible: boolean,
+rememberState: boolean,
 };
-export type Size = "xs" | "sm" | "md" | "lg" | "xl";
-export type SortDirection = "asc" | "desc";
+export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type SortDirection = 'asc' | 'desc';
 export type Stack = {
-  align: Align | null;
-  direction: string | null;
-  gap: Gap | null;
-  height: Height | null;
-  justify: Justify | null;
-  width: Width | null;
+align: Align | null,
+direction: string | null,
+gap: Gap | null,
+height: Height | null,
+justify: Justify | null,
+width: Width | null,
 };
 export type Tab = {
-  confirm: {
-    required: boolean;
-    redirectUrl: string;
-    timeout?: number;
-  } | null;
-  label: string;
-  value: string;
+confirm: {
+required: boolean,
+redirectUrl: string,
+timeout?: number,
+} | null,
+label: string,
+value: string,
 };
 export type Table = {
-  actionsLabel: string;
-  bulkActions: Action[];
-  columns: ColumnData[];
-  emptyLabel: string;
-  endpoint: string | null;
-  layout: string | null;
-  lazy: boolean | null;
-  ref: string | null;
-  striped: boolean | null;
+actionsLabel: string,
+bulkActions: Action[],
+columns: ColumnData[],
+emptyLabel: string,
+endpoint: string | null,
+layout: string | null,
+lazy: boolean | null,
+ref: string | null,
+striped: boolean | null,
 };
 export type TableNode = {
-  type: "table";
-  key?: string;
-  id?: string;
-  props: Table;
+type: 'table',
+key?: string,
+id?: string,
+props: Table,
 };
 export type TableSort = {
-  readonly key: string;
-  readonly direction: SortDirection;
+readonly key: string,
+readonly direction: SortDirection,
 };
 export type Tabs = {
-  activeValue: string;
-  defaultValue: string | null;
-  orientation: Orientation;
-  queryKey: string;
+activeValue: string,
+defaultValue: string | null,
+orientation: Orientation,
+queryKey: string,
 };
 export type Text = {
-  align: Align | null;
-  text: string;
+align: Align | null,
+text: string,
 };
 export type TextColumnProps = {
-  readonly date: {
-    format: string | null;
-  } | null;
-  readonly copyable: boolean;
-  readonly link: {
-    href: string | null;
-    external: boolean;
-  } | null;
+readonly date: {
+format: string | null,
+} | null,
+readonly copyable: boolean,
+readonly link: {
+href: string | null,
+external: boolean,
+} | null,
 };
 export type TextInput = {
-  autoComplete: string | null;
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  name: string;
-  placeholder: string | null;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  tabIndex: number | null;
-  type: string | null;
-  value: unknown;
+autoComplete: string | null,
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+name: string,
+placeholder: string | null,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+tabIndex: number | null,
+type: string | null,
+value: unknown,
 };
 export type Textarea = {
-  autoFocus: boolean | null;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
-  dependsOnAny: boolean | null;
-  dependsOnKeys: string[] | null;
-  disabled: boolean | null;
-  helperText: string | null;
-  hidden: boolean | null;
-  label: string | null;
-  name: string;
-  placeholder: string | null;
-  prefill: boolean | null;
-  prefillRefreshOn: string[] | null;
-  prefillResetOn: string[] | null;
-  readOnly: boolean | null;
-  required: boolean | null;
-  rows: number | null;
-  tabIndex: number | null;
-  value: unknown;
+autoFocus: boolean | null,
+conditions: {
+visible?: Condition[],
+required?: Condition[],
+readOnly?: Condition[],
+disabled?: Condition[],
+} | null,
+dependsOnAny: boolean | null,
+dependsOnKeys: string[] | null,
+disabled: boolean | null,
+helperText: string | null,
+hidden: boolean | null,
+label: string | null,
+name: string,
+placeholder: string | null,
+prefill: boolean | null,
+prefillRefreshOn: string[] | null,
+prefillResetOn: string[] | null,
+readOnly: boolean | null,
+required: boolean | null,
+rows: number | null,
+tabIndex: number | null,
+value: unknown,
 };
 export type ToastEffect = {
-  readonly toast: ToastMessage;
+readonly toast: ToastMessage,
 };
 export type ToastMessage = {
-  duration: number | null;
-  persistent: boolean;
-  dismissible: boolean;
-  action: Node | null;
-  variant: ToastVariant;
-  message: string;
+duration: number | null,
+persistent: boolean,
+dismissible: boolean,
+action: Node | null,
+variant: ToastVariant,
+message: string,
 };
-export type ToastVariant = "success" | "info" | "warning" | "error";
+export type ToastVariant = 'success' | 'info' | 'warning' | 'error';
 export type UserMenu = {
-  avatar: string | null;
-  email: string | null;
-  name: string;
+avatar: string | null,
+email: string | null,
+name: string,
 };
-export type Width = "full" | "sm" | "md" | "lg" | "fill";
+export type Width = 'full' | 'sm' | 'md' | 'lg' | 'fill';

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1,799 +1,876 @@
 export type Action = {
-confirmation: Confirmation | null,
-effects: Effect[],
-endpoint: string | null,
-form: Form | null,
-icon: string | null,
-label: string | null,
-lazyForm: boolean | null,
-method: HttpMethod | null,
-ref: string | null,
-variant: ButtonVariant | null,
+  confirmation: Confirmation | null;
+  effects: Effect[];
+  endpoint: string | null;
+  form: Form | null;
+  icon: string | null;
+  label: string | null;
+  lazyForm: boolean | null;
+  method: HttpMethod | null;
+  ref: string | null;
+  variant: ButtonVariant | null;
 };
 export type ActionGroup = {
-label: string,
-ref: string | null,
+  label: string;
+  ref: string | null;
 };
-export type ActionNode = {
-type: 'action',
-key?: string,
-id?: string,
-props: Action,
-} | {
-type: 'action.group',
-key?: string,
-id?: string,
-props: ActionGroup,
-schema?: Node[],
-} | {
-type: 'bulkAction',
-key?: string,
-id?: string,
-props: BulkAction,
-};
-export type Align = 'center' | 'left' | 'start' | 'stretch';
+export type ActionNode =
+  | {
+      type: "action";
+      key?: string;
+      id?: string;
+      props: Action;
+    }
+  | {
+      type: "action.group";
+      key?: string;
+      id?: string;
+      props: ActionGroup;
+      schema?: Node[];
+    }
+  | {
+      type: "bulkAction";
+      key?: string;
+      id?: string;
+      props: BulkAction;
+    };
+export type Align = "center" | "left" | "start" | "stretch";
 export type Badge = {
-label: string,
+  label: string;
 };
 export type BadgeColumnProps = {
-readonly colors: Record<string | number, string> | null,
+  readonly colors: Record<string | number, string> | null;
 };
 export type Breadcrumbs = Record<string, never>;
 export type Builder = {
-addLabel: string | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-defaultItems: number,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-layout: RowLayout,
-maxItems: number | null,
-minItems: number | null,
-name: string,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-reorderable: boolean,
-required: boolean | null,
-value: unknown,
+  addLabel: string | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  defaultItems: number;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  layout: RowLayout;
+  maxItems: number | null;
+  minItems: number | null;
+  name: string;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  reorderable: boolean;
+  required: boolean | null;
+  value: unknown;
 };
 export type BulkAction = {
-confirmation: Confirmation | null,
-effects: Effect[],
-endpoint: string | null,
-form: Form | null,
-icon: string | null,
-label: string | null,
-lazyForm: boolean | null,
-method: HttpMethod | null,
-ref: string | null,
-variant: ButtonVariant | null,
+  confirmation: Confirmation | null;
+  effects: Effect[];
+  endpoint: string | null;
+  form: Form | null;
+  icon: string | null;
+  label: string | null;
+  lazyForm: boolean | null;
+  method: HttpMethod | null;
+  ref: string | null;
+  variant: ButtonVariant | null;
 };
 export type Button = {
-buttonType: ButtonType,
-href: string | null,
-label: string,
-variant: ButtonVariant | null,
+  buttonType: ButtonType;
+  href: string | null;
+  label: string;
+  variant: ButtonVariant | null;
 };
-export type ButtonType = 'button' | 'submit' | 'reset';
-export type ButtonVariant = 'default' | 'destructive' | 'ghost' | 'info' | 'link' | 'outline' | 'secondary' | 'success';
+export type ButtonType = "button" | "submit" | "reset";
+export type ButtonVariant =
+  | "default"
+  | "destructive"
+  | "ghost"
+  | "info"
+  | "link"
+  | "outline"
+  | "secondary"
+  | "success";
 export type Card = {
-description: string | null,
-title: string | null,
+  description: string | null;
+  title: string | null;
 };
 export type Checkbox = {
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-name: string,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-tabIndex: number | null,
-value: unknown,
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  name: string;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  tabIndex: number | null;
+  value: unknown;
 };
 export type Choice = {
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-name: string,
-options: Option[],
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-tabIndex: number | null,
-value: unknown,
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  name: string;
+  options: Option[];
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  tabIndex: number | null;
+  value: unknown;
 };
 export type CloseModalEffect = {
-readonly modal: string | null,
+  readonly modal: string | null;
 };
-export type Color = 'muted' | 'primary' | 'success' | 'info' | 'warning' | 'danger';
+export type Color = "muted" | "primary" | "success" | "info" | "warning" | "danger";
 export type ColumnData = {
-readonly key: string,
-readonly label: string,
-readonly type: ColumnType | string,
-readonly sortable: boolean | null,
-readonly filter: ColumnFilter | null,
-readonly columns: ColumnData[] | null,
-readonly props: Record<string, unknown> | null,
+  readonly key: string;
+  readonly label: string;
+  readonly type: ColumnType | string;
+  readonly sortable: boolean | null;
+  readonly filter: ColumnFilter | null;
+  readonly columns: ColumnData[] | null;
+  readonly props: Record<string, unknown> | null;
 };
 export type ColumnFilter = {
-readonly enabled: boolean,
-readonly type: FilterType,
-readonly operators: Op[],
-readonly defaultOperator: Op,
+  readonly enabled: boolean;
+  readonly type: FilterType;
+  readonly operators: Op[];
+  readonly defaultOperator: Op;
 };
 export type ColumnPropsMap = {
-badge: BadgeColumnProps,
-icon: IconColumnProps,
-image: ImageColumnProps,
-text: TextColumnProps,
+  badge: BadgeColumnProps;
+  icon: IconColumnProps;
+  image: ImageColumnProps;
+  text: TextColumnProps;
 };
-export type ColumnType = 'text' | 'stack' | 'badge' | 'icon' | 'image';
+export type ColumnType = "text" | "stack" | "badge" | "icon" | "image";
 export type Condition = {
-readonly field: string,
-readonly operator: Op,
-readonly value: unknown,
+  readonly field: string;
+  readonly operator: Op;
+  readonly value: unknown;
 };
 export type Confirmation = {
-readonly title: string,
-readonly description: string | null,
-readonly confirmLabel: string | null,
-readonly cancelLabel: string | null,
+  readonly title: string;
+  readonly description: string | null;
+  readonly confirmLabel: string | null;
+  readonly cancelLabel: string | null;
 };
-export type CoreNode = {
-type: 'badge',
-key?: string,
-props: Badge,
-} | {
-type: 'button',
-key?: string,
-props: Button,
-} | {
-type: 'card',
-key?: string,
-props: Card,
-schema?: Node[],
-} | {
-type: 'grid',
-key?: string,
-props: Grid,
-schema?: Node[],
-} | {
-type: 'heading',
-key?: string,
-props: Heading,
-} | {
-type: 'icon',
-key?: string,
-props: Icon,
-} | {
-type: 'link',
-key?: string,
-props: Link,
-} | {
-type: 'modal',
-key?: string,
-id?: string,
-props: Modal,
-schema?: Node[],
-} | {
-type: 'section',
-key?: string,
-props: Section,
-schema?: Node[],
-} | {
-type: 'segmented-control',
-key?: string,
-props: SegmentedControl,
-} | {
-type: 'stack',
-key?: string,
-props: Stack,
-schema?: Node[],
-} | {
-type: 'tab',
-key?: string,
-props: Tab,
-schema?: Node[],
-} | {
-type: 'tabs',
-key?: string,
-props: Tabs,
-schema?: Node[],
-} | {
-type: 'text',
-key?: string,
-props: Text,
-};
+export type CoreNode =
+  | {
+      type: "badge";
+      key?: string;
+      props: Badge;
+    }
+  | {
+      type: "button";
+      key?: string;
+      props: Button;
+    }
+  | {
+      type: "card";
+      key?: string;
+      props: Card;
+      schema?: Node[];
+    }
+  | {
+      type: "grid";
+      key?: string;
+      props: Grid;
+      schema?: Node[];
+    }
+  | {
+      type: "heading";
+      key?: string;
+      props: Heading;
+    }
+  | {
+      type: "icon";
+      key?: string;
+      props: Icon;
+    }
+  | {
+      type: "link";
+      key?: string;
+      props: Link;
+    }
+  | {
+      type: "modal";
+      key?: string;
+      id?: string;
+      props: Modal;
+      schema?: Node[];
+    }
+  | {
+      type: "section";
+      key?: string;
+      props: Section;
+      schema?: Node[];
+    }
+  | {
+      type: "segmented-control";
+      key?: string;
+      props: SegmentedControl;
+    }
+  | {
+      type: "stack";
+      key?: string;
+      props: Stack;
+      schema?: Node[];
+    }
+  | {
+      type: "tab";
+      key?: string;
+      props: Tab;
+      schema?: Node[];
+    }
+  | {
+      type: "tabs";
+      key?: string;
+      props: Tabs;
+      schema?: Node[];
+    }
+  | {
+      type: "text";
+      key?: string;
+      props: Text;
+    };
 export type DateInput = {
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-max: string | null,
-min: string | null,
-name: string,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-tabIndex: number | null,
-value: unknown,
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  max: string | null;
+  min: string | null;
+  name: string;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  tabIndex: number | null;
+  value: unknown;
 };
 export type DownloadEffect = {
-readonly url: string,
+  readonly url: string;
 };
 export type Dropdown = {
-icon: string | null,
-label: string,
+  icon: string | null;
+  label: string;
 };
-export type Effect = {
-type: 'closeModal',
-} & CloseModalEffect | {
-type: 'download',
-} & DownloadEffect | {
-type: 'openModal',
-} & OpenModalEffect | {
-type: 'redirect',
-} & RedirectEffect | {
-type: 'reloadComponent',
-} & ReloadComponentEffect | {
-type: 'reloadPage',
-} & ReloadPageEffect | {
-type: 'resetForm',
-} & ResetFormEffect | {
-type: 'toast',
-} & ToastEffect;
-export type EffectType = 'toast' | 'reloadComponent' | 'reloadPage' | 'redirect' | 'download' | 'openModal' | 'closeModal' | 'resetForm';
+export type Effect =
+  | ({
+      type: "closeModal";
+    } & CloseModalEffect)
+  | ({
+      type: "download";
+    } & DownloadEffect)
+  | ({
+      type: "openModal";
+    } & OpenModalEffect)
+  | ({
+      type: "redirect";
+    } & RedirectEffect)
+  | ({
+      type: "reloadComponent";
+    } & ReloadComponentEffect)
+  | ({
+      type: "reloadPage";
+    } & ReloadPageEffect)
+  | ({
+      type: "resetForm";
+    } & ResetFormEffect)
+  | ({
+      type: "toast";
+    } & ToastEffect);
+export type EffectType =
+  | "toast"
+  | "reloadComponent"
+  | "reloadPage"
+  | "redirect"
+  | "download"
+  | "openModal"
+  | "closeModal"
+  | "resetForm";
 export type FilterClause = {
-readonly field: string,
-readonly operator: string,
-readonly value: string,
+  readonly field: string;
+  readonly operator: string;
+  readonly value: string;
 };
-export type FilterType = 'text' | 'number' | 'date' | 'boolean';
+export type FilterType = "text" | "number" | "date" | "boolean";
 export type Form = {
-action: string | null,
-errorBag: string | null,
-method: HttpMethod | null,
-precognitive: boolean | null,
-ref: string | null,
-resetOnError: string[] | boolean | null,
-resetOnSuccess: string[] | boolean | null,
-state: Record<string, unknown>,
-status: string | null,
-submitButton: boolean | null,
-submitLabel: string | null,
-validationSummaryLabel: string,
-validationTimeout: number | null,
+  action: string | null;
+  errorBag: string | null;
+  method: HttpMethod | null;
+  precognitive: boolean | null;
+  ref: string | null;
+  resetOnError: string[] | boolean | null;
+  resetOnSuccess: string[] | boolean | null;
+  state: Record<string, unknown>;
+  status: string | null;
+  submitButton: boolean | null;
+  submitLabel: string | null;
+  validationSummaryLabel: string;
+  validationTimeout: number | null;
 };
-export type FormFieldNode = {
-type: 'form.builder',
-key?: string,
-props: Builder,
-} | {
-type: 'form.checkbox',
-key?: string,
-props: Checkbox,
-} | {
-type: 'form.choice',
-key?: string,
-props: Choice,
-} | {
-type: 'form.date-input',
-key?: string,
-props: DateInput,
-} | {
-type: 'form.hidden-input',
-key?: string,
-props: HiddenInput,
-} | {
-type: 'form.number-input',
-key?: string,
-props: NumberInput,
-} | {
-type: 'form.password-input',
-key?: string,
-props: PasswordInput,
-} | {
-type: 'form.repeater',
-key?: string,
-props: Repeater,
-} | {
-type: 'form.rich-editor',
-key?: string,
-props: RichEditor,
-} | {
-type: 'form.select',
-key?: string,
-props: Select,
-} | {
-type: 'form.text-input',
-key?: string,
-props: TextInput,
-} | {
-type: 'form.textarea',
-key?: string,
-props: Textarea,
-};
-export type FormNode = FormFieldNode | {
-type: 'form',
-key?: string,
-id?: string,
-props: Form,
-schema?: Node[],
-};
-export type FormNodeType = FormNode['type'];
+export type FormFieldNode =
+  | {
+      type: "form.builder";
+      key?: string;
+      props: Builder;
+    }
+  | {
+      type: "form.checkbox";
+      key?: string;
+      props: Checkbox;
+    }
+  | {
+      type: "form.choice";
+      key?: string;
+      props: Choice;
+    }
+  | {
+      type: "form.date-input";
+      key?: string;
+      props: DateInput;
+    }
+  | {
+      type: "form.hidden-input";
+      key?: string;
+      props: HiddenInput;
+    }
+  | {
+      type: "form.number-input";
+      key?: string;
+      props: NumberInput;
+    }
+  | {
+      type: "form.password-input";
+      key?: string;
+      props: PasswordInput;
+    }
+  | {
+      type: "form.repeater";
+      key?: string;
+      props: Repeater;
+    }
+  | {
+      type: "form.rich-editor";
+      key?: string;
+      props: RichEditor;
+    }
+  | {
+      type: "form.select";
+      key?: string;
+      props: Select;
+    }
+  | {
+      type: "form.text-input";
+      key?: string;
+      props: TextInput;
+    }
+  | {
+      type: "form.textarea";
+      key?: string;
+      props: Textarea;
+    };
+export type FormNode =
+  | FormFieldNode
+  | {
+      type: "form";
+      key?: string;
+      id?: string;
+      props: Form;
+      schema?: Node[];
+    };
+export type FormNodeType = FormNode["type"];
 export type Fragment = {
-endpoint: string | null,
-lazy: boolean | null,
-ref: string | null,
+  endpoint: string | null;
+  lazy: boolean | null;
+  ref: string | null;
 };
 export type FragmentNode = {
-type: 'fragment',
-key?: string,
-id?: string,
-props: Fragment,
-schema?: Node[],
+  type: "fragment";
+  key?: string;
+  id?: string;
+  props: Fragment;
+  schema?: Node[];
 };
-export type Gap = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+export type Gap = "xs" | "sm" | "md" | "lg" | "xl";
 export type Grid = {
-columns: number | null,
+  columns: number | null;
 };
 export type Heading = {
-level: number,
-text: string,
+  level: number;
+  text: string;
 };
-export type Height = 'full' | 'screen';
+export type Height = "full" | "screen";
 export type HiddenInput = {
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-name: string,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-value: unknown,
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  name: string;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  value: unknown;
 };
 export type HttpMethod = import("@inertiajs/core").Method;
 export type Icon = {
-class: string | null,
-color: Color | null,
-name: string,
-size: Size,
+  class: string | null;
+  color: Color | null;
+  name: string;
+  size: Size;
 };
 export type IconColumnProps = {
-readonly icon: string | null,
-readonly icons: Record<string | number, string> | null,
-readonly colors: Record<string | number, string> | null,
+  readonly icon: string | null;
+  readonly icons: Record<string | number, string> | null;
+  readonly colors: Record<string | number, string> | null;
 };
 export type ImageColumnProps = {
-readonly circular: boolean,
-readonly size: number | null,
+  readonly circular: boolean;
+  readonly size: number | null;
 };
-export type Justify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
-export type LayoutNode = {
-type: 'breadcrumbs',
-key?: string,
-props: Breadcrumbs,
-} | {
-type: 'dropdown',
-key?: string,
-props: Dropdown,
-schema?: Node[],
-} | {
-type: 'menu',
-key?: string,
-props: Menu,
-schema?: Node[],
-} | {
-type: 'menu-item',
-key?: string,
-props: MenuItem,
-schema?: Node[],
-} | {
-type: 'outlet',
-key?: string,
-props: Outlet,
-} | {
-type: 'sidebar',
-key?: string,
-props: Sidebar,
-schema?: Node[],
-} | {
-type: 'user-menu',
-key?: string,
-props: UserMenu,
-schema?: Node[],
-};
+export type Justify = "start" | "center" | "end" | "between" | "around" | "evenly";
+export type LayoutNode =
+  | {
+      type: "breadcrumbs";
+      key?: string;
+      props: Breadcrumbs;
+    }
+  | {
+      type: "dropdown";
+      key?: string;
+      props: Dropdown;
+      schema?: Node[];
+    }
+  | {
+      type: "menu";
+      key?: string;
+      props: Menu;
+      schema?: Node[];
+    }
+  | {
+      type: "menu-item";
+      key?: string;
+      props: MenuItem;
+      schema?: Node[];
+    }
+  | {
+      type: "outlet";
+      key?: string;
+      props: Outlet;
+    }
+  | {
+      type: "sidebar";
+      key?: string;
+      props: Sidebar;
+      schema?: Node[];
+    }
+  | {
+      type: "user-menu";
+      key?: string;
+      props: UserMenu;
+      schema?: Node[];
+    };
 export type Link = {
-href: string | null,
-label: string,
-method: HttpMethod | null,
-tabIndex: number | null,
+  href: string | null;
+  label: string;
+  method: HttpMethod | null;
+  tabIndex: number | null;
 };
 export type Menu = Record<string, never>;
 export type MenuItem = {
-href: string | null,
-icon: string | null,
-label: string,
-method: HttpMethod | null,
+  href: string | null;
+  icon: string | null;
+  label: string;
+  method: HttpMethod | null;
 };
 export type Modal = {
-closeLabel: string,
-description: string | null,
-open: boolean | null,
-ref: string | null,
-title: string | null,
+  closeLabel: string;
+  description: string | null;
+  open: boolean | null;
+  ref: string | null;
+  title: string | null;
 };
 export type Node = FormNode | CoreNode | ActionNode | FragmentNode | TableNode | LayoutNode;
-export type NodeType = Node['type'];
+export type NodeType = Node["type"];
 export type NumberInput = {
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-max: number | null,
-min: number | null,
-name: string,
-placeholder: string | null,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-slider: boolean | null,
-step: number | null,
-tabIndex: number | null,
-value: unknown,
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  max: number | null;
+  min: number | null;
+  name: string;
+  placeholder: string | null;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  slider: boolean | null;
+  step: number | null;
+  tabIndex: number | null;
+  value: unknown;
 };
-export type Op = 'contains' | 'starts_with' | 'ends_with' | 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'not_in' | 'before' | 'after' | 'empty' | 'filled';
+export type Op =
+  | "contains"
+  | "starts_with"
+  | "ends_with"
+  | "eq"
+  | "neq"
+  | "gt"
+  | "gte"
+  | "lt"
+  | "lte"
+  | "in"
+  | "not_in"
+  | "before"
+  | "after"
+  | "empty"
+  | "filled";
 export type OpenModalEffect = {
-readonly modal: string,
+  readonly modal: string;
 };
 export type Option = {
-readonly label: string,
-readonly value: string,
+  readonly label: string;
+  readonly value: string;
 };
-export type Orientation = 'horizontal' | 'vertical';
+export type Orientation = "horizontal" | "vertical";
 export type Outlet = Record<string, never>;
-export type PageContainer = 'centered' | 'default';
-export type PageLayout = 'app' | 'auth' | 'none';
-export type PaginationType = 'none' | 'simple' | 'table' | 'infinite';
+export type PageContainer = "centered" | "default";
+export type PageLayout = "app" | "auth" | "none";
+export type PaginationType = "none" | "simple" | "table" | "infinite";
 export type PasswordInput = {
-autoComplete: string | null,
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-confirmation: {
-label: string,
-name: string,
-placeholder: string,
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-labelAction: {
-href: string,
-label: string,
-tabIndex?: number,
-} | null,
-name: string,
-passwordRules: string | null,
-placeholder: string | null,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-tabIndex: number | null,
-value: unknown,
+  autoComplete: string | null;
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  confirmation: {
+    label: string;
+    name: string;
+    placeholder: string;
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  labelAction: {
+    href: string;
+    label: string;
+    tabIndex?: number;
+  } | null;
+  name: string;
+  passwordRules: string | null;
+  placeholder: string | null;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  tabIndex: number | null;
+  value: unknown;
 };
 export type RedirectEffect = {
-readonly url: string,
+  readonly url: string;
 };
 export type ReloadComponentEffect = {
-readonly component: string,
+  readonly component: string;
 };
 export type ReloadPageEffect = object;
 export type Repeater = {
-addLabel: string | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-defaultItems: number,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-itemLabel: string | null,
-label: string | null,
-layout: RowLayout,
-maxItems: number | null,
-minItems: number | null,
-name: string,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-reorderable: boolean,
-required: boolean | null,
-value: unknown,
+  addLabel: string | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  defaultItems: number;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  itemLabel: string | null;
+  label: string | null;
+  layout: RowLayout;
+  maxItems: number | null;
+  minItems: number | null;
+  name: string;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  reorderable: boolean;
+  required: boolean | null;
+  value: unknown;
 };
 export type ResetFormEffect = {
-readonly form: string | null,
+  readonly form: string | null;
 };
 export type RichEditor = {
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-name: string,
-placeholder: string | null,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-value: unknown,
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  name: string;
+  placeholder: string | null;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  value: unknown;
 };
-export type RowLayout = 'stack' | 'table';
+export type RowLayout = "stack" | "table";
 export type Section = {
-collapsed: boolean,
-collapsible: boolean,
-description: string | null,
-headerActions: undefined[],
-rememberState: boolean,
-title: string | null,
+  collapsed: boolean;
+  collapsible: boolean;
+  description: string | null;
+  headerActions: undefined[];
+  rememberState: boolean;
+  title: string | null;
 };
 export type SegmentedControl = {
-emits: string | null,
-label: string | null,
-name: string,
-options: Option[],
-value: string | null,
+  emits: string | null;
+  label: string | null;
+  name: string;
+  options: Option[];
+  value: string | null;
 };
 export type Select = {
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-emptyLabel: string,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-multiple: boolean | null,
-name: string,
-options: Option[],
-placeholder: string | null,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-searchPlaceholder: string,
-searchable: boolean | null,
-tabIndex: number | null,
-value: unknown,
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  emptyLabel: string;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  multiple: boolean | null;
+  name: string;
+  options: Option[];
+  placeholder: string | null;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  searchPlaceholder: string;
+  searchable: boolean | null;
+  tabIndex: number | null;
+  value: unknown;
 };
 export type Sidebar = {
-collapsible: boolean,
-rememberState: boolean,
+  collapsible: boolean;
+  rememberState: boolean;
 };
-export type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-export type SortDirection = 'asc' | 'desc';
+export type Size = "xs" | "sm" | "md" | "lg" | "xl";
+export type SortDirection = "asc" | "desc";
 export type Stack = {
-align: Align | null,
-direction: string | null,
-gap: Gap | null,
-height: Height | null,
-justify: Justify | null,
-width: Width | null,
+  align: Align | null;
+  direction: string | null;
+  gap: Gap | null;
+  height: Height | null;
+  justify: Justify | null;
+  width: Width | null;
 };
 export type Tab = {
-confirm: {
-required: boolean,
-redirectUrl: string,
-timeout?: number,
-} | null,
-label: string,
-value: string,
+  confirm: {
+    required: boolean;
+    redirectUrl: string;
+    timeout?: number;
+  } | null;
+  label: string;
+  value: string;
 };
 export type Table = {
-actionsLabel: string,
-bulkActions: Action[],
-columns: ColumnData[],
-emptyLabel: string,
-endpoint: string | null,
-layout: string | null,
-lazy: boolean | null,
-ref: string | null,
-striped: boolean | null,
+  actionsLabel: string;
+  bulkActions: Action[];
+  columns: ColumnData[];
+  emptyLabel: string;
+  endpoint: string | null;
+  layout: string | null;
+  lazy: boolean | null;
+  ref: string | null;
+  striped: boolean | null;
 };
 export type TableNode = {
-type: 'table',
-key?: string,
-id?: string,
-props: Table,
+  type: "table";
+  key?: string;
+  id?: string;
+  props: Table;
 };
 export type TableSort = {
-readonly key: string,
-readonly direction: SortDirection,
+  readonly key: string;
+  readonly direction: SortDirection;
 };
 export type Tabs = {
-activeValue: string,
-defaultValue: string | null,
-orientation: Orientation,
-queryKey: string,
+  activeValue: string;
+  defaultValue: string | null;
+  orientation: Orientation;
+  queryKey: string;
 };
 export type Text = {
-align: Align | null,
-text: string,
+  align: Align | null;
+  text: string;
 };
 export type TextColumnProps = {
-readonly date: {
-format: string | null,
-} | null,
-readonly copyable: boolean,
-readonly link: {
-href: string | null,
-external: boolean,
-} | null,
+  readonly date: {
+    format: string | null;
+  } | null;
+  readonly copyable: boolean;
+  readonly link: {
+    href: string | null;
+    external: boolean;
+  } | null;
 };
 export type TextInput = {
-autoComplete: string | null,
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-name: string,
-placeholder: string | null,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-tabIndex: number | null,
-type: string | null,
-value: unknown,
+  autoComplete: string | null;
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  name: string;
+  placeholder: string | null;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  tabIndex: number | null;
+  type: string | null;
+  value: unknown;
 };
 export type Textarea = {
-autoFocus: boolean | null,
-conditions: {
-visible?: Condition[],
-required?: Condition[],
-readOnly?: Condition[],
-disabled?: Condition[],
-} | null,
-dependsOnAny: boolean | null,
-dependsOnKeys: string[] | null,
-disabled: boolean | null,
-helperText: string | null,
-hidden: boolean | null,
-label: string | null,
-name: string,
-placeholder: string | null,
-prefill: boolean | null,
-prefillRefreshOn: string[] | null,
-prefillResetOn: string[] | null,
-readOnly: boolean | null,
-required: boolean | null,
-rows: number | null,
-tabIndex: number | null,
-value: unknown,
+  autoFocus: boolean | null;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean | null;
+  dependsOnKeys: string[] | null;
+  disabled: boolean | null;
+  helperText: string | null;
+  hidden: boolean | null;
+  label: string | null;
+  name: string;
+  placeholder: string | null;
+  prefill: boolean | null;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean | null;
+  required: boolean | null;
+  rows: number | null;
+  tabIndex: number | null;
+  value: unknown;
 };
 export type ToastEffect = {
-readonly toast: ToastMessage,
+  readonly toast: ToastMessage;
 };
 export type ToastMessage = {
-duration: number | null,
-persistent: boolean,
-dismissible: boolean,
-action: Node | null,
-variant: ToastVariant,
-message: string,
+  duration: number | null;
+  persistent: boolean;
+  dismissible: boolean;
+  action: Node | null;
+  variant: ToastVariant;
+  message: string;
 };
-export type ToastVariant = 'success' | 'info' | 'warning' | 'error';
+export type ToastVariant = "success" | "info" | "warning" | "error";
 export type UserMenu = {
-avatar: string | null,
-email: string | null,
-name: string,
+  avatar: string | null;
+  email: string | null;
+  name: string;
 };
-export type Width = 'full' | 'sm' | 'md' | 'lg' | 'fill';
+export type Width = "full" | "sm" | "md" | "lg" | "fill";

--- a/src/Support/Testing/Assertions/ActionAssertions.php
+++ b/src/Support/Testing/Assertions/ActionAssertions.php
@@ -28,7 +28,11 @@ final readonly class ActionAssertions
 
     public function assertEndpoint(string $endpoint): self
     {
-        Assert::assertSame($endpoint, $this->node->prop('endpoint'));
+        Assert::assertSame($endpoint, $this->node->prop('endpoint'), sprintf(
+            'Expected action [%s] endpoint to be [%s].',
+            $this->node->id() ?? '*',
+            $endpoint,
+        ));
 
         return $this;
     }
@@ -58,8 +62,15 @@ final readonly class ActionAssertions
     {
         $confirmation = $this->node->prop('confirmation');
 
-        Assert::assertIsArray($confirmation, 'Action has no confirmation dialog.');
-        Assert::assertSame($title, $confirmation['title'] ?? null);
+        Assert::assertIsArray($confirmation, sprintf(
+            'Expected action [%s] to have a confirmation dialog.',
+            $this->node->id() ?? '*',
+        ));
+        Assert::assertSame($title, $confirmation['title'] ?? null, sprintf(
+            'Expected action [%s] confirmation title to be [%s].',
+            $this->node->id() ?? '*',
+            $title,
+        ));
 
         return $this;
     }

--- a/src/Support/Testing/Assertions/ActionAssertions.php
+++ b/src/Support/Testing/Assertions/ActionAssertions.php
@@ -8,7 +8,7 @@ use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Support\Testing\ComponentNode;
 use PHPUnit\Framework\Assert;
 
-final readonly class ActionAssertions
+final class ActionAssertions
 {
     public function __construct(
         private readonly ComponentNode $node,

--- a/src/Support/Testing/Assertions/ActionAssertions.php
+++ b/src/Support/Testing/Assertions/ActionAssertions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing\Assertions;
+
+use Lattice\Lattice\Support\Testing\ComponentNode;
+
+final class ActionAssertions
+{
+    public function __construct(
+        private readonly ComponentNode $node,
+        private readonly ComponentAssertions $root,
+    ) {}
+
+    public function end(): ComponentAssertions
+    {
+        return $this->root;
+    }
+}

--- a/src/Support/Testing/Assertions/ActionAssertions.php
+++ b/src/Support/Testing/Assertions/ActionAssertions.php
@@ -4,14 +4,75 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\Testing\Assertions;
 
+use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Support\Testing\ComponentNode;
+use PHPUnit\Framework\Assert;
 
-final class ActionAssertions
+final readonly class ActionAssertions
 {
     public function __construct(
         private readonly ComponentNode $node,
         private readonly ComponentAssertions $root,
     ) {}
+
+    public function assertLabel(string $label): self
+    {
+        Assert::assertSame($label, $this->node->prop('label'), sprintf(
+            'Expected action [%s] label to be [%s].',
+            $this->node->id() ?? '*',
+            $label,
+        ));
+
+        return $this;
+    }
+
+    public function assertEndpoint(string $endpoint): self
+    {
+        Assert::assertSame($endpoint, $this->node->prop('endpoint'));
+
+        return $this;
+    }
+
+    public function assertVariant(ButtonVariant $variant): self
+    {
+        Assert::assertSame($variant->value, $this->node->prop('variant'), sprintf(
+            'Expected action [%s] variant to be [%s].',
+            $this->node->id() ?? '*',
+            $variant->value,
+        ));
+
+        return $this;
+    }
+
+    public function assertHasConfirmation(): self
+    {
+        Assert::assertIsArray($this->node->prop('confirmation'), sprintf(
+            'Expected action [%s] to have a confirmation dialog.',
+            $this->node->id() ?? '*',
+        ));
+
+        return $this;
+    }
+
+    public function assertConfirmationTitle(string $title): self
+    {
+        $confirmation = $this->node->prop('confirmation');
+
+        Assert::assertIsArray($confirmation, 'Action has no confirmation dialog.');
+        Assert::assertSame($title, $confirmation['title'] ?? null);
+
+        return $this;
+    }
+
+    public function assertHasForm(): self
+    {
+        Assert::assertIsArray($this->node->prop('form'), sprintf(
+            'Expected action [%s] to have an embedded form.',
+            $this->node->id() ?? '*',
+        ));
+
+        return $this;
+    }
 
     public function end(): ComponentAssertions
     {

--- a/src/Support/Testing/Assertions/ComponentAssertions.php
+++ b/src/Support/Testing/Assertions/ComponentAssertions.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing\Assertions;
+
+use Closure;
+use Lattice\Lattice\Support\Testing\ComponentNode;
+use PHPUnit\Framework\Assert;
+
+final class ComponentAssertions
+{
+    public function __construct(private readonly ComponentNode $node) {}
+
+    public function form(?string $id = null, ?Closure $tap = null): FormAssertions|self
+    {
+        $node = $this->node->firstOfTypeIncludingSelf('form', $id);
+
+        Assert::assertNotNull($node, sprintf(
+            'Lattice form [%s] not found. Rendered: [%s].',
+            $id ?? '*',
+            implode(', ', $this->node->availableSelectors()),
+        ));
+
+        $assertions = new FormAssertions($node, $this);
+
+        if ($tap !== null) {
+            $tap($assertions);
+
+            return $this;
+        }
+
+        return $assertions;
+    }
+
+    public function table(?string $id = null, ?Closure $tap = null): TableAssertions|self
+    {
+        $node = $this->node->firstOfTypeIncludingSelf('table', $id);
+
+        Assert::assertNotNull($node, sprintf(
+            'Lattice table [%s] not found. Rendered: [%s].',
+            $id ?? '*',
+            implode(', ', $this->node->availableSelectors()),
+        ));
+
+        $assertions = new TableAssertions($node, $this);
+
+        if ($tap !== null) {
+            $tap($assertions);
+
+            return $this;
+        }
+
+        return $assertions;
+    }
+
+    public function action(string $id, ?Closure $tap = null): ActionAssertions|self
+    {
+        $node = $this->node->firstOfTypeIncludingSelf('action', $id);
+
+        Assert::assertNotNull($node, sprintf(
+            'Lattice action [%s] not found. Rendered: [%s].',
+            $id,
+            implode(', ', $this->node->availableSelectors()),
+        ));
+
+        $assertions = new ActionAssertions($node, $this);
+
+        if ($tap !== null) {
+            $tap($assertions);
+
+            return $this;
+        }
+
+        return $assertions;
+    }
+
+    public function assertRendered(string $selector): self
+    {
+        Assert::assertNotEmpty($this->select($selector), sprintf(
+            'Expected [%s] to be rendered. Rendered: [%s].',
+            $selector,
+            implode(', ', $this->node->availableSelectors()),
+        ));
+
+        return $this;
+    }
+
+    public function assertNotRendered(string $selector): self
+    {
+        Assert::assertEmpty($this->select($selector), sprintf(
+            'Expected [%s] to NOT be rendered, but it was.',
+            $selector,
+        ));
+
+        return $this;
+    }
+
+    public function assertRenderedCount(string $type, int $count): self
+    {
+        Assert::assertCount($count, $this->select($type));
+
+        return $this;
+    }
+
+    public function assertHasForm(?string $id = null): self
+    {
+        return $this->assertRendered($id === null ? 'form' : 'form:'.$id);
+    }
+
+    public function assertHasTable(?string $id = null): self
+    {
+        return $this->assertRendered($id === null ? 'table' : 'table:'.$id);
+    }
+
+    /**
+     * @return array<int, ComponentNode>
+     */
+    private function select(string $selector): array
+    {
+        [$type, $id] = array_pad(explode(':', $selector, 2), 2, null);
+
+        return $this->node->findAllIncludingSelf(
+            static fn (ComponentNode $node): bool => $node->type() === $type
+                && ($id === null || $node->id() === $id),
+        );
+    }
+}

--- a/src/Support/Testing/Assertions/FieldAssertions.php
+++ b/src/Support/Testing/Assertions/FieldAssertions.php
@@ -18,6 +18,12 @@ final class FieldAssertions
         private readonly ?ComponentNode $formNode = null,
     ) {}
 
+    /**
+     * Asserts the field is not force-hidden via ->hidden(). It does NOT evaluate
+     * conditional visibility: a field shown only by ->visibleWhen(...) still passes
+     * here because its default `hidden` flag is null. Use assertVisibleWhen($state)
+     * to evaluate visibility for a given form state.
+     */
     public function assertVisible(): self
     {
         Assert::assertNotSame(true, $this->node->prop('hidden'), sprintf(
@@ -28,6 +34,10 @@ final class FieldAssertions
         return $this;
     }
 
+    /**
+     * Asserts the field is force-hidden via ->hidden(). It does NOT evaluate
+     * conditional visibility; use assertHiddenWhen($state) for that.
+     */
     public function assertHidden(): self
     {
         Assert::assertSame(true, $this->node->prop('hidden'), sprintf(
@@ -39,6 +49,10 @@ final class FieldAssertions
     }
 
     /**
+     * Evaluates this field's own `visible` conditions against the given form
+     * state. It does not account for an ancestor (section/tab) being hidden — a
+     * field visible by its own rule reports visible even inside a hidden section.
+     *
      * @param  array<string, mixed>  $state
      */
     public function assertVisibleWhen(array $state): self
@@ -116,6 +130,11 @@ final class FieldAssertions
         return $this;
     }
 
+    /**
+     * Asserts the value the field is seeded with. A ->fill()ed form's state for
+     * this field wins; otherwise the field's own ->value() is used — matching the
+     * bound-edit runtime precedence.
+     */
     public function assertInitialValue(mixed $expected): self
     {
         Assert::assertSame($expected, $this->initialValue(), sprintf(

--- a/src/Support/Testing/Assertions/FieldAssertions.php
+++ b/src/Support/Testing/Assertions/FieldAssertions.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing\Assertions;
+
+use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Forms\Conditions\Condition;
+use Lattice\Lattice\Forms\FormData;
+use Lattice\Lattice\Support\Testing\ComponentNode;
+use PHPUnit\Framework\Assert;
+
+final class FieldAssertions
+{
+    public function __construct(
+        private readonly ComponentNode $node,
+        private readonly FormAssertions $form,
+        private readonly ?ComponentNode $formNode = null,
+    ) {}
+
+    public function assertVisible(): self
+    {
+        Assert::assertNotSame(true, $this->node->prop('hidden'), sprintf(
+            'Expected field [%s] to be visible, but hidden=true.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertHidden(): self
+    {
+        Assert::assertSame(true, $this->node->prop('hidden'), sprintf(
+            'Expected field [%s] to be hidden, but hidden is not true.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public function assertVisibleWhen(array $state): self
+    {
+        Assert::assertTrue($this->evaluate('visible', $state), sprintf(
+            'Expected field [%s] to be visible when %s.',
+            $this->name(),
+            json_encode($state),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public function assertHiddenWhen(array $state): self
+    {
+        Assert::assertFalse($this->evaluate('visible', $state), sprintf(
+            'Expected field [%s] to be hidden when %s.',
+            $this->name(),
+            json_encode($state),
+        ));
+
+        return $this;
+    }
+
+    public function assertRequired(): self
+    {
+        Assert::assertSame(true, $this->node->prop('required'), sprintf(
+            'Expected field [%s] to be required.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertOptional(): self
+    {
+        Assert::assertNotSame(true, $this->node->prop('required'), sprintf(
+            'Expected field [%s] to be optional.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertDisabled(): self
+    {
+        Assert::assertSame(true, $this->node->prop('disabled'), sprintf(
+            'Expected field [%s] to be disabled.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertEnabled(): self
+    {
+        Assert::assertNotSame(true, $this->node->prop('disabled'), sprintf(
+            'Expected field [%s] to be enabled.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertReadOnly(): self
+    {
+        Assert::assertSame(true, $this->node->prop('readOnly'), sprintf(
+            'Expected field [%s] to be read-only.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertInitialValue(mixed $expected): self
+    {
+        Assert::assertSame($expected, $this->initialValue(), sprintf(
+            'Expected field [%s] initial value to match.',
+            $this->name(),
+        ));
+
+        return $this;
+    }
+
+    public function assertHasCondition(string $type, string $field, Op $operator, mixed $value): self
+    {
+        $expected = ['field' => $field, 'operator' => $operator->value, 'value' => $value];
+
+        Assert::assertContainsEquals($expected, $this->conditionClauses($type), sprintf(
+            'Expected field [%s] to have a [%s] condition on [%s].',
+            $this->name(),
+            $type,
+            $field,
+        ));
+
+        return $this;
+    }
+
+    public function end(): FormAssertions
+    {
+        return $this->form;
+    }
+
+    private function name(): string
+    {
+        $name = $this->node->prop('name');
+
+        return is_string($name) ? $name : '?';
+    }
+
+    private function initialValue(): mixed
+    {
+        $name = $this->node->prop('name');
+
+        if ($this->formNode !== null && is_string($name)) {
+            $state = $this->formNode->prop('state');
+
+            if (is_array($state) && array_key_exists($name, $state)) {
+                return $state[$name];
+            }
+        }
+
+        return $this->node->prop('value');
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    private function evaluate(string $type, array $state): bool
+    {
+        if ($this->node->prop('hidden') === true) {
+            return false;
+        }
+
+        $data = FormData::make($state);
+
+        foreach ($this->conditionClauses($type) as $clause) {
+            $condition = new Condition($clause['field'], Op::from($clause['operator']), $clause['value']);
+
+            if (! $condition->matches($data)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<int, array{field: string, operator: string, value: mixed}>
+     */
+    private function conditionClauses(string $type): array
+    {
+        $conditions = $this->node->prop('conditions');
+
+        if (! is_array($conditions)) {
+            return [];
+        }
+
+        $clauses = $conditions[$type] ?? [];
+
+        return is_array($clauses) ? $clauses : [];
+    }
+}

--- a/src/Support/Testing/Assertions/FilterAssertions.php
+++ b/src/Support/Testing/Assertions/FilterAssertions.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing\Assertions;
+
+use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Tables\Enums\FilterType;
+use PHPUnit\Framework\Assert;
+
+final class FilterAssertions
+{
+    /**
+     * @param  array<string, mixed>  $filter
+     */
+    public function __construct(
+        private readonly string $key,
+        private readonly array $filter,
+        private readonly TableAssertions $table,
+    ) {}
+
+    public function assertType(FilterType $type): self
+    {
+        Assert::assertSame($type->value, $this->filter['type'] ?? null, sprintf(
+            'Expected filter [%s] to be of type [%s].',
+            $this->key,
+            $type->value,
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, Op>  $operators
+     */
+    public function assertOperators(array $operators): self
+    {
+        $expected = array_map(static fn (Op $op): string => $op->value, $operators);
+
+        Assert::assertSame($expected, $this->filter['operators'] ?? null, sprintf(
+            'Expected filter [%s] operators to match.',
+            $this->key,
+        ));
+
+        return $this;
+    }
+
+    public function assertDefaultOperator(Op $operator): self
+    {
+        Assert::assertSame($operator->value, $this->filter['defaultOperator'] ?? null, sprintf(
+            'Expected filter [%s] default operator to be [%s].',
+            $this->key,
+            $operator->value,
+        ));
+
+        return $this;
+    }
+
+    public function end(): TableAssertions
+    {
+        return $this->table;
+    }
+}

--- a/src/Support/Testing/Assertions/FormAssertions.php
+++ b/src/Support/Testing/Assertions/FormAssertions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing\Assertions;
+
+use Lattice\Lattice\Support\Testing\ComponentNode;
+
+final class FormAssertions
+{
+    public function __construct(
+        private readonly ComponentNode $node,
+        private readonly ComponentAssertions $root,
+    ) {}
+
+    public function end(): ComponentAssertions
+    {
+        return $this->root;
+    }
+}

--- a/src/Support/Testing/Assertions/FormAssertions.php
+++ b/src/Support/Testing/Assertions/FormAssertions.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\Testing\Assertions;
 
+use Closure;
 use Lattice\Lattice\Support\Testing\ComponentNode;
+use PHPUnit\Framework\Assert;
 
 final class FormAssertions
 {
@@ -12,6 +14,58 @@ final class FormAssertions
         private readonly ComponentNode $node,
         private readonly ComponentAssertions $root,
     ) {}
+
+    public function field(string $name, ?Closure $tap = null): FieldAssertions|self
+    {
+        $node = $this->node->field($name);
+
+        Assert::assertNotNull($node, sprintf(
+            'Lattice form field [%s] not found at [%s]. Available fields: [%s].',
+            $name,
+            $this->node->path(),
+            implode(', ', $this->node->availableFieldNames()),
+        ));
+
+        $assertions = new FieldAssertions($node, $this, $this->node);
+
+        if ($tap !== null) {
+            $tap($assertions);
+
+            return $this;
+        }
+
+        return $assertions;
+    }
+
+    public function assertHasField(string $name): self
+    {
+        Assert::assertNotNull($this->node->field($name), sprintf(
+            'Expected form [%s] to have field [%s]. Available fields: [%s].',
+            $this->node->id() ?? '*',
+            $name,
+            implode(', ', $this->node->availableFieldNames()),
+        ));
+
+        return $this;
+    }
+
+    public function assertMissingField(string $name): self
+    {
+        Assert::assertNull($this->node->field($name), sprintf(
+            'Expected form [%s] to NOT have field [%s], but it does.',
+            $this->node->id() ?? '*',
+            $name,
+        ));
+
+        return $this;
+    }
+
+    public function assertSubmitsTo(string $endpoint): self
+    {
+        Assert::assertSame($endpoint, $this->node->prop('action'));
+
+        return $this;
+    }
 
     public function end(): ComponentAssertions
     {

--- a/src/Support/Testing/Assertions/TableAssertions.php
+++ b/src/Support/Testing/Assertions/TableAssertions.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\Testing\Assertions;
 
+use Closure;
 use Lattice\Lattice\Support\Testing\ComponentNode;
+use PHPUnit\Framework\Assert;
 
 final class TableAssertions
 {
@@ -13,8 +15,132 @@ final class TableAssertions
         private readonly ComponentAssertions $root,
     ) {}
 
+    public function filter(string $key, ?Closure $tap = null): FilterAssertions|self
+    {
+        $filter = $this->filterFor($key);
+
+        Assert::assertNotNull($filter, sprintf(
+            'Expected table [%s] to have filter [%s]. Available filters: [%s].',
+            $this->node->id() ?? '*',
+            $key,
+            implode(', ', $this->filterKeys()),
+        ));
+
+        $assertions = new FilterAssertions($key, $filter, $this);
+
+        if ($tap !== null) {
+            $tap($assertions);
+
+            return $this;
+        }
+
+        return $assertions;
+    }
+
+    public function assertHasFilter(string $key): self
+    {
+        Assert::assertNotNull($this->filterFor($key), sprintf(
+            'Expected table [%s] to have filter [%s]. Available filters: [%s].',
+            $this->node->id() ?? '*',
+            $key,
+            implode(', ', $this->filterKeys()),
+        ));
+
+        return $this;
+    }
+
+    public function assertMissingFilter(string $key): self
+    {
+        Assert::assertNull($this->filterFor($key), sprintf(
+            'Expected table [%s] to NOT have filter [%s], but it does.',
+            $this->node->id() ?? '*',
+            $key,
+        ));
+
+        return $this;
+    }
+
+    public function assertHasColumn(string $key): self
+    {
+        Assert::assertNotNull($this->columnFor($key), sprintf(
+            'Expected table [%s] to have column [%s]. Available columns: [%s].',
+            $this->node->id() ?? '*',
+            $key,
+            implode(', ', array_map(static fn (array $c): string => (string) ($c['key'] ?? '?'), $this->columns())),
+        ));
+
+        return $this;
+    }
+
+    public function assertHasBulkAction(string $id): self
+    {
+        Assert::assertNotNull(
+            $this->node->firstOfType('action', $id),
+            sprintf('Expected table [%s] to have bulk action [%s].', $this->node->id() ?? '*', $id),
+        );
+
+        return $this;
+    }
+
     public function end(): ComponentAssertions
     {
         return $this->root;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function columns(): array
+    {
+        $columns = $this->node->prop('columns');
+
+        return is_array($columns) ? array_values(array_filter($columns, 'is_array')) : [];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function columnFor(string $key): ?array
+    {
+        foreach ($this->columns() as $column) {
+            if (($column['key'] ?? null) === $key) {
+                return $column;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function filterFor(string $key): ?array
+    {
+        $column = $this->columnFor($key);
+        $filter = $column['filter'] ?? null;
+
+        if (is_array($filter) && ($filter['enabled'] ?? false) === true) {
+            return $filter;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function filterKeys(): array
+    {
+        $keys = [];
+
+        foreach ($this->columns() as $column) {
+            $filter = $column['filter'] ?? null;
+
+            if (is_array($filter) && ($filter['enabled'] ?? false) === true) {
+                $keys[] = (string) ($column['key'] ?? '?');
+            }
+        }
+
+        return $keys;
     }
 }

--- a/src/Support/Testing/Assertions/TableAssertions.php
+++ b/src/Support/Testing/Assertions/TableAssertions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing\Assertions;
+
+use Lattice\Lattice\Support\Testing\ComponentNode;
+
+final class TableAssertions
+{
+    public function __construct(
+        private readonly ComponentNode $node,
+        private readonly ComponentAssertions $root,
+    ) {}
+
+    public function end(): ComponentAssertions
+    {
+        return $this->root;
+    }
+}

--- a/src/Support/Testing/AssertsLatticeComponents.php
+++ b/src/Support/Testing/AssertsLatticeComponents.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing;
+
+use JsonSerializable;
+use Lattice\Lattice\Support\Testing\Assertions\ComponentAssertions;
+
+trait AssertsLatticeComponents
+{
+    /**
+     * @param  JsonSerializable|array<string, mixed>  $component
+     */
+    public function assertLatticeComponent(JsonSerializable|array $component): ComponentAssertions
+    {
+        $wire = is_array($component)
+            ? $component
+            : json_decode(json_encode($component, JSON_THROW_ON_ERROR), true);
+
+        return new ComponentAssertions(new ComponentNode($wire));
+    }
+}

--- a/src/Support/Testing/AssertsLatticeComponents.php
+++ b/src/Support/Testing/AssertsLatticeComponents.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\Testing;
 
+use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use Inertia\Testing\AssertableInertia;
 use JsonSerializable;
@@ -23,6 +24,9 @@ trait AssertsLatticeComponents
         return new ComponentAssertions(new ComponentNode($wire));
     }
 
+    /**
+     * @param  TestResponse<Response>  $response
+     */
     public function assertLatticePage(TestResponse $response): ComponentAssertions
     {
         $page = AssertableInertia::fromTestResponse($response)->toArray();

--- a/src/Support/Testing/AssertsLatticeComponents.php
+++ b/src/Support/Testing/AssertsLatticeComponents.php
@@ -25,32 +25,9 @@ trait AssertsLatticeComponents
 
     public function assertLatticePage(TestResponse $response): ComponentAssertions
     {
-        $schema = $this->extractLatticeSchema($response);
+        $page = AssertableInertia::fromTestResponse($response)->toArray();
+        $schema = $page['props']['lattice']['schema'] ?? [];
 
         return new ComponentAssertions(ComponentNode::root(is_array($schema) ? $schema : []));
-    }
-
-    /**
-     * @return array<int, mixed>
-     */
-    private function extractLatticeSchema(TestResponse $response): array
-    {
-        if ($response->headers->has('X-Inertia')) {
-            $page = $response->json();
-
-            return $page['props']['lattice']['schema'] ?? [];
-        }
-
-        if ($response->baseRequest !== null) {
-            $url = $response->baseRequest->getUri();
-            $xhrResponse = $this->get($url, ['X-Inertia' => 'true']);
-            $page = $xhrResponse->json();
-
-            return $page['props']['lattice']['schema'] ?? [];
-        }
-
-        $schema = AssertableInertia::fromTestResponse($response)->toArray()['props']['lattice']['schema'] ?? [];
-
-        return is_array($schema) ? $schema : [];
     }
 }

--- a/src/Support/Testing/AssertsLatticeComponents.php
+++ b/src/Support/Testing/AssertsLatticeComponents.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\Testing;
 
+use Illuminate\Testing\TestResponse;
+use Inertia\Testing\AssertableInertia;
 use JsonSerializable;
 use Lattice\Lattice\Support\Testing\Assertions\ComponentAssertions;
 
@@ -19,5 +21,36 @@ trait AssertsLatticeComponents
             : json_decode(json_encode($component, JSON_THROW_ON_ERROR), true);
 
         return new ComponentAssertions(new ComponentNode($wire));
+    }
+
+    public function assertLatticePage(TestResponse $response): ComponentAssertions
+    {
+        $schema = $this->extractLatticeSchema($response);
+
+        return new ComponentAssertions(ComponentNode::root(is_array($schema) ? $schema : []));
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function extractLatticeSchema(TestResponse $response): array
+    {
+        if ($response->headers->has('X-Inertia')) {
+            $page = $response->json();
+
+            return $page['props']['lattice']['schema'] ?? [];
+        }
+
+        if ($response->baseRequest !== null) {
+            $url = $response->baseRequest->getUri();
+            $xhrResponse = $this->get($url, ['X-Inertia' => 'true']);
+            $page = $xhrResponse->json();
+
+            return $page['props']['lattice']['schema'] ?? [];
+        }
+
+        $schema = AssertableInertia::fromTestResponse($response)->toArray()['props']['lattice']['schema'] ?? [];
+
+        return is_array($schema) ? $schema : [];
     }
 }

--- a/src/Support/Testing/ComponentNode.php
+++ b/src/Support/Testing/ComponentNode.php
@@ -138,7 +138,7 @@ final class ComponentNode
     {
         $selectors = [];
 
-        foreach ($this->descendants() as $node) {
+        foreach ([$this, ...$this->descendants()] as $node) {
             $type = $node->type();
 
             if ($type === null) {

--- a/src/Support/Testing/ComponentNode.php
+++ b/src/Support/Testing/ComponentNode.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing;
+
+final class ComponentNode
+{
+    private const NESTED_COMPONENT_PROPS = ['form', 'headerActions', 'bulkActions', 'actions'];
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __construct(
+        private readonly array $data,
+        private readonly string $path = 'root',
+    ) {}
+
+    /**
+     * @param  array<int, array<string, mixed>>  $nodes
+     */
+    public static function root(array $nodes, string $path = 'page'): self
+    {
+        return new self(['type' => null, 'id' => null, 'props' => [], 'schema' => array_values($nodes)], $path);
+    }
+
+    public function type(): ?string
+    {
+        $type = $this->data['type'] ?? null;
+
+        return is_string($type) ? $type : null;
+    }
+
+    public function id(): ?string
+    {
+        $id = $this->data['id'] ?? null;
+
+        return is_string($id) ? $id : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function props(): array
+    {
+        $props = $this->data['props'] ?? [];
+
+        return is_array($props) ? $props : [];
+    }
+
+    public function prop(string $key): mixed
+    {
+        return $this->props()[$key] ?? null;
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return array<int, self>
+     */
+    public function descendants(): array
+    {
+        $all = [];
+
+        foreach ($this->componentChildren() as $child) {
+            $all[] = $child;
+
+            foreach ($child->descendants() as $deep) {
+                $all[] = $deep;
+            }
+        }
+
+        return $all;
+    }
+
+    /**
+     * @param  callable(self): bool  $matcher
+     */
+    public function find(callable $matcher): ?self
+    {
+        foreach ($this->descendants() as $node) {
+            if ($matcher($node)) {
+                return $node;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  callable(self): bool  $matcher
+     * @return array<int, self>
+     */
+    public function findAll(callable $matcher): array
+    {
+        return array_values(array_filter($this->descendants(), $matcher));
+    }
+
+    /**
+     * @param  callable(self): bool  $matcher
+     * @return array<int, self>
+     */
+    public function findAllIncludingSelf(callable $matcher): array
+    {
+        $matches = $this->findAll($matcher);
+
+        if ($matcher($this)) {
+            array_unshift($matches, $this);
+        }
+
+        return $matches;
+    }
+
+    public function firstOfType(string $type, ?string $id = null): ?self
+    {
+        return $this->find($this->typeMatcher($type, $id));
+    }
+
+    public function firstOfTypeIncludingSelf(string $type, ?string $id = null): ?self
+    {
+        $matcher = $this->typeMatcher($type, $id);
+
+        return $matcher($this) ? $this : $this->find($matcher);
+    }
+
+    public function field(string $name): ?self
+    {
+        return $this->find(static fn (self $node): bool => $node->prop('name') === $name);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function availableSelectors(): array
+    {
+        $selectors = [];
+
+        foreach ($this->descendants() as $node) {
+            $type = $node->type();
+
+            if ($type === null) {
+                continue;
+            }
+
+            $selectors[] = $node->id() !== null ? $type.':'.$node->id() : $type;
+        }
+
+        return array_values(array_unique($selectors));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function availableFieldNames(): array
+    {
+        $names = [];
+
+        foreach ($this->descendants() as $node) {
+            $name = $node->prop('name');
+
+            if (is_string($name)) {
+                $names[] = $name;
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * @return callable(self): bool
+     */
+    private function typeMatcher(string $type, ?string $id): callable
+    {
+        return static fn (self $node): bool => $node->type() === $type
+            && ($id === null || $node->id() === $id);
+    }
+
+    /**
+     * @return array<int, self>
+     */
+    private function componentChildren(): array
+    {
+        $children = $this->schemaChildren();
+
+        foreach (self::NESTED_COMPONENT_PROPS as $key) {
+            foreach ($this->nodesFrom($this->props()[$key] ?? null) as $node) {
+                $children[] = $node;
+            }
+        }
+
+        return $children;
+    }
+
+    /**
+     * @return array<int, self>
+     */
+    private function schemaChildren(): array
+    {
+        $schema = $this->data['schema'] ?? [];
+
+        if (! is_array($schema)) {
+            return [];
+        }
+
+        $children = [];
+
+        foreach (array_values($schema) as $child) {
+            if (is_array($child) && isset($child['type'])) {
+                $children[] = new self($child, $this->childPath($child));
+            }
+        }
+
+        return $children;
+    }
+
+    /**
+     * @return array<int, self>
+     */
+    private function nodesFrom(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        if (isset($value['type']) && array_key_exists('props', $value)) {
+            return [new self($value, $this->childPath($value))];
+        }
+
+        $nodes = [];
+
+        foreach ($value as $item) {
+            if (is_array($item) && isset($item['type']) && array_key_exists('props', $item)) {
+                $nodes[] = new self($item, $this->childPath($item));
+            }
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * @param  array<string, mixed>  $child
+     */
+    private function childPath(array $child): string
+    {
+        $label = is_string($child['id'] ?? null) ? $child['id'] : (string) ($child['type'] ?? '?');
+
+        return $this->path.' › '.$label;
+    }
+}

--- a/src/Support/Testing/ComponentNode.php
+++ b/src/Support/Testing/ComponentNode.php
@@ -208,7 +208,7 @@ final class ComponentNode
         $children = [];
 
         foreach (array_values($schema) as $child) {
-            if (is_array($child) && isset($child['type'])) {
+            if (is_array($child) && isset($child['type']) && array_key_exists('props', $child)) {
                 $children[] = new self($child, $this->childPath($child));
             }
         }

--- a/tests/Feature/ActionWireShapeTest.php
+++ b/tests/Feature/ActionWireShapeTest.php
@@ -23,7 +23,7 @@ it('serializes the action wire shape', function (): void {
         ->confirm('Archive product?', 'This hides the product.', 'Archive', 'Keep')
         ->effects([Effect::reloadComponent('table'), Effect::reloadPage()]);
 
-    $payload = json_decode(json_encode($action), true);
+    $payload = wire($action);
 
     expect($payload['type'])->toBe('action');
     expect($payload['id'])->toBe('archive');
@@ -53,7 +53,7 @@ it('accepts arbitrary string icons', function (): void {
         ->icon('custom.spark')
         ->method(HttpMethod::Delete);
 
-    $payload = json_decode(json_encode($action), true);
+    $payload = wire($action);
 
     expect($payload['props']['icon'])->toBe('custom.spark');
     expect($payload['props']['method'])->toBe('delete');
@@ -66,7 +66,7 @@ it('serializes an embedded form schema', function (): void {
             Textarea::make('reason', 'Reason')->required(),
         ]);
 
-    $payload = json_decode(json_encode($action), true);
+    $payload = wire($action);
 
     expect($payload['props']['form']['type'])->toBe('form');
     expect($payload['props']['form']['schema'])->toHaveCount(1);
@@ -77,7 +77,7 @@ it('serializes an embedded form schema', function (): void {
 it('serializes a null form when none is attached', function (): void {
     $action = Action::make('plain')->label('Plain');
 
-    $payload = json_decode(json_encode($action), true);
+    $payload = wire($action);
 
     expect($payload['props']['form'])->toBeNull();
 });
@@ -85,7 +85,7 @@ it('serializes a null form when none is attached', function (): void {
 it('serializes the full confirmation shape and includes empty effects', function (): void {
     $action = Action::make('simple')->confirm('Sure?');
 
-    $payload = json_decode(json_encode($action), true);
+    $payload = wire($action);
 
     expect($payload['props']['confirmation'])->toBe([
         'title' => 'Sure?',
@@ -101,7 +101,7 @@ it('serializes the action group wire shape', function (): void {
         ->label('Actions')
         ->actions([Action::make('a')->label('A')]);
 
-    $payload = json_decode(json_encode($group), true);
+    $payload = wire($group);
 
     expect($payload['type'])->toBe('action.group');
     expect($payload['id'])->toBe('row-actions');
@@ -114,7 +114,7 @@ it('serializes the action group wire shape', function (): void {
 it('carries typed props through Action::use from the registry', function (): void {
     Lattice::actions([ArchiveProductAction::class]);
 
-    $payload = json_decode(json_encode(Action::use(ArchiveProductAction::class)), true);
+    $payload = wire(Action::use(ArchiveProductAction::class));
 
     expect($payload['type'])->toBe('action');
     expect($payload['id'])->toBe('workbench.products.archive');
@@ -136,7 +136,7 @@ it('carries typed props through Action::use from the registry', function (): voi
 it('carries typed props through BulkAction::use from the registry', function (): void {
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
-    $payload = json_decode(json_encode(BulkAction::use(ArchiveSelectedProductsAction::class)), true);
+    $payload = wire(BulkAction::use(ArchiveSelectedProductsAction::class));
 
     expect($payload['type'])->toBe('bulkAction');
     expect($payload['id'])->toBe('workbench.products.archive-selected');

--- a/tests/Feature/BlockWireShapeTest.php
+++ b/tests/Feature/BlockWireShapeTest.php
@@ -5,9 +5,9 @@ use Lattice\Lattice\Forms\Components\Block;
 use Lattice\Lattice\Forms\Components\TextInput;
 
 it('serialises a block as type + label + schema', function (): void {
-    $wire = json_decode(json_encode(
+    $wire = wire(
         Block::make('product')->label('Product line')->schema([TextInput::make('qty')])
-    ), true);
+    );
 
     expect($wire['type'])->toBe('product')
         ->and($wire['label'])->toBe('Product line')
@@ -17,7 +17,7 @@ it('serialises a block as type + label + schema', function (): void {
 });
 
 it('defaults the label to a title-cased type', function (): void {
-    $wire = json_decode(json_encode(Block::make('product')->schema([])), true);
+    $wire = wire(Block::make('product')->schema([]));
 
     expect($wire['label'])->toBe('Product');
 });

--- a/tests/Feature/BuilderWireShapeTest.php
+++ b/tests/Feature/BuilderWireShapeTest.php
@@ -7,7 +7,7 @@ use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
 
 it('serialises a builder with its blocks and props', function (): void {
-    $wire = json_decode(json_encode(
+    $wire = wire(
         Builder::make('items', 'Line items')
             ->blocks([
                 Block::make('text')->label('Text')->schema([Textarea::make('content')]),
@@ -16,7 +16,7 @@ it('serialises a builder with its blocks and props', function (): void {
             ->minItems(1)
             ->maxItems(20)
             ->addLabel('Add block')
-    ), true);
+    );
 
     expect($wire['type'])->toBe('form.builder')
         ->and($wire['props']['name'])->toBe('items')

--- a/tests/Feature/FormWireShapeTest.php
+++ b/tests/Feature/FormWireShapeTest.php
@@ -18,7 +18,7 @@ it('serializes the form container wire shape', function (): void {
         ->fill(['email' => 'a@b.c'])
         ->schema([TextInput::make('email')]);
 
-    $payload = json_decode(json_encode($form), true);
+    $payload = wire($form);
 
     expect($payload['type'])->toBe('form');
     expect($payload['id'])->toBe('demo');

--- a/tests/Feature/LatticePageTest.php
+++ b/tests/Feature/LatticePageTest.php
@@ -103,7 +103,7 @@ test('lattice component factories stay open for extension', function () {
     $badgeClass = (new class extends Badge {})::class;
     $badge = $badgeClass::make('Extended badge', 'extended-badge');
 
-    expect($badge)->toBeInstanceOf($badgeClass)
+    expect($badge::class)->toBe($badgeClass)
         ->and((new ReflectionClass(Badge::class))->isFinal())->toBeFalse();
 });
 

--- a/tests/Feature/ProductsTest.php
+++ b/tests/Feature/ProductsTest.php
@@ -9,6 +9,8 @@ use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
+use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
 use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tables\InvalidTableQuery;
 use Lattice\Lattice\Tables\TableQuery;
@@ -25,6 +27,8 @@ use function Pest\Laravel\get;
 use function Pest\Laravel\patch;
 use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
+
+uses(AssertsLatticeComponents::class);
 
 /**
  * @param  array<string, mixed>  $component
@@ -52,24 +56,24 @@ function productHeaders(array $component, array $extra = []): array
 }
 
 test('forms serialize initial state for bound edit values', function () {
-    $form = wire(Form::make('product-form')
+    $form = Form::make('product-form')
         ->fill([
             'name' => 'Desk Lamp',
             'sku' => 'LAMP-001',
         ])
         ->schema([
             TextInput::make('name', 'Name'),
-        ]));
-
-    expect($form)
-        ->toMatchArray([
-            'type' => 'form',
-            'id' => 'product-form',
-        ])
-        ->and($form['props']['state'])->toBe([
-            'name' => 'Desk Lamp',
-            'sku' => 'LAMP-001',
         ]);
+
+    $this->assertLatticeComponent($form)
+        ->assertHasForm('product-form')
+        ->form('product-form', fn (FormAssertions $f) => $f
+            ->field('name')->assertInitialValue('Desk Lamp'));
+
+    expect(wire($form)['props']['state'])->toBe([
+        'name' => 'Desk Lamp',
+        'sku' => 'LAMP-001',
+    ]);
 });
 
 test('forms can enable precognitive validation with a delay', function () {

--- a/tests/Feature/ProductsTest.php
+++ b/tests/Feature/ProductsTest.php
@@ -10,7 +10,6 @@ use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
-use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
 use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tables\InvalidTableQuery;
 use Lattice\Lattice\Tables\TableQuery;
@@ -27,8 +26,6 @@ use function Pest\Laravel\get;
 use function Pest\Laravel\patch;
 use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
-
-uses(AssertsLatticeComponents::class);
 
 /**
  * @param  array<string, mixed>  $component

--- a/tests/Feature/RepeaterWireShapeTest.php
+++ b/tests/Feature/RepeaterWireShapeTest.php
@@ -13,7 +13,7 @@ it('serialises a repeater with its row-template schema and props', function (): 
         ->itemLabel('Line')
         ->defaultItems(2);
 
-    $wire = json_decode(json_encode($repeater), true);
+    $wire = wire($repeater);
 
     expect($wire['type'])->toBe('form.repeater')
         ->and($wire['props']['name'])->toBe('items')
@@ -30,7 +30,7 @@ it('serialises a repeater with its row-template schema and props', function (): 
 });
 
 it('defaults reorderable on and defaultItems to 1', function (): void {
-    $wire = json_decode(json_encode(Repeater::make('items')->schema([TextInput::make('name')])), true);
+    $wire = wire(Repeater::make('items')->schema([TextInput::make('name')]));
 
     expect($wire['props']['reorderable'])->toBeTrue()
         ->and($wire['props']['defaultItems'])->toBe(1);

--- a/tests/Feature/RowLayoutTest.php
+++ b/tests/Feature/RowLayoutTest.php
@@ -6,13 +6,13 @@ use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\TextInput;
 
 it('defaults to the stack layout', function (): void {
-    $wire = json_decode(json_encode(Repeater::make('items')->schema([TextInput::make('a')])), true);
+    $wire = wire(Repeater::make('items')->schema([TextInput::make('a')]));
     expect($wire['props']['layout'])->toBe('stack');
 });
 
 it('opts into the table layout via table()', function (): void {
-    $repeater = json_decode(json_encode(Repeater::make('items')->table()->schema([TextInput::make('a')])), true);
-    $builder = json_decode(json_encode(Builder::make('items')->table()), true);
+    $repeater = wire(Repeater::make('items')->table()->schema([TextInput::make('a')]));
+    $builder = wire(Builder::make('items')->table());
 
     expect($repeater['props']['layout'])->toBe('table')
         ->and($builder['props']['layout'])->toBe('table');

--- a/tests/Feature/TableWireShapeTest.php
+++ b/tests/Feature/TableWireShapeTest.php
@@ -21,7 +21,7 @@ it('serializes the table component wire shape', function (): void {
         ->striped(true)
         ->result(TableResult::make([['name' => 'A'], ['name' => 'B']]), TableQuery::empty());
 
-    $payload = json_decode(json_encode($table), true);
+    $payload = wire($table);
 
     expect($payload['type'])->toBe('table');
     expect($payload['props']['endpoint'])->toBe('/tables/demo');
@@ -67,7 +67,7 @@ it('narrows the offered operators when a column restricts them', function (): vo
 
     expect($column->availableOperators())->toBe([Op::Equals, Op::Contains]);
 
-    $filter = json_decode(json_encode($column), true)['filter'];
+    $filter = wire($column)['filter'];
 
     expect($filter['operators'])->toBe(['eq', 'contains'])
         ->and($filter['defaultOperator'])->toBe('eq');
@@ -78,7 +78,7 @@ it('keeps empty data present on a lazy table (wire trap)', function (): void {
 
     $table = app(TableRegistry::class)->lazyComponent(ProductsTable::class);
 
-    $payload = json_decode(json_encode($table), true);
+    $payload = wire($table);
 
     expect($payload['type'])->toBe('table');
     expect($payload['props']['lazy'])->toBeTrue();

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -6,8 +6,15 @@ use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
+use Lattice\Lattice\Support\Testing\Assertions\FilterAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
+use Lattice\Lattice\Support\Testing\Assertions\TableAssertions;
 use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Components\Table;
+use Lattice\Lattice\Tables\Enums\FilterType;
+use Lattice\Lattice\Tables\TableQuery;
+use Lattice\Lattice\Tables\TableResult;
 use PHPUnit\Framework\AssertionFailedError;
 
 uses(AssertsLatticeComponents::class);
@@ -54,4 +61,27 @@ it('asserts field visibility, conditions and initial value', function (): void {
                 ->assertHiddenWhen(['type' => 'personal'])
                 ->assertHasCondition('visible', 'type', Op::Equals, 'business'))
             ->field('secret', fn (FieldAssertions $f) => $f->assertHidden()));
+});
+
+it('asserts table filters, columns and operators', function (): void {
+    $table = Table::make('products')
+        ->endpoint('/tables/products')
+        ->columns([
+            TextColumn::make('name')->label('Name')->filterable(),
+            TextColumn::make('price')->label('Price'),
+        ])
+        ->result(TableResult::make([]), TableQuery::empty());
+
+    $this->assertLatticeComponent($table)
+        ->table('products', fn (TableAssertions $table) => $table
+            ->assertHasColumn('name')
+            ->assertHasFilter('name')
+            ->assertMissingFilter('price')
+            ->filter('name', fn (FilterAssertions $f) => $f
+                ->assertType(FilterType::Text)
+                ->assertDefaultOperator(Op::Contains)
+                ->assertOperators([
+                    Op::Contains, Op::StartsWith, Op::EndsWith,
+                    Op::Equals, Op::NotEquals, Op::Empty, Op::Filled,
+                ])));
 });

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -23,6 +23,8 @@ use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableResult;
 use PHPUnit\Framework\AssertionFailedError;
 
+use function Pest\Laravel\withoutVite;
+
 uses(AssertsLatticeComponents::class);
 
 it('navigates a built form and asserts page rendering by visibility', function (): void {
@@ -111,6 +113,8 @@ it('asserts action state', function (): void {
 });
 
 it('asserts against a rendered Inertia page', function (): void {
+    withoutVite();
+
     Route::get('lattice-demo-page', fn () => Inertia::render('lattice/page', [
         'lattice' => [
             'schema' => json_decode(json_encode([

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Op;
@@ -106,4 +108,26 @@ it('asserts action state', function (): void {
             ->assertHasConfirmation()
             ->assertConfirmationTitle('Archive product?')
             ->assertHasForm());
+});
+
+it('asserts against a rendered Inertia page', function (): void {
+    Route::get('lattice-demo-page', fn () => Inertia::render('lattice/page', [
+        'lattice' => [
+            'schema' => json_decode(json_encode([
+                Form::make('create')->action('/products')->schema([
+                    TextInput::make('email')->value('a@b.c'),
+                ]),
+                Table::make('products')
+                    ->columns([TextColumn::make('name')->filterable()])
+                    ->result(TableResult::make([]), TableQuery::empty()),
+            ], JSON_THROW_ON_ERROR), true),
+        ],
+    ]))->middleware('web');
+
+    $this->assertLatticePage($this->get('lattice-demo-page'))
+        ->assertRendered('form:create')
+        ->assertRendered('table:products')
+        ->table('products', fn (TableAssertions $t) => $t->assertHasFilter('name'))
+        ->form('create', fn (FormAssertions $f) => $f
+            ->field('email')->assertInitialValue('a@b.c'));
 });

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -2,9 +2,13 @@
 
 declare(strict_types=1);
 
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Testing\Assertions\ActionAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FilterAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
@@ -84,4 +88,22 @@ it('asserts table filters, columns and operators', function (): void {
                     Op::Contains, Op::StartsWith, Op::EndsWith,
                     Op::Equals, Op::NotEquals, Op::Empty, Op::Filled,
                 ])));
+});
+
+it('asserts action state', function (): void {
+    $action = Action::make('archive')
+        ->endpoint('/lattice/actions/archive')
+        ->label('Archive')
+        ->variant(ButtonVariant::Destructive)
+        ->confirm('Archive product?', 'This hides the product.')
+        ->form([Textarea::make('reason')->label('Reason')]);
+
+    $this->assertLatticeComponent($action)
+        ->action('archive', fn (ActionAssertions $a) => $a
+            ->assertLabel('Archive')
+            ->assertEndpoint('/lattice/actions/archive')
+            ->assertVariant(ButtonVariant::Destructive)
+            ->assertHasConfirmation()
+            ->assertConfirmationTitle('Archive product?')
+            ->assertHasForm());
 });

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
+use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
 use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
 use PHPUnit\Framework\AssertionFailedError;
 
@@ -26,4 +29,29 @@ it('fails with a helpful message when a selector is not rendered', function (): 
 
     expect(fn () => $this->assertLatticeComponent($form)->assertRendered('table:products'))
         ->toThrow(AssertionFailedError::class, 'table:products');
+});
+
+it('asserts field visibility, conditions and initial value', function (): void {
+    $form = Form::make('create')
+        ->action('/products')
+        ->fill(['email' => 'a@b.c'])
+        ->schema([
+            TextInput::make('email')->label('Email'),
+            TextInput::make('company')->visibleWhen('type', 'business'),
+            TextInput::make('secret')->hidden(),
+        ]);
+
+    $this->assertLatticeComponent($form)
+        ->form('create', fn (FormAssertions $form) => $form
+            ->assertSubmitsTo('/products')
+            ->assertHasField('email')
+            ->assertMissingField('nope')
+            ->field('email', fn (FieldAssertions $f) => $f
+                ->assertVisible()
+                ->assertInitialValue('a@b.c'))
+            ->field('company', fn (FieldAssertions $f) => $f
+                ->assertVisibleWhen(['type' => 'business'])
+                ->assertHiddenWhen(['type' => 'personal'])
+                ->assertHasCondition('visible', 'type', Op::Equals, 'business'))
+            ->field('secret', fn (FieldAssertions $f) => $f->assertHidden()));
 });

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -141,14 +141,14 @@ it('asserts against a rendered Inertia page', function (): void {
 
     Route::get('lattice-demo-page', fn () => Inertia::render('lattice/page', [
         'lattice' => [
-            'schema' => json_decode(json_encode([
+            'schema' => wire([
                 Form::make('create')->action('/products')->schema([
                     TextInput::make('email')->value('a@b.c'),
                 ]),
                 Table::make('products')
                     ->columns([TextColumn::make('name')->filterable()])
                     ->result(TableResult::make([]), TableQuery::empty()),
-            ], JSON_THROW_ON_ERROR), true),
+            ]),
         ],
     ]))->middleware('web');
 

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -15,7 +15,6 @@ use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FilterAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\TableAssertions;
-use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tables\Enums\FilterType;
@@ -24,8 +23,6 @@ use Lattice\Lattice\Tables\TableResult;
 use PHPUnit\Framework\AssertionFailedError;
 
 use function Pest\Laravel\withoutVite;
-
-uses(AssertsLatticeComponents::class);
 
 it('navigates a built form and asserts page rendering by visibility', function (): void {
     $form = Form::make('create')->action('/products')->schema([

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -112,6 +112,33 @@ it('asserts action state', function (): void {
             ->assertHasForm());
 });
 
+it('asserts field required, optional, disabled, enabled and read-only flags', function (): void {
+    $form = Form::make('flags')->schema([
+        TextInput::make('plain')->label('Plain'),
+        TextInput::make('req')->required(),
+        TextInput::make('ro')->readOnly(),
+        TextInput::make('dis')->disabled(),
+    ]);
+
+    $this->assertLatticeComponent($form)
+        ->form('flags', fn (FormAssertions $f) => $f
+            ->field('plain', fn (FieldAssertions $x) => $x->assertOptional()->assertEnabled())
+            ->field('req', fn (FieldAssertions $x) => $x->assertRequired())
+            ->field('ro', fn (FieldAssertions $x) => $x->assertReadOnly())
+            ->field('dis', fn (FieldAssertions $x) => $x->assertDisabled()));
+});
+
+it('asserts table presence and bulk actions', function (): void {
+    $table = Table::make('orders')
+        ->columns([TextColumn::make('ref')->label('Ref')])
+        ->bulkActions([Action::make('archive')->label('Archive')])
+        ->result(TableResult::make([]), TableQuery::empty());
+
+    $this->assertLatticeComponent($table)
+        ->assertHasTable('orders')
+        ->table('orders', fn (TableAssertions $t) => $t->assertHasBulkAction('archive'));
+});
+
 it('asserts against a rendered Inertia page', function (): void {
     withoutVite();
 

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
+use PHPUnit\Framework\AssertionFailedError;
+
+uses(AssertsLatticeComponents::class);
+
+it('navigates a built form and asserts page rendering by visibility', function (): void {
+    $form = Form::make('create')->action('/products')->schema([
+        TextInput::make('email')->label('Email'),
+    ]);
+
+    $this->assertLatticeComponent($form)
+        ->assertRendered('form:create')
+        ->assertNotRendered('form:missing')
+        ->assertRenderedCount('form', 1)
+        ->assertHasForm('create');
+});
+
+it('fails with a helpful message when a selector is not rendered', function (): void {
+    $form = Form::make('create')->schema([]);
+
+    expect(fn () => $this->assertLatticeComponent($form)->assertRendered('table:products'))
+        ->toThrow(AssertionFailedError::class, 'table:products');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -97,7 +97,7 @@ function latticeHeaders(string $ref): array
  */
 function dumpFixture(string $key, array $nodes): void
 {
-    $normalized = json_decode(json_encode($nodes, JSON_THROW_ON_ERROR), true);
+    $normalized = wire($nodes);
 
     file_put_contents(
         dirname(__DIR__).'/docs/fixtures/'.$key.'.json',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Tests;
 use Bambamboole\LaravelI18Next\I18NextServiceProvider;
 use Inertia\ServiceProvider as InertiaServiceProvider;
 use Lattice\Lattice\LatticeServiceProvider;
+use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -13,6 +14,7 @@ use Workbench\App\Providers\WorkbenchServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
+    use AssertsLatticeComponents;
     use WithLaravelMigrations;
     use WithWorkbench;
 

--- a/tests/Unit/Attributes/ColumnAttributeTest.php
+++ b/tests/Unit/Attributes/ColumnAttributeTest.php
@@ -2,13 +2,11 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Attributes\Column;
-use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Tables\Columns\BadgeColumnProps;
 
 it('is a Component attribute carrying type and props class', function () {
     $attribute = new Column(type: 'badge', props: BadgeColumnProps::class);
 
-    expect($attribute)->toBeInstanceOf(Component::class)
-        ->and($attribute->type)->toBe('badge')
+    expect($attribute->type)->toBe('badge')
         ->and($attribute->props)->toBe(BadgeColumnProps::class);
 });

--- a/tests/Unit/Tables/ColumnDataTest.php
+++ b/tests/Unit/Tables/ColumnDataTest.php
@@ -13,7 +13,7 @@ it('serializes common fields plus a typed props object', function () {
         props: new BadgeColumnProps(colors: ['active' => 'green']),
     );
 
-    expect(json_decode(json_encode($data), true))->toBe([
+    expect(wire($data))->toBe([
         'key' => 'status',
         'label' => 'Status',
         'type' => 'badge',

--- a/tests/Unit/Tables/ColumnPropsTest.php
+++ b/tests/Unit/Tables/ColumnPropsTest.php
@@ -2,13 +2,11 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Tables\Columns\BadgeColumnProps;
-use Lattice\Lattice\Tables\Columns\ColumnProps;
 use Lattice\Lattice\Tables\Columns\TextColumnProps;
 
 it('props VOs implement the ColumnProps contract and serialize full shape', function () {
     $badge = new BadgeColumnProps(colors: ['active' => 'green']);
-    expect($badge)->toBeInstanceOf(ColumnProps::class)
-        ->and(json_decode(json_encode($badge), true))->toBe(['colors' => ['active' => 'green']]);
+    expect(json_decode(json_encode($badge), true))->toBe(['colors' => ['active' => 'green']]);
 
     $text = new TextColumnProps;
     expect(json_decode(json_encode($text), true))->toBe([

--- a/tests/Unit/Tables/ColumnPropsTest.php
+++ b/tests/Unit/Tables/ColumnPropsTest.php
@@ -6,10 +6,10 @@ use Lattice\Lattice\Tables\Columns\TextColumnProps;
 
 it('props VOs implement the ColumnProps contract and serialize full shape', function () {
     $badge = new BadgeColumnProps(colors: ['active' => 'green']);
-    expect(json_decode(json_encode($badge), true))->toBe(['colors' => ['active' => 'green']]);
+    expect(wire($badge))->toBe(['colors' => ['active' => 'green']]);
 
     $text = new TextColumnProps;
-    expect(json_decode(json_encode($text), true))->toBe([
+    expect(wire($text))->toBe([
         'date' => null,
         'copyable' => false,
         'link' => null,

--- a/tests/Unit/Testing/ComponentNodeTest.php
+++ b/tests/Unit/Testing/ComponentNodeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Support\Testing\ComponentNode;
+
+function node(array $data): ComponentNode
+{
+    return new ComponentNode($data);
+}
+
+it('reads type, id and props', function (): void {
+    $n = node(['type' => 'form', 'id' => 'create', 'props' => ['action' => '/p'], 'schema' => []]);
+
+    expect($n->type())->toBe('form')
+        ->and($n->id())->toBe('create')
+        ->and($n->prop('action'))->toBe('/p');
+});
+
+it('finds a descendant by type and id through schema', function (): void {
+    $root = ComponentNode::root([
+        ['type' => 'stack', 'id' => null, 'props' => [], 'schema' => [
+            ['type' => 'action', 'id' => 'archive', 'props' => ['label' => 'Archive'], 'schema' => []],
+        ]],
+    ]);
+
+    expect($root->firstOfType('action', 'archive')?->prop('label'))->toBe('Archive')
+        ->and($root->firstOfType('action', 'missing'))->toBeNull();
+});
+
+it('descends into embedded form and bulkActions props', function (): void {
+    $root = ComponentNode::root([
+        ['type' => 'table', 'id' => 't', 'props' => ['bulkActions' => [
+            ['type' => 'action', 'id' => 'delete', 'props' => [], 'schema' => []],
+        ]], 'schema' => []],
+        ['type' => 'action', 'id' => 'edit', 'props' => ['form' => [
+            'type' => 'form', 'id' => 'edit-form', 'props' => [], 'schema' => [
+                ['type' => 'form.textarea', 'id' => null, 'props' => ['name' => 'reason'], 'schema' => []],
+            ],
+        ]], 'schema' => []],
+    ]);
+
+    expect($root->firstOfType('action', 'delete'))->not->toBeNull()
+        ->and($root->field('reason'))->not->toBeNull();
+});
+
+it('finds a field by name and lists available field names', function (): void {
+    $form = node(['type' => 'form', 'id' => 'f', 'props' => [], 'schema' => [
+        ['type' => 'form.text-input', 'id' => null, 'props' => ['name' => 'email'], 'schema' => []],
+        ['type' => 'form.number-input', 'id' => null, 'props' => ['name' => 'price'], 'schema' => []],
+    ]]);
+
+    expect($form->field('email')?->prop('name'))->toBe('email')
+        ->and($form->field('nope'))->toBeNull()
+        ->and($form->availableFieldNames())->toBe(['email', 'price']);
+});
+
+it('matches itself when the root is the target type', function (): void {
+    $form = node(['type' => 'form', 'id' => 'create', 'props' => [], 'schema' => []]);
+
+    expect($form->firstOfTypeIncludingSelf('form', 'create'))->toBe($form);
+});

--- a/tests/Unit/Testing/ComponentNodeTest.php
+++ b/tests/Unit/Testing/ComponentNodeTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Support\Testing\ComponentNode;
 
+/**
+ * @param  array<string, mixed>  $data
+ */
 function componentNode(array $data): ComponentNode
 {
     return new ComponentNode($data);

--- a/tests/Unit/Testing/ComponentNodeTest.php
+++ b/tests/Unit/Testing/ComponentNodeTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Support\Testing\ComponentNode;
 
-function node(array $data): ComponentNode
+function componentNode(array $data): ComponentNode
 {
     return new ComponentNode($data);
 }
 
 it('reads type, id and props', function (): void {
-    $n = node(['type' => 'form', 'id' => 'create', 'props' => ['action' => '/p'], 'schema' => []]);
+    $n = componentNode(['type' => 'form', 'id' => 'create', 'props' => ['action' => '/p'], 'schema' => []]);
 
     expect($n->type())->toBe('form')
         ->and($n->id())->toBe('create')
@@ -45,7 +45,7 @@ it('descends into embedded form and bulkActions props', function (): void {
 });
 
 it('finds a field by name and lists available field names', function (): void {
-    $form = node(['type' => 'form', 'id' => 'f', 'props' => [], 'schema' => [
+    $form = componentNode(['type' => 'form', 'id' => 'f', 'props' => [], 'schema' => [
         ['type' => 'form.text-input', 'id' => null, 'props' => ['name' => 'email'], 'schema' => []],
         ['type' => 'form.number-input', 'id' => null, 'props' => ['name' => 'price'], 'schema' => []],
     ]]);
@@ -56,7 +56,7 @@ it('finds a field by name and lists available field names', function (): void {
 });
 
 it('matches itself when the root is the target type', function (): void {
-    $form = node(['type' => 'form', 'id' => 'create', 'props' => [], 'schema' => []]);
+    $form = componentNode(['type' => 'form', 'id' => 'create', 'props' => [], 'schema' => []]);
 
     expect($form->firstOfTypeIncludingSelf('form', 'create'))->toBe($form);
 });


### PR DESCRIPTION
## Summary

Adds a public testing API for asserting against Lattice's serialized component tree, modeled on Filament's test helpers but adapted to Lattice's stateless Inertia wire tree.

`AssertsLatticeComponents` (trait) exposes two entry doors that produce the same fluent assertion engine:
- `assertLatticeComponent($form|$table|$action|$array)` — assert against a component built in the test (object entry, no HTTP).
- `assertLatticePage($response)` — assert against a rendered page, reading the component tree from the Inertia `lattice.schema` prop.

A pure `ComponentNode` value object navigates the wire tree; six fluent nodes assert on it:
- **Page rendering** (visibility): `assertRendered('action:archive')`, `assertNotRendered(...)`, `assertRenderedCount(...)` — reflects what survived `shouldRender()`/`authorize()`.
- **Forms/fields**: `field()`, `assertHasField`, `assertSubmitsTo`, `assertVisible/Hidden`, `assertVisibleWhen/HiddenWhen` (reuses the real `Condition`/`FormData` evaluation — no duplicated logic), `assertRequired/Optional`, `assertDisabled/Enabled`, `assertReadOnly`, `assertInitialValue`, `assertHasCondition`.
- **Tables/filters**: `assertHasFilter/assertMissingFilter`, `assertHasColumn`, `assertHasBulkAction`, `filter()->assertType/assertOperators/assertDefaultOperator`.
- **Actions**: `assertLabel/assertEndpoint/assertVariant/assertHasConfirmation/assertConfirmationTitle/assertHasForm`.

Failure messages list available selectors/fields/filters for fast debugging.

`tests/Feature/ProductsTest.php` migrates one assertion to the new API as real-world validation. Existing serialization-contract tests (`*WireShapeTest`, per-component `serializes X`) intentionally stay low-level.

## Example

```php
uses(AssertsLatticeComponents::class);

$this->assertLatticePage($this->get('/products'))
    ->assertRendered('table:products')
    ->table('products', fn ($t) => $t->assertHasFilter('status'))
    ->form('create', fn ($f) => $f->field('email')->assertVisible()->assertInitialValue('a@b.c'));
```

## Test Plan
- [x] `composer test` green (452 passing)
- [x] New unit tests: `tests/Unit/Testing/ComponentNodeTest.php`
- [x] New feature tests cover both entry doors and every public assertion: `tests/Feature/Testing/AssertsLatticeComponentsTest.php`