### PR TITLE
refactor: file upload renderer cleanups (post-#101 review)

### DIFF
--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -39,7 +39,7 @@ export const FileUploadComponent: RendererComponent<"form.file-upload"> = ({ nod
   const scope = useFieldScope();
   const domName = scope ? scope.scopedName(name) : name;
   const errorKey = scope ? scope.errorKey(name) : name;
-  const uploadKey = scope ? scope.errorKey(name) : name;
+  const uploadKey = errorKey;
   const values = useFormValues();
   const inputId = useId();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -218,20 +218,10 @@ export const FileUploadComponent: RendererComponent<"form.file-upload"> = ({ nod
               {item.status === "error" && (
                 <span className="text-lt-danger">{t("file-upload.failed", "Failed")}</span>
               )}
-              {!item.existing && (
+              {(!item.existing || !scope) && (
                 <button
                   aria-label={t("file-upload.remove", "Remove {{name}}", { name: item.name })}
-                  disabled={locked}
-                  onClick={() => removeItem(item.id)}
-                  type="button"
-                >
-                  {t("file-upload.remove-label", "Remove")}
-                </button>
-              )}
-              {item.existing && !scope && (
-                <button
-                  aria-label={t("file-upload.remove", "Remove {{name}}", { name: item.name })}
-                  data-test={testIdentity(`${name}-remove-existing`)}
+                  data-test={item.existing ? testIdentity(`${name}-remove-existing`) : undefined}
                   disabled={locked}
                   onClick={() => removeItem(item.id)}
                   type="button"
@@ -256,35 +246,23 @@ export const FileUploadComponent: RendererComponent<"form.file-upload"> = ({ nod
             <input key={token} name={`${name}__removed[]`} type="hidden" value={token} />
           ))}
 
-        {signed ? (
-          <input
-            accept={props.accept ?? undefined}
-            aria-label={props.label ?? name}
-            className="sr-only"
-            data-test={testIdentity(`${name}-input`)}
-            id={inputId}
-            multiple={multiple}
-            onChange={(event) => {
-              addFiles(event.target.files);
+        <input
+          accept={props.accept ?? undefined}
+          aria-label={props.label ?? name}
+          className="sr-only"
+          data-test={testIdentity(`${name}-input`)}
+          id={inputId}
+          multiple={multiple}
+          name={signed ? undefined : fieldName}
+          onChange={(event) => {
+            addFiles(event.target.files);
+            if (signed) {
               event.target.value = "";
-            }}
-            ref={fileInputRef}
-            type="file"
-          />
-        ) : (
-          <input
-            accept={props.accept ?? undefined}
-            aria-label={props.label ?? name}
-            className="sr-only"
-            data-test={testIdentity(`${name}-input`)}
-            id={inputId}
-            multiple={multiple}
-            name={fieldName}
-            onChange={(event) => addFiles(event.target.files)}
-            ref={fileInputRef}
-            type="file"
-          />
-        )}
+            }
+          }}
+          ref={fileInputRef}
+          type="file"
+        />
       </div>
     </FormFieldFrame>
   );

--- a/src/Forms/Components/FileUpload.php
+++ b/src/Forms/Components/FileUpload.php
@@ -162,11 +162,6 @@ class FileUpload extends Field
         return ["{$this->name()}.*" => [$this->itemRule()]];
     }
 
-    public function castValue(mixed $value): mixed
-    {
-        return $value;
-    }
-
     public function prefill(mixed $value): void
     {
         $paths = array_values(array_filter(


### PR DESCRIPTION
Behavior-preserving cleanups from the #101 review, all in/around the FileUpload renderer.

1. **Drop dead `castValue` override** (`FileUpload.php`) — was byte-identical to `Field::castValue`; now inherits the parent. (`prefill`/`resolveRules`/`nestedRules` remain genuinely overridden.)
2. **Collapse the two `<input type="file">` blocks** into one (`name={signed ? undefined : fieldName}`, conditional `value` reset in `onChange`).
3. **Collapse the two remove `<button>` blocks** into one (`(!item.existing || !scope)`, conditional `data-test`). The existing-file-inside-a-row case still renders no button.
4. **Reuse `errorKey` for `uploadKey`** — they computed the same expression.

## Test plan
- [ ] `composer check` — 571 pass, PHPStan 0, Pint clean
- [ ] `npm run check` — lint/format/tsc/vitest/build green
- [ ] `composer test:browser` — all 4 FileUpload browser tests pass (multipart, removal, signed flow, RustFS integration)