### PR TITLE
feat: add resizable column layouts

### DIFF
--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -7,6 +7,7 @@
                     {
                         "props": {
                             "autoFocus": null,
+                            "columnWidth": "md",
                             "conditions": null,
                             "dependsOnAny": null,
                             "dependsOnKeys": null,
@@ -37,6 +38,7 @@
                         "props": {
                             "autoComplete": null,
                             "autoFocus": null,
+                            "columnWidth": "md",
                             "conditions": null,
                             "dependsOnAny": null,
                             "dependsOnKeys": null,
@@ -61,6 +63,7 @@
                         "props": {
                             "autoComplete": null,
                             "autoFocus": null,
+                            "columnWidth": "md",
                             "conditions": null,
                             "dependsOnAny": null,
                             "dependsOnKeys": null,
@@ -85,6 +88,7 @@
                         "props": {
                             "autoComplete": null,
                             "autoFocus": null,
+                            "columnWidth": "md",
                             "conditions": null,
                             "dependsOnAny": null,
                             "dependsOnKeys": null,
@@ -111,6 +115,7 @@
         ],
         "props": {
             "addLabel": "Add block",
+            "columnWidth": "md",
             "conditions": null,
             "defaultItems": 0,
             "dependsOnAny": null,
@@ -129,6 +134,7 @@
             "readOnly": null,
             "reorderable": true,
             "required": null,
+            "resizableColumns": null,
             "value": null
         },
         "type": "form.builder"

--- a/docs/fixtures/checkbox.basic.json
+++ b/docs/fixtures/checkbox.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/choice.basic.json
+++ b/docs/fixtures/choice.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/date-input.basic.json
+++ b/docs/fixtures/date-input.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.default-value.json
+++ b/docs/fixtures/field.default-value.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.disabled.json
+++ b/docs/fixtures/field.disabled.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.helper-text.json
+++ b/docs/fixtures/field.helper-text.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.read-only.json
+++ b/docs/fixtures/field.read-only.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,
@@ -38,6 +39,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": {
                 "required": [
                     {

--- a/docs/fixtures/field.required.json
+++ b/docs/fixtures/field.required.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,
@@ -34,6 +35,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": {
                 "visible": [
                     {

--- a/docs/fixtures/number-input.basic.json
+++ b/docs/fixtures/number-input.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/number-input.slider.json
+++ b/docs/fixtures/number-input.slider.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/password-input.basic.json
+++ b/docs/fixtures/password-input.basic.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "confirmation": null,
             "dependsOnAny": null,

--- a/docs/fixtures/password-input.confirmation.json
+++ b/docs/fixtures/password-input.confirmation.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "confirmation": {
                 "label": "Confirm password",

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "addLabel": "Add line",
+            "columnWidth": "md",
             "conditions": null,
             "defaultItems": 1,
             "dependsOnAny": null,
@@ -21,6 +22,7 @@
             "readOnly": null,
             "reorderable": true,
             "required": null,
+            "resizableColumns": null,
             "value": null
         },
         "schema": [
@@ -28,6 +30,7 @@
                 "props": {
                     "autoComplete": null,
                     "autoFocus": null,
+                    "columnWidth": "md",
                     "conditions": null,
                     "dependsOnAny": null,
                     "dependsOnKeys": null,
@@ -52,6 +55,7 @@
                 "props": {
                     "autoComplete": null,
                     "autoFocus": null,
+                    "columnWidth": "md",
                     "conditions": null,
                     "dependsOnAny": null,
                     "dependsOnKeys": null,

--- a/docs/fixtures/rich-editor.basic.json
+++ b/docs/fixtures/rich-editor.basic.json
@@ -1,6 +1,7 @@
 [
     {
         "props": {
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/select.basic.json
+++ b/docs/fixtures/select.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/select.multiple.json
+++ b/docs/fixtures/select.multiple.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -15,7 +15,8 @@
                         "size": 32
                     },
                     "sortable": null,
-                    "type": "image"
+                    "type": "image",
+                    "width": "md"
                 },
                 {
                     "columns": null,
@@ -28,7 +29,8 @@
                         "link": null
                     },
                     "sortable": null,
-                    "type": "text"
+                    "type": "text",
+                    "width": "md"
                 },
                 {
                     "columns": null,
@@ -43,7 +45,8 @@
                         }
                     },
                     "sortable": null,
-                    "type": "badge"
+                    "type": "badge",
+                    "width": "md"
                 },
                 {
                     "columns": null,
@@ -62,7 +65,8 @@
                         ]
                     },
                     "sortable": null,
-                    "type": "icon"
+                    "type": "icon",
+                    "width": "md"
                 }
             ],
             "data": [
@@ -97,6 +101,7 @@
                 "to": 3,
                 "total": 3
             },
+            "resizableColumns": null,
             "state": {
                 "filters": [],
                 "page": 1,

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -29,7 +29,8 @@
                         "link": null
                     },
                     "sortable": true,
-                    "type": "text"
+                    "type": "text",
+                    "width": "md"
                 },
                 {
                     "columns": null,
@@ -56,7 +57,8 @@
                         "link": null
                     },
                     "sortable": true,
-                    "type": "text"
+                    "type": "text",
+                    "width": "md"
                 },
                 {
                     "columns": null,
@@ -69,7 +71,8 @@
                         "link": null
                     },
                     "sortable": null,
-                    "type": "text"
+                    "type": "text",
+                    "width": "md"
                 },
                 {
                     "columns": null,
@@ -84,7 +87,8 @@
                         "link": null
                     },
                     "sortable": true,
-                    "type": "text"
+                    "type": "text",
+                    "width": "md"
                 }
             ],
             "data": [
@@ -119,6 +123,7 @@
                 "to": 3,
                 "total": 3
             },
+            "resizableColumns": null,
             "state": {
                 "filters": [],
                 "page": 1,

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -18,7 +18,8 @@
                                 "link": null
                             },
                             "sortable": true,
-                            "type": "text"
+                            "type": "text",
+                            "width": "md"
                         },
                         {
                             "columns": null,
@@ -31,7 +32,8 @@
                                 "link": null
                             },
                             "sortable": null,
-                            "type": "text"
+                            "type": "text",
+                            "width": "md"
                         }
                     ],
                     "filter": null,
@@ -39,7 +41,8 @@
                     "label": "User",
                     "props": null,
                     "sortable": null,
-                    "type": "stack"
+                    "type": "stack",
+                    "width": "xl"
                 },
                 {
                     "columns": null,
@@ -52,7 +55,8 @@
                         "link": null
                     },
                     "sortable": null,
-                    "type": "text"
+                    "type": "text",
+                    "width": "md"
                 }
             ],
             "data": [
@@ -79,6 +83,7 @@
                 "to": 2,
                 "total": 2
             },
+            "resizableColumns": null,
             "state": {
                 "filters": [],
                 "page": 1,

--- a/docs/fixtures/text-input.email.json
+++ b/docs/fixtures/text-input.email.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/text-input.required.json
+++ b/docs/fixtures/text-input.required.json
@@ -3,6 +3,7 @@
         "props": {
             "autoComplete": null,
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/docs/fixtures/textarea.basic.json
+++ b/docs/fixtures/textarea.basic.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "autoFocus": null,
+            "columnWidth": "md",
             "conditions": null,
             "dependsOnAny": null,
             "dependsOnKeys": null,

--- a/resources/js/core/column-sizing.test.ts
+++ b/resources/js/core/column-sizing.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildColumnGridTemplate, columnWidthTrack, maxColumnWidthPx } from "./column-sizing";
+
+describe("column sizing", () => {
+  it("maps width tokens to stable grid tracks", () => {
+    expect(columnWidthTrack("xs")).toBe("minmax(4rem, 0.35fr)");
+    expect(columnWidthTrack("xl")).toBe("minmax(16rem, 2fr)");
+  });
+
+  it("builds a shared grid template with fixed utility tracks", () => {
+    expect(
+      buildColumnGridTemplate({
+        columns: [
+          { key: "qty", width: "xs" },
+          { key: "description", width: "xl" },
+        ],
+        leadingTracks: ["3rem"],
+        trailingTracks: ["3rem"],
+      }),
+    ).toBe("3rem minmax(4rem, 0.35fr) minmax(16rem, 2fr) 3rem");
+  });
+
+  it("exposes a maximum width for resize handles", () => {
+    expect(maxColumnWidthPx({ key: "description", width: "xl" })).toBe(1024);
+  });
+});

--- a/resources/js/core/column-sizing.ts
+++ b/resources/js/core/column-sizing.ts
@@ -1,0 +1,62 @@
+import type { ColumnWidth } from "@lattice-php/lattice/types/generated";
+
+export type SizableColumn = {
+  key: string;
+  label?: string;
+  width: ColumnWidth;
+};
+
+export const DEFAULT_COLUMN_WIDTH: ColumnWidth = "md";
+
+const tracks: Record<
+  ColumnWidth,
+  { track: string; minPx: number; defaultPx: number; maxPx: number }
+> = {
+  xs: { track: "minmax(4rem, 0.35fr)", minPx: 64, defaultPx: 96, maxPx: 1024 },
+  sm: { track: "minmax(6rem, 0.5fr)", minPx: 96, defaultPx: 128, maxPx: 1024 },
+  md: { track: "minmax(8rem, 1fr)", minPx: 128, defaultPx: 176, maxPx: 1024 },
+  lg: { track: "minmax(12rem, 1.5fr)", minPx: 192, defaultPx: 240, maxPx: 1024 },
+  xl: { track: "minmax(16rem, 2fr)", minPx: 256, defaultPx: 320, maxPx: 1024 },
+};
+
+export function columnWidthTrack(width: ColumnWidth): string {
+  return tracks[width].track;
+}
+
+export function minColumnWidthPx(column: SizableColumn): number {
+  return tracks[column.width].minPx;
+}
+
+export function defaultColumnWidthPx(column: SizableColumn): number {
+  return tracks[column.width].defaultPx;
+}
+
+export function maxColumnWidthPx(column: SizableColumn): number {
+  return tracks[column.width].maxPx;
+}
+
+export function buildColumnGridTemplate({
+  columns,
+  leadingTracks = [],
+  trailingTracks = [],
+  overrides = {},
+}: {
+  columns: SizableColumn[];
+  leadingTracks?: string[];
+  trailingTracks?: string[];
+  overrides?: Record<string, number | undefined>;
+}): string {
+  return [
+    ...leadingTracks,
+    ...columns.map((column) => {
+      const override = overrides[column.key];
+
+      if (override !== undefined) {
+        return `${Math.min(maxColumnWidthPx(column), Math.max(minColumnWidthPx(column), override))}px`;
+      }
+
+      return columnWidthTrack(column.width);
+    }),
+    ...trailingTracks,
+  ].join(" ");
+}

--- a/resources/js/core/use-column-resizing.test.tsx
+++ b/resources/js/core/use-column-resizing.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SizableColumn } from "./column-sizing";
+import { useColumnResizing } from "./use-column-resizing";
+
+const columns: SizableColumn[] = [
+  {
+    key: "qty",
+    label: "Qty",
+    width: "sm",
+  },
+];
+
+function Harness() {
+  const { gridTemplateColumns, getResizeHandleProps } = useColumnResizing({
+    enabled: true,
+    columns,
+  });
+
+  return (
+    <>
+      <div data-testid="grid" style={{ gridTemplateColumns }} />
+      <div {...getResizeHandleProps(columns[0])} />
+    </>
+  );
+}
+
+describe("useColumnResizing", () => {
+  it("updates the grid template while dragging a handle", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "208px" });
+  });
+
+  it("resizes with keyboard arrows and resets with enter", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "136px" });
+
+    fireEvent.keyDown(handle, { key: "Enter" });
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+  });
+
+  it("describes and clamps the resize maximum", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    expect(handle).toHaveAttribute("aria-valuemax", "1024");
+
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 2000, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "1024px" });
+  });
+});

--- a/resources/js/core/use-column-resizing.ts
+++ b/resources/js/core/use-column-resizing.ts
@@ -1,0 +1,168 @@
+import type { HTMLAttributes, KeyboardEvent, PointerEvent } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  buildColumnGridTemplate,
+  defaultColumnWidthPx,
+  maxColumnWidthPx,
+  minColumnWidthPx,
+  type SizableColumn,
+} from "./column-sizing";
+
+type DragState = {
+  key: string;
+  startWidth: number;
+  startX: number;
+};
+
+type ResizeHandleProps = HTMLAttributes<HTMLDivElement> & {
+  "aria-label": string;
+  "aria-orientation": "vertical";
+  "aria-valuemax": number;
+  "aria-valuemin": number;
+  "aria-valuenow": number;
+  role: "separator";
+  tabIndex: number;
+};
+
+export function useColumnResizing({
+  columns,
+  enabled,
+  leadingTracks = [],
+  trailingTracks = [],
+}: {
+  columns: SizableColumn[];
+  enabled: boolean;
+  leadingTracks?: string[];
+  trailingTracks?: string[];
+}) {
+  const [overrides, setOverrides] = useState<Record<string, number | undefined>>({});
+  const drag = useRef<DragState | null>(null);
+
+  const gridTemplateColumns = useMemo(
+    () =>
+      buildColumnGridTemplate({
+        columns,
+        leadingTracks,
+        trailingTracks,
+        overrides: enabled ? overrides : {},
+      }),
+    [columns, enabled, leadingTracks, overrides, trailingTracks],
+  );
+
+  const setColumnWidth = useCallback((column: SizableColumn, width: number) => {
+    setOverrides((current) => ({
+      ...current,
+      [column.key]: Math.min(maxColumnWidthPx(column), Math.max(minColumnWidthPx(column), width)),
+    }));
+  }, []);
+
+  const resetColumnWidth = useCallback((column: SizableColumn) => {
+    setOverrides((current) => {
+      const next = { ...current };
+      delete next[column.key];
+
+      return next;
+    });
+  }, []);
+
+  const currentColumnWidth = useCallback(
+    (column: SizableColumn): number => overrides[column.key] ?? defaultColumnWidthPx(column),
+    [overrides],
+  );
+
+  const getResizeHandleProps = useCallback(
+    (column: SizableColumn): ResizeHandleProps => {
+      const max = maxColumnWidthPx(column);
+      const min = minColumnWidthPx(column);
+      const current = currentColumnWidth(column);
+      const label = column.label ?? column.key;
+
+      const resizeBy = (delta: number): void => setColumnWidth(column, current + delta);
+
+      return {
+        "aria-label": `Resize ${label}`,
+        "aria-orientation": "vertical",
+        "aria-valuemax": max,
+        "aria-valuemin": min,
+        "aria-valuenow": current,
+        className:
+          "absolute inset-y-0 right-0 hidden w-2 cursor-col-resize touch-none items-stretch justify-center md:flex after:my-1 after:w-px after:bg-transparent hover:after:bg-lt-border focus-visible:outline-none focus-visible:after:bg-lt-ring",
+        onDoubleClick: () => resetColumnWidth(column),
+        onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+          if (!enabled) {
+            return;
+          }
+
+          const step = event.shiftKey ? 32 : 8;
+
+          if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            resizeBy(-step);
+          }
+
+          if (event.key === "ArrowRight") {
+            event.preventDefault();
+            resizeBy(step);
+          }
+
+          if (event.key === "Home") {
+            event.preventDefault();
+            setColumnWidth(column, min);
+          }
+
+          if (event.key === "End") {
+            event.preventDefault();
+            setColumnWidth(column, max);
+          }
+
+          if (event.key === "Enter" || event.key === "Escape") {
+            event.preventDefault();
+            resetColumnWidth(column);
+          }
+        },
+        onPointerDown: (event: PointerEvent<HTMLDivElement>) => {
+          if (!enabled) {
+            return;
+          }
+
+          const parentWidth = event.currentTarget.parentElement?.getBoundingClientRect().width ?? 0;
+          drag.current = {
+            key: column.key,
+            startWidth: parentWidth > 0 ? parentWidth : current,
+            startX: event.clientX,
+          };
+          event.currentTarget.setPointerCapture?.(event.pointerId);
+          event.preventDefault();
+        },
+        onPointerMove: (event: PointerEvent<HTMLDivElement>) => {
+          const active = drag.current;
+
+          if (!enabled || active?.key !== column.key) {
+            return;
+          }
+
+          setColumnWidth(column, active.startWidth + event.clientX - active.startX);
+        },
+        onPointerUp: (event: PointerEvent<HTMLDivElement>) => {
+          const active = drag.current;
+
+          if (active?.key !== column.key) {
+            return;
+          }
+
+          drag.current = null;
+          event.currentTarget.releasePointerCapture?.(event.pointerId);
+        },
+        role: "separator",
+        tabIndex: 0,
+      };
+    },
+    [currentColumnWidth, enabled, resetColumnWidth, setColumnWidth],
+  );
+
+  return {
+    getResizeHandleProps,
+    gridTemplateColumns,
+    resetColumnWidth,
+  };
+}

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -84,6 +84,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
               onMove={onMove}
               onRemove={onRemove}
               registerRow={registerRow}
+              resizableColumns={props.resizableColumns === true}
             />
           </>
         ) : (

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -59,6 +59,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             onMove={onMove}
             onRemove={onRemove}
             registerRow={registerRow}
+            resizableColumns={props.resizableColumns === true}
           />
         ) : (
           rows.map((row, index) => {

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -35,11 +35,15 @@ vi.mock("@lattice-php/lattice/core/renderer", async () => {
 import { FormProvider } from "../context";
 import { FormValuesProvider } from "../values";
 import { RepeaterComponent } from "./repeater";
-import { TableRows } from "./table-rows";
+import { TableRows, type TableColumn } from "./table-rows";
 
-const columns = [
-  { name: "qty", label: "Qty" },
-  { name: "price", label: "Price" },
+const columns: TableColumn[] = [
+  { name: "qty", label: "Qty", columnWidth: "md" },
+  { name: "price", label: "Price", columnWidth: "md" },
+];
+const sizedColumns: TableColumn[] = [
+  { name: "qty", label: "Qty", columnWidth: "xs" },
+  { name: "description", label: "Description", columnWidth: "xl" },
 ];
 const qtyNode = { id: "q", type: "form.text-input", props: { name: "qty" } } as never;
 const priceNode = { id: "p", type: "form.text-input", props: { name: "price" } } as never;
@@ -117,6 +121,60 @@ it("registers each row element for FLIP", () => {
   expect(calls.some(([k, el]) => k === "a" && el !== null)).toBe(true);
 });
 
+it("uses column width hints when building the table grid", () => {
+  render(
+    <TableRows
+      base="items"
+      columns={sizedColumns}
+      rows={[{ key: "a", index: 0, row: {}, template: [qtyNode, priceNode], span: false }]}
+      reorderable={true}
+      removable={() => true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+    />,
+  );
+
+  expect(screen.getByText("Qty").parentElement).toHaveStyle({
+    gridTemplateColumns: "3rem minmax(4rem, 0.35fr) minmax(16rem, 2fr) 3rem",
+  });
+});
+
+it("does not render column resize handles unless enabled", () => {
+  render(
+    <TableRows
+      base="items"
+      columns={columns}
+      rows={[{ key: "a", index: 0, row: {}, template: [qtyNode, priceNode], span: false }]}
+      reorderable={true}
+      removable={() => true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+    />,
+  );
+
+  expect(screen.queryByRole("separator", { name: "Resize Qty" })).not.toBeInTheDocument();
+});
+
+it("renders column resize handles when enabled", () => {
+  render(
+    <TableRows
+      base="items"
+      columns={columns}
+      rows={[{ key: "a", index: 0, row: {}, template: [qtyNode, priceNode], span: false }]}
+      reorderable={true}
+      removable={() => true}
+      resizableColumns={true}
+      onField={noop}
+      onMove={noop}
+      onRemove={noop}
+    />,
+  );
+
+  expect(screen.getByRole("separator", { name: "Resize Qty" })).toBeInTheDocument();
+});
+
 function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
   return render(
     <FormProvider
@@ -147,7 +205,9 @@ const tableNode = {
     minItems: 0,
     maxItems: 5,
   },
-  schema: [{ id: "q", type: "form.text-input", props: { name: "qty", label: "Qty" } }],
+  schema: [
+    { id: "q", type: "form.text-input", props: { name: "qty", label: "Qty", columnWidth: "md" } },
+  ],
 } as never;
 
 it("does not re-render sibling table rows when one row changes", () => {

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -1,14 +1,20 @@
 import type { Node } from "@lattice-php/lattice/core/types";
-import { Icon } from "@lattice-php/lattice/icons";
-import { memo } from "react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
+import { DEFAULT_COLUMN_WIDTH, type SizableColumn } from "@lattice-php/lattice/core/column-sizing";
+import { useColumnResizing } from "@lattice-php/lattice/core/use-column-resizing";
+import { Icon } from "@lattice-php/lattice/icons";
+import { memo, useMemo } from "react";
+import type { ColumnWidth } from "@lattice-php/lattice/types/generated";
 import { FieldScopeProvider } from "../field-scope";
 import { TableCellProvider } from "../row-layout-context";
 import { RowActions } from "./row-actions";
 import { RowButton } from "./row-item";
 import type { RepeaterRow } from "./repeater-rows";
 
-export type TableColumn = { name: string; label: string };
+const rowControlTrack = "3rem";
+const rowActionTrack = "3rem";
+
+export type TableColumn = { name: string; label: string; columnWidth: ColumnWidth };
 
 export type TableRowModel = {
   key: string;
@@ -20,8 +26,16 @@ export type TableRowModel = {
 
 export function columnsFromSchema(nodes: Node[]): TableColumn[] {
   return nodes.map((node) => {
-    const props = node.props as { name: unknown; label?: unknown };
-    return { name: String(props.name), label: String(props.label ?? props.name) };
+    const props = node.props as {
+      name: unknown;
+      label?: unknown;
+      columnWidth?: ColumnWidth | null;
+    };
+    return {
+      name: String(props.name),
+      label: String(props.label ?? props.name),
+      columnWidth: props.columnWidth ?? DEFAULT_COLUMN_WIDTH,
+    };
   });
 }
 
@@ -149,6 +163,7 @@ export function TableRows({
   onMove,
   onRemove,
   registerRow,
+  resizableColumns = false,
 }: {
   base: string;
   columns: TableColumn[];
@@ -159,19 +174,36 @@ export function TableRows({
   onMove: (index: number, delta: number) => void;
   onRemove: (index: number) => void;
   registerRow?: (key: string, el: HTMLElement | null) => void;
+  resizableColumns?: boolean;
 }) {
-  // For columnar (non-span) rows, template node order must match columns order,
-  // as cells are placed by grid position.
-  const gridTemplateColumns = `auto repeat(${columns.length}, minmax(0, 1fr)) auto`;
+  const sizingColumns = useMemo<SizableColumn[]>(
+    () =>
+      columns.map((column) => ({
+        key: column.name,
+        label: column.label,
+        width: column.columnWidth,
+      })),
+    [columns],
+  );
+  const { getResizeHandleProps, gridTemplateColumns } = useColumnResizing({
+    columns: sizingColumns,
+    enabled: resizableColumns,
+    leadingTracks: [rowControlTrack],
+    trailingTracks: [rowActionTrack],
+  });
 
   return (
     <div className="overflow-x-auto">
       <div className="flex min-w-max flex-col gap-2">
         <div className="grid items-center gap-x-3" style={{ gridTemplateColumns }}>
           <div />
-          {columns.map((column) => (
-            <div key={column.name} className="text-xs font-medium text-lt-muted-fg">
+          {columns.map((column, index) => (
+            <div
+              key={column.name}
+              className="relative min-w-0 pr-3 text-xs font-medium text-lt-muted-fg"
+            >
               {column.label}
+              {resizableColumns && <div {...getResizeHandleProps(sizingColumns[index])} />}
             </div>
           ))}
           <div />

--- a/resources/js/table/column-registry.test.tsx
+++ b/resources/js/table/column-registry.test.tsx
@@ -6,8 +6,11 @@ import { createPlugin, createRegistry } from "../core/registry";
 import { ColumnCell } from "./components/table-cell";
 
 function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): ColumnData {
+  const type = partial.type ?? "text";
+
   return {
-    type: "text",
+    type,
+    width: type === "stack" ? "xl" : "md",
     sortable: null,
     filter: null,
     columns: null,

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@lattice-php/lattice/icons";
+import type { HTMLAttributes } from "react";
 import { getColumnAriaSort, getColumnSort } from "../query";
 import type { TableColumn, TableSort, TableState } from "../types";
 
@@ -23,11 +24,13 @@ function SortIndicator({ sort }: { sort: TableSort | undefined }) {
 export function ColumnHeader({
   column,
   processing,
+  resizeHandleProps,
   sort,
   state,
 }: {
   column: TableColumn;
   processing: boolean;
+  resizeHandleProps?: HTMLAttributes<HTMLDivElement>;
   sort: (column: TableColumn) => void;
   state: TableState;
 }) {
@@ -36,7 +39,7 @@ export function ColumnHeader({
   return (
     <div
       aria-sort={getColumnAriaSort(columnSort)}
-      className="min-w-0 px-4 py-3 text-left align-middle font-medium text-lt-muted-fg"
+      className="relative min-w-0 px-4 py-3 pr-5 text-left align-middle font-medium text-lt-muted-fg"
       role="columnheader"
     >
       {column.sortable ? (
@@ -54,6 +57,7 @@ export function ColumnHeader({
       ) : (
         <span className="block truncate">{column.label}</span>
       )}
+      {resizeHandleProps && <div {...resizeHandleProps} />}
     </div>
   );
 }

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -7,6 +7,7 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): ColumnData {
   return {
     type: "text",
+    width: "md",
     sortable: null,
     filter: null,
     columns: null,

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -5,8 +5,11 @@ import type { ColumnData } from "@lattice-php/lattice/types/generated";
 import TableComponent from "./table";
 
 function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): ColumnData {
+  const type = partial.type ?? "text";
+
   return {
-    type: "text",
+    type,
+    width: type === "stack" ? "xl" : "md",
     sortable: null,
     filter: null,
     columns: null,
@@ -109,6 +112,74 @@ describe("Lattice table component", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy Email" }));
 
     expect(screen.getByRole("button", { name: "Copied Email" })).toBeVisible();
+  });
+
+  it("uses column width hints when building the table grid", () => {
+    const node = {
+      id: "workbench.products",
+      props: {
+        columns: [
+          col({
+            key: "qty",
+            label: "Qty",
+            width: "sm",
+          }),
+          col({
+            key: "description",
+            label: "Description",
+            width: "xl",
+          }),
+        ],
+        data: [],
+        state: {
+          filters: [],
+          page: 1,
+          perPage: 25,
+          sorts: [],
+        },
+      },
+      type: "table",
+    } satisfies TableNode;
+
+    render(<TableComponent node={node}>{null}</TableComponent>);
+
+    expect(screen.getByRole("columnheader", { name: "Qty" }).parentElement).toHaveStyle(
+      "--lattice-table-columns: minmax(6rem, 0.5fr) minmax(16rem, 2fr)",
+    );
+  });
+
+  it("renders column resize handles only when enabled", () => {
+    const node = {
+      id: "workbench.products",
+      props: {
+        columns: [
+          col({
+            key: "qty",
+            label: "Qty",
+          }),
+        ],
+        data: [],
+        state: {
+          filters: [],
+          page: 1,
+          perPage: 25,
+          sorts: [],
+        },
+      },
+      type: "table",
+    } satisfies TableNode;
+
+    const { rerender } = render(<TableComponent node={node}>{null}</TableComponent>);
+
+    expect(screen.queryByRole("separator", { name: "Resize Qty" })).not.toBeInTheDocument();
+
+    rerender(
+      <TableComponent node={{ ...node, props: { ...node.props, resizableColumns: true } }}>
+        {null}
+      </TableComponent>,
+    );
+
+    expect(screen.getByRole("separator", { name: "Resize Qty" })).toBeInTheDocument();
   });
 
   it("renders grid rows with stack columns and row actions without table cells", async () => {

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -1,9 +1,15 @@
 import { type ReactNode, useMemo } from "react";
 import { useT } from "@lattice-php/lattice/i18n";
+import { useColumnResizing } from "@lattice-php/lattice/core/use-column-resizing";
 import type { TableNode } from "../types";
 import { getBulkActions } from "../bulk";
 import { flattenColumns, getRowActions, getRowKey } from "../payload";
-import { getColumnGridTemplate, getQueryParams, getVisiblePages } from "../query";
+import {
+  getQueryParams,
+  getTableSizingColumns,
+  getTableUtilityTracks,
+  getVisiblePages,
+} from "../query";
 import { useTable } from "../use-table";
 import { useTableSelection } from "../use-table-selection";
 import { BulkBar } from "./bulk-bar";
@@ -60,10 +66,18 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   const striped = node.props?.striped === true;
   const hasFilters = columns.some((column) => column.filter?.enabled);
   const filterEntries = filters.map((clause, index) => ({ clause, index }));
-  const gridTemplateColumns = useMemo(
-    () => getColumnGridTemplate(columns, hasActions, hasBulkActions),
-    [columns, hasActions, hasBulkActions],
+  const sizingColumns = useMemo(() => getTableSizingColumns(columns), [columns]);
+  const utilityTracks = useMemo(
+    () => getTableUtilityTracks(hasActions, hasBulkActions),
+    [hasActions, hasBulkActions],
   );
+  const resizingEnabled = node.props?.resizableColumns === true;
+  const { getResizeHandleProps, gridTemplateColumns } = useColumnResizing({
+    columns: sizingColumns,
+    enabled: resizingEnabled,
+    leadingTracks: utilityTracks.leadingTracks,
+    trailingTracks: utilityTracks.trailingTracks,
+  });
 
   return (
     <div
@@ -121,11 +135,14 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                 />
               </div>
             )}
-            {columns.map((column) => (
+            {columns.map((column, index) => (
               <ColumnHeader
                 column={column}
                 key={column.key}
                 processing={processing}
+                resizeHandleProps={
+                  resizingEnabled ? getResizeHandleProps(sizingColumns[index]) : undefined
+                }
                 sort={sort}
                 state={state}
               />

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -1,4 +1,6 @@
 import { translate } from "@lattice-php/lattice/i18n";
+import { DEFAULT_COLUMN_WIDTH } from "@lattice-php/lattice/core/column-sizing";
+import type { ColumnWidth } from "@lattice-php/lattice/types/generated";
 import type { TableColumn, TableSort, TableState } from "./types";
 
 export function getColumnSort(state: TableState, column: TableColumn): TableSort | undefined {
@@ -119,26 +121,22 @@ export function getVisiblePages(currentPage: number, lastPage: number): number[]
   return Array.from({ length: 5 }, (_, index) => start + index);
 }
 
-export function getColumnGridTemplate(
-  columns: TableColumn[],
-  hasActions: boolean,
-  hasSelection: boolean,
-): string {
-  const tracks: string[] = columns.map((column) =>
-    column.type === "stack" ? "minmax(13rem, 2fr)" : "minmax(7rem, 1fr)",
-  );
+export function getTableSizingColumns(columns: TableColumn[]) {
+  return columns.map((column) => ({
+    key: column.key,
+    label: column.label,
+    width: columnWidthOrDefault(column),
+  }));
+}
 
-  // Selection and action tracks use fixed widths, not max-content: the header,
-  // filter, and body rows are independent grids, so a content-sized track would
-  // resolve to a different width in each one, changing the free space left for
-  // the 1fr columns and drifting them out of alignment across rows.
-  if (hasActions) {
-    tracks.push("10rem");
-  }
+function columnWidthOrDefault(column: TableColumn): ColumnWidth {
+  return (column.width ?? (column.type === "stack" ? "xl" : DEFAULT_COLUMN_WIDTH)) as ColumnWidth;
+}
 
-  if (hasSelection) {
-    tracks.unshift("3rem");
-  }
-
-  return tracks.join(" ");
+export function getTableUtilityTracks(hasActions: boolean, hasSelection: boolean) {
+  // Utility tracks are fixed because the independent header/filter/body grids would drift with content-sized tracks.
+  return {
+    leadingTracks: hasSelection ? ["3rem"] : [],
+    trailingTracks: hasActions ? ["10rem"] : [],
+  };
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -44,6 +44,7 @@ export type BadgeColumnProps = {
 export type Breadcrumbs = Record<string, never>;
 export type Builder = {
   addLabel: string | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -67,6 +68,7 @@ export type Builder = {
   readOnly: boolean | null;
   reorderable: boolean;
   required: boolean | null;
+  resizableColumns: boolean | null;
   value: unknown;
 };
 export type BulkAction = {
@@ -103,6 +105,7 @@ export type Card = {
 };
 export type Checkbox = {
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -126,6 +129,7 @@ export type Checkbox = {
 };
 export type Choice = {
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -156,6 +160,7 @@ export type ColumnData = {
   readonly key: string;
   readonly label: string;
   readonly type: ColumnType | string;
+  readonly width: ColumnWidth;
   readonly sortable: boolean | null;
   readonly filter: ColumnFilter | null;
   readonly columns: ColumnData[] | null;
@@ -174,6 +179,7 @@ export type ColumnPropsMap = {
   text: TextColumnProps;
 };
 export type ColumnType = "text" | "stack" | "badge" | "icon" | "image";
+export type ColumnWidth = "xs" | "sm" | "md" | "lg" | "xl";
 export type Condition = {
   readonly field: string;
   readonly operator: Op;
@@ -271,6 +277,7 @@ export type CoreNode =
     };
 export type DateInput = {
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -449,6 +456,7 @@ export type Heading = {
 };
 export type Height = "full" | "screen";
 export type HiddenInput = {
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -545,6 +553,7 @@ export type Node = FormNode | CoreNode | ActionNode | FragmentNode | TableNode |
 export type NodeType = Node["type"];
 export type NumberInput = {
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -602,6 +611,7 @@ export type PaginationType = "none" | "simple" | "table" | "infinite";
 export type PasswordInput = {
   autoComplete: string | null;
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -648,6 +658,7 @@ export type ReloadComponentEffect = {
 export type ReloadPageEffect = object;
 export type Repeater = {
   addLabel: string | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -672,12 +683,14 @@ export type Repeater = {
   readOnly: boolean | null;
   reorderable: boolean;
   required: boolean | null;
+  resizableColumns: boolean | null;
   value: unknown;
 };
 export type ResetFormEffect = {
   readonly form: string | null;
 };
 export type RichEditor = {
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -717,6 +730,7 @@ export type SegmentedControl = {
 };
 export type Select = {
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -776,6 +790,7 @@ export type Table = {
   layout: string | null;
   lazy: boolean | null;
   ref: string | null;
+  resizableColumns: boolean | null;
   striped: boolean | null;
 };
 export type TableNode = {
@@ -813,6 +828,7 @@ export type TextColumnProps = {
 export type TextInput = {
   autoComplete: string | null;
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];
@@ -838,6 +854,7 @@ export type TextInput = {
 };
 export type Textarea = {
   autoFocus: boolean | null;
+  columnWidth: ColumnWidth;
   conditions: {
     visible?: Condition[];
     required?: Condition[];

--- a/src/Console/stubs/column.php.stub
+++ b/src/Console/stubs/column.php.stub
@@ -15,6 +15,7 @@ class {{ class }} extends Column
             key: $this->key,
             label: $this->label,
             type: '{{ type }}',
+            width: $this->resolvedWidth(),
             props: new {{ class }}Props,
         );
     }

--- a/src/Core/Enums/ColumnWidth.php
+++ b/src/Core/Enums/ColumnWidth.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum ColumnWidth: string
+{
+    case Xs = 'xs';
+    case Sm = 'sm';
+    case Md = 'md';
+    case Lg = 'lg';
+    case Xl = 'xl';
+}

--- a/src/Forms/Components/Concerns/HasRowLayout.php
+++ b/src/Forms/Components/Concerns/HasRowLayout.php
@@ -10,9 +10,18 @@ trait HasRowLayout
 {
     public RowLayout $layout = RowLayout::Stack;
 
+    public ?bool $resizableColumns = null;
+
     public function table(): static
     {
         $this->layout = RowLayout::Table;
+
+        return $this;
+    }
+
+    public function resizableColumns(bool $resizable = true): static
+    {
+        $this->resizableColumns = $resizable ?: null;
 
         return $this;
     }

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Core\Components\Component;
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Forms\Conditions\Condition;
 use Lattice\Lattice\Forms\Conditions\ConditionSet;
@@ -19,6 +20,8 @@ abstract class Field extends Component
     public ?string $label = null;
 
     public ?string $helperText = null;
+
+    public ColumnWidth $columnWidth = ColumnWidth::Md;
 
     public mixed $value = null;
 
@@ -115,6 +118,13 @@ abstract class Field extends Component
     public function label(string $label): static
     {
         $this->label = $label;
+
+        return $this;
+    }
+
+    public function columnWidth(ColumnWidth $width): static
+    {
+        $this->columnWidth = $width;
 
         return $this;
     }

--- a/src/Tables/Columns/BadgeColumn.php
+++ b/src/Tables/Columns/BadgeColumn.php
@@ -39,6 +39,7 @@ class BadgeColumn extends Column implements Filterable, Sortable
             key: $this->key,
             label: $this->label,
             type: ColumnType::Badge,
+            width: $this->resolvedWidth(),
             sortable: $this->sortableValue(),
             filter: $this->filterValue(),
             props: new BadgeColumnProps(colors: $this->colors === [] ? null : $this->colors),

--- a/src/Tables/Columns/Column.php
+++ b/src/Tables/Columns/Column.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Tables\Columns;
 
 use Illuminate\Support\Collection;
 use JsonSerializable;
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 
 /**
  * @phpstan-consistent-constructor
@@ -12,6 +13,8 @@ use JsonSerializable;
 abstract class Column implements JsonSerializable
 {
     protected string $label;
+
+    protected ?ColumnWidth $width = null;
 
     public function __construct(public readonly string $key)
     {
@@ -39,7 +42,24 @@ abstract class Column implements JsonSerializable
         return $this;
     }
 
+    public function width(ColumnWidth $width): static
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
     abstract public function toData(): ColumnData;
+
+    protected function resolvedWidth(): ColumnWidth
+    {
+        return $this->width ?? $this->defaultWidth();
+    }
+
+    protected function defaultWidth(): ColumnWidth
+    {
+        return ColumnWidth::Md;
+    }
 
     protected function sortableValue(): ?bool
     {

--- a/src/Tables/Columns/ColumnData.php
+++ b/src/Tables/Columns/ColumnData.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Tables\Columns;
 
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 /**
@@ -22,6 +23,7 @@ final readonly class ColumnData implements JsonSerializable
         public string $key,
         public string $label,
         public ColumnType|string $type,
+        public ColumnWidth $width = ColumnWidth::Md,
         public ?bool $sortable = null,
         public ?ColumnFilter $filter = null,
         public ?array $columns = null,
@@ -37,6 +39,7 @@ final readonly class ColumnData implements JsonSerializable
             'key' => $this->key,
             'label' => $this->label,
             'type' => $this->type instanceof ColumnType ? $this->type->value : $this->type,
+            'width' => $this->width->value,
             'sortable' => $this->sortable,
             'filter' => $this->filter,
             'columns' => $this->columns,

--- a/src/Tables/Columns/IconColumn.php
+++ b/src/Tables/Columns/IconColumn.php
@@ -69,6 +69,7 @@ class IconColumn extends Column
             key: $this->key,
             label: $this->label,
             type: ColumnType::Icon,
+            width: $this->resolvedWidth(),
             props: new IconColumnProps(
                 icon: $this->icon,
                 icons: $this->icons === [] ? null : $this->icons,

--- a/src/Tables/Columns/ImageColumn.php
+++ b/src/Tables/Columns/ImageColumn.php
@@ -40,6 +40,7 @@ class ImageColumn extends Column
             key: $this->key,
             label: $this->label,
             type: ColumnType::Image,
+            width: $this->resolvedWidth(),
             props: new ImageColumnProps(
                 circular: $this->circular,
                 size: $this->size,

--- a/src/Tables/Columns/StackColumn.php
+++ b/src/Tables/Columns/StackColumn.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Columns;
 
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 class StackColumn extends Column
@@ -29,6 +30,7 @@ class StackColumn extends Column
             key: $this->key,
             label: $this->label,
             type: ColumnType::Stack,
+            width: $this->resolvedWidth(),
             sortable: $this->sortableValue(),
             filter: $this->filterValue(),
             columns: array_map(
@@ -36,5 +38,11 @@ class StackColumn extends Column
                 $this->columns,
             ),
         );
+    }
+
+    #[\Override]
+    protected function defaultWidth(): ColumnWidth
+    {
+        return ColumnWidth::Xl;
     }
 }

--- a/src/Tables/Columns/TextColumn.php
+++ b/src/Tables/Columns/TextColumn.php
@@ -93,6 +93,7 @@ class TextColumn extends Column implements Filterable, Sortable
             key: $this->key,
             label: $this->label,
             type: ColumnType::Text,
+            width: $this->resolvedWidth(),
             sortable: $this->sortableValue(),
             filter: $this->filterValue(),
             props: new TextColumnProps(

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -38,6 +38,8 @@ class Table extends Component
 
     public ?bool $lazy = null;
 
+    public ?bool $resizableColumns = null;
+
     public string $actionsLabel = 'Actions';
 
     public string $emptyLabel = 'No results';
@@ -129,6 +131,13 @@ class Table extends Component
     public function striped(bool $striped): static
     {
         $this->striped = $striped ?: null;
+
+        return $this;
+    }
+
+    public function resizableColumns(bool $resizable = true): static
+    {
+        $this->resizableColumns = $resizable ?: null;
 
         return $this;
     }

--- a/src/Tables/TableDefinition.php
+++ b/src/Tables/TableDefinition.php
@@ -44,6 +44,11 @@ abstract class TableDefinition extends Definition
         return false;
     }
 
+    public function resizableColumns(): bool
+    {
+        return false;
+    }
+
     public function actionsLabel(): string
     {
         return 'Actions';

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -55,6 +55,7 @@ final class TableRegistry extends DefinitionRegistry
             ->columns($columns)
             ->layout($definition->layout())
             ->striped($definition->striped())
+            ->resizableColumns($definition->resizableColumns())
             ->actionsLabel($definition->actionsLabel())
             ->emptyLabel($definition->emptyLabel())
             ->bulkActions($this->bulkActions($definition, $key))

--- a/tests/Browser/Forms/TableLayoutTest.php
+++ b/tests/Browser/Forms/TableLayoutTest.php
@@ -6,7 +6,8 @@ it('renders the table layout with a shared header and round-trips a typed payloa
     $page = visit('/builder-table');
 
     $page->assertSee('Line items')->assertNoSmoke()
-        ->assertSee('Product')->assertSee('Qty')->assertSee('Price');
+        ->assertSee('Product')->assertSee('Qty')->assertSee('Price')
+        ->assertPresent('[aria-label="Resize Qty"]');
 
     $page->click('@builder-add')->click('@builder-add-product')
         ->fill('input[name="items[0][product]"]', 'SKU-9')

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -38,6 +38,7 @@ test('registered tables serialize their configured endpoint columns state and in
                 'bulkActions' => [],
                 'striped' => null,
                 'lazy' => null,
+                'resizableColumns' => null,
                 'actionsLabel' => 'Actions',
                 'emptyLabel' => 'No results',
                 'columns' => [
@@ -54,6 +55,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         ],
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                        'width' => 'md',
                     ],
                     [
                         'key' => 'status',
@@ -68,6 +70,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         ],
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                        'width' => 'md',
                     ],
                     [
                         'key' => 'email',
@@ -77,6 +80,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         'filter' => null,
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                        'width' => 'md',
                     ],
                 ],
                 'data' => [
@@ -115,6 +119,7 @@ test('registered tables can serialize lazily without running their query', funct
                 'layout' => null,
                 'bulkActions' => [],
                 'striped' => null,
+                'resizableColumns' => null,
                 'actionsLabel' => 'Actions',
                 'emptyLabel' => 'No results',
                 'columns' => [
@@ -126,6 +131,7 @@ test('registered tables can serialize lazily without running their query', funct
                         'filter' => null,
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                        'width' => 'md',
                     ],
                 ],
                 'data' => [],
@@ -170,6 +176,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                         'filter' => null,
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                        'width' => 'md',
                     ],
                     [
                         'key' => 'email',
@@ -179,9 +186,11 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                         'filter' => null,
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                        'width' => 'md',
                     ],
                 ],
                 'props' => null,
+                'width' => 'xl',
             ],
             [
                 'key' => 'status',
@@ -191,6 +200,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                 'filter' => null,
                 'columns' => null,
                 'props' => ['date' => null, 'copyable' => false, 'link' => null],
+                'width' => 'md',
             ],
         ])
         ->and($table['props']['data'][0]['actions'][0])->toMatchArray([

--- a/tests/Fixtures/TypeScript/SampleColumn.php
+++ b/tests/Fixtures/TypeScript/SampleColumn.php
@@ -18,6 +18,7 @@ class SampleColumn extends Column
             key: $this->key,
             label: $this->label,
             type: 'column.rating',
+            width: $this->resolvedWidth(),
             props: new SampleColumnProps($this->max),
         );
     }

--- a/tests/Unit/Forms/Components/RowLayoutTest.php
+++ b/tests/Unit/Forms/Components/RowLayoutTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\TextInput;
@@ -16,4 +17,28 @@ it('opts into the table layout via table()', function (): void {
 
     expect($repeater['props']['layout'])->toBe('table')
         ->and($builder['props']['layout'])->toBe('table');
+});
+
+it('serializes table layout column width hints on row fields', function (): void {
+    $wire = wire(Repeater::make('items')->table()->schema([
+        TextInput::make('qty')->columnWidth(ColumnWidth::Xs),
+    ]));
+
+    expect($wire['schema'][0]['props']['columnWidth'])->toBe('xs');
+});
+
+it('serializes default row field column widths', function (): void {
+    $wire = wire(Repeater::make('items')->table()->schema([
+        TextInput::make('qty'),
+    ]));
+
+    expect($wire['schema'][0]['props']['columnWidth'])->toBe('md');
+});
+
+it('serializes resizable column opt-in on row table layouts', function (): void {
+    $wire = wire(Repeater::make('items')->table()->resizableColumns()->schema([
+        TextInput::make('qty'),
+    ]));
+
+    expect($wire['props']['resizableColumns'])->toBeTrue();
 });

--- a/tests/Unit/Forms/FormSerializationTest.php
+++ b/tests/Unit/Forms/FormSerializationTest.php
@@ -82,6 +82,7 @@ test('password inputs can request automatic confirmation fields', function () {
                 'autoFocus' => null,
                 'placeholder' => null,
                 'tabIndex' => null,
+                'columnWidth' => 'md',
             ],
         ]);
 });

--- a/tests/Unit/Tables/Columns/ColumnDataTest.php
+++ b/tests/Unit/Tables/Columns/ColumnDataTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Tables\Columns\BadgeColumnProps;
 use Lattice\Lattice\Tables\Columns\ColumnData;
 use Lattice\Lattice\Tables\Enums\ColumnType;
@@ -10,6 +11,7 @@ it('serializes common fields plus a typed props object', function () {
         key: 'status',
         label: 'Status',
         type: ColumnType::Badge,
+        width: ColumnWidth::Sm,
         props: new BadgeColumnProps(colors: ['active' => 'green']),
     );
 
@@ -17,9 +19,20 @@ it('serializes common fields plus a typed props object', function () {
         'key' => 'status',
         'label' => 'Status',
         'type' => 'badge',
+        'width' => 'sm',
         'sortable' => null,
         'filter' => null,
         'columns' => null,
         'props' => ['colors' => ['active' => 'green']],
     ]);
+});
+
+it('serializes the default column width', function () {
+    $data = new ColumnData(
+        key: 'status',
+        label: 'Status',
+        type: ColumnType::Text,
+    );
+
+    expect(wire($data)['width'])->toBe('md');
 });

--- a/tests/Unit/Tables/Components/TableWireShapeTest.php
+++ b/tests/Unit/Tables/Components/TableWireShapeTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Tables\Columns\TextColumn;
@@ -14,7 +15,7 @@ it('serializes the table component wire shape', function (): void {
     $table = Table::make('demo')
         ->endpoint('/tables/demo')
         ->columns([
-            TextColumn::make('name')->label('Name')->sortable()->filterable(),
+            TextColumn::make('name')->label('Name')->width(ColumnWidth::Lg)->sortable()->filterable(),
             TextColumn::make('price')->label('Price')->numeric(),
         ])
         ->layout('table')
@@ -31,8 +32,10 @@ it('serializes the table component wire shape', function (): void {
         'key' => 'name',
         'label' => 'Name',
         'type' => 'text',
+        'width' => 'lg',
         'sortable' => true,
     ]);
+    expect($payload['props']['columns'][1]['width'])->toBe('md');
     expect($payload['props']['columns'][0])->toHaveKey('filter');
     expect($payload['props']['data'])->toBe([['name' => 'A'], ['name' => 'B']]);
     expect($payload['props']['state'])->toBe([

--- a/workbench/app/Forms/BuilderTableDemoForm.php
+++ b/workbench/app/Forms/BuilderTableDemoForm.php
@@ -7,6 +7,7 @@ namespace Workbench\App\Forms;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Form;
 use Lattice\Lattice\Core\Components\Card;
+use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Forms\Components\Block;
 use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
@@ -26,11 +27,12 @@ class BuilderTableDemoForm extends FormDefinition
                 Card::make('Line items')->schema([
                     Builder::make('items', 'Line items')
                         ->table()
+                        ->resizableColumns()
                         ->blocks([
                             Block::make('product')->label('Product line')->schema([
-                                TextInput::make('product', 'Product')->required(),
-                                TextInput::make('qty', 'Qty')->rules(['numeric']),
-                                TextInput::make('price', 'Price')->rules(['numeric']),
+                                TextInput::make('product', 'Product')->columnWidth(ColumnWidth::Lg)->required(),
+                                TextInput::make('qty', 'Qty')->columnWidth(ColumnWidth::Xs)->rules(['numeric']),
+                                TextInput::make('price', 'Price')->columnWidth(ColumnWidth::Sm)->rules(['numeric']),
                             ]),
                             Block::make('text')->label('Text')->schema([
                                 Textarea::make('content', 'Content')->required(),

--- a/workbench/app/Tables/Columns/StatusBadgeColumn.php
+++ b/workbench/app/Tables/Columns/StatusBadgeColumn.php
@@ -36,6 +36,7 @@ class StatusBadgeColumn extends Column implements Filterable
             key: $this->key,
             label: $this->label,
             type: 'column.status-badge',
+            width: $this->resolvedWidth(),
             filter: $this->filterValue(),
             props: new StatusBadgeColumnProps(
                 colorMap: $this->colorMap !== [] ? $this->colorMap : null,


### PR DESCRIPTION
## Summary
- add shared `ColumnWidth` tokens with `columnWidth()` for row-table fields and `width()` for table columns
- add opt-in `resizableColumns()` for Builder/Repeater table layouts and standalone tables
- share grid sizing/resizing behavior across row tables and tables, including drag and keyboard handles

## UI before/after
- before: row table and table columns only used fixed/default grid tracks
- after: configured width tokens shape initial columns, and opted-in tables render accessible resize handles

## Verification
- `composer test`
- `npm run format:check`
- `npm run lint:github`
- `npm run typecheck`
- `npm test`
- `npm run build:lib`
- `npm run build && composer test:browser`
- `vendor/bin/pint --format agent`