### PR TITLE
Select::optionsFrom — Eloquent-backed options without coupling forms to a model

### DIFF
--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -4,6 +4,7 @@ description: A dropdown for choosing one or several options, with optional serve
 ---
 
 import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
 
 The select lets the user pick from a list of options. Create one with `Select::make()` and pass the
 options with `->options()`. Each option is a label/value pair built with `Select::option()`.
@@ -85,6 +86,33 @@ Select::make('author_id', 'Author')
         ->map(fn (User $user) => Select::option($user->name, (string) $user->id))
         ->all());
 ```
+
+## Options from a model
+
+Backing a select with an Eloquent model is the common case, so `->optionsFrom()` takes an
+`OptionSource` and wires both the search and the selected-label resolution from one declaration.
+`EloquentOptions` is the shipped source:
+
+```php
+use Lattice\Lattice\Forms\EloquentOptions;
+
+Select::make('author_id', 'Author')
+    ->optionsFrom(EloquentOptions::make(User::class)->label('name'));
+```
+
+`->label()` and `->value()` pick the display and value columns (value defaults to the key). Add
+`->searchColumns(['name', 'email'])` to match more than the label, `->scope(fn ($query) => $query->where('active', true))`
+to constrain the query, and `->limit(50)` to cap results.
+
+<Info>
+The select itself never imports Eloquent — `EloquentOptions` is an opt-in adapter behind the
+`OptionSource` contract, mirroring how `EloquentTableSource` backs a table. Implement `OptionSource`
+to back a select from an API, a search index, or an array instead.
+</Info>
+
+`optionsFrom` only resolves the *options*. The selected value (e.g. `author_id`) is a normal field
+value, so it is validated and returned in the submitted array like any other — your handler persists
+it. Lattice forms stay decoupled from the model.
 
 ## Common options
 

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Core\Concerns\HasPlaceholder;
 use Lattice\Lattice\Core\Concerns\HasTabIndex;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Facades\Evaluate;
+use Lattice\Lattice\Forms\Contracts\OptionSource;
 use Lattice\Lattice\Forms\FormData;
 
 #[Component('form.select')]
@@ -26,6 +27,8 @@ class Select extends Field
     private ?Closure $searchResolver = null;
 
     private ?Closure $selectedResolver = null;
+
+    private ?OptionSource $optionSource = null;
 
     public ?bool $multiple = null;
 
@@ -70,11 +73,24 @@ class Select extends Field
     }
 
     /**
+     * Resolve options (search + selected-label) from an {@see OptionSource} — e.g.
+     * an Eloquent model — instead of inline closures. The source bears any
+     * persistence concern, so the Select stays storage-agnostic.
+     */
+    public function optionsFrom(OptionSource $source): static
+    {
+        $this->optionSource = $source;
+        $this->searchable = true;
+
+        return $this;
+    }
+
+    /**
      * @internal
      */
     public function isSearchable(): bool
     {
-        return $this->searchResolver !== null;
+        return $this->optionSource !== null || $this->searchResolver !== null;
     }
 
     /**
@@ -98,6 +114,10 @@ class Select extends Field
      */
     public function resolveSearch(string $query, FormData $data, Request $request): array
     {
+        if ($this->optionSource !== null) {
+            return $this->normalizeOptions($this->optionSource->search($query));
+        }
+
         if ($this->searchResolver === null) {
             return [];
         }
@@ -109,7 +129,7 @@ class Select extends Field
 
     public function prefill(mixed $value): void
     {
-        if ($this->selectedResolver === null) {
+        if ($this->optionSource === null && $this->selectedResolver === null) {
             return;
         }
 
@@ -122,11 +142,12 @@ class Select extends Field
             return;
         }
 
-        $context = Evaluate::context()
-            ->named('values', $values)
-            ->named('component', $this);
-
-        $resolved = $this->normalizeOptions(Evaluate::resolve($this->selectedResolver, $context));
+        $resolved = $this->optionSource !== null
+            ? $this->normalizeOptions($this->optionSource->selected($values))
+            : $this->normalizeOptions(Evaluate::resolve(
+                $this->selectedResolver,
+                Evaluate::context()->named('values', $values)->named('component', $this),
+            ));
         $existing = $this->options;
 
         $merged = [...$existing];

--- a/src/Forms/Contracts/OptionSource.php
+++ b/src/Forms/Contracts/OptionSource.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Contracts;
+
+use Lattice\Lattice\Core\Option;
+
+/**
+ * Where a searchable Select's options come from. Lattice ships an Eloquent
+ * source; implement this for any other backing store (an array, an API, a
+ * search index). Keeps the Select itself free of any persistence concern.
+ */
+interface OptionSource
+{
+    /**
+     * Options matching the search query — an empty query returns the initial set.
+     *
+     * @return list<Option>
+     */
+    public function search(string $query): array;
+
+    /**
+     * Options for the currently-selected value(s), used to render labels on edit
+     * forms. Always receives an array so a single and a multiple select behave alike.
+     *
+     * @param  list<string>  $values
+     * @return list<Option>
+     */
+    public function selected(array $values): array;
+}

--- a/src/Forms/EloquentOptions.php
+++ b/src/Forms/EloquentOptions.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Core\Option;
+use Lattice\Lattice\Forms\Contracts\OptionSource;
+
+/**
+ * An {@see OptionSource} backed by an Eloquent model — the opt-in bridge that
+ * keeps Eloquent out of the Select itself, mirroring how `EloquentTableSource`
+ * backs a table without coupling the core table classes.
+ */
+final class EloquentOptions implements OptionSource
+{
+    /** @var list<string>|null */
+    private ?array $searchColumns = null;
+
+    /** @var Closure(Builder<Model>): mixed|null */
+    private ?Closure $scope = null;
+
+    private int $limit = 50;
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    private function __construct(
+        private readonly string $model,
+        private string $labelKey = 'name',
+        private string $valueKey = 'id',
+    ) {}
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    public static function make(string $model): self
+    {
+        return new self($model);
+    }
+
+    public function label(string $column): self
+    {
+        $this->labelKey = $column;
+
+        return $this;
+    }
+
+    public function value(string $column): self
+    {
+        $this->valueKey = $column;
+
+        return $this;
+    }
+
+    /**
+     * Columns matched against the query; defaults to the label column.
+     *
+     * @param  list<string>  $columns
+     */
+    public function searchColumns(array $columns): self
+    {
+        $this->searchColumns = $columns;
+
+        return $this;
+    }
+
+    /**
+     * Constrain the query (e.g. only active rows). Applied to both search and selected.
+     *
+     * @param  Closure(Builder<Model>): mixed  $scope
+     */
+    public function scope(Closure $scope): self
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function search(string $query): array
+    {
+        $builder = $this->query();
+
+        if ($query !== '') {
+            $columns = $this->searchColumns ?? [$this->labelKey];
+            $builder->where(function (Builder $nested) use ($columns, $query): void {
+                foreach ($columns as $column) {
+                    $nested->orWhere($column, 'like', '%'.$query.'%');
+                }
+            });
+        }
+
+        return $this->toOptions($builder->orderBy($this->labelKey)->limit($this->limit)->get());
+    }
+
+    public function selected(array $values): array
+    {
+        if ($values === []) {
+            return [];
+        }
+
+        return $this->toOptions($this->query()->whereIn($this->valueKey, $values)->get());
+    }
+
+    /**
+     * @return Builder<Model>
+     */
+    private function query(): Builder
+    {
+        $builder = $this->model::query();
+
+        if ($this->scope !== null) {
+            $scoped = ($this->scope)($builder);
+
+            if ($scoped instanceof Builder) {
+                $builder = $scoped;
+            }
+        }
+
+        return $builder;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $models
+     * @return list<Option>
+     */
+    private function toOptions(Collection $models): array
+    {
+        return $models
+            ->map(fn (Model $model): Option => new Option(
+                (string) $model->getAttribute($this->labelKey),
+                (string) $model->getAttribute($this->valueKey),
+            ))
+            ->values()
+            ->all();
+    }
+}

--- a/src/Forms/EloquentOptions.php
+++ b/src/Forms/EloquentOptions.php
@@ -25,13 +25,15 @@ final class EloquentOptions implements OptionSource
 
     private int $limit = 50;
 
+    private ?string $resolvedValueKey = null;
+
     /**
      * @param  class-string<Model>  $model
      */
     private function __construct(
         private readonly string $model,
         private string $labelKey = 'name',
-        private string $valueKey = 'id',
+        private ?string $valueKey = null,
     ) {}
 
     /**
@@ -52,6 +54,7 @@ final class EloquentOptions implements OptionSource
     public function value(string $column): self
     {
         $this->valueKey = $column;
+        $this->resolvedValueKey = null;
 
         return $this;
     }
@@ -109,7 +112,15 @@ final class EloquentOptions implements OptionSource
             return [];
         }
 
-        return $this->toOptions($this->query()->whereIn($this->valueKey, $values)->get());
+        return $this->toOptions($this->query()->whereIn($this->valueColumn(), $values)->get());
+    }
+
+    /**
+     * The value column, defaulting to the model's primary key when not set explicitly.
+     */
+    private function valueColumn(): string
+    {
+        return $this->resolvedValueKey ??= $this->valueKey ?? (new $this->model)->getKeyName();
     }
 
     /**
@@ -139,7 +150,7 @@ final class EloquentOptions implements OptionSource
         return $models
             ->map(fn (Model $model): Option => new Option(
                 (string) $model->getAttribute($this->labelKey),
-                (string) $model->getAttribute($this->valueKey),
+                (string) $model->getAttribute($this->valueColumn()),
             ))
             ->values()
             ->all();

--- a/tests/Feature/Forms/EloquentOptionsTest.php
+++ b/tests/Feature/Forms/EloquentOptionsTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Option;
+use Lattice\Lattice\Forms\EloquentOptions;
+use Workbench\App\Models\Product;
+
+it('searches an eloquent model by its label column', function (): void {
+    Product::factory()->create(['name' => 'Alpha Chair']);
+    Product::factory()->create(['name' => 'Beta Table']);
+
+    $options = EloquentOptions::make(Product::class)->label('name')->search('chair');
+
+    expect($options)->toHaveCount(1)
+        ->and($options[0]->label)->toBe('Alpha Chair');
+});
+
+it('returns the initial set (ordered by label) for an empty query, capped by the limit', function (): void {
+    foreach (['Cedar', 'Alder', 'Birch'] as $name) {
+        Product::factory()->create(['name' => $name]);
+    }
+
+    $options = EloquentOptions::make(Product::class)->label('name')->limit(2)->search('');
+
+    expect(array_map(fn (Option $o): string => $o->label, $options))->toBe(['Alder', 'Birch']);
+});
+
+it('resolves selected values to their labels and keys', function (): void {
+    $product = Product::factory()->create(['name' => 'Gamma Shelf']);
+
+    $options = EloquentOptions::make(Product::class)->label('name')->selected([(string) $product->getKey()]);
+
+    expect($options)->toHaveCount(1)
+        ->and($options[0]->label)->toBe('Gamma Shelf')
+        ->and($options[0]->value)->toBe((string) $product->getKey());
+});
+
+it('applies a query scope to both search and selected', function (): void {
+    Product::factory()->create(['name' => 'Visible', 'status' => 'active']);
+    $hidden = Product::factory()->create(['name' => 'Hidden', 'status' => 'archived']);
+
+    $source = EloquentOptions::make(Product::class)
+        ->label('name')
+        ->scope(fn ($query) => $query->where('status', 'active'));
+
+    expect($source->search(''))->toHaveCount(1)
+        ->and($source->selected([(string) $hidden->getKey()]))->toBe([]);
+});

--- a/tests/Feature/Forms/EloquentOptionsTest.php
+++ b/tests/Feature/Forms/EloquentOptionsTest.php
@@ -1,9 +1,24 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\Model;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\EloquentOptions;
 use Workbench\App\Models\Product;
+
+/** A model keyed by a non-`id` column (reuses the products table, keyed on its unique sku). */
+final class SkuKeyedProduct extends Model
+{
+    protected $table = 'products';
+
+    protected $primaryKey = 'sku';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $guarded = [];
+}
 
 it('searches an eloquent model by its label column', function (): void {
     Product::factory()->create(['name' => 'Alpha Chair']);
@@ -33,6 +48,19 @@ it('resolves selected values to their labels and keys', function (): void {
     expect($options)->toHaveCount(1)
         ->and($options[0]->label)->toBe('Gamma Shelf')
         ->and($options[0]->value)->toBe((string) $product->getKey());
+});
+
+it('defaults the value column to the model key for a non-id primary key', function (): void {
+    Product::factory()->create(['name' => 'Keyed', 'sku' => 'SKU-XYZ']);
+
+    $source = EloquentOptions::make(SkuKeyedProduct::class)->label('name');
+
+    $selected = $source->selected(['SKU-XYZ']);
+    expect($selected)->toHaveCount(1)
+        ->and($selected[0]->label)->toBe('Keyed')
+        ->and($selected[0]->value)->toBe('SKU-XYZ');
+
+    expect($source->search('keyed')[0]->value)->toBe('SKU-XYZ');
 });
 
 it('applies a query scope to both search and selected', function (): void {

--- a/tests/Feature/Forms/SelectOptionsSourceTest.php
+++ b/tests/Feature/Forms/SelectOptionsSourceTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Option;
+use Lattice\Lattice\Forms\Components\Select;
+use Lattice\Lattice\Forms\Contracts\OptionSource;
+use Lattice\Lattice\Forms\FormData;
+
+/** An in-memory option source — proves the Select talks only to the contract, never Eloquent. */
+function arrayOptionSource(): OptionSource
+{
+    return new class implements OptionSource
+    {
+        /** @var array<int|string, string> */
+        private array $people = ['1' => 'Ada', '2' => 'Linus', '3' => 'Grace'];
+
+        public function search(string $query): array
+        {
+            $matches = $query === ''
+                ? $this->people
+                : array_filter($this->people, fn (string $name): bool => str_contains(strtolower($name), strtolower($query)));
+
+            return array_map(
+                fn (string $name, int|string $id): Option => new Option($name, (string) $id),
+                $matches,
+                array_keys($matches),
+            );
+        }
+
+        public function selected(array $values): array
+        {
+            return array_map(
+                fn (string $id): Option => new Option($this->people[$id] ?? "User {$id}", $id),
+                $values,
+            );
+        }
+    };
+}
+
+it('marks a select searchable once an option source is attached', function (): void {
+    expect(Select::make('author_id')->optionsFrom(arrayOptionSource())->isSearchable())->toBeTrue();
+});
+
+it('resolves search options through the option source', function (): void {
+    $select = Select::make('author_id')->optionsFrom(arrayOptionSource());
+
+    $options = $select->resolveSearch('lin', FormData::make([]), Request::create('/'));
+
+    expect($options)->toHaveCount(1)
+        ->and($options[0]->label)->toBe('Linus')
+        ->and($options[0]->value)->toBe('2');
+});
+
+it('prefills a selected value label through the option source', function (): void {
+    $select = Select::make('author_id')->optionsFrom(arrayOptionSource());
+
+    $select->prefill('2');
+
+    expect($select->options)->toHaveCount(1)
+        ->and($select->options[0]->label)->toBe('Linus')
+        ->and($select->options[0]->value)->toBe('2');
+});
+
+it('prefills multiple selected values for a multiple select', function (): void {
+    $select = Select::make('authors')->multiple()->optionsFrom(arrayOptionSource());
+
+    $select->prefill(['1', '3']);
+
+    expect(array_map(fn (Option $o): string => $o->label, $select->options))->toBe(['Ada', 'Grace']);
+});

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -12,6 +12,7 @@ use Lattice\Lattice\Forms\Components\Choice;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\EloquentOptions;
 use Lattice\Lattice\Forms\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Models\Product;
@@ -45,19 +46,14 @@ class ProductForm extends FormDefinition
                     Select::make('related_products', __('workbench.forms.product.fields.related-products'))
                         ->multiple()
                         ->placeholder(__('workbench.common.search-products'))
-                        ->searchable(fn (string $search) => Product::query()
-                            ->where('name', 'like', "%{$search}%")
-                            ->when($product, fn ($builder) => $builder->whereKeyNot($product->getKey()))
-                            ->orderBy('name')
-                            ->limit(10)
-                            ->get()
-                            ->map(fn (Product $related) => Select::option($related->name, (string) $related->getKey()))
-                            ->all())
-                        ->resolveSelectedUsing(fn (array $values) => Product::query()
-                            ->whereIn('id', $values)
-                            ->get()
-                            ->map(fn (Product $related) => Select::option($related->name, (string) $related->getKey()))
-                            ->all())
+                        ->optionsFrom(
+                            EloquentOptions::make(Product::class)
+                                ->label('name')
+                                ->limit(10)
+                                ->scope(fn ($query) => $product
+                                    ? $query->whereKeyNot($product->getKey())
+                                    : $query),
+                        )
                         ->rules(['nullable', 'array']),
                 ]),
             ]);


### PR DESCRIPTION
Implements #115 (Select `->relationship()`) in a way that **keeps forms decoupled from Eloquent** — the constraint that drove the design.

## The reframing

Forms are 100% model-agnostic: a form produces a validated array, and the consumer's `handle()` persists it. So for a BelongsTo, the FK (`author_id`) is just a normal field value the consumer already saves — **"save the related key" is automatic**. That leaves `->relationship()` as purely *option resolution* (search + resolving the selected value's label).

Filament's `->relationship('author', 'name')` works because the form is bound to a model; we deliberately aren't. So the relationship config is **self-contained on the field**, and the Eloquent lives in an **opt-in adapter behind a contract** — exactly how `EloquentTableSource` backs a table without coupling the core table classes.

## What's added

- **`OptionSource` contract** (`src/Forms/Contracts/OptionSource.php`): `search(string $query)` + `selected(array $values)`. Core `Select` depends only on this and never imports Eloquent.
- **`EloquentOptions` adapter** (`src/Forms/EloquentOptions.php`): the opt-in Eloquent bridge — `EloquentOptions::make(Author::class)->label('name')->value('id')->searchColumns([…])->scope(fn (\$q) => …)->limit(50)`.
- **`Select::optionsFrom(OptionSource)`**: marks the field searchable and delegates `resolveSearch` + `prefill` to the source. The existing `searchable()`/`resolveSelectedUsing()` closures are untouched.

```php
Select::make('author_id', 'Author')
    ->optionsFrom(EloquentOptions::make(User::class)->label('name'));
```

## Notes

- **No wire-shape change** — purely server-side resolution (no generated-types or client changes).
- **Scope is BelongsTo option-resolution.** HasMany/BelongsToMany *sync* (the repeater-relationship case) is separate and stays deferred.
- **Dogfooded:** the workbench `ProductForm` related-products field collapses from two ~10-line closures to one `optionsFrom(...)`; the existing `ProductRelatedProductsTest` exercises it end-to-end.

## Verification

- `composer check` — PHPStan + Pint clean; 518 Pest, only the 2 pre-existing `I18nextTranslationsTest` workbench failures (confirmed identical on bare `main` in a fresh worktree; CI's full build passes them).
- `npm run docs:build` green (new "Options from a model" section on the Select page).
- New tests: an in-memory `OptionSource` fake (proves the Select talks only to the contract) + an `EloquentOptions` feature suite (search, empty-query initial set, selected resolution, scope).