### PR TITLE
Consumer-defined per-row actions for Repeater & Builder

### DIFF
--- a/docs/content/docs/forms/fields/builder.mdx
+++ b/docs/content/docs/forms/fields/builder.mdx
@@ -111,10 +111,17 @@ Builder::make('items', 'Line items')
     ->table();
 ```
 
-Reorder controls (↑↓) sit on the left of each row and the remove action on the right; once a row
-carries more than one action they collapse into a ⋯ menu. Reordering slides each row to its new
-position, and the table scrolls horizontally on narrow screens. The slide animation is skipped when
-the viewer prefers reduced motion.
+Reorder controls (↑↓) sit on the left of each row and the row actions on the right; once a row carries
+more than one action they collapse into a ⋯ menu. Reordering slides each row to its new position, and
+the table scrolls horizontally on narrow screens. The slide animation is skipped when the viewer
+prefers reduced motion.
+
+## Row actions
+
+Like the repeater, the builder takes `->rowActions([RowAction::duplicate(), RowAction::remove()])` to
+declare the per-row menu — the built-in **Duplicate** and **Remove** actions, customisable with
+`->label()`/`->icon()`/`->destructive()`. See [Repeater → Row actions](/forms/fields/repeater/#row-actions)
+for the full rundown.
 
 ## Validation
 

--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -101,6 +101,7 @@ same menu renders in both the stacked and table layouts — reorder controls sta
 
 `RowAction::duplicate()` and `RowAction::remove()` are the built-ins; chain `->label()`, `->icon()`, or
 `->destructive()` to customise each. Remove is hidden automatically while the row sits at `minItems`.
+Pass an empty array — `->rowActions([])` — to drop the menu entirely.
 
 ## Labels
 

--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -73,10 +73,34 @@ Repeater::make('items', 'Line items')
     ->table();
 ```
 
-Reorder controls (↑↓) sit on the left of each row and the remove action on the right; once a row
-carries more than one action they collapse into a ⋯ menu. Reordering slides each row to its new
-position, and the table scrolls horizontally on narrow screens. The slide animation is skipped when
+Reorder controls (↑↓) sit on the left of each row and the [row actions](#row-actions) on the right;
+once a row carries more than one action they collapse into a ⋯ menu. Reordering slides each row to its
+new position, and the table scrolls horizontally on narrow screens. The slide animation is skipped when
 the viewer prefers reduced motion.
+
+## Row actions
+
+Every row carries an action menu. By default it holds just **Remove** (hidden while the row is at
+`minItems`). Pass `->rowActions()` to declare the menu yourself, including the built-in **Duplicate**
+that clones a row in place. A single action renders inline; two or more collapse into a ⋯ menu. The
+same menu renders in both the stacked and table layouts — reorder controls stay separate.
+
+<ComponentExample
+  php={`Repeater::make('items', 'Line items')
+    ->schema([
+        TextInput::make('name', 'Name'),
+        TextInput::make('qty', 'Qty')->rules(['numeric']),
+    ])
+    ->rowActions([
+        RowAction::duplicate(),
+        RowAction::remove()->label('Delete'),
+    ]);`}
+  fixture="repeater.row-actions"
+  values={{ items: [{ name: "Widget", qty: "3" }] }}
+/>
+
+`RowAction::duplicate()` and `RowAction::remove()` are the built-ins; chain `->label()`, `->icon()`, or
+`->destructive()` to customise each. Remove is hidden automatically while the row sits at `minItems`.
 
 ## Labels
 

--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -136,6 +136,7 @@
             "required": null,
             "resizableColumns": null,
             "resizeIndicator": false,
+            "rowActions": [],
             "value": null
         },
         "type": "form.builder"

--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -136,7 +136,7 @@
             "required": null,
             "resizableColumns": null,
             "resizeIndicator": false,
-            "rowActions": [],
+            "rowActions": null,
             "value": null
         },
         "type": "form.builder"

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -24,7 +24,7 @@
             "required": null,
             "resizableColumns": null,
             "resizeIndicator": false,
-            "rowActions": [],
+            "rowActions": null,
             "value": null
         },
         "schema": [

--- a/docs/fixtures/repeater.row-actions.json
+++ b/docs/fixtures/repeater.row-actions.json
@@ -1,7 +1,7 @@
 [
     {
         "props": {
-            "addLabel": "Add line",
+            "addLabel": null,
             "columnWidth": "md",
             "conditions": null,
             "defaultItems": 1,
@@ -13,8 +13,8 @@
             "itemLabel": null,
             "label": "Line items",
             "layout": "stack",
-            "maxItems": 5,
-            "minItems": 1,
+            "maxItems": null,
+            "minItems": null,
             "name": "items",
             "prefill": null,
             "prefillRefreshOn": null,
@@ -24,7 +24,22 @@
             "required": null,
             "resizableColumns": null,
             "resizeIndicator": false,
-            "rowActions": [],
+            "rowActions": [
+                {
+                    "destructive": false,
+                    "icon": null,
+                    "key": "duplicate",
+                    "label": null,
+                    "type": "duplicate"
+                },
+                {
+                    "destructive": true,
+                    "icon": null,
+                    "key": "remove",
+                    "label": "Delete",
+                    "type": "remove"
+                }
+            ],
             "value": null
         },
         "schema": [
@@ -46,7 +61,7 @@
                     "prefillRefreshOn": null,
                     "prefillResetOn": null,
                     "readOnly": null,
-                    "required": true,
+                    "required": null,
                     "tabIndex": null,
                     "type": null,
                     "value": null

--- a/lang/de/lattice.php
+++ b/lang/de/lattice.php
@@ -85,4 +85,8 @@ return [
         'allSelected' => 'Alle :count ausgewählt',
         'selectAllMatching' => 'Alle :total passenden auswählen',
     ],
+    'rowActions' => [
+        'duplicate' => 'Duplizieren',
+        'remove' => 'Entfernen',
+    ],
 ];

--- a/lang/en/lattice.php
+++ b/lang/en/lattice.php
@@ -85,4 +85,8 @@ return [
         'allSelected' => 'All :count selected',
         'selectAllMatching' => 'Select all :total matching',
     ],
+    'rowActions' => [
+        'duplicate' => 'Duplicate',
+        'remove' => 'Remove',
+    ],
 ];

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -1,5 +1,5 @@
 import { expect, it, vi, beforeAll, afterAll } from "vitest";
-import { configure, getConfig, fireEvent, render, screen } from "@testing-library/react";
+import { configure, getConfig, fireEvent, render, screen, within } from "@testing-library/react";
 
 let prev: string;
 beforeAll(() => {
@@ -109,7 +109,8 @@ it("can remove an unknown-block row", () => {
     items: [{ type: "video" }, { type: "text", content: "keep" }],
   });
   expect(screen.getByText(/Unknown block/i)).toBeInTheDocument();
-  fireEvent.click(screen.getByTestId("repeater-items-remove-0"));
+  const firstRow = screen.getByTestId("repeater-items-row-0");
+  fireEvent.click(within(firstRow).getByTestId("row-action-remove"));
   expect(screen.queryByText(/Unknown block/i)).not.toBeInTheDocument();
 });
 

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -20,7 +20,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
   const blocks = ((node as unknown as { blocks?: Block[] }).blocks ?? []) as Block[];
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
-  const { rows, onField, onRemove, onMove, append } = useRowCollection(
+  const { rows, onField, onRemove, onMove, onDuplicate, append } = useRowCollection(
     name,
     props.defaultItems ?? 0,
   );
@@ -80,9 +80,11 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
               rows={tableRows}
               reorderable={props.reorderable ?? false}
               removable={() => !atMin}
+              rowActions={props.rowActions}
               onField={onField}
               onMove={onMove}
               onRemove={onRemove}
+              onDuplicate={onDuplicate}
               registerRow={registerRow}
               resizableColumns={props.resizableColumns === true}
               resizeIndicator={props.resizeIndicator === true}
@@ -111,9 +113,11 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
                     isFirst={index === 0}
                     isLast={index === rows.length - 1}
                     removable={!atMin}
+                    rowActions={props.rowActions}
                     onField={onField}
                     onRemove={onRemove}
                     onMove={onMove}
+                    onDuplicate={onDuplicate}
                   />
                 ) : (
                   <div

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -1,10 +1,12 @@
 import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
-import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
 import { useDependentField } from "../use-dependent-field";
 import { BlockAddMenu, type BlockOption } from "./block-add-menu";
 import { ROW_ID_KEY } from "./repeater-rows";
+import { buildRowActions } from "./row-action-menu";
+import { RowActions } from "./row-actions";
 import { RowItem } from "./row-item";
 import { columnsFromSchema, TableRows } from "./table-rows";
 import { useFlipReorder } from "./use-flip-reorder";
@@ -24,6 +26,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
     name,
     props.defaultItems ?? 0,
   );
+  const { t } = useT("lattice");
   const orderSignature = rows.map((r) => String(r[ROW_ID_KEY] ?? "")).join(",");
   const registerRow = useFlipReorder(orderSignature);
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
@@ -125,17 +128,15 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
                     className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
                   >
                     <span>Unknown block: {String(row.type)}</span>
-                    {!atMin && (
-                      <button
-                        type="button"
-                        aria-label="Remove"
-                        data-test={`repeater-${name}-remove-${index}`}
-                        className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
-                        onClick={() => onRemove(index)}
-                      >
-                        <Icon name="trash-2" />
-                      </button>
-                    )}
+                    <RowActions
+                      actions={buildRowActions(props.rowActions, {
+                        index,
+                        removable: !atMin,
+                        onRemove,
+                        onDuplicate,
+                        t,
+                      })}
+                    />
                   </div>
                 )}
               </div>

--- a/resources/js/form/components/fields/repeater-rows.test.ts
+++ b/resources/js/form/components/fields/repeater-rows.test.ts
@@ -1,6 +1,24 @@
 import { expect, it } from "vitest";
-import { addRow, moveRow, removeRow, seedRows } from "./repeater-rows";
+import { addRow, duplicateRow, moveRow, removeRow, seedRows } from "./repeater-rows";
 import { ensureRowIds, ROW_ID_KEY, withRowId } from "./repeater-rows";
+
+it("duplicateRow inserts a fresh copy right after the source, with a new id", () => {
+  const a = withRowId({ name: "first" });
+  const b = withRowId({ name: "second" });
+  const out = duplicateRow([a, b], 0);
+
+  expect(out).toHaveLength(3);
+  expect(out[0]).toBe(a);
+  expect(out[1].name).toBe("first");
+  expect(typeof out[1][ROW_ID_KEY]).toBe("string");
+  expect(out[1][ROW_ID_KEY]).not.toBe(a[ROW_ID_KEY]);
+  expect(out[2]).toBe(b);
+});
+
+it("duplicateRow returns the rows unchanged for an out-of-range index", () => {
+  const rows = [withRowId({ name: "only" })];
+  expect(duplicateRow(rows, 5)).toBe(rows);
+});
 
 it("seeds rows from an existing value", () => {
   expect(seedRows([{ name: "a" }], 3)).toEqual([{ name: "a" }]);

--- a/resources/js/form/components/fields/repeater-rows.ts
+++ b/resources/js/form/components/fields/repeater-rows.ts
@@ -34,6 +34,16 @@ export function removeRow(rows: RepeaterRow[], index: number): RepeaterRow[] {
   return rows.filter((_, i) => i !== index);
 }
 
+export function duplicateRow(rows: RepeaterRow[], index: number): RepeaterRow[] {
+  const source = rows[index];
+  if (!source) {
+    return rows;
+  }
+
+  const { [ROW_ID_KEY]: _id, ...copy } = source;
+  return [...rows.slice(0, index + 1), withRowId(copy), ...rows.slice(index + 1)];
+}
+
 export function moveRow(rows: RepeaterRow[], from: number, to: number): RepeaterRow[] {
   const next = [...rows];
   const [moved] = next.splice(from, 1);

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -1,5 +1,5 @@
 import { expect, it, vi, beforeAll, afterAll } from "vitest";
-import { configure, getConfig, fireEvent, render, screen } from "@testing-library/react";
+import { configure, getConfig, fireEvent, render, screen, within } from "@testing-library/react";
 
 // The form convention is data-test; scope the RTL testIdAttribute to this file only.
 let prevTestIdAttribute: string;
@@ -100,8 +100,41 @@ it("removes a row", () => {
     items: [{ name: "a" }, { name: "b" }],
   });
   expect(screen.getAllByTestId("child")).toHaveLength(2);
-  fireEvent.click(screen.getByTestId("repeater-items-remove-0"));
+  const firstRow = screen.getByTestId("repeater-items-row-0");
+  fireEvent.click(within(firstRow).getByTestId("row-action-remove"));
   expect(screen.getAllByTestId("child")).toHaveLength(1);
+});
+
+it("renders declared row actions in a kebab and duplicates a row", () => {
+  const node = {
+    id: "r",
+    type: "form.repeater",
+    props: {
+      name: "items",
+      reorderable: true,
+      defaultItems: 1,
+      minItems: 0,
+      maxItems: 3,
+      label: "Line items",
+      rowActions: [
+        { type: "duplicate", key: "duplicate", label: null, icon: null, destructive: false },
+        { type: "remove", key: "remove", label: null, icon: null, destructive: true },
+      ],
+    },
+    schema: [{ id: "c", type: "form.text-input", props: { name: "name", label: "Name" } }],
+  } as never;
+
+  wrap(<RepeaterComponent node={node}>{null}</RepeaterComponent>, {
+    items: [{ name: "a" }],
+  });
+
+  expect(screen.getAllByTestId("child")).toHaveLength(1);
+
+  const firstRow = screen.getByTestId("repeater-items-row-0");
+  fireEvent.click(within(firstRow).getByTestId("row-actions-menu"));
+  fireEvent.click(screen.getByTestId("row-action-duplicate"));
+
+  expect(screen.getAllByTestId("child")).toHaveLength(2);
 });
 
 it("shows the array-level error for the repeater field", () => {

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -16,7 +16,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
   const name = props.name;
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
-  const { rows, onField, onRemove, onMove, append } = useRowCollection(
+  const { rows, onField, onRemove, onMove, onDuplicate, append } = useRowCollection(
     name,
     props.defaultItems ?? 1,
   );
@@ -55,9 +55,11 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
             rows={tableRows}
             reorderable={props.reorderable ?? false}
             removable={() => !atMin}
+            rowActions={props.rowActions}
             onField={onField}
             onMove={onMove}
             onRemove={onRemove}
+            onDuplicate={onDuplicate}
             registerRow={registerRow}
             resizableColumns={props.resizableColumns === true}
             resizeIndicator={props.resizeIndicator === true}
@@ -77,9 +79,11 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
                   isFirst={index === 0}
                   isLast={index === rows.length - 1}
                   removable={!atMin}
+                  rowActions={props.rowActions}
                   onField={onField}
                   onRemove={onRemove}
                   onMove={onMove}
+                  onDuplicate={onDuplicate}
                 />
               </div>
             );

--- a/resources/js/form/components/fields/row-action-menu.test.ts
+++ b/resources/js/form/components/fields/row-action-menu.test.ts
@@ -20,14 +20,15 @@ function context(overrides: Partial<RowActionContext> = {}): RowActionContext {
     removable: true,
     onRemove: vi.fn<(index: number) => void>(),
     onDuplicate: vi.fn<(index: number) => void>(),
+    t: (_key, fallback) => fallback,
     ...overrides,
   };
 }
 
 describe("buildRowActions", () => {
-  it("defaults to a remove action when nothing is declared and the row is removable", () => {
+  it("defaults to a remove action when undeclared (null) and the row is removable", () => {
     const ctx = context();
-    const actions = buildRowActions([], ctx);
+    const actions = buildRowActions(null, ctx);
 
     expect(actions).toHaveLength(1);
     expect(actions[0].key).toBe("remove");
@@ -35,8 +36,21 @@ describe("buildRowActions", () => {
     expect(ctx.onRemove).toHaveBeenCalledWith(1);
   });
 
-  it("defaults to no actions when nothing is declared and the row is not removable", () => {
-    expect(buildRowActions([], context({ removable: false }))).toEqual([]);
+  it("defaults to no actions when undeclared (null) and the row is not removable", () => {
+    expect(buildRowActions(null, context({ removable: false }))).toEqual([]);
+  });
+
+  it("disables row actions entirely for an explicit empty array", () => {
+    expect(buildRowActions([], context())).toEqual([]);
+  });
+
+  it("resolves built-in labels through the translator", () => {
+    const [action] = buildRowActions(
+      [wireAction({ type: "duplicate" })],
+      context({ t: (key) => `t:${key}` }),
+    );
+
+    expect(action.label).toBe("t:rowActions.duplicate");
   });
 
   it("maps a duplicate action to onDuplicate with client-default label and icon", () => {

--- a/resources/js/form/components/fields/row-action-menu.test.ts
+++ b/resources/js/form/components/fields/row-action-menu.test.ts
@@ -1,0 +1,70 @@
+import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
+import { describe, expect, it, vi } from "vitest";
+import { buildRowActions, type RowActionContext } from "./row-action-menu";
+
+function wireAction(
+  overrides: Partial<WireRowAction> & Pick<WireRowAction, "type">,
+): WireRowAction {
+  return {
+    key: overrides.type,
+    label: null,
+    icon: null,
+    destructive: false,
+    ...overrides,
+  };
+}
+
+function context(overrides: Partial<RowActionContext> = {}): RowActionContext {
+  return {
+    index: 1,
+    removable: true,
+    onRemove: vi.fn<(index: number) => void>(),
+    onDuplicate: vi.fn<(index: number) => void>(),
+    ...overrides,
+  };
+}
+
+describe("buildRowActions", () => {
+  it("defaults to a remove action when nothing is declared and the row is removable", () => {
+    const ctx = context();
+    const actions = buildRowActions([], ctx);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].key).toBe("remove");
+    actions[0].onClick();
+    expect(ctx.onRemove).toHaveBeenCalledWith(1);
+  });
+
+  it("defaults to no actions when nothing is declared and the row is not removable", () => {
+    expect(buildRowActions([], context({ removable: false }))).toEqual([]);
+  });
+
+  it("maps a duplicate action to onDuplicate with client-default label and icon", () => {
+    const ctx = context();
+    const [action] = buildRowActions([wireAction({ type: "duplicate" })], ctx);
+
+    expect(action.label).toBe("Duplicate");
+    expect(action.icon).toBe("copy");
+    action.onClick();
+    expect(ctx.onDuplicate).toHaveBeenCalledWith(1);
+  });
+
+  it("honours overridden label and icon", () => {
+    const [action] = buildRowActions(
+      [wireAction({ type: "duplicate", label: "Clone", icon: "files" })],
+      context(),
+    );
+
+    expect(action.label).toBe("Clone");
+    expect(action.icon).toBe("files");
+  });
+
+  it("drops a declared remove action when the row is not removable", () => {
+    const actions = buildRowActions(
+      [wireAction({ type: "duplicate" }), wireAction({ type: "remove" })],
+      context({ removable: false }),
+    );
+
+    expect(actions.map((a) => a.key)).toEqual(["duplicate"]);
+  });
+});

--- a/resources/js/form/components/fields/row-action-menu.ts
+++ b/resources/js/form/components/fields/row-action-menu.ts
@@ -1,0 +1,64 @@
+import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
+import type { RowAction } from "./row-actions";
+
+/** Localised display defaults for the built-in row actions; the server sends null. */
+const BUILT_IN: Record<"duplicate" | "remove", { label: string; icon: string }> = {
+  duplicate: { label: "Duplicate", icon: "copy" },
+  remove: { label: "Remove", icon: "trash-2" },
+};
+
+export type RowActionContext = {
+  index: number;
+  removable: boolean;
+  onRemove: (index: number) => void;
+  onDuplicate: (index: number) => void;
+};
+
+/**
+ * Resolves the declared (or default) wire row actions into the click-wired client
+ * actions the kebab renders. An undeclared menu falls back to the built-in remove;
+ * remove is dropped while the row sits at its minimum.
+ */
+export function buildRowActions(declared: WireRowAction[], ctx: RowActionContext): RowAction[] {
+  const source = declared?.length ? declared : defaultActions(ctx.removable);
+
+  return source
+    .map((action) => toClientAction(action, ctx))
+    .filter((action): action is RowAction => action !== null);
+}
+
+function defaultActions(removable: boolean): WireRowAction[] {
+  if (!removable) {
+    return [];
+  }
+
+  return [{ type: "remove", key: "remove", label: null, icon: null, destructive: true }];
+}
+
+function toClientAction(action: WireRowAction, ctx: RowActionContext): RowAction | null {
+  if (action.type === "duplicate") {
+    return {
+      key: action.key,
+      label: action.label ?? BUILT_IN.duplicate.label,
+      icon: action.icon ?? BUILT_IN.duplicate.icon,
+      destructive: action.destructive,
+      onClick: () => ctx.onDuplicate(ctx.index),
+    };
+  }
+
+  if (action.type === "remove") {
+    if (!ctx.removable) {
+      return null;
+    }
+
+    return {
+      key: action.key,
+      label: action.label ?? BUILT_IN.remove.label,
+      icon: action.icon ?? BUILT_IN.remove.icon,
+      destructive: action.destructive,
+      onClick: () => ctx.onRemove(ctx.index),
+    };
+  }
+
+  return null;
+}

--- a/resources/js/form/components/fields/row-action-menu.ts
+++ b/resources/js/form/components/fields/row-action-menu.ts
@@ -1,10 +1,12 @@
 import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
 import type { RowAction } from "./row-actions";
 
-/** Localised display defaults for the built-in row actions; the server sends null. */
-const BUILT_IN: Record<"duplicate" | "remove", { label: string; icon: string }> = {
-  duplicate: { label: "Duplicate", icon: "copy" },
-  remove: { label: "Remove", icon: "trash-2" },
+export type RowActionTranslate = (key: string, fallback: string) => string;
+
+/** Translation key + fallback and icon for each built-in; the server sends null labels. */
+const BUILT_IN: Record<"duplicate" | "remove", { key: string; fallback: string; icon: string }> = {
+  duplicate: { key: "rowActions.duplicate", fallback: "Duplicate", icon: "copy" },
+  remove: { key: "rowActions.remove", fallback: "Remove", icon: "trash-2" },
 };
 
 export type RowActionContext = {
@@ -12,15 +14,20 @@ export type RowActionContext = {
   removable: boolean;
   onRemove: (index: number) => void;
   onDuplicate: (index: number) => void;
+  t: RowActionTranslate;
 };
 
 /**
- * Resolves the declared (or default) wire row actions into the click-wired client
- * actions the kebab renders. An undeclared menu falls back to the built-in remove;
- * remove is dropped while the row sits at its minimum.
+ * Resolves the declared wire row actions into the click-wired client actions the
+ * kebab renders. `null` (undeclared) falls back to the built-in remove; an empty
+ * array disables row actions entirely. Remove is dropped while the row is at its
+ * minimum, and built-in labels resolve through i18n when the server sends none.
  */
-export function buildRowActions(declared: WireRowAction[], ctx: RowActionContext): RowAction[] {
-  const source = declared?.length ? declared : defaultActions(ctx.removable);
+export function buildRowActions(
+  declared: WireRowAction[] | null,
+  ctx: RowActionContext,
+): RowAction[] {
+  const source = declared ?? defaultActions(ctx.removable);
 
   return source
     .map((action) => toClientAction(action, ctx))
@@ -37,10 +44,12 @@ function defaultActions(removable: boolean): WireRowAction[] {
 
 function toClientAction(action: WireRowAction, ctx: RowActionContext): RowAction | null {
   if (action.type === "duplicate") {
+    const builtIn = BUILT_IN.duplicate;
+
     return {
       key: action.key,
-      label: action.label ?? BUILT_IN.duplicate.label,
-      icon: action.icon ?? BUILT_IN.duplicate.icon,
+      label: action.label ?? ctx.t(builtIn.key, builtIn.fallback),
+      icon: action.icon ?? builtIn.icon,
       destructive: action.destructive,
       onClick: () => ctx.onDuplicate(ctx.index),
     };
@@ -51,10 +60,12 @@ function toClientAction(action: WireRowAction, ctx: RowActionContext): RowAction
       return null;
     }
 
+    const builtIn = BUILT_IN.remove;
+
     return {
       key: action.key,
-      label: action.label ?? BUILT_IN.remove.label,
-      icon: action.icon ?? BUILT_IN.remove.icon,
+      label: action.label ?? ctx.t(builtIn.key, builtIn.fallback),
+      icon: action.icon ?? builtIn.icon,
       destructive: action.destructive,
       onClick: () => ctx.onRemove(ctx.index),
     };

--- a/resources/js/form/components/fields/row-actions.test.tsx
+++ b/resources/js/form/components/fields/row-actions.test.tsx
@@ -39,3 +39,28 @@ it("renders nothing for an empty action list", () => {
   const { container } = render(<RowActions actions={[]} />);
   expect(container).toBeEmptyDOMElement();
 });
+
+it("applies destructive styling to an inline action", () => {
+  render(
+    <RowActions
+      actions={[
+        { key: "remove", label: "Remove", icon: "trash-2", onClick: () => {}, destructive: true },
+      ]}
+    />,
+  );
+  expect(screen.getByTestId("row-action-remove")).toHaveClass("text-lt-danger");
+});
+
+it("applies destructive styling to a menu item", () => {
+  render(
+    <RowActions
+      actions={[
+        { key: "duplicate", label: "Duplicate", icon: "copy", onClick: () => {} },
+        { key: "remove", label: "Remove", icon: "trash-2", onClick: () => {}, destructive: true },
+      ]}
+    />,
+  );
+  fireEvent.click(screen.getByTestId("row-actions-menu"));
+  expect(screen.getByTestId("row-action-remove")).toHaveClass("text-lt-danger");
+  expect(screen.getByTestId("row-action-duplicate")).not.toHaveClass("text-lt-danger");
+});

--- a/resources/js/form/components/fields/row-actions.tsx
+++ b/resources/js/form/components/fields/row-actions.tsx
@@ -10,6 +10,20 @@ export type RowAction = {
   destructive?: boolean;
 };
 
+function inlineClass(destructive?: boolean): string {
+  return destructive
+    ? "text-lt-danger hover:text-lt-danger [&_svg]:size-lt-icon-sm"
+    : "text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm";
+}
+
+function menuItemClass(destructive?: boolean): string {
+  const base =
+    "flex w-full items-center gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm [&_svg]:size-lt-icon-sm";
+  return destructive
+    ? `${base} text-lt-danger hover:bg-lt-danger/10`
+    : `${base} hover:bg-lt-accent hover:text-lt-accent-fg`;
+}
+
 export function RowActions({ actions }: { actions: RowAction[] }) {
   const [open, setOpen] = useState(false);
 
@@ -24,7 +38,7 @@ export function RowActions({ actions }: { actions: RowAction[] }) {
         type="button"
         aria-label={action.label}
         data-test={`row-action-${action.key}`}
-        className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-sm"
+        className={inlineClass(action.destructive)}
         onClick={action.onClick}
       >
         <Icon name={action.icon} />
@@ -55,7 +69,7 @@ export function RowActions({ actions }: { actions: RowAction[] }) {
               key={action.key}
               type="button"
               data-test={`row-action-${action.key}`}
-              className="flex w-full items-center gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm hover:bg-lt-accent hover:text-lt-accent-fg [&_svg]:size-lt-icon-sm"
+              className={menuItemClass(action.destructive)}
               onClick={() => {
                 action.onClick();
                 setOpen(false);

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -3,7 +3,10 @@ import type { ReactNode } from "react";
 import { memo } from "react";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
+import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
 import { FieldScopeProvider } from "../field-scope";
+import { buildRowActions } from "./row-action-menu";
+import { RowActions } from "./row-actions";
 import type { RepeaterRow } from "./repeater-rows";
 
 export function RowButton({
@@ -40,9 +43,11 @@ export type RowItemProps = {
   isFirst: boolean;
   isLast: boolean;
   removable: boolean;
+  rowActions: WireRowAction[];
   onField: (index: number, field: string, value: unknown) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, delta: number) => void;
+  onDuplicate: (index: number) => void;
 };
 
 // Memoised so editing one row doesn't re-render its siblings. Its props are kept
@@ -58,9 +63,11 @@ export const RowItem = memo(function RowItem({
   isFirst,
   isLast,
   removable,
+  rowActions,
   onField,
   onRemove,
   onMove,
+  onDuplicate,
 }: RowItemProps) {
   return (
     <div
@@ -88,15 +95,9 @@ export const RowItem = memo(function RowItem({
               <Icon name="arrow-down" />
             </RowButton>
           )}
-          {removable && (
-            <RowButton
-              label="Remove"
-              testId={`repeater-${base}-remove-${index}`}
-              onClick={() => onRemove(index)}
-            >
-              <Icon name="trash-2" />
-            </RowButton>
-          )}
+          <RowActions
+            actions={buildRowActions(rowActions, { index, removable, onRemove, onDuplicate })}
+          />
         </div>
       </div>
 

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { memo } from "react";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
+import { useT } from "@lattice-php/lattice/i18n";
 import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
 import { FieldScopeProvider } from "../field-scope";
 import { buildRowActions } from "./row-action-menu";
@@ -43,7 +44,7 @@ export type RowItemProps = {
   isFirst: boolean;
   isLast: boolean;
   removable: boolean;
-  rowActions: WireRowAction[];
+  rowActions: WireRowAction[] | null;
   onField: (index: number, field: string, value: unknown) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, delta: number) => void;
@@ -69,6 +70,8 @@ export const RowItem = memo(function RowItem({
   onMove,
   onDuplicate,
 }: RowItemProps) {
+  const { t } = useT("lattice");
+
   return (
     <div
       data-test={`repeater-${base}-row-${index}`}
@@ -96,7 +99,7 @@ export const RowItem = memo(function RowItem({
             </RowButton>
           )}
           <RowActions
-            actions={buildRowActions(rowActions, { index, removable, onRemove, onDuplicate })}
+            actions={buildRowActions(rowActions, { index, removable, onRemove, onDuplicate, t })}
           />
         </div>
       </div>

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -62,6 +62,8 @@ it("renders the header columns once and a columnar row's scoped cells", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
     />,
   );
   expect(screen.getByText("Qty")).toBeInTheDocument();
@@ -81,6 +83,8 @@ it("renders a spanning row in a single full-width cell", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
     />,
   );
   expect(screen.getByTestId("table-row-items-0-span")).toBeInTheDocument();
@@ -98,6 +102,8 @@ it("shows a remove action when removable", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
     />,
   );
   expect(screen.getByTestId("row-action-remove")).toBeInTheDocument();
@@ -115,6 +121,8 @@ it("registers each row element for FLIP", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
       registerRow={(k, el) => calls.push([k, el])}
     />,
   );
@@ -132,6 +140,8 @@ it("uses column width hints when building the table grid", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
     />,
   );
 
@@ -151,6 +161,8 @@ it("does not render column resize handles unless enabled", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
     />,
   );
 
@@ -169,6 +181,8 @@ it("renders column resize handles when enabled", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
+      rowActions={[]}
+      onDuplicate={noop}
     />,
   );
 

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -62,7 +62,7 @@ it("renders the header columns once and a columnar row's scoped cells", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
     />,
   );
@@ -83,7 +83,7 @@ it("renders a spanning row in a single full-width cell", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
     />,
   );
@@ -102,7 +102,7 @@ it("shows a remove action when removable", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
     />,
   );
@@ -121,7 +121,7 @@ it("registers each row element for FLIP", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
       registerRow={(k, el) => calls.push([k, el])}
     />,
@@ -140,7 +140,7 @@ it("uses column width hints when building the table grid", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
     />,
   );
@@ -161,7 +161,7 @@ it("does not render column resize handles unless enabled", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
     />,
   );
@@ -181,7 +181,7 @@ it("renders column resize handles when enabled", () => {
       onField={noop}
       onMove={noop}
       onRemove={noop}
-      rowActions={[]}
+      rowActions={null}
       onDuplicate={noop}
     />,
   );

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -3,6 +3,7 @@ import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import { DEFAULT_COLUMN_WIDTH, type SizableColumn } from "@lattice-php/lattice/core/column-sizing";
 import { useColumnResizing } from "@lattice-php/lattice/core/use-column-resizing";
 import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
 import { memo, useMemo } from "react";
 import type { ColumnWidth, RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
 import { FieldScopeProvider } from "../field-scope";
@@ -53,7 +54,7 @@ type TableRowItemProps = {
   flipKey: string;
   reorderable: boolean;
   removable: boolean;
-  rowActions: WireRowAction[];
+  rowActions: WireRowAction[] | null;
   onField: (index: number, field: string, value: unknown) => void;
   onMove: (index: number, delta: number) => void;
   onRemove: (index: number) => void;
@@ -81,6 +82,8 @@ const TableRowItem = memo(function TableRowItem({
   onDuplicate,
   registerRow,
 }: TableRowItemProps) {
+  const { t } = useT("lattice");
+
   return (
     <div
       ref={(el) => registerRow?.(flipKey, el)}
@@ -139,7 +142,7 @@ const TableRowItem = memo(function TableRowItem({
 
       <div className="flex items-center">
         <RowActions
-          actions={buildRowActions(rowActions, { index, removable, onRemove, onDuplicate })}
+          actions={buildRowActions(rowActions, { index, removable, onRemove, onDuplicate, t })}
         />
       </div>
     </div>
@@ -166,7 +169,7 @@ export function TableRows({
   rows: TableRowModel[];
   reorderable: boolean;
   removable: (index: number) => boolean;
-  rowActions: WireRowAction[];
+  rowActions: WireRowAction[] | null;
   onField: (index: number, field: string, value: unknown) => void;
   onMove: (index: number, delta: number) => void;
   onRemove: (index: number) => void;

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -4,9 +4,10 @@ import { DEFAULT_COLUMN_WIDTH, type SizableColumn } from "@lattice-php/lattice/c
 import { useColumnResizing } from "@lattice-php/lattice/core/use-column-resizing";
 import { Icon } from "@lattice-php/lattice/icons";
 import { memo, useMemo } from "react";
-import type { ColumnWidth } from "@lattice-php/lattice/types/generated";
+import type { ColumnWidth, RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
 import { FieldScopeProvider } from "../field-scope";
 import { TableCellProvider } from "../row-layout-context";
+import { buildRowActions } from "./row-action-menu";
 import { RowActions } from "./row-actions";
 import { RowButton } from "./row-item";
 import type { RepeaterRow } from "./repeater-rows";
@@ -52,9 +53,11 @@ type TableRowItemProps = {
   flipKey: string;
   reorderable: boolean;
   removable: boolean;
+  rowActions: WireRowAction[];
   onField: (index: number, field: string, value: unknown) => void;
   onMove: (index: number, delta: number) => void;
   onRemove: (index: number) => void;
+  onDuplicate: (index: number) => void;
   registerRow?: (key: string, el: HTMLElement | null) => void;
 };
 
@@ -71,9 +74,11 @@ const TableRowItem = memo(function TableRowItem({
   flipKey,
   reorderable,
   removable,
+  rowActions,
   onField,
   onMove,
   onRemove,
+  onDuplicate,
   registerRow,
 }: TableRowItemProps) {
   return (
@@ -134,19 +139,7 @@ const TableRowItem = memo(function TableRowItem({
 
       <div className="flex items-center">
         <RowActions
-          actions={
-            removable
-              ? [
-                  {
-                    key: "remove",
-                    label: "Remove",
-                    icon: "trash-2",
-                    onClick: () => onRemove(index),
-                    destructive: true,
-                  },
-                ]
-              : []
-          }
+          actions={buildRowActions(rowActions, { index, removable, onRemove, onDuplicate })}
         />
       </div>
     </div>
@@ -159,9 +152,11 @@ export function TableRows({
   rows,
   reorderable,
   removable,
+  rowActions,
   onField,
   onMove,
   onRemove,
+  onDuplicate,
   registerRow,
   resizableColumns = false,
   resizeIndicator = false,
@@ -171,9 +166,11 @@ export function TableRows({
   rows: TableRowModel[];
   reorderable: boolean;
   removable: (index: number) => boolean;
+  rowActions: WireRowAction[];
   onField: (index: number, field: string, value: unknown) => void;
   onMove: (index: number, delta: number) => void;
   onRemove: (index: number) => void;
+  onDuplicate: (index: number) => void;
   registerRow?: (key: string, el: HTMLElement | null) => void;
   resizableColumns?: boolean;
   resizeIndicator?: boolean;
@@ -228,9 +225,11 @@ export function TableRows({
             flipKey={row.key}
             reorderable={reorderable}
             removable={removable(row.index)}
+            rowActions={rowActions}
             onField={onField}
             onMove={onMove}
             onRemove={onRemove}
+            onDuplicate={onDuplicate}
             registerRow={registerRow}
           />
         ))}

--- a/resources/js/form/components/fields/use-row-collection.test.tsx
+++ b/resources/js/form/components/fields/use-row-collection.test.tsx
@@ -41,3 +41,16 @@ it("stamps an id on an appended row", () => {
   act(() => c.append({ a: "3" }));
   expect(c.rows[2][ROW_ID_KEY]).toBeTruthy();
 });
+
+it("duplicates a row in place with a fresh id", () => {
+  let c!: ReturnType<typeof useRowCollection>;
+  harness((latest) => (c = latest));
+  const id0 = c.rows[0][ROW_ID_KEY];
+
+  act(() => c.onDuplicate(0));
+
+  expect(c.rows).toHaveLength(3);
+  expect(c.rows[1].a).toBe("1");
+  expect(c.rows[1][ROW_ID_KEY]).not.toBe(id0);
+  expect(c.rows[2].a).toBe("2");
+});

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,6 +1,7 @@
 import { useCallback, useLayoutEffect } from "react";
 import { useFormValue, useSetFormValue } from "../values";
 import {
+  duplicateRow,
   ensureRowIds,
   moveRow,
   removeRow,
@@ -14,6 +15,7 @@ export type RowCollection = {
   onField: (index: number, field: string, value: unknown) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, delta: number) => void;
+  onDuplicate: (index: number) => void;
   append: (row: RepeaterRow) => void;
 };
 
@@ -54,10 +56,14 @@ export function useRowCollection(name: string, defaultItems: number): RowCollect
       mutate((current) => moveRow(current, index, index + delta)),
     [mutate],
   );
+  const onDuplicate = useCallback(
+    (index: number): void => mutate((current) => duplicateRow(current, index)),
+    [mutate],
+  );
   const append = useCallback(
     (row: RepeaterRow): void => mutate((current) => [...current, withRowId(row)]),
     [mutate],
   );
 
-  return { rows, onField, onRemove, onMove, append };
+  return { rows, onField, onRemove, onMove, onDuplicate, append };
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -75,7 +75,7 @@ export type Builder = {
   required: boolean | null;
   resizableColumns: boolean | null;
   resizeIndicator: boolean;
-  rowActions: RowAction[];
+  rowActions: RowAction[] | null;
   value: unknown;
 };
 export type BulkAction = {
@@ -696,7 +696,7 @@ export type Repeater = {
   required: boolean | null;
   resizableColumns: boolean | null;
   resizeIndicator: boolean;
-  rowActions: RowAction[];
+  rowActions: RowAction[] | null;
   value: unknown;
 };
 export type ResetFormEffect = {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -75,6 +75,7 @@ export type Builder = {
   required: boolean | null;
   resizableColumns: boolean | null;
   resizeIndicator: boolean;
+  rowActions: RowAction[];
   value: unknown;
 };
 export type BulkAction = {
@@ -695,6 +696,7 @@ export type Repeater = {
   required: boolean | null;
   resizableColumns: boolean | null;
   resizeIndicator: boolean;
+  rowActions: RowAction[];
   value: unknown;
 };
 export type ResetFormEffect = {
@@ -723,6 +725,14 @@ export type RichEditor = {
   required: boolean | null;
   value: unknown;
 };
+export type RowAction = {
+  type: RowActionType;
+  key: string;
+  label: string | null;
+  icon: string | null;
+  destructive: boolean;
+};
+export type RowActionType = "duplicate" | "remove";
 export type RowLayout = "stack" | "table";
 export type Section = {
   collapsed: boolean;

--- a/src/Forms/Components/Builder.php
+++ b/src/Forms/Components/Builder.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
+use Lattice\Lattice\Forms\Components\Concerns\HasRowActions;
 use Lattice\Lattice\Forms\Components\Concerns\HasRowLayout;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowPrefills;
@@ -16,6 +17,7 @@ use Lattice\Lattice\Forms\FormData;
 class Builder extends Field implements ProvidesRowFields, ProvidesRowPrefills
 {
     use HandlesRowSchemas;
+    use HasRowActions;
     use HasRowLayout;
 
     /**

--- a/src/Forms/Components/Concerns/HasRowActions.php
+++ b/src/Forms/Components/Concerns/HasRowActions.php
@@ -8,9 +8,12 @@ use Lattice\Lattice\Forms\Components\RowAction;
 trait HasRowActions
 {
     /**
-     * @var array<int, RowAction>
+     * Null until declared, so the client can tell "undeclared" (use the default
+     * menu) apart from an explicit empty list (no row actions at all).
+     *
+     * @var array<int, RowAction>|null
      */
-    public array $rowActions = [];
+    public ?array $rowActions = null;
 
     /**
      * @param  array<int, RowAction>  $actions

--- a/src/Forms/Components/Concerns/HasRowActions.php
+++ b/src/Forms/Components/Concerns/HasRowActions.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components\Concerns;
+
+use Lattice\Lattice\Forms\Components\RowAction;
+
+trait HasRowActions
+{
+    /**
+     * @var array<int, RowAction>
+     */
+    public array $rowActions = [];
+
+    /**
+     * @param  array<int, RowAction>  $actions
+     */
+    public function rowActions(array $actions): static
+    {
+        $this->rowActions = $actions;
+
+        return $this;
+    }
+}

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
 use Lattice\Lattice\Forms\Components\Concerns\HandlesRowSchemas;
+use Lattice\Lattice\Forms\Components\Concerns\HasRowActions;
 use Lattice\Lattice\Forms\Components\Concerns\HasRowLayout;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowPrefills;
@@ -18,6 +19,7 @@ class Repeater extends Field implements ProvidesRowFields, ProvidesRowPrefills
 {
     use HandlesRowSchemas;
     use HasChildSchema;
+    use HasRowActions;
     use HasRowLayout;
 
     public ?int $minItems = null;

--- a/src/Forms/Components/RowAction.php
+++ b/src/Forms/Components/RowAction.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components;
+
+use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Forms\Enums\RowActionType;
+
+/**
+ * A per-row action declared on a Repeater or Builder. The built-in types map to
+ * client-side row mutations (duplicate, remove). `label` and `icon` are null by
+ * default so the client supplies the localised defaults.
+ */
+#[TypeScript]
+final class RowAction implements JsonSerializable
+{
+    private function __construct(
+        public RowActionType $type,
+        public string $key,
+        public ?string $label = null,
+        public ?string $icon = null,
+        public bool $destructive = false,
+    ) {}
+
+    public static function duplicate(): self
+    {
+        return new self(RowActionType::Duplicate, 'duplicate');
+    }
+
+    public static function remove(): self
+    {
+        return new self(RowActionType::Remove, 'remove', destructive: true);
+    }
+
+    public function label(string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    public function icon(string $icon): self
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function destructive(bool $destructive = true): self
+    {
+        $this->destructive = $destructive;
+
+        return $this;
+    }
+
+    /**
+     * @return array{type: string, key: string, label: string|null, icon: string|null, destructive: bool}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->type->value,
+            'key' => $this->key,
+            'label' => $this->label,
+            'icon' => $this->icon,
+            'destructive' => $this->destructive,
+        ];
+    }
+}

--- a/src/Forms/Enums/RowActionType.php
+++ b/src/Forms/Enums/RowActionType.php
@@ -5,11 +5,7 @@ namespace Lattice\Lattice\Forms\Enums;
 
 use Lattice\Lattice\Attributes\TypeScript;
 
-/**
- * Discriminates a row action's behaviour: the built-in client mutations the row
- * collection already understands. Reordering stays a separate affordance driven
- * by `reorderable`, not a row action.
- */
+// Reordering is a separate affordance (`reorderable`), so there are no move cases here.
 #[TypeScript]
 enum RowActionType: string
 {

--- a/src/Forms/Enums/RowActionType.php
+++ b/src/Forms/Enums/RowActionType.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+/**
+ * Discriminates a row action's behaviour: the built-in client mutations the row
+ * collection already understands. Reordering stays a separate affordance driven
+ * by `reorderable`, not a row action.
+ */
+#[TypeScript]
+enum RowActionType: string
+{
+    case Duplicate = 'duplicate';
+    case Remove = 'remove';
+}

--- a/tests/Browser/Forms/PricingBuilderTest.php
+++ b/tests/Browser/Forms/PricingBuilderTest.php
@@ -27,7 +27,7 @@ it('prefills computed prices, keeps manual edits, and re-prices untouched rows',
         ->assertValue('input[name="items[1][price]"]', '200')
         ->assertValue('input[name="items[2][price]"]', '300')
         ->fill('input[name="items[1][price]"]', '1.00')
-        ->click('@repeater-items-remove-0')
+        ->click('[data-test="repeater-items-row-0"] [data-test="row-action-remove"]')
         ->click('[data-test="select-customer"]')
         ->click('@select-customer-option-initech')
         ->wait(1)

--- a/tests/Feature/TypeScript/WireShapeGenerationTest.php
+++ b/tests/Feature/TypeScript/WireShapeGenerationTest.php
@@ -34,3 +34,23 @@ it('generates the I18nConfig wire shape', function () {
         ->toContain('export type I18nConfig = {')
         ->toMatch('/export type I18nConfig = \{\s*readonly enabled: boolean;\s*readonly saveMissing: boolean;\s*\};/');
 });
+
+it('generates the RowAction wire shape and its type enum', function () {
+    expect(generatedModule())
+        ->toContain('export type RowActionType =')
+        ->toMatch('/export type RowActionType =\s*\|? ?"duplicate"\s*\| "remove";/')
+        ->toContain('export type RowAction = {')
+        ->toMatch('/export type RowAction = \{\s*type: RowActionType;\s*key: string;\s*label: string \| null;\s*icon: string \| null;\s*destructive: boolean;\s*\};/');
+});
+
+it('exposes rowActions on the Repeater and Builder field props', function () {
+    $module = generatedModule();
+
+    expect($module)
+        ->toContain('export type Repeater = {')
+        ->toContain('export type Builder = {')
+        ->toContain('rowActions: RowAction[];');
+
+    // Both Repeater and Builder must carry it.
+    expect(substr_count($module, 'rowActions: RowAction[];'))->toBe(2);
+});

--- a/tests/Feature/TypeScript/WireShapeGenerationTest.php
+++ b/tests/Feature/TypeScript/WireShapeGenerationTest.php
@@ -49,8 +49,7 @@ it('exposes rowActions on the Repeater and Builder field props', function () {
     expect($module)
         ->toContain('export type Repeater = {')
         ->toContain('export type Builder = {')
-        ->toContain('rowActions: RowAction[];');
+        ->toContain('rowActions: RowAction[] | null;');
 
-    // Both Repeater and Builder must carry it.
-    expect(substr_count($module, 'rowActions: RowAction[];'))->toBe(2);
+    expect(substr_count($module, 'rowActions: RowAction[] | null;'))->toBe(2);
 });

--- a/tests/Unit/Docs/RepeaterDocsTest.php
+++ b/tests/Unit/Docs/RepeaterDocsTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\RowAction;
 use Lattice\Lattice\Forms\Components\TextInput;
 
 describe('docs fixtures', function (): void {
@@ -20,5 +21,21 @@ describe('docs fixtures', function (): void {
         ]);
 
         expect('docs/fixtures/repeater.basic.json')->toBeReadableFile();
+    });
+
+    it('dumps the repeater row-actions example', function (): void {
+        dumpFixture('repeater.row-actions', [
+            Repeater::make('items', 'Line items')
+                ->schema([
+                    TextInput::make('name', 'Name'),
+                    TextInput::make('qty', 'Qty')->rules(['numeric']),
+                ])
+                ->rowActions([
+                    RowAction::duplicate(),
+                    RowAction::remove()->label('Delete'),
+                ]),
+        ]);
+
+        expect('docs/fixtures/repeater.row-actions.json')->toBeReadableFile();
     });
 });

--- a/tests/Unit/Forms/Components/RepeaterWireShapeTest.php
+++ b/tests/Unit/Forms/Components/RepeaterWireShapeTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\RowAction;
 use Lattice\Lattice\Forms\Components\TextInput;
 
 it('serialises a repeater with its row-template schema and props', function (): void {
@@ -34,4 +35,24 @@ it('defaults reorderable on and defaultItems to 1', function (): void {
 
     expect($wire['props']['reorderable'])->toBeTrue()
         ->and($wire['props']['defaultItems'])->toBe(1);
+});
+
+it('serialises an empty rowActions array when none are declared', function (): void {
+    $wire = wire(Repeater::make('items')->schema([TextInput::make('name')]));
+
+    expect($wire['props']['rowActions'])->toBe([]);
+});
+
+it('serialises declared rowActions into the field props', function (): void {
+    $wire = wire(
+        Repeater::make('items')
+            ->schema([TextInput::make('name')])
+            ->rowActions([RowAction::duplicate(), RowAction::remove()->label('Delete')]),
+    );
+
+    expect($wire['props']['rowActions'])->toHaveCount(2)
+        ->and($wire['props']['rowActions'][0]['type'])->toBe('duplicate')
+        ->and($wire['props']['rowActions'][1]['type'])->toBe('remove')
+        ->and($wire['props']['rowActions'][1]['label'])->toBe('Delete')
+        ->and($wire['props']['rowActions'][1]['destructive'])->toBeTrue();
 });

--- a/tests/Unit/Forms/Components/RepeaterWireShapeTest.php
+++ b/tests/Unit/Forms/Components/RepeaterWireShapeTest.php
@@ -37,8 +37,14 @@ it('defaults reorderable on and defaultItems to 1', function (): void {
         ->and($wire['props']['defaultItems'])->toBe(1);
 });
 
-it('serialises an empty rowActions array when none are declared', function (): void {
+it('serialises rowActions as null when none are declared', function (): void {
     $wire = wire(Repeater::make('items')->schema([TextInput::make('name')]));
+
+    expect($wire['props']['rowActions'])->toBeNull();
+});
+
+it('serialises an explicit empty rowActions array to disable the row menu', function (): void {
+    $wire = wire(Repeater::make('items')->schema([TextInput::make('name')])->rowActions([]));
 
     expect($wire['props']['rowActions'])->toBe([]);
 });

--- a/tests/Unit/Forms/Components/RowActionTest.php
+++ b/tests/Unit/Forms/Components/RowActionTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\RowAction;
+
+/**
+ * @return array<string, mixed>
+ */
+function serializeRowAction(RowAction $action): array
+{
+    return json_decode(json_encode($action, JSON_THROW_ON_ERROR), true);
+}
+
+it('serialises the built-in duplicate action with client-defaulted label and icon', function (): void {
+    expect(serializeRowAction(RowAction::duplicate()))->toBe([
+        'type' => 'duplicate',
+        'key' => 'duplicate',
+        'label' => null,
+        'icon' => null,
+        'destructive' => false,
+    ]);
+});
+
+it('marks the remove action destructive by default', function (): void {
+    $wire = serializeRowAction(RowAction::remove());
+
+    expect($wire['type'])->toBe('remove')
+        ->and($wire['destructive'])->toBeTrue();
+});
+
+it('overrides label, icon and destructive fluently', function (): void {
+    $wire = serializeRowAction(
+        RowAction::duplicate()->label('Clone')->icon('files')->destructive(),
+    );
+
+    expect($wire['label'])->toBe('Clone')
+        ->and($wire['icon'])->toBe('files')
+        ->and($wire['destructive'])->toBeTrue();
+});


### PR DESCRIPTION
Implements the first slice of #143 (solo): a **declarable per-row action menu** on line-item fields, unified across the stack and table layouts. Server-backed row actions are a planned follow-up.

## What it does

```php
Repeater::make('lines')
    ->schema([...])
    ->rowActions([
        RowAction::duplicate(),
        RowAction::remove()->label('Delete'),
    ]);
```

- **PHP:** `RowActionType` enum + `RowAction` value object (`#[TypeScript]`) with built-in factories `duplicate()` / `remove()` and fluent `label()`/`icon()`/`destructive()`. A `HasRowActions` trait exposes `->rowActions([...])` on **Repeater and Builder**, serialized as a generated `RowAction[]` prop.
- **Client:** a new `duplicate` row mutation; a wire→client mapper (`buildRowActions`) that resolves declared (or default) actions with localized built-in labels/icons and per-row enabling (remove hidden at `minItems`). The `RowActions` kebab now renders in **both** layouts — the stack layout drops its bespoke remove button. A single action renders inline; 2+ collapse into a ⋯ menu.
- **Backward compatible:** an undeclared menu defaults to remove-only, matching today's behavior. Reorder stays a separate affordance driven by `reorderable`.
- **Docs:** new "Row actions" section on the Repeater page with a live example; Builder cross-links it.

## Design notes

- `moveUp`/`moveDown` are intentionally **not** row actions — reordering is a distinct affordance, so the menu stays "remove + duplicate + (later) custom".
- The stack remove button's test id changed from `repeater-<name>-remove-<i>` to the shared `row-action-remove` (inside the indexed row container). The one browser test that used the old selector (`PricingBuilderTest`) is updated to scope within the row.

## Verification

- `composer check` — Pint, PHPStan, Pest green **except 2 pre-existing workbench-i18n tests** (`I18nextTranslationsTest`) that fail identically on bare `main` in a fresh worktree (a local workbench-setup artifact, not from this change; CI's full build passes them).
- `npm run check` — oxlint, oxfmt, tsc, vitest, build:lib all green. New tests: `RowAction` VO serialization, repeater wire (`rowActions`), `duplicateRow`, `onDuplicate`, the mapper (5 cases), and a kebab-render-and-duplicate test.
- `npm run docs:build` green; new `repeater.row-actions` fixture committed.
- Browser suite not run locally (unprovisioned worktree, as before) — the affected selector is updated; worth a CI run since this is rendered UI.