### PR TITLE
Make row fields server-aware

### DIFF
--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -1,0 +1,117 @@
+import { act, configure, fireEvent, getConfig, render, screen } from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { fakeNode } from "@lattice/lattice/test-support";
+import { FormProvider } from "../context";
+import { FieldScopeProvider } from "../field-scope";
+import { FormValuesProvider } from "../values";
+import { SelectComponent } from "./select";
+
+const { postFormAction } = vi.hoisted(() => ({
+  postFormAction: vi.fn<
+    (
+      action: string,
+      componentRef: string,
+      body: Record<string, unknown>,
+      signal: AbortSignal,
+    ) => Promise<{ options: [] }>
+  >(() => Promise.resolve({ options: [] })),
+}));
+
+vi.mock("../form-transport", () => ({
+  FORM_DEBOUNCE_MS: 250,
+  postFormAction,
+}));
+
+let previousTestIdAttribute: string;
+
+beforeAll(() => {
+  previousTestIdAttribute = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+
+afterAll(() => {
+  configure({ testIdAttribute: previousTestIdAttribute });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+function renderSelect({
+  initial,
+  row,
+}: {
+  initial: Record<string, unknown>;
+  row?: Record<string, unknown>;
+}) {
+  const node = fakeNode({
+    type: "form.select",
+    props: {
+      name: "product",
+      label: "Product",
+      searchable: true,
+      options: [],
+      emptyLabel: "No products",
+      searchPlaceholder: "Search products",
+    },
+  });
+
+  const select = <SelectComponent node={node}>{null}</SelectComponent>;
+  const scoped = row ? (
+    <FieldScopeProvider base="items" index={0} row={row} onChange={() => {}}>
+      {select}
+    </FieldScopeProvider>
+  ) : (
+    select
+  );
+
+  return render(
+    <FormProvider
+      value={{
+        action: "/forms/products",
+        clearErrors: () => {},
+        componentRef: "ref-1",
+        errors: {},
+        fieldLabels: {},
+        precognitive: false,
+        processing: false,
+        validate: () => {},
+      }}
+    >
+      <FormValuesProvider initial={initial}>{scoped}</FormValuesProvider>
+    </FormProvider>,
+  );
+}
+
+async function search(query: string): Promise<void> {
+  fireEvent.click(screen.getByTestId("select-product"));
+  fireEvent.change(screen.getByTestId("select-product-search"), {
+    target: { value: query },
+  });
+
+  await act(async () => {
+    vi.advanceTimersByTime(250);
+    await Promise.resolve();
+  });
+}
+
+describe("SelectComponent search", () => {
+  it("posts a row search path with current form values inside a row", async () => {
+    vi.useFakeTimers();
+
+    const row = { __rowId: "r1", category: "chairs", product: "" };
+    const initial = { customer: "acme", items: [row] };
+
+    renderSelect({ initial, row });
+
+    await search("desk");
+
+    expect(postFormAction).toHaveBeenCalledWith(
+      "/forms/products",
+      "ref-1",
+      { _search: "items.0.product", q: "desk", ...initial },
+      expect.any(AbortSignal),
+    );
+  });
+});

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -11,7 +11,7 @@ import { useResolvedNode } from "../resolved-nodes";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFieldScope } from "../field-scope";
-import { useFormValue } from "../values";
+import { useFormValue, useFormValues } from "../values";
 
 function toValues(stored: unknown, fallback: unknown): string[] {
   const source = stored ?? fallback;
@@ -38,6 +38,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
   const scope = useFieldScope();
   const domName = scope ? scope.scopedName(name) : name;
   const errorKey = scope ? scope.errorKey(name) : name;
+  const searchKey = scope ? scope.errorKey(name) : name;
   const placeholder = props.placeholder || "Select…";
   const multiple = props.multiple ?? false;
   const searchable = props.searchable ?? false;
@@ -47,6 +48,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
   );
 
   const globalValue = useFormValue(name);
+  const values = useFormValues();
   const storedValue = scope ? scope.getValue(name) : globalValue;
   const selected = useMemo(() => toValues(storedValue, props.value), [storedValue, props.value]);
 
@@ -85,7 +87,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
       void postFormAction<{ options?: Option[] }>(
         action,
         componentRef,
-        { _search: name, q: query },
+        { ...values, _search: searchKey, q: query },
         controller.signal,
       )
         .then((response) => {
@@ -99,7 +101,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
       window.clearTimeout(timer);
       controller.abort();
     };
-  }, [query, searchable, action, componentRef, name]);
+  }, [query, searchable, action, componentRef, searchKey, values]);
 
   function commit(next: string[]): void {
     change(name, multiple ? next : (next[0] ?? ""));

--- a/resources/js/form/components/form-transport.test.ts
+++ b/resources/js/form/components/form-transport.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ROW_ID_KEY } from "./fields/repeater-rows";
+import { postFormAction } from "./form-transport";
+
+describe("postFormAction", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("strips client row ids from JSON payloads", async () => {
+    const fetchMock = vi.fn<typeof fetch>(() =>
+      Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await postFormAction(
+      "/forms/products",
+      "component-ref",
+      {
+        _search: "items.0.product",
+        q: "desk",
+        items: [
+          {
+            [ROW_ID_KEY]: "r1",
+            category: "chairs",
+            product: "",
+            children: [{ [ROW_ID_KEY]: "r2", name: "Nested" }],
+          },
+        ],
+      },
+      new AbortController().signal,
+    );
+
+    const body = fetchMock.mock.calls[0]?.[1]?.body;
+
+    expect(JSON.parse(String(body))).toEqual({
+      _search: "items.0.product",
+      q: "desk",
+      items: [
+        {
+          category: "chairs",
+          product: "",
+          children: [{ name: "Nested" }],
+        },
+      ],
+    });
+  });
+});

--- a/resources/js/form/components/form-transport.ts
+++ b/resources/js/form/components/form-transport.ts
@@ -5,6 +5,7 @@
  */
 
 import { withRefHeader } from "@lattice/lattice/core/component-ref";
+import { ROW_ID_KEY } from "./fields/repeater-rows";
 
 export const FORM_DEBOUNCE_MS = 250;
 
@@ -12,6 +13,27 @@ export function xsrfToken(): string {
   const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
 
   return match ? decodeURIComponent(match[1]) : "";
+}
+
+function scrubFormPayload(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(scrubFormPayload);
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).reduce<Record<string, unknown>>(
+      (payload, [key, item]) => {
+        if (key !== ROW_ID_KEY) {
+          payload[key] = scrubFormPayload(item);
+        }
+
+        return payload;
+      },
+      {},
+    );
+  }
+
+  return value;
 }
 
 export function postFormAction<T>(
@@ -31,6 +53,6 @@ export function postFormAction<T>(
       "X-XSRF-TOKEN": xsrfToken(),
       ...withRefHeader(componentRef),
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(scrubFormPayload(body)),
   }).then((response) => (response.ok ? (response.json() as Promise<T>) : null));
 }

--- a/src/Forms/Components/Builder.php
+++ b/src/Forms/Components/Builder.php
@@ -8,11 +8,12 @@ use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
 use Lattice\Lattice\Forms\Components\Concerns\HasRowLayout;
+use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowPrefills;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.builder')]
-class Builder extends Field implements ProvidesRowPrefills
+class Builder extends Field implements ProvidesRowFields, ProvidesRowPrefills
 {
     use HandlesRowSchemas;
     use HasRowLayout;

--- a/src/Forms/Components/Concerns/HandlesRowSchemas.php
+++ b/src/Forms/Components/Concerns/HandlesRowSchemas.php
@@ -32,9 +32,14 @@ trait HandlesRowSchemas
 
         foreach ($rows as $index => $row) {
             $row = is_array($row) ? $row : [];
+            $scope = $this->rowScope($data, $row);
 
             foreach ($this->rowFields($row) as $child) {
-                $childRules = $child->resolvedRulesWithRequired($data, $request);
+                if (! $child->isVisible($scope)) {
+                    continue;
+                }
+
+                $childRules = $child->resolvedRulesWithRequired($scope, $request);
 
                 if ($childRules !== []) {
                     $rules["{$name}.{$index}.{$child->name()}"] = $childRules;
@@ -43,6 +48,74 @@ trait HandlesRowSchemas
         }
 
         return $rules;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    public function rowScope(FormData $form, array $row): FormData
+    {
+        return FormData::make([...$form->all(), ...$row]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    public function rowField(array $row, string $name): ?Field
+    {
+        foreach ($this->rowFields($row) as $field) {
+            if ($field->name() === $name) {
+                return $field;
+            }
+        }
+
+        return null;
+    }
+
+    public function prefillRowFields(mixed $rows): void
+    {
+        if (! is_array($rows)) {
+            return;
+        }
+
+        $fields = [];
+        $values = [];
+
+        foreach ($rows as $row) {
+            $row = is_array($row) ? $row : [];
+
+            foreach ($this->rowFields($row) as $field) {
+                $name = $field->name();
+
+                if (! array_key_exists($name, $row)) {
+                    continue;
+                }
+
+                $key = spl_object_id($field);
+                $fields[$key] = $field;
+
+                foreach ($this->filledRowValues($row[$name]) as $value) {
+                    $values[$key][$value] = $value;
+                }
+            }
+        }
+
+        foreach ($values as $key => $fieldValues) {
+            $fields[$key]->prefill(array_values($fieldValues));
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function filledRowValues(mixed $value): array
+    {
+        $values = is_array($value) ? $value : [$value];
+
+        return array_values(array_filter(
+            array_map(static fn (mixed $item): string => (string) $item, $values),
+            static fn (string $item): bool => $item !== '',
+        ));
     }
 
     /**

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -11,6 +11,7 @@ use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\ContainerComponent;
 use Lattice\Lattice\Core\Components\IsInteractive;
 use Lattice\Lattice\Core\Concerns\HasHttpMethod;
+use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Forms\FormRegistry;
 
@@ -177,8 +178,14 @@ class Form extends ContainerComponent
     protected function prefillFields(array $data): array
     {
         foreach ($this->descendants() as $component) {
-            if ($component instanceof Field && array_key_exists($component->name(), $this->state)) {
-                $component->prefill($this->state[$component->name()]);
+            if (! $component instanceof Field || ! array_key_exists($component->name(), $this->state)) {
+                continue;
+            }
+
+            $component->prefill($this->state[$component->name()]);
+
+            if ($component instanceof ProvidesRowFields) {
+                $component->prefillRowFields($this->state[$component->name()]);
             }
         }
 

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -9,11 +9,12 @@ use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
 use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
 use Lattice\Lattice\Forms\Components\Concerns\HasRowLayout;
+use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowPrefills;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.repeater')]
-class Repeater extends Field implements ProvidesRowPrefills
+class Repeater extends Field implements ProvidesRowFields, ProvidesRowPrefills
 {
     use HandlesRowSchemas;
     use HasChildSchema;

--- a/src/Forms/Concerns/ResolvesFormFields.php
+++ b/src/Forms/Concerns/ResolvesFormFields.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Field;
 use Lattice\Lattice\Forms\Components\Select;
+use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowPrefills;
 use Lattice\Lattice\Forms\FormData;
 use Symfony\Component\HttpFoundation\Response;
@@ -37,14 +38,60 @@ trait ResolvesFormFields
         $name = $request->string('_search')->toString();
         $query = $request->string('q')->toString();
         $data = FormData::fromRequest($request);
+        $fields = $this->formFields($request);
 
-        $field = $this->formFields($request)
+        $field = $fields
             ->first(fn (Field $field): bool => $field->name() === $name);
+        $scope = $data;
+
+        if ($field === null) {
+            [$field, $scope] = $this->rowSearchTarget($fields, $name, $data);
+        }
 
         abort_if($field === null, Response::HTTP_NOT_FOUND);
         abort_unless($field instanceof Select && $field->isSearchable(), Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        return ['options' => $field->resolveSearch($query, $data, $request)];
+        return ['options' => $field->resolveSearch($query, $scope, $request)];
+    }
+
+    /**
+     * @param  Collection<int, Field>  $fields
+     * @return array{0: Field|null, 1: FormData}
+     */
+    private function rowSearchTarget(Collection $fields, string $path, FormData $data): array
+    {
+        $segments = explode('.', $path);
+
+        if (count($segments) < 3 || ! ctype_digit($segments[1])) {
+            return [null, $data];
+        }
+
+        $base = $segments[0];
+        $rowIndex = (int) $segments[1];
+        $name = implode('.', array_slice($segments, 2));
+
+        $container = $fields->first(
+            fn (Field $field): bool => $field->name() === $base && $field instanceof ProvidesRowFields,
+        );
+
+        if (! $container instanceof ProvidesRowFields) {
+            return [null, $data];
+        }
+
+        $rows = $data->get($base);
+
+        if (! is_array($rows) || ! array_key_exists($rowIndex, $rows) || ! is_array($rows[$rowIndex])) {
+            return [null, $data];
+        }
+
+        $row = $rows[$rowIndex];
+        $field = $container->rowField($row, $name);
+
+        if ($field === null) {
+            return [null, $data];
+        }
+
+        return [$field, $container->rowScope($data, $row)];
     }
 
     /**

--- a/src/Forms/Contracts/ProvidesRowFields.php
+++ b/src/Forms/Contracts/ProvidesRowFields.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Contracts;
+
+use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\FormData;
+
+interface ProvidesRowFields
+{
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    public function rowField(array $row, string $name): ?Field;
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    public function rowScope(FormData $form, array $row): FormData;
+
+    public function prefillRowFields(mixed $rows): void;
+}

--- a/tests/Browser/Forms/PricingBuilderTest.php
+++ b/tests/Browser/Forms/PricingBuilderTest.php
@@ -55,3 +55,24 @@ it('evaluates row field visibility against same-row siblings', function (): void
         ->assertNoSmoke()
         ->assertNoJavaScriptErrors();
 });
+
+it('searches products inside a builder row select', function (): void {
+    foreach (range(1, 20) as $number) {
+        Product::factory()->create(['name' => sprintf('Alpha Product %02d', $number), 'price' => 10.00]);
+    }
+
+    Product::factory()->create(['name' => 'Zulu Search Only', 'price' => 400.00]);
+
+    visit('/builder-pricing')
+        ->assertSee('Pricing Builder Demo')
+        ->click('@builder-add')
+        ->click('@builder-add-product')
+        ->click('[data-test="repeater-items-row-0"] [data-test="select-product"]')
+        ->fill('input[aria-label="Search options"]', 'zulu')
+        ->assertSee('Zulu Search Only')
+        ->click('Zulu Search Only')
+        ->wait(1)
+        ->assertValue('input[name="items[0][price]"]', '400')
+        ->assertNoSmoke()
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/BuilderValidationTest.php
+++ b/tests/Feature/BuilderValidationTest.php
@@ -61,3 +61,69 @@ it('does not require a text row to satisfy product rules', function (): void {
 
     expect($validated['items'][0]['type'])->toBe('text');
 });
+
+it('requires block children from same-row sibling conditions', function (): void {
+    $field = Builder::make('items')
+        ->blocks([
+            Block::make('product')->schema([
+                TextInput::make('product'),
+                TextInput::make('note')->requiredWhen('product', '!=', ''),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'product', 'product' => '', 'note' => ''],
+        ['type' => 'product', 'product' => 'SKU-1', 'note' => ''],
+    ]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect(array_keys($errors ?? []))->toBe(['items.1.note']);
+});
+
+it('lets block row values shadow same-named form values for conditions', function (): void {
+    $field = Builder::make('items')
+        ->blocks([
+            Block::make('product')->schema([
+                TextInput::make('product'),
+                TextInput::make('note')->requiredWhen('product', '!=', ''),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', [
+        'product' => 'GLOBAL-SKU',
+        'items' => [
+            ['type' => 'product', 'product' => '', 'note' => ''],
+        ],
+    ]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'][0]['type'])->toBe('product');
+});
+
+it('skips validation for block children hidden by same-row conditions', function (): void {
+    $field = Builder::make('items')
+        ->blocks([
+            Block::make('product')->schema([
+                TextInput::make('kind'),
+                TextInput::make('note')
+                    ->visibleWhen('kind', 'paid')
+                    ->rules(['required']),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'product', 'kind' => 'free'],
+    ]]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'][0]['type'])->toBe('product');
+});

--- a/tests/Feature/RepeaterValidationTest.php
+++ b/tests/Feature/RepeaterValidationTest.php
@@ -50,3 +50,63 @@ it('casts each row through child field casts', function (): void {
 
     expect($validated['items'])->toBe([['name' => 'A'], ['name' => 'B']]);
 });
+
+it('requires row children from same-row sibling conditions', function (): void {
+    $field = Repeater::make('items')
+        ->schema([
+            TextInput::make('product'),
+            TextInput::make('note')->requiredWhen('product', '!=', ''),
+        ]);
+
+    $request = Request::create('/', 'POST', ['items' => [
+        ['product' => '', 'note' => ''],
+        ['product' => 'SKU-1', 'note' => ''],
+    ]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect(array_keys($errors ?? []))->toBe(['items.1.note']);
+});
+
+it('lets row values shadow same-named form values for conditions', function (): void {
+    $field = Repeater::make('items')
+        ->schema([
+            TextInput::make('product'),
+            TextInput::make('note')->requiredWhen('product', '!=', ''),
+        ]);
+
+    $request = Request::create('/', 'POST', [
+        'product' => 'GLOBAL-SKU',
+        'items' => [
+            ['product' => '', 'note' => ''],
+        ],
+    ]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'][0]['product'])->toBe('');
+});
+
+it('skips validation for row children hidden by same-row conditions', function (): void {
+    $field = Repeater::make('items')
+        ->schema([
+            TextInput::make('kind'),
+            TextInput::make('note')
+                ->visibleWhen('kind', 'paid')
+                ->rules(['required']),
+        ]);
+
+    $request = Request::create('/', 'POST', ['items' => [
+        ['kind' => 'free'],
+    ]]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'][0]['kind'])->toBe('free');
+});

--- a/tests/Feature/SelectPrefillTest.php
+++ b/tests/Feature/SelectPrefillTest.php
@@ -1,7 +1,10 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\Select;
 
 /**
@@ -10,6 +13,22 @@ use Lattice\Lattice\Forms\Components\Select;
 function prefilledOptions(Form $form): array
 {
     return wire($form)['schema'][0]['props']['options'] ?? [];
+}
+
+/**
+ * @return array<int, array{label: string, value: string}>
+ */
+function repeaterPrefilledOptions(Form $form): array
+{
+    return wire($form)['schema'][0]['schema'][0]['props']['options'] ?? [];
+}
+
+/**
+ * @return array<int, array{label: string, value: string}>
+ */
+function builderPrefilledOptions(Form $form): array
+{
+    return wire($form)['schema'][0]['blocks'][0]['schema'][0]['props']['options'] ?? [];
 }
 
 it('resolves the label for a single filled id', function (): void {
@@ -93,4 +112,60 @@ it('does not resolve when there is no filled value', function (): void {
     wire($form);
 
     expect($resolved)->toBeFalse();
+});
+
+it('resolves labels for filled ids inside repeater rows', function (): void {
+    $received = null;
+
+    $form = Form::make('f')
+        ->fill(['items' => [
+            ['product' => '5'],
+            ['product' => '8'],
+        ]])
+        ->schema([
+            Repeater::make('items')->schema([
+                Select::make('product', 'Product')
+                    ->resolveSelectedUsing(function (array $values) use (&$received) {
+                        $received = $values;
+
+                        return collect($values)
+                            ->map(fn (string $id) => Select::option("Product {$id}", $id))
+                            ->all();
+                    }),
+            ]),
+        ]);
+
+    expect(repeaterPrefilledOptions($form))->toBe([
+        ['label' => 'Product 5', 'value' => '5'],
+        ['label' => 'Product 8', 'value' => '8'],
+    ])->and($received)->toBe(['5', '8']);
+});
+
+it('resolves labels for filled ids inside builder rows', function (): void {
+    $received = null;
+
+    $form = Form::make('f')
+        ->fill(['items' => [
+            ['type' => 'product', 'product' => '5'],
+            ['type' => 'product', 'product' => '8'],
+        ]])
+        ->schema([
+            Builder::make('items')->blocks([
+                Block::make('product')->schema([
+                    Select::make('product', 'Product')
+                        ->resolveSelectedUsing(function (array $values) use (&$received) {
+                            $received = $values;
+
+                            return collect($values)
+                                ->map(fn (string $id) => Select::option("Product {$id}", $id))
+                                ->all();
+                        }),
+                ]),
+            ]),
+        ]);
+
+    expect(builderPrefilledOptions($form))->toBe([
+        ['label' => 'Product 5', 'value' => '5'],
+        ['label' => 'Product 8', 'value' => '8'],
+    ])->and($received)->toBe(['5', '8']);
 });

--- a/tests/Feature/SelectSearchTest.php
+++ b/tests/Feature/SelectSearchTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 use Illuminate\Http\Request;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Block;
+use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -30,6 +34,42 @@ function searchableDefinition(): FormDefinition
                         ['label' => "Match: {$query}", 'value' => '1'],
                         ['label' => 'Other', 'value' => '2'],
                     ]),
+            ]);
+        }
+
+        public function handle(Request $request): Response
+        {
+            return new Response('ok');
+        }
+    };
+}
+
+function rowSearchDefinition(): FormDefinition
+{
+    return new class extends FormDefinition
+    {
+        public function definition(Form $form, Request $request): Form
+        {
+            $resolver = fn (string $query, FormData $data) => [
+                Select::option(
+                    "{$data->get('customer')}:{$data->get('category')}:{$query}",
+                    '1',
+                ),
+            ];
+
+            return $form->schema([
+                TextInput::make('customer'),
+                Repeater::make('items')->schema([
+                    TextInput::make('category'),
+                    Select::make('plan')->options([Select::option('Free', 'free')]),
+                    Select::make('product')->searchable($resolver),
+                ]),
+                Builder::make('blocks')->blocks([
+                    Block::make('product')->schema([
+                        TextInput::make('category'),
+                        Select::make('product')->searchable($resolver),
+                    ]),
+                ]),
             ]);
         }
 
@@ -64,6 +104,64 @@ it('aborts with 422 when the field is not searchable', function (): void {
         Request::create('/', 'POST', ['_search' => 'plan', 'q' => 'x']),
     );
 })->throws(HttpException::class);
+
+it('resolves options for a searchable select inside a repeater row', function (): void {
+    $result = rowSearchDefinition()->searchOptions(
+        Request::create('/', 'POST', [
+            '_search' => 'items.0.product',
+            'q' => 'desk',
+            'customer' => 'acme',
+            'items' => [
+                ['category' => 'chairs'],
+            ],
+        ]),
+    );
+
+    expect($result)->toEqual([
+        'options' => [
+            new Option('acme:chairs:desk', '1'),
+        ],
+    ]);
+});
+
+it('resolves options for a searchable select inside a builder row', function (): void {
+    $result = rowSearchDefinition()->searchOptions(
+        Request::create('/', 'POST', [
+            '_search' => 'blocks.0.product',
+            'q' => 'lamp',
+            'customer' => 'initech',
+            'blocks' => [
+                ['type' => 'product', 'category' => 'lighting'],
+            ],
+        ]),
+    );
+
+    expect($result)->toEqual([
+        'options' => [
+            new Option('initech:lighting:lamp', '1'),
+        ],
+    ]);
+});
+
+it('aborts with 422 when a row select is not searchable', function (): void {
+    $status = null;
+
+    try {
+        rowSearchDefinition()->searchOptions(
+            Request::create('/', 'POST', [
+                '_search' => 'items.0.plan',
+                'q' => 'free',
+                'items' => [
+                    ['category' => 'chairs'],
+                ],
+            ]),
+        );
+    } catch (HttpException $exception) {
+        $status = $exception->getStatusCode();
+    }
+
+    expect($status)->toBe(Response::HTTP_UNPROCESSABLE_ENTITY);
+});
 
 it('searches options through the form endpoint with a signed reference', function (): void {
     Lattice::forms([ShowcaseForm::class]);

--- a/workbench/app/Forms/PricingBuilderDemoForm.php
+++ b/workbench/app/Forms/PricingBuilderDemoForm.php
@@ -6,6 +6,7 @@ namespace Workbench\App\Forms;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Form;
 use Lattice\Lattice\Core\Components\Card;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Block;
 use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
@@ -27,8 +28,6 @@ class PricingBuilderDemoForm extends FormDefinition
 
     public function definition(FormComponent $form, Request $request): FormComponent
     {
-        $products = Product::query()->orderBy('name')->limit(20)->get();
-
         return $form
             ->precognitive(300)
             ->schema([
@@ -46,11 +45,10 @@ class PricingBuilderDemoForm extends FormDefinition
                                 Textarea::make('content', 'Content')->required(),
                             ]),
                             Block::make('product')->label('Product line')->schema([
-                                Select::make('product', 'Product')->options(
-                                    $products
-                                        ->map(fn (Product $product) => Select::option($product->name, (string) $product->getKey()))
-                                        ->all(),
-                                ),
+                                Select::make('product', 'Product')
+                                    ->options($this->productOptions(limit: 20))
+                                    ->searchable(fn (string $query) => $this->productOptions(query: $query, limit: 10))
+                                    ->resolveSelectedUsing(fn (array $values) => $this->productOptions(values: $values)),
                                 TextInput::make('qty', 'Qty')->rules(['numeric']),
                                 TextInput::make('price', 'Price')->rules(['numeric'])->value(
                                     fn (FormData $row, FormData $form) => $this->priceFor($row->get('product'), $form->get('customer')),
@@ -75,6 +73,32 @@ class PricingBuilderDemoForm extends FormDefinition
         $this->validate($request);
 
         return redirect('/builder-pricing');
+    }
+
+    /**
+     * @param  array<int, string>|null  $values
+     * @return array<int, Option>
+     */
+    private function productOptions(?string $query = null, ?array $values = null, ?int $limit = null): array
+    {
+        $builder = Product::query()->orderBy('name');
+
+        if ($query !== null) {
+            $builder->where('name', 'like', "%{$query}%");
+        }
+
+        if ($values !== null) {
+            $builder->whereIn('id', $values);
+        }
+
+        if ($limit !== null) {
+            $builder->limit($limit);
+        }
+
+        return $builder
+            ->get()
+            ->map(fn (Product $product) => Select::option($product->name, (string) $product->getKey()))
+            ->all();
     }
 
     private function priceFor(mixed $productId, mixed $customer): ?float


### PR DESCRIPTION
## Summary
- enforce row-scoped Repeater/Builder conditions during server validation
- support server search for Select fields inside Repeater/Builder rows
- resolve row Select option labels for stored edit values

## Tests
- vendor/bin/pint --dirty --format agent
- npm run format:check
- npm run lint:github
- npm run typecheck
- composer test
- npm test
- npm run build
- npm run build:lib
- composer test:browser