### PR TITLE
refactor: collapse Effect hierarchy and unify the toast pipeline

### DIFF
--- a/resources/js/events/event-bridge.test.tsx
+++ b/resources/js/events/event-bridge.test.tsx
@@ -1,73 +1,29 @@
 import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { EventBridge } from "@lattice-php/lattice";
-
-type FlashListener = (
-  event: CustomEvent<{
-    flash?: {
-      toast?: unknown;
-    };
-  }>,
-) => void;
-
-const router = vi.hoisted(() => ({
-  on: vi.fn<(event: string, listener: FlashListener) => () => void>(() => () => undefined),
-  reload: vi.fn<() => void>(),
-}));
-
-vi.mock("@inertiajs/react", () => ({
-  router,
-}));
+import type { ToastMessage } from "@lattice-php/lattice";
 
 describe("EventBridge", () => {
-  beforeEach(() => {
-    router.on.mockClear();
-    router.reload.mockReset();
-  });
-
-  it("passes inertia flash toast messages to the host renderer", () => {
-    const onToast = vi.fn<(toast: { message: string; variant: string }) => void>();
-
-    render(<EventBridge onToast={onToast} />);
-
-    const [, listener] = router.on.mock.calls[0] as ["flash", FlashListener];
-
-    listener(
-      new CustomEvent("flash", {
-        detail: {
-          flash: {
-            toast: {
-              message: "Profile saved.",
-              variant: "info",
-            },
-          },
-        },
-      }),
-    );
-
-    expect(onToast).toHaveBeenCalledWith({
-      message: "Profile saved.",
-      variant: "info",
-    });
-  });
-
-  it("passes lattice toast events to the host renderer", () => {
-    const onToast = vi.fn<(toast: { message: string; variant: string }) => void>();
+  it("forwards lattice toast events to the host renderer with the full message", () => {
+    const onToast = vi.fn<(toast: ToastMessage) => void>();
 
     render(<EventBridge onToast={onToast} />);
 
     window.dispatchEvent(
       new CustomEvent("lattice:toast", {
         detail: {
-          message: "Action handled.",
           type: "toast",
-          variant: "warning",
+          toast: { message: "Action handled.", variant: "warning" },
         },
       }),
     );
 
     expect(onToast).toHaveBeenCalledWith({
+      action: null,
+      dismissible: true,
+      duration: null,
       message: "Action handled.",
+      persistent: false,
       variant: "warning",
     });
   });
@@ -88,20 +44,17 @@ describe("EventBridge", () => {
     expect(onAppearanceChange).toHaveBeenCalledWith("dark");
   });
 
-  it("does not reload the whole page for component reload events", () => {
-    render(
-      <EventBridge onToast={vi.fn<(toast: { message: string; variant: string }) => void>()} />,
-    );
+  it("ignores toast events without a message", () => {
+    const onToast = vi.fn<(toast: ToastMessage) => void>();
+
+    render(<EventBridge onToast={onToast} />);
 
     window.dispatchEvent(
-      new CustomEvent("lattice:reload-component", {
-        detail: {
-          component: "settings.passkeys",
-          type: "reloadComponent",
-        },
+      new CustomEvent("lattice:toast", {
+        detail: { type: "toast", toast: { variant: "warning" } },
       }),
     );
 
-    expect(router.reload).not.toHaveBeenCalled();
+    expect(onToast).not.toHaveBeenCalled();
   });
 });

--- a/resources/js/events/event-bridge.tsx
+++ b/resources/js/events/event-bridge.tsx
@@ -1,75 +1,23 @@
-import { router } from "@inertiajs/react";
 import { useEffect } from "react";
+import { onToast as subscribeToToasts } from "@lattice-php/lattice/toast/toast";
+import type { ToastMessage } from "@lattice-php/lattice/toast/toast";
 import { LATTICE_EVENT } from "./event-names";
 
-export const toastVariants = ["success", "info", "warning", "error"] as const;
 export const appearances = ["light", "dark", "system"] as const;
 
-export type ToastVariant = (typeof toastVariants)[number];
 export type Appearance = (typeof appearances)[number];
-
-export type ToastMessage = {
-  message: string;
-  variant: ToastVariant;
-};
 
 type EventBridgeProps = {
   onAppearanceChange?: (appearance: Appearance) => void;
   onToast?: (toast: ToastMessage) => void;
 };
 
-type ToastEvent = CustomEvent<{
-  message?: unknown;
-  variant?: unknown;
-}>;
-
 type AppearanceEvent = CustomEvent<{
   value?: unknown;
 }>;
 
-type InertiaFlashEvent = CustomEvent<{
-  flash?: {
-    toast?: unknown;
-  };
-}>;
-
-function isToastVariant(value: unknown): value is ToastVariant {
-  return toastVariants.some((variant) => variant === value);
-}
-
 function isAppearance(value: unknown): value is Appearance {
   return appearances.some((appearance) => appearance === value);
-}
-
-function normalizeFlashToast(value: unknown): ToastMessage | null {
-  if (typeof value !== "object" || value === null) {
-    return null;
-  }
-
-  const candidate = value as Partial<ToastMessage>;
-
-  if (typeof candidate.message !== "string" || !isToastVariant(candidate.variant)) {
-    return null;
-  }
-
-  return {
-    message: candidate.message,
-    variant: candidate.variant,
-  };
-}
-
-function normalizeLatticeToast(event: Event): ToastMessage | null {
-  const detail = (event as ToastEvent).detail;
-  const message = detail?.message;
-
-  if (typeof message !== "string" || message === "") {
-    return null;
-  }
-
-  return {
-    message,
-    variant: isToastVariant(detail.variant) ? detail.variant : "success",
-  };
 }
 
 export function EventBridge({ onAppearanceChange, onToast }: EventBridgeProps) {
@@ -78,33 +26,7 @@ export function EventBridge({ onAppearanceChange, onToast }: EventBridgeProps) {
       return;
     }
 
-    return router.on("flash", (event) => {
-      const toast = normalizeFlashToast((event as InertiaFlashEvent).detail?.flash?.toast);
-
-      if (toast) {
-        onToast(toast);
-      }
-    });
-  }, [onToast]);
-
-  useEffect(() => {
-    if (!onToast) {
-      return;
-    }
-
-    const listener = (event: Event): void => {
-      const toast = normalizeLatticeToast(event);
-
-      if (toast) {
-        onToast(toast);
-      }
-    };
-
-    window.addEventListener(LATTICE_EVENT.toast, listener);
-
-    return () => {
-      window.removeEventListener(LATTICE_EVENT.toast, listener);
-    };
+    return subscribeToToasts(onToast);
   }, [onToast]);
 
   useEffect(() => {

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -18,7 +18,7 @@ export {
   useSidebarCollapsed,
 } from "./layout";
 export { Provider, useColumnRegistry, useRegistry } from "./provider";
-export { Toaster } from "./toast";
+export { onToast, showToast, Toaster } from "./toast";
 export {
   createPlugin,
   createRegistry,
@@ -57,7 +57,8 @@ export type { Method } from "@inertiajs/core";
 export type { ActionEffect } from "./action/effects";
 export type { ResolvedAppearance, UseAppearanceReturn } from "./appearance";
 export type { CopiedValue, CopyFn, UseClipboardReturn } from "./clipboard";
-export type { Appearance, ToastMessage, ToastVariant } from "./events/event-bridge";
+export type { Appearance } from "./events/event-bridge";
+export type { ToastMessage, ToastVariant } from "./toast";
 export type {
   IconName,
   IconRendererFunction,

--- a/resources/js/layout/schema-layout.test.tsx
+++ b/resources/js/layout/schema-layout.test.tsx
@@ -7,6 +7,11 @@ import SchemaLayout from "./schema-layout";
 
 vi.mock("@inertiajs/react", () => ({
   usePage: vi.fn<() => unknown>(),
+  router: {
+    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
+      () => () => undefined,
+    ),
+  },
 }));
 
 const mockedUsePage = vi.mocked(usePage);

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -6,6 +6,11 @@ import Page from "./page";
 
 vi.mock("@inertiajs/react", () => ({
   Head: ({ title }: { title?: string }) => <title>{title}</title>,
+  router: {
+    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
+      () => () => undefined,
+    ),
+  },
 }));
 
 function payload(lattice: Partial<PagePayload> = {}): PagePayload {

--- a/resources/js/provider.tsx
+++ b/resources/js/provider.tsx
@@ -5,7 +5,7 @@ import { SpriteProvider } from "./icons/sprite";
 import type { SpriteValue } from "./icons/sprite";
 import { registry as defaultRegistry } from "./registry";
 import type { ColumnRegistry } from "./table/column-registry";
-import { Toaster } from "./toast";
+import { Toaster, useFlashToasts } from "./toast";
 
 const defaultSprite: SpriteValue = { href: "" };
 
@@ -22,6 +22,8 @@ export function Provider({
   sprite?: SpriteValue;
   toaster?: boolean;
 }) {
+  useFlashToasts();
+
   return (
     <RegistryContext.Provider value={registry}>
       <SpriteProvider sprite={sprite}>

--- a/resources/js/toast/index.ts
+++ b/resources/js/toast/index.ts
@@ -1,1 +1,4 @@
 export { Toaster } from "./toaster";
+export { isToastVariant, normalizeToast, normalizeToastMessage, onToast, showToast } from "./toast";
+export type { ToastMessage, ToastVariant } from "./toast";
+export { useFlashToasts } from "./use-flash-toasts";

--- a/resources/js/toast/toast.ts
+++ b/resources/js/toast/toast.ts
@@ -1,0 +1,68 @@
+import type { ToastMessage, ToastVariant } from "@lattice-php/lattice/types/generated";
+import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
+
+export type { ToastMessage, ToastVariant };
+
+const variants = ["success", "info", "warning", "error"] as const satisfies readonly ToastVariant[];
+
+export function isToastVariant(value: unknown): value is ToastVariant {
+  return variants.some((variant) => variant === value);
+}
+
+/**
+ * Coerce a raw toast value (server flash payload or event detail) into a
+ * ToastMessage, defaulting optional fields, or null when it is malformed.
+ */
+export function normalizeToastMessage(value: unknown): ToastMessage | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const toast = value as Record<string, unknown>;
+
+  if (typeof toast.message !== "string" || toast.message === "") {
+    return null;
+  }
+
+  return {
+    action: (toast.action as ToastMessage["action"]) ?? null,
+    dismissible: toast.dismissible !== false,
+    duration: typeof toast.duration === "number" ? toast.duration : null,
+    message: toast.message,
+    persistent: toast.persistent === true,
+    variant: isToastVariant(toast.variant) ? toast.variant : "success",
+  };
+}
+
+/** Coerce a `lattice:toast` event detail (`{ toast: {...} }`) into a ToastMessage. */
+export function normalizeToast(detail: unknown): ToastMessage | null {
+  if (typeof detail !== "object" || detail === null) {
+    return null;
+  }
+
+  return normalizeToastMessage((detail as { toast?: unknown }).toast);
+}
+
+/** Emit a toast onto the shared `lattice:toast` bus. */
+export function showToast(toast: ToastMessage): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(LATTICE_EVENT.toast, { detail: { toast } }));
+}
+
+/** Subscribe to the shared toast bus. Returns an unsubscribe function. */
+export function onToast(callback: (toast: ToastMessage) => void): () => void {
+  const listener = (event: Event): void => {
+    const toast = normalizeToast((event as CustomEvent).detail);
+
+    if (toast) {
+      callback(toast);
+    }
+  };
+
+  window.addEventListener(LATTICE_EVENT.toast, listener);
+
+  return () => window.removeEventListener(LATTICE_EVENT.toast, listener);
+}

--- a/resources/js/toast/toaster.test.tsx
+++ b/resources/js/toast/toaster.test.tsx
@@ -9,6 +9,11 @@ vi.mock("@inertiajs/react", () => ({
   Link: ({ children, href }: { children: ReactNode; href: string }) => (
     <a href={href}>{children}</a>
   ),
+  router: {
+    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
+      () => () => undefined,
+    ),
+  },
 }));
 
 function emit(toast: unknown): void {

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -4,12 +4,10 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
 import type { ToastMessage, ToastVariant } from "@lattice-php/lattice/types/generated";
-import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
+import { onToast } from "@lattice-php/lattice/toast/toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
 import { useRegistry } from "@lattice-php/lattice/provider";
-
-const variants = ["success", "info", "warning", "error"] as const satisfies readonly ToastVariant[];
 
 type ToastItem = ToastMessage & { id: number };
 
@@ -32,63 +30,24 @@ const variantStyles: Record<ToastVariant, { accent: string; icon: ReactNode }> =
   },
 };
 
-function isVariant(value: unknown): value is ToastVariant {
-  return variants.some((variant) => variant === value);
-}
-
 let nextId = 0;
-
-function normalize(detail: unknown): ToastMessage | null {
-  if (typeof detail !== "object" || detail === null) {
-    return null;
-  }
-
-  const data = (detail as { toast?: unknown }).toast;
-
-  if (typeof data !== "object" || data === null) {
-    return null;
-  }
-
-  const toast = data as Record<string, unknown>;
-
-  if (typeof toast.message !== "string" || toast.message === "") {
-    return null;
-  }
-
-  return {
-    action: (toast.action as ToastMessage["action"]) ?? null,
-    dismissible: toast.dismissible !== false,
-    duration: typeof toast.duration === "number" ? toast.duration : null,
-    message: toast.message,
-    persistent: toast.persistent === true,
-    variant: isVariant(toast.variant) ? toast.variant : "success",
-  };
-}
 
 export function Toaster({ duration = 4000 }: { duration?: number }) {
   const { t } = useT("lattice");
   const registry = useRegistry();
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
-  function push(detail: unknown): void {
-    const item = normalize(detail);
-
-    if (item) {
-      setToasts((current) => [...current, { ...item, id: nextId++ }]);
-    }
-  }
-
   function dismiss(id: number): void {
     setToasts((current) => current.filter((toast) => toast.id !== id));
   }
 
-  useEffect(() => {
-    const listener = (event: Event): void => push((event as CustomEvent).detail);
-
-    window.addEventListener(LATTICE_EVENT.toast, listener);
-
-    return () => window.removeEventListener(LATTICE_EVENT.toast, listener);
-  }, []);
+  useEffect(
+    () =>
+      onToast((toast) => {
+        setToasts((current) => [...current, { ...toast, id: nextId++ }]);
+      }),
+    [],
+  );
 
   return (
     <Toast.Provider duration={duration} swipeDirection="down">

--- a/resources/js/toast/use-flash-toasts.test.tsx
+++ b/resources/js/toast/use-flash-toasts.test.tsx
@@ -1,0 +1,71 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
+import { useFlashToasts } from "./use-flash-toasts";
+
+type FlashListener = (
+  event: CustomEvent<{
+    flash?: {
+      toast?: unknown;
+    };
+  }>,
+) => void;
+
+const router = vi.hoisted(() => ({
+  on: vi.fn<(event: string, listener: FlashListener) => () => void>(() => () => undefined),
+}));
+
+vi.mock("@inertiajs/react", () => ({ router }));
+
+function Host() {
+  useFlashToasts();
+
+  return null;
+}
+
+describe("useFlashToasts", () => {
+  beforeEach(() => router.on.mockClear());
+
+  it("funnels Laravel flash toasts onto the shared lattice:toast bus", () => {
+    const received = vi.fn<(event: Event) => void>();
+    window.addEventListener(LATTICE_EVENT.toast, received);
+
+    render(<Host />);
+
+    const [event, listener] = router.on.mock.calls[0] as ["flash", FlashListener];
+    expect(event).toBe("flash");
+
+    listener(
+      new CustomEvent("flash", {
+        detail: { flash: { toast: { message: "Profile saved.", variant: "info" } } },
+      }),
+    );
+
+    expect(received).toHaveBeenCalledTimes(1);
+    const dispatched = received.mock.calls[0]?.[0] as CustomEvent;
+    expect(dispatched.detail.toast).toEqual({
+      action: null,
+      dismissible: true,
+      duration: null,
+      message: "Profile saved.",
+      persistent: false,
+      variant: "info",
+    });
+
+    window.removeEventListener(LATTICE_EVENT.toast, received);
+  });
+
+  it("ignores flash payloads without a toast", () => {
+    const received = vi.fn<(event: Event) => void>();
+    window.addEventListener(LATTICE_EVENT.toast, received);
+
+    render(<Host />);
+
+    const [, listener] = router.on.mock.calls[0] as ["flash", FlashListener];
+    listener(new CustomEvent("flash", { detail: { flash: {} } }));
+
+    expect(received).not.toHaveBeenCalled();
+
+    window.removeEventListener(LATTICE_EVENT.toast, received);
+  });
+});

--- a/resources/js/toast/use-flash-toasts.ts
+++ b/resources/js/toast/use-flash-toasts.ts
@@ -1,0 +1,26 @@
+import { router } from "@inertiajs/react";
+import { useEffect } from "react";
+import { normalizeToastMessage, showToast } from "@lattice-php/lattice/toast/toast";
+
+type InertiaFlashEvent = CustomEvent<{
+  flash?: {
+    toast?: unknown;
+  };
+}>;
+
+/**
+ * Funnels Laravel flash toasts (`Inertia::flash('toast', ...)`) onto the shared
+ * `lattice:toast` bus so the built-in Toaster and any consumer subscriber render
+ * them through the same pipeline as action effects.
+ */
+export function useFlashToasts(): void {
+  useEffect(() => {
+    return router.on("flash", (event) => {
+      const toast = normalizeToastMessage((event as InertiaFlashEvent).detail?.flash?.toast);
+
+      if (toast) {
+        showToast(toast);
+      }
+    });
+  }, []);
+}

--- a/src/Actions/ActionResult.php
+++ b/src/Actions/ActionResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Actions;
 
 use JsonSerializable;
-use Lattice\Lattice\Actions\Contracts\Effect as EffectContract;
+use Lattice\Lattice\Actions\Effects\AbstractEffect;
 use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\ToastVariant;
 use Lattice\Lattice\Core\Values\ToastMessage;
@@ -14,7 +14,7 @@ final readonly class ActionResult implements JsonSerializable
 {
     /**
      * @param  array<string, mixed>  $data
-     * @param  array<int, EffectContract>  $effects
+     * @param  array<int, AbstractEffect>  $effects
      */
     private function __construct(
         public bool $ok,
@@ -38,7 +38,7 @@ final readonly class ActionResult implements JsonSerializable
         return new self(false, $data);
     }
 
-    public function effect(EffectContract $effect): self
+    public function effect(AbstractEffect $effect): self
     {
         return new self($this->ok, $this->data, [
             ...$this->effects,
@@ -87,7 +87,7 @@ final readonly class ActionResult implements JsonSerializable
     }
 
     /**
-     * @return array{ok: bool, data: array<string, mixed>, effects: array<int, EffectContract>}
+     * @return array{ok: bool, data: array<string, mixed>, effects: array<int, AbstractEffect>}
      */
     public function jsonSerialize(): array
     {

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -7,7 +7,7 @@ use BackedEnum;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\Confirmation;
-use Lattice\Lattice\Actions\Contracts\Effect;
+use Lattice\Lattice\Actions\Effects\AbstractEffect;
 use Lattice\Lattice\Attributes;
 use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\IsInteractive;
@@ -36,7 +36,7 @@ class Action extends Component
     public ?Confirmation $confirmation = null;
 
     /**
-     * @var array<int, Effect>
+     * @var array<int, AbstractEffect>
      */
     public array $effects = [];
 
@@ -93,7 +93,7 @@ class Action extends Component
     }
 
     /**
-     * @param  array<int, Effect>  $effects
+     * @param  array<int, AbstractEffect>  $effects
      */
     public function effects(array $effects): static
     {

--- a/src/Actions/Contracts/Effect.php
+++ b/src/Actions/Contracts/Effect.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace Lattice\Lattice\Actions\Contracts;
-
-use JsonSerializable;
-
-interface Effect extends JsonSerializable {}

--- a/src/Actions/Effects/AbstractEffect.php
+++ b/src/Actions/Effects/AbstractEffect.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Actions\Effects;
 
 use InvalidArgumentException;
-use Lattice\Lattice\Actions\Contracts\Effect as EffectContract;
-use Lattice\Lattice\Attributes\Effect as EffectAttribute;
+use JsonSerializable;
+use Lattice\Lattice\Attributes\AsEffect;
 use Spatie\Attributes\Attributes;
 
-abstract readonly class Effect implements EffectContract
+abstract readonly class AbstractEffect implements JsonSerializable
 {
     /**
      * @return array<string, mixed>
@@ -31,11 +31,11 @@ abstract readonly class Effect implements EffectContract
      */
     private static function resolveType(string $class): string
     {
-        $effect = Attributes::get($class, EffectAttribute::class);
+        $effect = Attributes::get($class, AsEffect::class);
 
         if ($effect === null) {
             throw new InvalidArgumentException(sprintf(
-                'Effect [%s] is missing the #[Effect] attribute that declares its wire type.',
+                'Effect [%s] is missing the #[AsEffect] attribute that declares its wire type.',
                 $class,
             ));
         }

--- a/src/Actions/Effects/CloseModalEffect.php
+++ b/src/Actions/Effects/CloseModalEffect.php
@@ -6,8 +6,8 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::CloseModal)]
-final readonly class CloseModalEffect extends Effect
+#[Attributes\AsEffect(EffectType::CloseModal)]
+final readonly class CloseModalEffect extends AbstractEffect
 {
     public function __construct(
         public ?string $modal = null,

--- a/src/Actions/Effects/DownloadEffect.php
+++ b/src/Actions/Effects/DownloadEffect.php
@@ -6,8 +6,8 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::Download)]
-final readonly class DownloadEffect extends Effect
+#[Attributes\AsEffect(EffectType::Download)]
+final readonly class DownloadEffect extends AbstractEffect
 {
     public function __construct(
         public string $url,

--- a/src/Actions/Effects/OpenModalEffect.php
+++ b/src/Actions/Effects/OpenModalEffect.php
@@ -6,8 +6,8 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::OpenModal)]
-final readonly class OpenModalEffect extends Effect
+#[Attributes\AsEffect(EffectType::OpenModal)]
+final readonly class OpenModalEffect extends AbstractEffect
 {
     public function __construct(
         public string $modal,

--- a/src/Actions/Effects/RedirectEffect.php
+++ b/src/Actions/Effects/RedirectEffect.php
@@ -6,8 +6,8 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::Redirect)]
-final readonly class RedirectEffect extends Effect
+#[Attributes\AsEffect(EffectType::Redirect)]
+final readonly class RedirectEffect extends AbstractEffect
 {
     public function __construct(
         public string $url,

--- a/src/Actions/Effects/ReloadComponentEffect.php
+++ b/src/Actions/Effects/ReloadComponentEffect.php
@@ -6,8 +6,8 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::ReloadComponent)]
-final readonly class ReloadComponentEffect extends Effect
+#[Attributes\AsEffect(EffectType::ReloadComponent)]
+final readonly class ReloadComponentEffect extends AbstractEffect
 {
     public function __construct(
         public string $component,

--- a/src/Actions/Effects/ReloadPageEffect.php
+++ b/src/Actions/Effects/ReloadPageEffect.php
@@ -6,5 +6,5 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::ReloadPage)]
-final readonly class ReloadPageEffect extends Effect {}
+#[Attributes\AsEffect(EffectType::ReloadPage)]
+final readonly class ReloadPageEffect extends AbstractEffect {}

--- a/src/Actions/Effects/ResetFormEffect.php
+++ b/src/Actions/Effects/ResetFormEffect.php
@@ -6,8 +6,8 @@ namespace Lattice\Lattice\Actions\Effects;
 use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 
-#[Attributes\Effect(EffectType::ResetForm)]
-final readonly class ResetFormEffect extends Effect
+#[Attributes\AsEffect(EffectType::ResetForm)]
+final readonly class ResetFormEffect extends AbstractEffect
 {
     public function __construct(
         public ?string $form = null,

--- a/src/Actions/Effects/ToastEffect.php
+++ b/src/Actions/Effects/ToastEffect.php
@@ -7,8 +7,8 @@ use Lattice\Lattice\Actions\Enums\EffectType;
 use Lattice\Lattice\Attributes;
 use Lattice\Lattice\Core\Values\ToastMessage;
 
-#[Attributes\Effect(EffectType::Toast)]
-final readonly class ToastEffect extends Effect
+#[Attributes\AsEffect(EffectType::Toast)]
+final readonly class ToastEffect extends AbstractEffect
 {
     public function __construct(
         public ToastMessage $toast,

--- a/src/Attributes/AsEffect.php
+++ b/src/Attributes/AsEffect.php
@@ -12,7 +12,7 @@ use Lattice\Lattice\Actions\Enums\EffectType;
  * Discovery shares ClassWalker, but the attribute stays distinct by design.
  */
 #[Attribute(Attribute::TARGET_CLASS)]
-final class Effect
+final class AsEffect
 {
     public function __construct(public readonly EffectType $type) {}
 }

--- a/workbench/app/Support/TypeScript/BaseProfile.php
+++ b/workbench/app/Support/TypeScript/BaseProfile.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Workbench\App\Support\TypeScript;
 
-use Lattice\Lattice\Actions\Contracts\Effect;
-use Lattice\Lattice\Attributes\Effect as EffectAttribute;
+use Lattice\Lattice\Actions\Effects\AbstractEffect;
+use Lattice\Lattice\Attributes\AsEffect as EffectAttribute;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Support\Discovery\ClassWalker;
 use Lattice\Lattice\Support\TypeScript\ComponentDiscovery;
@@ -72,7 +72,7 @@ final class BaseProfile implements TypeScriptProfile
                     Form::class,
                     $domainNodes,
                     'form',
-                    Effect::class,
+                    AbstractEffect::class,
                     $effects,
                     $columnProps,
                 ),


### PR DESCRIPTION
Two structural cleanups surfaced during a package-wide review. Quality only — behavior-preserving except two intended fixes noted below.

## Effects — collapse to `AbstractEffect`
- Removed the redundant `Actions\Contracts\Effect` marker interface (nothing implemented it without the base).
- Renamed the abstract base `Effects\Effect` → `AbstractEffect` (now `implements JsonSerializable` directly).
- Renamed the `#[Effect]` attribute → `#[AsEffect]`, dropping the last `as Effect*` alias.
- The public `Effect::toast()` factory is unchanged, and the generated `Effect` TypeScript union is byte-identical.

## Toasts — single pipeline
- New shared `toast/toast.ts` (`normalizeToast`, `showToast`, `onToast`) so the built-in `Toaster` and `EventBridge` consume one bus and one canonical `ToastMessage` type (the rich generated one).
- New `useFlashToasts` mounted in `Provider` funnels `Inertia::flash('toast')` onto the same bus.

### Fixes
- **`EventBridge.onToast` silently dropped action toasts** — it read the wrong event shape (`detail.message` vs `detail.toast`). It now reads the canonical shape and forwards the full `ToastMessage`.
- **Flash toasts never rendered via the default `Toaster`** — only `EventBridge` saw them. They now flow through the shared bus, matching what the docs already describe.

### Behavior changes (worth a changelog line)
- Flash toasts now render via the default `Toaster`.
- `EventBridge.onToast` payload widened `{message, variant}` → full `ToastMessage`.
- A consumer wiring `EventBridge.onToast` to their own UI should set `<Provider toaster={false}>` to avoid double-render (both subscribe to one bus) — consistent with the existing docs guidance.

## Verification
- `composer check`: Pint, PHPStan, 534 Pest ✓
- `npm run check`: oxlint/oxfmt, tsc, 340 Vitest, `build:lib` ✓
- 55 browser tests ✓ (incl. the 3 action→toast `ToastTest` flows)
- New regression tests: action toast reaches `EventBridge.onToast` with full payload; flash funnels onto the bus