### PR TITLE
feat: add column resize indicators and clamping

### DIFF
--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -135,6 +135,7 @@
             "reorderable": true,
             "required": null,
             "resizableColumns": null,
+            "resizeIndicator": false,
             "value": null
         },
         "type": "form.builder"

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -23,6 +23,7 @@
             "reorderable": true,
             "required": null,
             "resizableColumns": null,
+            "resizeIndicator": false,
             "value": null
         },
         "schema": [

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -102,6 +102,7 @@
                 "total": 3
             },
             "resizableColumns": null,
+            "resizeIndicator": false,
             "state": {
                 "filters": [],
                 "page": 1,

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -124,6 +124,7 @@
                 "total": 3
             },
             "resizableColumns": null,
+            "resizeIndicator": false,
             "state": {
                 "filters": [],
                 "page": 1,

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -84,6 +84,7 @@
                 "total": 2
             },
             "resizableColumns": null,
+            "resizeIndicator": false,
             "state": {
                 "filters": [],
                 "page": 1,

--- a/resources/js/core/use-column-resizing.test.tsx
+++ b/resources/js/core/use-column-resizing.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SizableColumn } from "./column-sizing";
 import { useColumnResizing } from "./use-column-resizing";
 
@@ -11,17 +11,63 @@ const columns: SizableColumn[] = [
   },
 ];
 
-function Harness() {
+const twoColumns: SizableColumn[] = [
+  {
+    key: "qty",
+    label: "Qty",
+    width: "sm",
+  },
+  {
+    key: "price",
+    label: "Price",
+    width: "md",
+  },
+];
+
+function rect(width: number): DOMRect {
+  return {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: width,
+    top: 0,
+    width,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+}
+
+function Harness({
+  columnGapPx = 0,
+  hookColumns = columns,
+  leadingTracks = [],
+  showIndicator = false,
+  trailingTracks = [],
+}: {
+  columnGapPx?: number;
+  hookColumns?: SizableColumn[];
+  leadingTracks?: string[];
+  showIndicator?: boolean;
+  trailingTracks?: string[];
+}) {
   const { gridTemplateColumns, getResizeHandleProps } = useColumnResizing({
     enabled: true,
-    columns,
+    columns: hookColumns,
+    columnGapPx,
+    leadingTracks,
+    showIndicator,
+    trailingTracks,
   });
 
   return (
-    <>
-      <div data-testid="grid" style={{ gridTemplateColumns }} />
-      <div {...getResizeHandleProps(columns[0])} />
-    </>
+    <div data-testid="grid" style={{ gridTemplateColumns }}>
+      {hookColumns.map((column) => (
+        <div key={column.key} data-testid={`cell-${column.key}`}>
+          <div {...getResizeHandleProps(column)} />
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -60,5 +106,38 @@ describe("useColumnResizing", () => {
     fireEvent.pointerMove(handle, { clientX: 2000, pointerId: 1 });
 
     expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "1024px" });
+  });
+
+  it("caps a dragged column to the available grid width", () => {
+    render(
+      <Harness
+        hookColumns={twoColumns}
+        leadingTracks={["3rem"]}
+        trailingTracks={["3rem"]}
+        columnGapPx={12}
+      />,
+    );
+
+    const grid = screen.getByTestId("grid");
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+    const cell = screen.getByTestId("cell-qty");
+
+    vi.spyOn(grid, "getBoundingClientRect").mockReturnValue(rect(420));
+    vi.spyOn(cell, "getBoundingClientRect").mockReturnValue(rect(128));
+
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 800, pointerId: 1 });
+
+    expect(grid).toHaveStyle({
+      gridTemplateColumns: "3rem 160px minmax(8rem, 1fr) 3rem",
+    });
+  });
+
+  it("can render a visible resize indicator", () => {
+    render(<Harness showIndicator={true} />);
+
+    expect(screen.getByRole("separator", { name: "Resize Qty" }).className.split(" ")).toContain(
+      "after:bg-lt-border",
+    );
   });
 });

--- a/resources/js/core/use-column-resizing.ts
+++ b/resources/js/core/use-column-resizing.ts
@@ -10,6 +10,7 @@ import {
 
 type DragState = {
   key: string;
+  maxWidth: number;
   startWidth: number;
   startX: number;
 };
@@ -25,14 +26,18 @@ type ResizeHandleProps = HTMLAttributes<HTMLDivElement> & {
 };
 
 export function useColumnResizing({
+  columnGapPx = 0,
   columns,
   enabled,
   leadingTracks = [],
+  showIndicator = false,
   trailingTracks = [],
 }: {
+  columnGapPx?: number;
   columns: SizableColumn[];
   enabled: boolean;
   leadingTracks?: string[];
+  showIndicator?: boolean;
   trailingTracks?: string[];
 }) {
   const [overrides, setOverrides] = useState<Record<string, number | undefined>>({});
@@ -49,10 +54,13 @@ export function useColumnResizing({
     [columns, enabled, leadingTracks, overrides, trailingTracks],
   );
 
-  const setColumnWidth = useCallback((column: SizableColumn, width: number) => {
+  const setColumnWidth = useCallback((column: SizableColumn, width: number, maxWidth?: number) => {
     setOverrides((current) => ({
       ...current,
-      [column.key]: Math.min(maxColumnWidthPx(column), Math.max(minColumnWidthPx(column), width)),
+      [column.key]: Math.min(
+        maxWidth ?? maxColumnWidthPx(column),
+        Math.max(minColumnWidthPx(column), width),
+      ),
     }));
   }, []);
 
@@ -76,8 +84,20 @@ export function useColumnResizing({
       const min = minColumnWidthPx(column);
       const current = currentColumnWidth(column);
       const label = column.label ?? column.key;
+      const indicatorClass = showIndicator ? "after:bg-lt-border" : "after:bg-transparent";
 
-      const resizeBy = (delta: number): void => setColumnWidth(column, current + delta);
+      const maxWidthForHandle = (handle: HTMLDivElement): number =>
+        maxColumnWidthForGrid({
+          column,
+          columnGapPx,
+          columns,
+          grid: handle.parentElement?.parentElement,
+          leadingTracks,
+          trailingTracks,
+        });
+
+      const resizeBy = (handle: HTMLDivElement, delta: number): void =>
+        setColumnWidth(column, current + delta, maxWidthForHandle(handle));
 
       return {
         "aria-label": `Resize ${label}`,
@@ -85,8 +105,7 @@ export function useColumnResizing({
         "aria-valuemax": max,
         "aria-valuemin": min,
         "aria-valuenow": current,
-        className:
-          "absolute inset-y-0 right-0 hidden w-2 cursor-col-resize touch-none items-stretch justify-center md:flex after:my-1 after:w-px after:bg-transparent hover:after:bg-lt-border focus-visible:outline-none focus-visible:after:bg-lt-ring",
+        className: `absolute inset-y-0 right-0 hidden w-2 cursor-col-resize touch-none items-stretch justify-center md:flex after:my-1 after:w-px ${indicatorClass} hover:after:bg-lt-border focus-visible:outline-none focus-visible:after:bg-lt-ring`,
         onDoubleClick: () => resetColumnWidth(column),
         onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
           if (!enabled) {
@@ -97,12 +116,12 @@ export function useColumnResizing({
 
           if (event.key === "ArrowLeft") {
             event.preventDefault();
-            resizeBy(-step);
+            resizeBy(event.currentTarget, -step);
           }
 
           if (event.key === "ArrowRight") {
             event.preventDefault();
-            resizeBy(step);
+            resizeBy(event.currentTarget, step);
           }
 
           if (event.key === "Home") {
@@ -112,7 +131,8 @@ export function useColumnResizing({
 
           if (event.key === "End") {
             event.preventDefault();
-            setColumnWidth(column, max);
+            const handleMax = maxWidthForHandle(event.currentTarget);
+            setColumnWidth(column, handleMax, handleMax);
           }
 
           if (event.key === "Enter" || event.key === "Escape") {
@@ -128,6 +148,7 @@ export function useColumnResizing({
           const parentWidth = event.currentTarget.parentElement?.getBoundingClientRect().width ?? 0;
           drag.current = {
             key: column.key,
+            maxWidth: maxWidthForHandle(event.currentTarget),
             startWidth: parentWidth > 0 ? parentWidth : current,
             startX: event.clientX,
           };
@@ -141,7 +162,11 @@ export function useColumnResizing({
             return;
           }
 
-          setColumnWidth(column, active.startWidth + event.clientX - active.startX);
+          setColumnWidth(
+            column,
+            active.startWidth + event.clientX - active.startX,
+            active.maxWidth,
+          );
         },
         onPointerUp: (event: PointerEvent<HTMLDivElement>) => {
           const active = drag.current;
@@ -157,7 +182,17 @@ export function useColumnResizing({
         tabIndex: 0,
       };
     },
-    [currentColumnWidth, enabled, resetColumnWidth, setColumnWidth],
+    [
+      columnGapPx,
+      columns,
+      currentColumnWidth,
+      enabled,
+      leadingTracks,
+      resetColumnWidth,
+      setColumnWidth,
+      showIndicator,
+      trailingTracks,
+    ],
   );
 
   return {
@@ -165,4 +200,67 @@ export function useColumnResizing({
     gridTemplateColumns,
     resetColumnWidth,
   };
+}
+
+function maxColumnWidthForGrid({
+  column,
+  columnGapPx,
+  columns,
+  grid,
+  leadingTracks,
+  trailingTracks,
+}: {
+  column: SizableColumn;
+  columnGapPx: number;
+  columns: SizableColumn[];
+  grid: Element | null | undefined;
+  leadingTracks: string[];
+  trailingTracks: string[];
+}): number {
+  const gridWidth = grid?.getBoundingClientRect().width ?? 0;
+
+  if (gridWidth <= 0) {
+    return maxColumnWidthPx(column);
+  }
+
+  const utilityWidth = [...leadingTracks, ...trailingTracks].reduce(
+    (sum, track) => sum + fixedTrackWidthPx(track),
+    0,
+  );
+  const siblingMinWidth = columns.reduce(
+    (sum, sibling) => (sibling.key === column.key ? sum : sum + minColumnWidthPx(sibling)),
+    0,
+  );
+  const trackCount = columns.length + leadingTracks.length + trailingTracks.length;
+  const gapWidth = Math.max(0, trackCount - 1) * columnGapPx;
+  const available = gridWidth - utilityWidth - siblingMinWidth - gapWidth;
+
+  return Math.min(maxColumnWidthPx(column), Math.max(minColumnWidthPx(column), available));
+}
+
+function fixedTrackWidthPx(track: string): number {
+  const value = track.trim();
+  const px = value.match(/^([0-9.]+)px$/);
+
+  if (px) {
+    return Number.parseFloat(px[1]);
+  }
+
+  const rem = value.match(/^([0-9.]+)rem$/);
+
+  if (rem) {
+    return Number.parseFloat(rem[1]) * rootFontSizePx();
+  }
+
+  return 0;
+}
+
+function rootFontSizePx(): number {
+  if (typeof window === "undefined") {
+    return 16;
+  }
+
+  const parsed = Number.parseFloat(window.getComputedStyle(document.documentElement).fontSize);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 16;
 }

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -85,6 +85,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
               onRemove={onRemove}
               registerRow={registerRow}
               resizableColumns={props.resizableColumns === true}
+              resizeIndicator={props.resizeIndicator === true}
             />
           </>
         ) : (

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -60,6 +60,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             onRemove={onRemove}
             registerRow={registerRow}
             resizableColumns={props.resizableColumns === true}
+            resizeIndicator={props.resizeIndicator === true}
           />
         ) : (
           rows.map((row, index) => {

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -164,6 +164,7 @@ export function TableRows({
   onRemove,
   registerRow,
   resizableColumns = false,
+  resizeIndicator = false,
 }: {
   base: string;
   columns: TableColumn[];
@@ -175,6 +176,7 @@ export function TableRows({
   onRemove: (index: number) => void;
   registerRow?: (key: string, el: HTMLElement | null) => void;
   resizableColumns?: boolean;
+  resizeIndicator?: boolean;
 }) {
   const sizingColumns = useMemo<SizableColumn[]>(
     () =>
@@ -188,7 +190,9 @@ export function TableRows({
   const { getResizeHandleProps, gridTemplateColumns } = useColumnResizing({
     columns: sizingColumns,
     enabled: resizableColumns,
+    columnGapPx: 12,
     leadingTracks: [rowControlTrack],
+    showIndicator: resizeIndicator,
     trailingTracks: [rowActionTrack],
   });
 

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -53,7 +53,7 @@ export function ColumnFilterControl({
   }
 
   return (
-    <div className="flex min-w-0 max-w-44 items-stretch">
+    <div className="flex min-w-0 max-w-80 items-stretch">
       <div className="min-w-0 flex-1">
         <FilterValueInput
           type={type}

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -76,6 +76,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
     columns: sizingColumns,
     enabled: resizingEnabled,
     leadingTracks: utilityTracks.leadingTracks,
+    showIndicator: node.props?.resizeIndicator === true,
     trailingTracks: utilityTracks.trailingTracks,
   });
 

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -69,6 +69,7 @@ export type Builder = {
   reorderable: boolean;
   required: boolean | null;
   resizableColumns: boolean | null;
+  resizeIndicator: boolean;
   value: unknown;
 };
 export type BulkAction = {
@@ -684,6 +685,7 @@ export type Repeater = {
   reorderable: boolean;
   required: boolean | null;
   resizableColumns: boolean | null;
+  resizeIndicator: boolean;
   value: unknown;
 };
 export type ResetFormEffect = {
@@ -791,6 +793,7 @@ export type Table = {
   lazy: boolean | null;
   ref: string | null;
   resizableColumns: boolean | null;
+  resizeIndicator: boolean;
   striped: boolean | null;
 };
 export type TableNode = {

--- a/src/Forms/Components/Concerns/HasRowLayout.php
+++ b/src/Forms/Components/Concerns/HasRowLayout.php
@@ -12,6 +12,8 @@ trait HasRowLayout
 
     public ?bool $resizableColumns = null;
 
+    public bool $resizeIndicator = false;
+
     public function table(): static
     {
         $this->layout = RowLayout::Table;
@@ -19,9 +21,10 @@ trait HasRowLayout
         return $this;
     }
 
-    public function resizableColumns(bool $resizable = true): static
+    public function resizableColumns(bool $resizable = true, bool $showIndicator = false): static
     {
         $this->resizableColumns = $resizable ?: null;
+        $this->resizeIndicator = $resizable && $showIndicator;
 
         return $this;
     }

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -40,6 +40,8 @@ class Table extends Component
 
     public ?bool $resizableColumns = null;
 
+    public bool $resizeIndicator = false;
+
     public string $actionsLabel = 'Actions';
 
     public string $emptyLabel = 'No results';
@@ -135,9 +137,10 @@ class Table extends Component
         return $this;
     }
 
-    public function resizableColumns(bool $resizable = true): static
+    public function resizableColumns(bool $resizable = true, bool $showIndicator = false): static
     {
         $this->resizableColumns = $resizable ?: null;
+        $this->resizeIndicator = $resizable && $showIndicator;
 
         return $this;
     }

--- a/src/Tables/TableDefinition.php
+++ b/src/Tables/TableDefinition.php
@@ -49,6 +49,11 @@ abstract class TableDefinition extends Definition
         return false;
     }
 
+    public function resizeIndicator(): bool
+    {
+        return false;
+    }
+
     public function actionsLabel(): string
     {
         return 'Actions';

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -55,7 +55,7 @@ final class TableRegistry extends DefinitionRegistry
             ->columns($columns)
             ->layout($definition->layout())
             ->striped($definition->striped())
-            ->resizableColumns($definition->resizableColumns())
+            ->resizableColumns($definition->resizableColumns(), $definition->resizeIndicator())
             ->actionsLabel($definition->actionsLabel())
             ->emptyLabel($definition->emptyLabel())
             ->bulkActions($this->bulkActions($definition, $key))

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -11,8 +11,9 @@ it('expands a collapsed menu group and navigates to a sub-page', function (): vo
         ->assertDontSee('Showcase')
         ->click('@menu-forms')
         ->assertSee('Showcase')
-        ->click('@menu-showcase')
-        ->assertSee('Form Showcase')
+        ->assertSee('Builder Table Demo')
+        ->click('@menu-builder-table-demo')
+        ->assertSee('Line items')
         ->assertNoSmoke();
 });
 

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -115,6 +115,8 @@ test('workbench pages serialize package component trees for inertia', function (
             ->where('lattice.title', 'Lattice Workbench')
             ->where('lattice.layout.key', 'app')
             ->where('lattice.layout.schema.0.type', 'stack')
+            ->where('lattice.layout.schema.0.schema.0.schema.0.schema.0.schema.1.schema.2.props.label', 'Builder Table Demo')
+            ->where('lattice.layout.schema.0.schema.0.schema.0.schema.0.schema.1.schema.2.props.href', '/builder-table')
             ->where('lattice.layout.schema.0.schema.1.schema.0.type', 'breadcrumbs')
             ->where('lattice.layout.schema.0.schema.1.schema.1.type', 'outlet')
             ->where('lattice.container', 'default')
@@ -128,7 +130,10 @@ test('workbench pages serialize package component trees for inertia', function (
             ->where('lattice.schema.0.schema.0.schema.1.props.text', 'Workbench page')
             ->where('lattice.schema.0.schema.1.type', 'grid')
             ->where('lattice.schema.0.schema.1.schema.0.type', 'card')
-            ->where('lattice.schema.0.schema.1.schema.0.props.title', 'Components'));
+            ->where('lattice.schema.0.schema.1.schema.0.props.title', 'Components')
+            ->where('lattice.schema.0.schema.5.id', 'workbench.users')
+            ->where('lattice.schema.0.schema.5.props.resizableColumns', true)
+            ->where('lattice.schema.0.schema.5.props.resizeIndicator', true));
 });
 
 test('workbench tables page serializes lazy tables for each pagination type', function () {
@@ -146,16 +151,24 @@ test('workbench tables page serializes lazy tables for each pagination type', fu
             ->where('lattice.schema.0.schema.1.schema.0.props.value', 'none')
             ->where('lattice.schema.0.schema.1.schema.0.schema.1.id', 'workbench.users.none')
             ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.lazy', true)
+            ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.resizableColumns', true)
+            ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.resizeIndicator', true)
             ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.data', [])
             ->where('lattice.schema.0.schema.1.schema.0.schema.1.props.pagination.mode', 'none')
             ->where('lattice.schema.0.schema.1.schema.1.props.value', 'simple')
             ->where('lattice.schema.0.schema.1.schema.1.schema.1.id', 'workbench.users.simple')
+            ->where('lattice.schema.0.schema.1.schema.1.schema.1.props.resizableColumns', true)
+            ->where('lattice.schema.0.schema.1.schema.1.schema.1.props.resizeIndicator', true)
             ->where('lattice.schema.0.schema.1.schema.1.schema.1.props.pagination.mode', 'simple')
             ->where('lattice.schema.0.schema.1.schema.2.props.value', 'table')
             ->where('lattice.schema.0.schema.1.schema.2.schema.1.id', 'workbench.users.table')
+            ->where('lattice.schema.0.schema.1.schema.2.schema.1.props.resizableColumns', true)
+            ->where('lattice.schema.0.schema.1.schema.2.schema.1.props.resizeIndicator', true)
             ->where('lattice.schema.0.schema.1.schema.2.schema.1.props.pagination.mode', 'table')
             ->where('lattice.schema.0.schema.1.schema.3.props.value', 'infinite')
             ->where('lattice.schema.0.schema.1.schema.3.schema.1.id', 'workbench.users.infinite')
+            ->where('lattice.schema.0.schema.1.schema.3.schema.1.props.resizableColumns', true)
+            ->where('lattice.schema.0.schema.1.schema.3.schema.1.props.resizeIndicator', true)
             ->where('lattice.schema.0.schema.1.schema.3.schema.1.props.pagination.mode', 'infinite'));
 });
 

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -39,6 +39,7 @@ test('registered tables serialize their configured endpoint columns state and in
                 'striped' => null,
                 'lazy' => null,
                 'resizableColumns' => null,
+                'resizeIndicator' => false,
                 'actionsLabel' => 'Actions',
                 'emptyLabel' => 'No results',
                 'columns' => [
@@ -120,6 +121,7 @@ test('registered tables can serialize lazily without running their query', funct
                 'bulkActions' => [],
                 'striped' => null,
                 'resizableColumns' => null,
+                'resizeIndicator' => false,
                 'actionsLabel' => 'Actions',
                 'emptyLabel' => 'No results',
                 'columns' => [

--- a/tests/Unit/Forms/Components/RowLayoutTest.php
+++ b/tests/Unit/Forms/Components/RowLayoutTest.php
@@ -40,5 +40,15 @@ it('serializes resizable column opt-in on row table layouts', function (): void 
         TextInput::make('qty'),
     ]));
 
-    expect($wire['props']['resizableColumns'])->toBeTrue();
+    expect($wire['props']['resizableColumns'])->toBeTrue()
+        ->and($wire['props']['resizeIndicator'])->toBeFalse();
+});
+
+it('serializes visible resize indicators on row table layouts', function (): void {
+    $wire = wire(Repeater::make('items')->table()->resizableColumns(showIndicator: true)->schema([
+        TextInput::make('qty'),
+    ]));
+
+    expect($wire['props']['resizableColumns'])->toBeTrue()
+        ->and($wire['props']['resizeIndicator'])->toBeTrue();
 });

--- a/tests/Unit/Tables/Components/TableWireShapeTest.php
+++ b/tests/Unit/Tables/Components/TableWireShapeTest.php
@@ -28,6 +28,7 @@ it('serializes the table component wire shape', function (): void {
     expect($payload['props']['endpoint'])->toBe('/tables/demo');
     expect($payload['props']['striped'])->toBeTrue();
     expect($payload['props']['layout'])->toBeNull();
+    expect($payload['props']['resizeIndicator'])->toBeFalse();
     expect($payload['props']['columns'][0])->toMatchArray([
         'key' => 'name',
         'label' => 'Name',
@@ -45,6 +46,13 @@ it('serializes the table component wire shape', function (): void {
         'perPage' => 25,
     ]);
     expect($payload['props']['bulkActions'])->toBe([]);
+});
+
+it('serializes visible resize indicators on table components', function (): void {
+    $payload = wire(Table::make('demo')->resizableColumns(showIndicator: true));
+
+    expect($payload['props']['resizableColumns'])->toBeTrue()
+        ->and($payload['props']['resizeIndicator'])->toBeTrue();
 });
 
 it('defaults a column to its value type operator set', function (): void {

--- a/workbench/app/Forms/BuilderTableDemoForm.php
+++ b/workbench/app/Forms/BuilderTableDemoForm.php
@@ -27,7 +27,7 @@ class BuilderTableDemoForm extends FormDefinition
                 Card::make('Line items')->schema([
                     Builder::make('items', 'Line items')
                         ->table()
-                        ->resizableColumns()
+                        ->resizableColumns(showIndicator: true)
                         ->blocks([
                             Block::make('product')->label('Product line')->schema([
                                 TextInput::make('product', 'Product')->columnWidth(ColumnWidth::Lg)->required(),

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -20,6 +20,7 @@ use Lattice\Lattice\Layouts\Components\MenuItem;
 use Lattice\Lattice\Layouts\Components\Outlet;
 use Lattice\Lattice\Layouts\Components\Sidebar;
 use Lattice\Lattice\Layouts\LayoutDefinition;
+use Workbench\App\Pages\BuilderTableDemoPage;
 use Workbench\App\Pages\DependentDemoPage;
 use Workbench\App\Pages\HomePage;
 use Workbench\App\Pages\ProductCreatePage;
@@ -47,14 +48,13 @@ final class AppLayout extends LayoutDefinition
                                     MenuItem::make('Forms')->icon('form-input')->children([
                                         MenuItem::fromPage(ShowcasePage::class)->label('Showcase'),
                                         MenuItem::fromPage(DependentDemoPage::class)->label('Dependent Fields'),
+                                        MenuItem::fromPage(BuilderTableDemoPage::class)->label('Builder Table Demo'),
                                         MenuItem::fromPage(ProductCreatePage::class)->label('Create Product'),
                                     ]),
                                     MenuItem::make('Tables')->icon(Icon::Table)->children([
                                         MenuItem::fromPage(ProductsPage::class)->label('Products'),
                                         MenuItem::fromPage(TablesPage::class)->label('Pagination Modes'),
                                     ]),
-                                    // A fully custom icon (workbench/resources/icons/spark.svg) the
-                                    // workbench adds to its own folder and references by name.
                                     MenuItem::fromPage(TabsPage::class)->label('Tabs')->icon('spark'),
                                 ]),
                                 Dropdown::make('user-menu')

--- a/workbench/app/Tables/BaseUsersTable.php
+++ b/workbench/app/Tables/BaseUsersTable.php
@@ -27,6 +27,18 @@ abstract class BaseUsersTable extends EloquentTableDefinition
         ];
     }
 
+    #[\Override]
+    public function resizableColumns(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function resizeIndicator(): bool
+    {
+        return true;
+    }
+
     /**
      * @return Builder<User>
      */

--- a/workbench/app/Tables/UsersTable.php
+++ b/workbench/app/Tables/UsersTable.php
@@ -42,6 +42,18 @@ class UsersTable extends EloquentTableDefinition
         return 25;
     }
 
+    #[\Override]
+    public function resizableColumns(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function resizeIndicator(): bool
+    {
+        return true;
+    }
+
     /**
      * @return Builder<User>
      */


### PR DESCRIPTION
## Summary
- add a non-null boolean resizeIndicator prop for row-layout and table column resizing
- support opt-in visible resize handles via resizableColumns(showIndicator: true)
- clamp resizing to the current grid width so columns cannot grow outside their container
- let table filter controls grow wider alongside resized columns
- expose the builder table demo in the Forms menu and enable resizable user tables

## Before / After
Before: resize handles were only discoverable on hover, dragging could grow columns beyond the form/table container, and filter controls stayed narrow even after a column was widened.
After: demos can opt into persistent handle indicators, resize calculations respect fixed utility tracks, gaps, and sibling minimum widths, and filters have more room in resized columns.

## Verification
- vendor/bin/pint --dirty --format agent
- composer types
- composer test
- npm run format:check
- npm run lint:github
- npm run typecheck
- npm test
- npm run build:lib
- npm run build
- ./vendor/bin/pest tests/Browser/Layout/SidebarTest.php tests/Browser/Forms/TableLayoutTest.php --compact