### PR TITLE
Generate wire value objects (ActionResult, TableQuery, TablePagination, I18nConfig)

### DIFF
--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -94,10 +94,13 @@
             "layout": null,
             "lazy": null,
             "pagination": {
+                "currentPage": null,
                 "from": 1,
                 "hasMore": false,
+                "lastPage": null,
                 "mode": "none",
                 "nextPage": null,
+                "perPage": null,
                 "to": 3,
                 "total": 3
             },

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -116,10 +116,13 @@
             "layout": null,
             "lazy": null,
             "pagination": {
+                "currentPage": null,
                 "from": 1,
                 "hasMore": false,
+                "lastPage": null,
                 "mode": "none",
                 "nextPage": null,
+                "perPage": null,
                 "to": 3,
                 "total": 3
             },

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -76,10 +76,13 @@
             "layout": null,
             "lazy": null,
             "pagination": {
+                "currentPage": null,
                 "from": 1,
                 "hasMore": false,
+                "lastPage": null,
                 "mode": "none",
                 "nextPage": null,
+                "perPage": null,
                 "to": 2,
                 "total": 2
             },

--- a/resources/js/action/effects.ts
+++ b/resources/js/action/effects.ts
@@ -1,14 +1,11 @@
 import { router } from "@inertiajs/react";
-import type { Effect, EffectType } from "@lattice-php/lattice/types/generated";
+import type { ActionResult, Effect, EffectType } from "@lattice-php/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
 
 export type ActionEffect = Effect;
 
-export type ActionResponse = {
-  data?: Record<string, unknown>;
-  effects?: ActionEffect[];
-  ok?: boolean;
-};
+/** The server's action response. Fields are optional: a handler may omit any of them. */
+export type ActionResponse = Partial<ActionResult>;
 
 const eventNames = {
   toast: LATTICE_EVENT.toast,

--- a/resources/js/core/types.ts
+++ b/resources/js/core/types.ts
@@ -1,5 +1,6 @@
 import type { ComponentType as ReactComponentType, ReactNode } from "react";
 import type {
+  I18nConfig,
   Node as WireNode,
   NodeType,
   Option,
@@ -83,9 +84,17 @@ export type LayoutPayload = {
   schema: Schema;
 };
 
+/**
+ * The page payload the server hydrates onto `lattice` (see PHP `Page::toArray`).
+ * Hand-written rather than generated: its `schema`/`layout.schema` are component
+ * trees serialized eagerly during the request (to fire side effects before the
+ * final encode), so they cannot be derived from a value object as typed `Node[]`.
+ * `i18n` is the generated single source of truth shared with the i18n backend.
+ */
 export type PagePayload = {
   breadcrumbs: PageBreadcrumb[];
   container: PageContainer;
+  i18n: I18nConfig;
   layout: LayoutPayload | null;
   schema: Schema;
   title: string | null;

--- a/resources/js/i18n/backend.ts
+++ b/resources/js/i18n/backend.ts
@@ -1,5 +1,9 @@
+import type { I18nConfig } from "@lattice-php/lattice/types/generated";
 import HttpBackend from "i18next-http-backend";
 import { ensureI18n, i18n } from "./instance";
+
+/** The i18n settings the backend shares to the frontend (Inertia `lattice.i18n`). */
+export type { I18nConfig };
 
 /** laravel-i18next's namespaced routes; an app behind a custom prefix overrides them via {@link BackendOptions}. */
 const DEFAULT_LOAD_PATH = "/locales/{{lng}}/{{ns}}.json";
@@ -14,12 +18,6 @@ export type BackendOptions = {
   saveMissing?: boolean;
   /** Extra request headers, e.g. the CSRF token for the saveMissing POST. */
   customHeaders?: () => Record<string, string>;
-};
-
-/** The i18n settings the backend shares to the frontend (Inertia `lattice.i18n`). */
-export type I18nConfig = {
-  enabled: boolean;
-  saveMissing: boolean;
 };
 
 /** Apply the i18n config shared from the backend; wires the HTTP backend only when `enabled`. */

--- a/resources/js/inertia.test.tsx
+++ b/resources/js/inertia.test.tsx
@@ -26,6 +26,7 @@ function payload(lattice: Partial<PagePayload> = {}): PagePayload {
     breadcrumbs: [],
     schema: [],
     container: "default",
+    i18n: { enabled: false, saveMissing: false },
     layout: null,
     title: "Lattice",
     ...lattice,

--- a/resources/js/layout/schema-layout.test.tsx
+++ b/resources/js/layout/schema-layout.test.tsx
@@ -16,6 +16,7 @@ function payload(lattice: Partial<PagePayload> = {}): PagePayload {
     breadcrumbs: [],
     schema: [],
     container: "default",
+    i18n: { enabled: false, saveMissing: false },
     layout: null,
     title: "Lattice",
     ...lattice,

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -13,6 +13,7 @@ function payload(lattice: Partial<PagePayload> = {}): PagePayload {
     breadcrumbs: [],
     schema: [],
     container: "default",
+    i18n: { enabled: false, saveMissing: false },
     layout: null,
     title: "Lattice",
     ...lattice,

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -29,7 +29,7 @@ export function TablePagination({
   return (
     <div className="flex items-center justify-between gap-3 border-t border-lt-border p-4 text-sm">
       <span>
-        {pagination.total === undefined
+        {pagination.total == null
           ? t("pagination.page", "Page {{page}}", { page: currentPage })
           : t("pagination.showing", "Showing {{from}}-{{to}} of {{total}}", {
               from: pagination.from ?? 0,

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -102,7 +102,17 @@ describe("table bulk actions", () => {
           page: 1,
           perPage: 25,
         },
-        pagination: { total: 50, currentPage: 1, lastPage: 2, mode: "table" },
+        pagination: {
+          mode: "table",
+          currentPage: 1,
+          lastPage: 2,
+          perPage: 25,
+          total: 50,
+          from: 1,
+          to: 50,
+          hasMore: false,
+          nextPage: null,
+        },
       },
     } satisfies TableNode;
 

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { TableNode } from "../types";
+import type { TableNode, TablePagination } from "../types";
 import type { ColumnData } from "@lattice-php/lattice/types/generated";
 import TableComponent from "./table";
 
@@ -15,6 +15,21 @@ function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): 
     columns: null,
     props: null,
     ...partial,
+  };
+}
+
+function pagination(overrides: Partial<TablePagination> = {}): TablePagination {
+  return {
+    mode: "none",
+    currentPage: null,
+    lastPage: null,
+    perPage: null,
+    total: null,
+    from: null,
+    to: null,
+    hasMore: false,
+    nextPage: null,
+    ...overrides,
   };
 }
 
@@ -441,9 +456,7 @@ describe("Lattice table component", () => {
         ],
         data: [{ id: 1, name: "Taylor" }],
         endpoint: "/lattice/tables/settings.passkeys",
-        pagination: {
-          mode: "none",
-        },
+        pagination: pagination(),
         state: {
           filters: [],
           page: 1,
@@ -529,13 +542,13 @@ describe("Lattice table component", () => {
         ],
         data: [{ id: 1, name: "Taylor" }],
         endpoint: "/lattice/tables/workbench.users",
-        pagination: {
-          currentPage: 1,
-          hasMore: true,
+        pagination: pagination({
           mode: "infinite",
-          nextPage: 2,
+          currentPage: 1,
           perPage: 1,
-        },
+          hasMore: true,
+          nextPage: 2,
+        }),
         state: {
           filters: [],
           page: 1,
@@ -587,10 +600,7 @@ describe("Lattice table component", () => {
           }),
         ],
         data: [{ id: 1, name: "Taylor" }],
-        pagination: {
-          mode: "none",
-          total: 1,
-        },
+        pagination: pagination({ total: 1 }),
         state: {
           filters: [],
           page: 1,
@@ -718,9 +728,7 @@ describe("Lattice table component", () => {
         data: [],
         endpoint: "/lattice/tables/workbench.users.none",
         lazy: true,
-        pagination: {
-          mode: "none",
-        },
+        pagination: pagination(),
         state: {
           filters: [],
           page: 1,

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -90,12 +90,12 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
           actions={bulkActions}
           selectedKeys={selection.selectedKeys}
           allMatching={selection.allMatching}
-          total={pagination.total}
+          total={pagination.total ?? undefined}
           query={getQueryParams(state)}
           canSelectAllMatching={
             selection.allVisibleSelected &&
             !selection.allMatching &&
-            pagination.total !== undefined &&
+            pagination.total != null &&
             pagination.total > selection.selectedKeys.length
           }
           onSelectAllMatching={selection.selectAllMatching}

--- a/resources/js/table/payload.ts
+++ b/resources/js/table/payload.ts
@@ -42,9 +42,21 @@ export function getRows(value: unknown): TableRow[] {
   );
 }
 
+const EMPTY_PAGINATION: TablePagination = {
+  mode: "none",
+  currentPage: null,
+  lastPage: null,
+  perPage: null,
+  total: null,
+  from: null,
+  to: null,
+  hasMore: false,
+  nextPage: null,
+};
+
 export function getPagination(value: unknown): TablePagination {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return {};
+    return EMPTY_PAGINATION;
   }
 
   return value as TablePagination;

--- a/resources/js/table/types.ts
+++ b/resources/js/table/types.ts
@@ -6,12 +6,13 @@ import type {
   ColumnType,
   FilterClause as WireFilterClause,
   Op,
-  PaginationType,
   Table,
+  TablePagination,
+  TableQuery,
   TableSort,
 } from "@lattice-php/lattice/types/generated";
 
-export type { ColumnData, ColumnFilter, ColumnType, TableSort };
+export type { ColumnData, ColumnFilter, ColumnType, TablePagination, TableSort };
 
 export type TableColumn = ColumnData;
 
@@ -26,23 +27,12 @@ export type FilterClause = Omit<WireFilterClause, "operator"> & {
   operator: Op;
 };
 
-export type TableState = {
+/**
+ * The wire `TableQuery` state, with `filters` narrowed to the client `FilterClause`
+ * (known `Op` operator) instead of the wire's free-string operator.
+ */
+export type TableState = Omit<TableQuery, "filters"> & {
   filters: FilterClause[];
-  sorts: TableSort[];
-  page: number;
-  perPage: number;
-};
-
-export type TablePagination = {
-  currentPage?: number;
-  hasMore?: boolean;
-  lastPage?: number;
-  mode?: PaginationType;
-  nextPage?: number | null;
-  perPage?: number;
-  total?: number;
-  from?: number | null;
-  to?: number | null;
 };
 
 export type TableResponse = {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -34,6 +34,11 @@ export type ActionNode =
       id?: string;
       props: BulkAction;
     };
+export type ActionResult = {
+  readonly ok: boolean;
+  readonly data: Record<string, unknown>;
+  readonly effects: Effect[];
+};
 export type Align = "center" | "left" | "start" | "stretch";
 export type Badge = {
   label: string;
@@ -479,6 +484,10 @@ export type HiddenInput = {
   value: unknown;
 };
 export type HttpMethod = import("@inertiajs/core").Method;
+export type I18nConfig = {
+  readonly enabled: boolean;
+  readonly saveMissing: boolean;
+};
 export type Icon = {
   class: string | null;
   color: Color | null;
@@ -801,6 +810,23 @@ export type TableNode = {
   key?: string;
   id?: string;
   props: Table;
+};
+export type TablePagination = {
+  readonly mode: PaginationType;
+  readonly currentPage: number | null;
+  readonly lastPage: number | null;
+  readonly perPage: number | null;
+  readonly total: number | null;
+  readonly from: number | null;
+  readonly to: number | null;
+  readonly hasMore: boolean;
+  readonly nextPage: number | null;
+};
+export type TableQuery = {
+  readonly filters: FilterClause[];
+  readonly sorts: TableSort[];
+  readonly page: number;
+  readonly perPage: number;
 };
 export type TableSort = {
   readonly key: string;

--- a/src/Actions/ActionResult.php
+++ b/src/Actions/ActionResult.php
@@ -5,9 +5,11 @@ namespace Lattice\Lattice\Actions;
 
 use JsonSerializable;
 use Lattice\Lattice\Actions\Contracts\Effect as EffectContract;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\ToastVariant;
 use Lattice\Lattice\Core\Values\ToastMessage;
 
+#[TypeScript]
 final readonly class ActionResult implements JsonSerializable
 {
     /**
@@ -15,9 +17,9 @@ final readonly class ActionResult implements JsonSerializable
      * @param  array<int, EffectContract>  $effects
      */
     private function __construct(
-        private bool $ok,
-        private array $data = [],
-        private array $effects = [],
+        public bool $ok,
+        public array $data = [],
+        public array $effects = [],
     ) {}
 
     /**

--- a/src/Http/I18nConfig.php
+++ b/src/Http/I18nConfig.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http;
+
+use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
+
+/**
+ * The i18n signals the backend shares to the renderer, mirrored from
+ * laravel-i18next's config so it stays the single source of truth. The frontend
+ * hardcodes the routes, so only these travel: whether translations are served
+ * and whether missing keys are reported back.
+ */
+#[TypeScript]
+final readonly class I18nConfig implements JsonSerializable
+{
+    public function __construct(
+        public bool $enabled,
+        public bool $saveMissing,
+    ) {}
+
+    public static function fromConfig(): self
+    {
+        return new self(
+            enabled: (bool) config('i18next.routes.enabled', false),
+            saveMissing: (bool) config('i18next.save_missing.enabled', false),
+        );
+    }
+
+    /**
+     * @return array{enabled: bool, saveMissing: bool}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'enabled' => $this->enabled,
+            'saveMissing' => $this->saveMissing,
+        ];
+    }
+}

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -68,7 +68,7 @@ abstract class Page implements PageContract
     }
 
     /**
-     * @return array{title: string|null, layout: array{key: string, schema: array<int, array<string, mixed>>}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, schema: array<int, array<string, mixed>>, i18n: array{enabled: bool, saveMissing: bool}}
+     * @return array{title: string|null, layout: array{key: string, schema: array<int, array<string, mixed>>}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, schema: array<int, array<string, mixed>>, i18n: I18nConfig}
      */
     public function toArray(PageSchema $schema, Request $request): array
     {
@@ -121,19 +121,9 @@ abstract class Page implements PageContract
         return json_decode(json_encode($schema->renderable(), JSON_THROW_ON_ERROR), true);
     }
 
-    /**
-     * i18n signals for the renderer, mirrored from laravel-i18next's config so it
-     * stays the single source of truth. The frontend hardcodes the routes, so only
-     * these travel: whether translations are served and whether missing keys are dumped.
-     *
-     * @return array{enabled: bool, saveMissing: bool}
-     */
-    private function i18nConfig(): array
+    private function i18nConfig(): I18nConfig
     {
-        return [
-            'enabled' => (bool) config('i18next.routes.enabled', false),
-            'saveMissing' => (bool) config('i18next.save_missing.enabled', false),
-        ];
+        return I18nConfig::fromConfig();
     }
 
     private function response(PageSchema $schema): Response

--- a/src/Tables/EloquentTableSource.php
+++ b/src/Tables/EloquentTableSource.php
@@ -39,11 +39,11 @@ final readonly class EloquentTableSource implements TableSource
         return match ($this->pagination) {
             PaginationType::None => TableResult::fromItems($builder->get(), PaginationType::None),
             PaginationType::Infinite, PaginationType::Simple => TableResult::fromSimplePaginator(
-                $builder->simplePaginate(perPage: $query->perPage(), page: $query->page()),
+                $builder->simplePaginate(perPage: $query->perPage, page: $query->page),
                 $this->pagination,
             ),
             PaginationType::Table => TableResult::fromPaginator(
-                $builder->paginate(perPage: $query->perPage(), page: $query->page()),
+                $builder->paginate(perPage: $query->perPage, page: $query->page),
             ),
         };
     }
@@ -79,7 +79,7 @@ final readonly class EloquentTableSource implements TableSource
     {
         $columns = Column::index($this->columns);
 
-        foreach ($query->filters() as $clause) {
+        foreach ($query->filters as $clause) {
             $column = $columns->get($clause->field);
 
             if ($column instanceof Filterable) {
@@ -93,7 +93,7 @@ final readonly class EloquentTableSource implements TableSource
             }
         }
 
-        foreach ($query->sorts() as $sort) {
+        foreach ($query->sorts as $sort) {
             $builder->orderBy($sort->key, $sort->direction->value);
         }
 

--- a/src/Tables/TablePagination.php
+++ b/src/Tables/TablePagination.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables;
+
+use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Tables\Enums\PaginationType;
+
+/**
+ * The table's pagination metadata as a single, closed wire shape: every producer
+ * fills the same keys, leaving the ones that do not apply to its mode as null.
+ * The `mode` discriminant lets the client decide which keys are meaningful.
+ */
+#[TypeScript]
+final readonly class TablePagination implements JsonSerializable
+{
+    public function __construct(
+        public PaginationType $mode,
+        public ?int $currentPage = null,
+        public ?int $lastPage = null,
+        public ?int $perPage = null,
+        public ?int $total = null,
+        public ?int $from = null,
+        public ?int $to = null,
+        public bool $hasMore = false,
+        public ?int $nextPage = null,
+    ) {}
+
+    /**
+     * The pre-load placeholder a lazy table renders before its first fetch:
+     * only the mode is known, every count is still null.
+     */
+    public static function pending(PaginationType $mode): self
+    {
+        return new self($mode);
+    }
+
+    /**
+     * @return array{mode: string, currentPage: int|null, lastPage: int|null, perPage: int|null, total: int|null, from: int|null, to: int|null, hasMore: bool, nextPage: int|null}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'mode' => $this->mode->value,
+            'currentPage' => $this->currentPage,
+            'lastPage' => $this->lastPage,
+            'perPage' => $this->perPage,
+            'total' => $this->total,
+            'from' => $this->from,
+            'to' => $this->to,
+            'hasMore' => $this->hasMore,
+            'nextPage' => $this->nextPage,
+        ];
+    }
+}

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -7,11 +7,13 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\Filterable;
 use Lattice\Lattice\Tables\Columns\Sortable;
 
+#[TypeScript]
 final readonly class TableQuery implements JsonSerializable
 {
     /**
@@ -19,10 +21,10 @@ final readonly class TableQuery implements JsonSerializable
      * @param  array<int, TableSort>  $sorts
      */
     private function __construct(
-        private array $filters,
-        private array $sorts,
-        private int $page,
-        private int $perPage,
+        public array $filters,
+        public array $sorts,
+        public int $page,
+        public int $perPage,
     ) {}
 
     public static function empty(int $defaultPerPage = 25): self
@@ -53,32 +55,6 @@ final readonly class TableQuery implements JsonSerializable
     private static function clampPerPage(int $perPage): int
     {
         return max(1, min(100, $perPage));
-    }
-
-    /**
-     * @return array<int, FilterClause>
-     */
-    public function filters(): array
-    {
-        return $this->filters;
-    }
-
-    /**
-     * @return array<int, TableSort>
-     */
-    public function sorts(): array
-    {
-        return $this->sorts;
-    }
-
-    public function page(): int
-    {
-        return $this->page;
-    }
-
-    public function perPage(): int
-    {
-        return $this->perPage;
     }
 
     /**

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -34,7 +34,7 @@ final class TableRegistry extends DefinitionRegistry
         return $this->buildComponent(
             $table,
             fn (TableDefinition $definition, TableQuery $query): TableResult => TableResult::make([])
-                ->pagination(['mode' => $definition->paginationType()->value]),
+                ->pagination(TablePagination::pending($definition->paginationType())),
             lazy: true,
         );
     }

--- a/src/Tables/TableResult.php
+++ b/src/Tables/TableResult.php
@@ -14,11 +14,10 @@ final readonly class TableResult implements JsonSerializable
 {
     /**
      * @param  array<int, array<string, mixed>>  $data
-     * @param  array<string, mixed>  $pagination
      */
     private function __construct(
         private array $data,
-        private array $pagination = [],
+        private ?TablePagination $pagination = null,
         private ?TableQuery $query = null,
     ) {}
 
@@ -37,17 +36,17 @@ final readonly class TableResult implements JsonSerializable
     {
         return new self(
             self::serializeRows($paginator->items()),
-            [
-                'mode' => PaginationType::Table->value,
-                'currentPage' => $paginator->currentPage(),
-                'lastPage' => $paginator->lastPage(),
-                'perPage' => $paginator->perPage(),
-                'total' => $paginator->total(),
-                'from' => $paginator->firstItem(),
-                'to' => $paginator->lastItem(),
-                'hasMore' => $paginator->hasMorePages(),
-                'nextPage' => $paginator->hasMorePages() ? $paginator->currentPage() + 1 : null,
-            ],
+            new TablePagination(
+                mode: PaginationType::Table,
+                currentPage: $paginator->currentPage(),
+                lastPage: $paginator->lastPage(),
+                perPage: $paginator->perPage(),
+                total: $paginator->total(),
+                from: $paginator->firstItem(),
+                to: $paginator->lastItem(),
+                hasMore: $paginator->hasMorePages(),
+                nextPage: $paginator->hasMorePages() ? $paginator->currentPage() + 1 : null,
+            ),
         );
     }
 
@@ -60,15 +59,15 @@ final readonly class TableResult implements JsonSerializable
     ): self {
         return new self(
             self::serializeRows($paginator->items()),
-            [
-                'mode' => $type->value,
-                'currentPage' => $paginator->currentPage(),
-                'perPage' => $paginator->perPage(),
-                'from' => $paginator->firstItem(),
-                'to' => $paginator->lastItem(),
-                'hasMore' => $paginator->hasMorePages(),
-                'nextPage' => $paginator->hasMorePages() ? $paginator->currentPage() + 1 : null,
-            ],
+            new TablePagination(
+                mode: $type,
+                currentPage: $paginator->currentPage(),
+                perPage: $paginator->perPage(),
+                from: $paginator->firstItem(),
+                to: $paginator->lastItem(),
+                hasMore: $paginator->hasMorePages(),
+                nextPage: $paginator->hasMorePages() ? $paginator->currentPage() + 1 : null,
+            ),
         );
     }
 
@@ -82,21 +81,18 @@ final readonly class TableResult implements JsonSerializable
 
         return new self(
             $rows,
-            [
-                'mode' => $type->value,
-                'total' => $total,
-                'from' => $total > 0 ? 1 : 0,
-                'to' => $total,
-                'hasMore' => false,
-                'nextPage' => null,
-            ],
+            new TablePagination(
+                mode: $type,
+                total: $total,
+                from: $total > 0 ? 1 : 0,
+                to: $total,
+                hasMore: false,
+                nextPage: null,
+            ),
         );
     }
 
-    /**
-     * @param  array<string, mixed>  $pagination
-     */
-    public function pagination(array $pagination): self
+    public function pagination(TablePagination $pagination): self
     {
         return new self($this->data, $pagination, $this->query);
     }
@@ -122,7 +118,7 @@ final readonly class TableResult implements JsonSerializable
     }
 
     /**
-     * @return array{data: array<int, array<string, mixed>>, pagination: array<string, mixed>, state: TableQuery}
+     * @return array{data: array<int, array<string, mixed>>, pagination: TablePagination|null, state: TableQuery}
      */
     public function jsonSerialize(): array
     {

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -97,7 +97,7 @@ test('registered tables serialize their configured endpoint columns state and in
                     'page' => 1,
                     'perPage' => 25,
                 ],
-                'pagination' => [],
+                'pagination' => null,
             ],
         ]);
 });
@@ -145,6 +145,14 @@ test('registered tables can serialize lazily without running their query', funct
                 ],
                 'pagination' => [
                     'mode' => 'table',
+                    'currentPage' => null,
+                    'lastPage' => null,
+                    'perPage' => null,
+                    'total' => null,
+                    'from' => null,
+                    'to' => null,
+                    'hasMore' => false,
+                    'nextPage' => null,
                 ],
             ],
         ]);
@@ -337,14 +345,14 @@ class WorkbenchUsersTable extends TableDefinition
                 'name' => 'Taylor',
                 'filters' => array_map(
                     fn ($filter): array => wire($filter),
-                    $query->filters(),
+                    $query->filters,
                 ),
                 'sorts' => array_map(
                     fn ($sort): array => [
                         'key' => $sort->key,
                         'direction' => $sort->direction,
                     ],
-                    $query->sorts(),
+                    $query->sorts,
                 ),
             ],
         ]));

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -99,7 +99,7 @@ test('eloquent tables can use simple pagination without totals', function () {
         ->assertOk()
         ->assertJsonCount(2, 'data')
         ->assertJsonPath('pagination.mode', 'simple')
-        ->assertJsonMissingPath('pagination.total')
+        ->assertJsonPath('pagination.total', null)
         ->assertJsonPath('pagination.hasMore', true)
         ->assertJsonPath('pagination.nextPage', 2);
 });

--- a/tests/Feature/TypeScript/WireShapeGenerationTest.php
+++ b/tests/Feature/TypeScript/WireShapeGenerationTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Locks the committed generated module to the wire value objects it must expose.
+ * The GeneratedTypesSnapshotTest separately guarantees this file stays in sync
+ * with `lattice:typescript`; here we assert the concrete shapes the client relies on.
+ */
+function generatedModule(): string
+{
+    return (string) file_get_contents(dirname(__DIR__, 3).'/resources/js/types/generated.ts');
+}
+
+it('generates the ActionResult wire shape', function () {
+    expect(generatedModule())
+        ->toContain('export type ActionResult = {')
+        ->toMatch('/export type ActionResult = \{\s*readonly ok: boolean;\s*readonly data: Record<string, unknown>;\s*readonly effects: Effect\[\];\s*\};/');
+});
+
+it('generates the TableQuery wire shape', function () {
+    expect(generatedModule())
+        ->toContain('export type TableQuery = {')
+        ->toMatch('/export type TableQuery = \{\s*readonly filters: FilterClause\[\];\s*readonly sorts: TableSort\[\];\s*readonly page: number;\s*readonly perPage: number;\s*\};/');
+});
+
+it('generates the flat TablePagination wire shape', function () {
+    expect(generatedModule())
+        ->toContain('export type TablePagination = {')
+        ->toMatch('/export type TablePagination = \{\s*readonly mode: PaginationType;\s*readonly currentPage: number \| null;\s*readonly lastPage: number \| null;\s*readonly perPage: number \| null;\s*readonly total: number \| null;\s*readonly from: number \| null;\s*readonly to: number \| null;\s*readonly hasMore: boolean;\s*readonly nextPage: number \| null;\s*\};/');
+});
+
+it('generates the I18nConfig wire shape', function () {
+    expect(generatedModule())
+        ->toContain('export type I18nConfig = {')
+        ->toMatch('/export type I18nConfig = \{\s*readonly enabled: boolean;\s*readonly saveMissing: boolean;\s*\};/');
+});

--- a/workbench/app/Tables/BaseUsersTable.php
+++ b/workbench/app/Tables/BaseUsersTable.php
@@ -46,7 +46,7 @@ abstract class BaseUsersTable extends EloquentTableDefinition
     {
         $builder = User::query()->select(['id', 'name', 'email', 'created_at', 'updated_at']);
 
-        if ($query->sorts() === []) {
+        if ($query->sorts === []) {
             $builder->orderBy('id');
         }
 

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -55,7 +55,7 @@ class ProductsTable extends EloquentTableDefinition
     {
         $builder = Product::query()->select(['id', 'name', 'sku', 'price', 'status', 'featured', 'updated_at']);
 
-        if ($query->sorts() === []) {
+        if ($query->sorts === []) {
             $builder->latest('id');
         }
 

--- a/workbench/app/Tables/UsersTable.php
+++ b/workbench/app/Tables/UsersTable.php
@@ -61,7 +61,7 @@ class UsersTable extends EloquentTableDefinition
     {
         $builder = User::query()->select(['id', 'name', 'email', 'created_at', 'updated_at']);
 
-        if ($query->sorts() === []) {
+        if ($query->sorts === []) {
             $builder->orderBy('id');
         }
 


### PR DESCRIPTION
Closes the #129 arc: derive the remaining server→client wire shapes from PHP value objects via `#[TypeScript]` instead of hand-writing them on the client.

## What's generated

| VO | Generated shape | Client change |
|---|---|---|
| `ActionResult` | `{ ok, data, effects: Effect[] }` | `ActionResponse = Partial<ActionResult>` |
| `TableQuery` | `{ filters, sorts, page, perPage }` | client `TableState` derives from it (narrows `filters` operator → `Op`) |
| `TablePagination` | flat closed shape — every key present, `null` where N/A | client consumes the generated type; presence checks use `== null` |
| `I18nConfig` | `{ enabled, saveMissing }` | fixes the `PagePayload` i18n drift (it omitted i18n) |

A VO is marked `#[TypeScript]` and its constructor-promoted props made **public** (the transformer skips private props). Generation is marker-based (`MarkedTypeDiscovery` → `ValueObjectTransformer`, run via `composer types`), superseding the stale allow-list mechanism named in #129.

## Key decisions

- **TablePagination → flat normalized VO** (not a mode-keyed discriminated union). The three `TableResult` producers fill one closed shape; lazy tables use `TablePagination::pending()`. A strict union was rejected because lazy tables emit a bare `{mode}` state and the client reads pagination fields unconditionally — flat matches actual consumption. **Wire change:** omitted keys → explicit nulls (alpha, no BC); PHP assertions and docs fixtures updated.
- **`PagePayload` stays hand-written, documented inline.** Its `schema`/`layout.schema` are component trees serialized eagerly during the request (to fire side effects before the final encode), so they can't be typed as `Node[]` from a VO without changing that timing. Full generation would need a serialization-timing redesign — separate ticket if wanted.
- **`ColumnData` flat-VO vs discriminator (the #129 sub-question): keep flat.** The flat `ColumnData` + `ColumnPropsMap`/`ColumnPropsOf` augmentation works without dev-only attributes.

## Verification

- `composer check` — Pint, PHPStan, 470 Pest (table/pagination feature tests, the new `WireShapeGenerationTest`, `GeneratedTypesSnapshotTest`).
- `npm run check` — oxlint, oxfmt, tsc, vitest, `build:lib`.
- Browser suite **not run** — unprovisioned in the worktree (uniform blank-page failures incl. the unrelated home-page smoke test). Worth a run in a provisioned env before merge since pagination is rendered UI.