### PR TITLE
feat: reset control for custom table column widths

### DIFF
--- a/lang/de/lattice.php
+++ b/lang/de/lattice.php
@@ -38,6 +38,7 @@ return [
         'close' => 'Schließen',
         'selectAllRows' => 'Alle Zeilen auswählen',
         'selectRow' => 'Zeile :key auswählen',
+        'resetColumnWidths' => 'Spaltenbreiten zurücksetzen',
     ],
     'file-upload' => [
         'dropzone' => 'Dateien hierher ziehen oder zum Auswählen klicken',

--- a/lang/en/lattice.php
+++ b/lang/en/lattice.php
@@ -38,6 +38,7 @@ return [
         'close' => 'Close',
         'selectAllRows' => 'Select all rows',
         'selectRow' => 'Select row :key',
+        'resetColumnWidths' => 'Reset column widths',
     ],
     'file-upload' => [
         'dropzone' => 'Drop files here or click to browse',

--- a/resources/icons/rotate-ccw.svg
+++ b/resources/icons/rotate-ccw.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-rotate-ccw"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+  <path d="M3 3v5h5" />
+</svg>

--- a/resources/js/core/use-column-resizing.test.tsx
+++ b/resources/js/core/use-column-resizing.test.tsx
@@ -57,20 +57,25 @@ function Harness({
   storageKey?: string;
   trailingTracks?: string[];
 }) {
-  const { gridTemplateColumns, getResizeHandleProps } = useColumnResizing({
-    enabled: true,
-    columns: hookColumns,
-    columnGapPx,
-    leadingTracks,
-    showIndicator,
-    storageKey,
-    trailingTracks,
-  });
+  const { gridTemplateColumns, getResizeHandleProps, hasOverrides, resetColumns } =
+    useColumnResizing({
+      enabled: true,
+      columns: hookColumns,
+      columnGapPx,
+      leadingTracks,
+      showIndicator,
+      storageKey,
+      trailingTracks,
+    });
 
   onGetter?.(getResizeHandleProps);
 
   return (
     <div data-testid="grid" style={{ gridTemplateColumns }}>
+      <span data-testid="has-overrides">{String(hasOverrides)}</span>
+      <button data-testid="reset" onClick={resetColumns} type="button">
+        reset
+      </button>
       {hookColumns.map((column) => (
         <div key={column.key} data-testid={`cell-${column.key}`}>
           <div {...getResizeHandleProps(column)} />
@@ -83,6 +88,26 @@ function Harness({
 describe("useColumnResizing", () => {
   beforeEach(() => {
     window.localStorage.clear();
+  });
+
+  it("exposes hasOverrides and resets every column width", () => {
+    render(<Harness storageKey="cols" />);
+
+    expect(screen.getByTestId("has-overrides")).toHaveTextContent("false");
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "208px" });
+    expect(screen.getByTestId("has-overrides")).toHaveTextContent("true");
+    expect(window.localStorage.getItem("cols")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("reset"));
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+    expect(screen.getByTestId("has-overrides")).toHaveTextContent("false");
+    expect(window.localStorage.getItem("cols")).toBeNull();
   });
 
   it("updates the grid template while dragging a handle", () => {

--- a/resources/js/core/use-column-resizing.ts
+++ b/resources/js/core/use-column-resizing.ts
@@ -102,6 +102,15 @@ export function useColumnResizing({
     [columnKeys, storageKey],
   );
 
+  const resetColumns = useCallback(() => {
+    setOverrides({});
+    overridesRef.current = {};
+    writeStoredOverrides(storageKey, columnKeys, {});
+  }, [columnKeys, storageKey]);
+
+  const hasOverrides =
+    enabled && Object.values(overrides).some((width) => typeof width === "number");
+
   const currentColumnWidth = useCallback(
     (column: SizableColumn): number =>
       overridesRef.current[column.key] ?? defaultColumnWidthPx(column),
@@ -228,6 +237,8 @@ export function useColumnResizing({
   return {
     getResizeHandleProps,
     gridTemplateColumns,
+    hasOverrides,
+    resetColumns,
     resetColumnWidth,
   };
 }

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -180,6 +180,7 @@ export function TableRows({
   resizableColumns?: boolean;
   resizeIndicator?: boolean;
 }) {
+  const { t } = useT("lattice");
   const sizingColumns = useMemo<SizableColumn[]>(
     () =>
       columns.map((column) => ({
@@ -189,56 +190,71 @@ export function TableRows({
       })),
     [columns],
   );
-  const { getResizeHandleProps, gridTemplateColumns } = useColumnResizing({
-    columns: sizingColumns,
-    enabled: resizableColumns,
-    columnGapPx: 12,
-    leadingTracks: rowControlTracks,
-    showIndicator: resizeIndicator,
-    storageKey: resizableColumns ? `lattice:table-columns:form:${base}` : undefined,
-    trailingTracks: rowActionTracks,
-  });
+  const { getResizeHandleProps, gridTemplateColumns, hasOverrides, resetColumns } =
+    useColumnResizing({
+      columns: sizingColumns,
+      enabled: resizableColumns,
+      columnGapPx: 12,
+      leadingTracks: rowControlTracks,
+      showIndicator: resizeIndicator,
+      storageKey: resizableColumns ? `lattice:table-columns:form:${base}` : undefined,
+      trailingTracks: rowActionTracks,
+    });
 
   return (
-    <div className="overflow-x-auto">
-      <div className="flex min-w-max flex-col gap-2">
-        <div className="grid items-center gap-x-3" style={{ gridTemplateColumns }}>
-          <div />
-          {columns.map((column, index) => (
-            <div
-              key={column.name}
-              className="relative min-w-0 pr-3 text-xs font-medium text-lt-muted-fg"
-            >
-              {column.label}
-              {resizableColumns && <div {...getResizeHandleProps(sizingColumns[index])} />}
-            </div>
-          ))}
-          <div />
-        </div>
+    <div className="relative">
+      {hasOverrides && (
+        <button
+          aria-label={t("a11y.resetColumnWidths", "Reset column widths")}
+          className="absolute right-1 top-1 z-10 hidden rounded-lt-sm p-1 text-lt-muted-fg hover:text-lt-fg md:inline-flex"
+          data-test="table-reset-columns"
+          onClick={resetColumns}
+          title={t("a11y.resetColumnWidths", "Reset column widths")}
+          type="button"
+        >
+          <Icon name="rotate-ccw" className="size-lt-icon-sm" />
+        </button>
+      )}
+      <div className="overflow-x-auto">
+        <div className="flex min-w-max flex-col gap-2">
+          <div className="grid items-center gap-x-3" style={{ gridTemplateColumns }}>
+            <div />
+            {columns.map((column, index) => (
+              <div
+                key={column.name}
+                className="relative min-w-0 pr-3 text-xs font-medium text-lt-muted-fg"
+              >
+                {column.label}
+                {resizableColumns && <div {...getResizeHandleProps(sizingColumns[index])} />}
+              </div>
+            ))}
+            <div />
+          </div>
 
-        {rows.map((row) => (
-          <TableRowItem
-            key={row.key}
-            base={base}
-            index={row.index}
-            row={row.row}
-            template={row.template}
-            span={row.span}
-            isFirst={row.index === 0}
-            isLast={row.index === rows.length - 1}
-            columnCount={columns.length}
-            gridTemplateColumns={gridTemplateColumns}
-            flipKey={row.key}
-            reorderable={reorderable}
-            removable={removable(row.index)}
-            rowActions={rowActions}
-            onField={onField}
-            onMove={onMove}
-            onRemove={onRemove}
-            onDuplicate={onDuplicate}
-            registerRow={registerRow}
-          />
-        ))}
+          {rows.map((row) => (
+            <TableRowItem
+              key={row.key}
+              base={base}
+              index={row.index}
+              row={row.row}
+              template={row.template}
+              span={row.span}
+              isFirst={row.index === 0}
+              isLast={row.index === rows.length - 1}
+              columnCount={columns.length}
+              gridTemplateColumns={gridTemplateColumns}
+              flipKey={row.key}
+              reorderable={reorderable}
+              removable={removable(row.index)}
+              rowActions={rowActions}
+              onField={onField}
+              onMove={onMove}
+              onRemove={onRemove}
+              onDuplicate={onDuplicate}
+              registerRow={registerRow}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useMemo } from "react";
 import { useT } from "@lattice-php/lattice/i18n";
 import { useColumnResizing } from "@lattice-php/lattice/core/use-column-resizing";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
+import { Icon } from "@lattice-php/lattice/icons";
 import type { TableNode } from "../types";
 import { getBulkActions } from "../bulk";
 import { flattenColumns, getRowActions, getRowKey } from "../payload";
@@ -74,200 +75,212 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   );
   const resizingEnabled = node.props?.resizableColumns === true;
   const resizeStorageIdentity = nodeIdentity(node);
-  const { getResizeHandleProps, gridTemplateColumns } = useColumnResizing({
-    columns: sizingColumns,
-    enabled: resizingEnabled,
-    leadingTracks: utilityTracks.leadingTracks,
-    showIndicator: node.props?.resizeIndicator === true,
-    storageKey:
-      resizingEnabled && resizeStorageIdentity
-        ? `lattice:table-columns:${resizeStorageIdentity}`
-        : undefined,
-    trailingTracks: utilityTracks.trailingTracks,
-  });
+  const { getResizeHandleProps, gridTemplateColumns, hasOverrides, resetColumns } =
+    useColumnResizing({
+      columns: sizingColumns,
+      enabled: resizingEnabled,
+      leadingTracks: utilityTracks.leadingTracks,
+      showIndicator: node.props?.resizeIndicator === true,
+      storageKey:
+        resizingEnabled && resizeStorageIdentity
+          ? `lattice:table-columns:${resizeStorageIdentity}`
+          : undefined,
+      trailingTracks: utilityTracks.trailingTracks,
+    });
 
   return (
-    <div
-      data-lattice-component={node.id}
-      className="overflow-x-auto rounded-lt-sm border border-lt-border"
-    >
-      {hasBulkActions && selection.active && (
-        <BulkBar
-          actions={bulkActions}
-          selectedKeys={selection.selectedKeys}
-          allMatching={selection.allMatching}
-          total={pagination.total ?? undefined}
-          query={getQueryParams(state)}
-          canSelectAllMatching={
-            selection.allVisibleSelected &&
-            !selection.allMatching &&
-            pagination.total != null &&
-            pagination.total > selection.selectedKeys.length
-          }
-          onSelectAllMatching={selection.selectAllMatching}
-          onCompleted={selection.clear}
-        />
+    <div data-lattice-component={node.id} className="relative">
+      {resizingEnabled && hasOverrides && (
+        <button
+          aria-label={t("a11y.resetColumnWidths", "Reset column widths")}
+          className="absolute right-1 top-1 z-10 hidden rounded-lt-sm p-1 text-lt-muted-fg hover:text-lt-fg md:inline-flex"
+          data-test="table-reset-columns"
+          onClick={resetColumns}
+          title={t("a11y.resetColumnWidths", "Reset column widths")}
+          type="button"
+        >
+          <Icon name="rotate-ccw" className="size-lt-icon-sm" />
+        </button>
       )}
-      {filters.length > 0 && (
-        <FilterStackBar
-          filters={filters}
-          columnsByKey={columnsByKey}
-          processing={processing}
-          onRemove={removeFilter}
-        />
-      )}
-      {state.sorts.length > 0 && (
-        <SortBar
-          columnsByKey={columnsByKey}
-          state={state}
-          processing={processing}
-          onClear={clearSort}
-        />
-      )}
-      <div className="min-w-full text-sm" role="table">
-        <div className="border-b border-lt-border bg-lt-muted/50" role="rowgroup">
-          <div
-            className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
-            role="row"
-            style={{ "--lattice-table-columns": gridTemplateColumns } as never}
-          >
-            {hasBulkActions && (
-              <div className="flex items-center px-4 py-3" role="columnheader">
-                <input
-                  type="checkbox"
-                  aria-label={t("a11y.selectAllRows", "Select all rows")}
-                  data-test="select-all"
-                  checked={selection.allSelected}
-                  onChange={selection.toggleAll}
-                />
-              </div>
-            )}
-            {columns.map((column, index) => (
-              <ColumnHeader
-                column={column}
-                key={column.key}
-                processing={processing}
-                resizeHandleProps={
-                  resizingEnabled ? getResizeHandleProps(sizingColumns[index]) : undefined
-                }
-                sort={sort}
-                state={state}
-              />
-            ))}
-            {hasActions && (
-              <div
-                className="px-4 py-3 text-right align-middle font-medium text-lt-muted-fg"
-                role="columnheader"
-              >
-                <span className="sr-only">{node.props?.actionsLabel}</span>
-              </div>
-            )}
-          </div>
-          {hasFilters && (
+      <div className="overflow-x-auto rounded-lt-sm border border-lt-border">
+        {hasBulkActions && selection.active && (
+          <BulkBar
+            actions={bulkActions}
+            selectedKeys={selection.selectedKeys}
+            allMatching={selection.allMatching}
+            total={pagination.total ?? undefined}
+            query={getQueryParams(state)}
+            canSelectAllMatching={
+              selection.allVisibleSelected &&
+              !selection.allMatching &&
+              pagination.total != null &&
+              pagination.total > selection.selectedKeys.length
+            }
+            onSelectAllMatching={selection.selectAllMatching}
+            onCompleted={selection.clear}
+          />
+        )}
+        {filters.length > 0 && (
+          <FilterStackBar
+            filters={filters}
+            columnsByKey={columnsByKey}
+            processing={processing}
+            onRemove={removeFilter}
+          />
+        )}
+        {state.sorts.length > 0 && (
+          <SortBar
+            columnsByKey={columnsByKey}
+            state={state}
+            processing={processing}
+            onClear={clearSort}
+          />
+        )}
+        <div className="min-w-full text-sm" role="table">
+          <div className="border-b border-lt-border bg-lt-muted/50" role="rowgroup">
             <div
-              className="hidden min-w-full border-t border-lt-border md:grid md:grid-cols-[var(--lattice-table-columns)]"
+              className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
               role="row"
               style={{ "--lattice-table-columns": gridTemplateColumns } as never}
             >
-              {hasBulkActions && <div className="px-4 py-2" role="cell" />}
-              {columns.map((column) => (
-                <div key={column.key} className="min-w-0 px-2 py-2" role="cell">
-                  {column.filter?.enabled && (
-                    <ColumnFilterControl
-                      column={column}
-                      clauses={filterEntries.filter((entry) => entry.clause.field === column.key)}
-                      processing={processing}
-                      onAdd={addFilter}
-                      onUpdate={updateFilter}
-                      onRemove={removeFilter}
-                    />
-                  )}
+              {hasBulkActions && (
+                <div className="flex items-center px-4 py-3" role="columnheader">
+                  <input
+                    type="checkbox"
+                    aria-label={t("a11y.selectAllRows", "Select all rows")}
+                    data-test="select-all"
+                    checked={selection.allSelected}
+                    onChange={selection.toggleAll}
+                  />
                 </div>
+              )}
+              {columns.map((column, index) => (
+                <ColumnHeader
+                  column={column}
+                  key={column.key}
+                  processing={processing}
+                  resizeHandleProps={
+                    resizingEnabled ? getResizeHandleProps(sizingColumns[index]) : undefined
+                  }
+                  sort={sort}
+                  state={state}
+                />
               ))}
-              {hasActions && <div className="px-4 py-2" role="cell" />}
-            </div>
-          )}
-        </div>
-        <div role="rowgroup">
-          {!hasLoaded ? (
-            <div className="p-4 text-lt-muted-fg" role="row">
-              <div role="cell">{t("table.loading", "Loading rows...")}</div>
-            </div>
-          ) : rowEntries.length === 0 ? (
-            <div className="p-8 text-center text-lt-muted-fg" role="row">
-              <div role="cell">{node.props?.emptyLabel}</div>
-            </div>
-          ) : (
-            rowEntries.map(({ row, actions, key }) => {
-              return (
+              {hasActions && (
                 <div
-                  key={key}
-                  className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
-                    striped ? "odd:bg-lt-muted/30" : ""
-                  }`}
-                  role="row"
-                  style={{ "--lattice-table-columns": gridTemplateColumns } as never}
+                  className="px-4 py-3 text-right align-middle font-medium text-lt-muted-fg"
+                  role="columnheader"
                 >
-                  {hasBulkActions && (
-                    <div className="flex items-center p-4" role="cell">
-                      <input
-                        type="checkbox"
-                        aria-label={t("a11y.selectRow", "Select row {{key}}", { key })}
-                        data-test={`select-row-${key}`}
-                        checked={selection.isSelected(key)}
-                        onChange={() => selection.toggle(key)}
-                      />
-                    </div>
-                  )}
-                  {columns.map((column) => (
-                    <div
-                      key={column.key}
-                      className="grid min-w-0 gap-1 p-4 align-middle"
-                      role="cell"
-                    >
-                      <span
-                        aria-hidden="true"
-                        className="text-xs font-medium text-lt-muted-fg md:hidden"
-                      >
-                        {column.label}
-                      </span>
-                      <div className="min-w-0 truncate">
-                        <ColumnCell column={column} row={row} />
-                      </div>
-                    </div>
-                  ))}
-                  {actions.length > 0 && (
-                    <div
-                      className="flex items-center justify-start gap-2 p-4 md:justify-end"
-                      role="cell"
-                    >
-                      {actions.map((action, actionIndex) => (
-                        <TableActionNode
-                          key={action.key ?? action.id ?? actionIndex}
-                          node={action}
-                        />
-                      ))}
-                    </div>
-                  )}
+                  <span className="sr-only">{node.props?.actionsLabel}</span>
                 </div>
-              );
-            })
-          )}
+              )}
+            </div>
+            {hasFilters && (
+              <div
+                className="hidden min-w-full border-t border-lt-border md:grid md:grid-cols-[var(--lattice-table-columns)]"
+                role="row"
+                style={{ "--lattice-table-columns": gridTemplateColumns } as never}
+              >
+                {hasBulkActions && <div className="px-4 py-2" role="cell" />}
+                {columns.map((column) => (
+                  <div key={column.key} className="min-w-0 px-2 py-2" role="cell">
+                    {column.filter?.enabled && (
+                      <ColumnFilterControl
+                        column={column}
+                        clauses={filterEntries.filter((entry) => entry.clause.field === column.key)}
+                        processing={processing}
+                        onAdd={addFilter}
+                        onUpdate={updateFilter}
+                        onRemove={removeFilter}
+                      />
+                    )}
+                  </div>
+                ))}
+                {hasActions && <div className="px-4 py-2" role="cell" />}
+              </div>
+            )}
+          </div>
+          <div role="rowgroup">
+            {!hasLoaded ? (
+              <div className="p-4 text-lt-muted-fg" role="row">
+                <div role="cell">{t("table.loading", "Loading rows...")}</div>
+              </div>
+            ) : rowEntries.length === 0 ? (
+              <div className="p-8 text-center text-lt-muted-fg" role="row">
+                <div role="cell">{node.props?.emptyLabel}</div>
+              </div>
+            ) : (
+              rowEntries.map(({ row, actions, key }) => {
+                return (
+                  <div
+                    key={key}
+                    className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
+                      striped ? "odd:bg-lt-muted/30" : ""
+                    }`}
+                    role="row"
+                    style={{ "--lattice-table-columns": gridTemplateColumns } as never}
+                  >
+                    {hasBulkActions && (
+                      <div className="flex items-center p-4" role="cell">
+                        <input
+                          type="checkbox"
+                          aria-label={t("a11y.selectRow", "Select row {{key}}", { key })}
+                          data-test={`select-row-${key}`}
+                          checked={selection.isSelected(key)}
+                          onChange={() => selection.toggle(key)}
+                        />
+                      </div>
+                    )}
+                    {columns.map((column) => (
+                      <div
+                        key={column.key}
+                        className="grid min-w-0 gap-1 p-4 align-middle"
+                        role="cell"
+                      >
+                        <span
+                          aria-hidden="true"
+                          className="text-xs font-medium text-lt-muted-fg md:hidden"
+                        >
+                          {column.label}
+                        </span>
+                        <div className="min-w-0 truncate">
+                          <ColumnCell column={column} row={row} />
+                        </div>
+                      </div>
+                    ))}
+                    {actions.length > 0 && (
+                      <div
+                        className="flex items-center justify-start gap-2 p-4 md:justify-end"
+                        role="cell"
+                      >
+                        {actions.map((action, actionIndex) => (
+                          <TableActionNode
+                            key={action.key ?? action.id ?? actionIndex}
+                            node={action}
+                          />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
         </div>
+        {hasLoaded && (
+          <TablePagination
+            pagination={pagination}
+            currentPage={currentPage}
+            processing={processing}
+            mode={mode}
+            hasNextPage={hasNextPage}
+            visiblePages={visiblePages}
+            infiniteLoaderRef={infiniteLoaderRef}
+            onPage={goToPage}
+            onLoadMore={loadMore}
+          />
+        )}
       </div>
-      {hasLoaded && (
-        <TablePagination
-          pagination={pagination}
-          currentPage={currentPage}
-          processing={processing}
-          mode={mode}
-          hasNextPage={hasNextPage}
-          visiblePages={visiblePages}
-          infiniteLoaderRef={infiniteLoaderRef}
-          onPage={goToPage}
-          onLoadMore={loadMore}
-        />
-      )}
     </div>
   );
 };

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -90,7 +90,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
 
   return (
     <div data-lattice-component={node.id} className="relative">
-      {resizingEnabled && hasOverrides && (
+      {hasOverrides && (
         <button
           aria-label={t("a11y.resetColumnWidths", "Reset column widths")}
           className="absolute right-1 top-1 z-10 hidden rounded-lt-sm p-1 text-lt-muted-fg hover:text-lt-fg md:inline-flex"

--- a/src/Core/Enums/Icon.php
+++ b/src/Core/Enums/Icon.php
@@ -47,6 +47,7 @@ enum Icon: string
     case PencilLine = 'pencil-line';
     case Plus = 'plus';
     case Quote = 'quote';
+    case RotateCcw = 'rotate-ccw';
     case Rows3 = 'rows-3';
     case Search = 'search';
     case Send = 'send';

--- a/tests/Browser/Forms/TableLayoutTest.php
+++ b/tests/Browser/Forms/TableLayoutTest.php
@@ -22,3 +22,29 @@ it('renders the table layout with a shared header and round-trips a typed payloa
         ->assertNoSmoke()
         ->assertNoJavaScriptErrors();
 });
+
+it('reveals a reset control for custom row-table column widths and clears them on click', function (): void {
+    $page = visit('/builder-table');
+    $page->resize(1280, 800);
+
+    $page->script(<<<'JS'
+        () => window.localStorage.setItem('lattice:table-columns:form:items', JSON.stringify({
+            columns: ['product', 'qty', 'price'],
+            overrides: { qty: 160 },
+        }))
+    JS);
+    $page->refresh();
+
+    $page->assertPresent('[aria-label="Resize Qty"]')
+        ->assertPresent('@table-reset-columns')
+        ->assertNoJavaScriptErrors();
+
+    $page->click('@table-reset-columns')
+        ->assertMissing('@table-reset-columns');
+
+    expect($page->script(
+        "() => window.localStorage.getItem('lattice:table-columns:form:items')",
+    ))->toBeNull();
+
+    $page->assertNoSmoke();
+});

--- a/tests/Browser/Tables/UsersTableTest.php
+++ b/tests/Browser/Tables/UsersTableTest.php
@@ -98,6 +98,35 @@ it('persists resized column widths until the column keys change', function (): v
     $page->assertNoSmoke();
 });
 
+it('reveals a reset control once columns are resized and clears them on click', function (): void {
+    seedWorkbenchUsers();
+
+    $page = visit('/');
+    $page->resize(1280, 800)->script('() => window.localStorage.clear()');
+    $page->refresh();
+
+    $page->assertPresent('[aria-label="Resize Name"]')
+        ->assertMissing('@table-reset-columns');
+
+    $page->keys('[aria-label="Resize Name"]', 'ArrowRight')
+        ->assertPresent('@table-reset-columns')
+        ->assertNoJavaScriptErrors();
+
+    expect($page->script(
+        "() => window.localStorage.getItem('lattice:table-columns:workbench.users')",
+    ))->not->toBeNull();
+
+    $page->click('@table-reset-columns')
+        ->assertMissing('@table-reset-columns');
+
+    expect($page->script(
+        "() => window.localStorage.getItem('lattice:table-columns:workbench.users')",
+    ))->toBeNull()
+        ->and(workbenchUsersTableColumns($page))->toStartWith('minmax(8rem, 1fr) ');
+
+    $page->assertNoSmoke();
+});
+
 function workbenchUsersTableColumns(mixed $page): string
 {
     return (string) $page->script(<<<'JS'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ const latticeIcons = [
   "send", "settings", "trash-2", "x",
   // Internal chrome
   "chevron-down", "chevron-right", "circle-alert", "circle-check", "circle-help", "circle-x",
-  "eye", "filter", "info", "loader-2", "minus", "panel-left", "plus", "search",
+  "eye", "filter", "info", "loader-2", "minus", "panel-left", "plus", "rotate-ccw", "search",
   // Rich-editor toolbar
   "align-center", "align-justify", "align-left", "align-right", "bold", "code",
   "columns-3", "heading-1", "heading-2", "heading-3", "highlighter", "italic",

--- a/workbench/resources/js/sprite-icons.ts
+++ b/workbench/resources/js/sprite-icons.ts
@@ -43,6 +43,7 @@ export const iconNames = [
   "pencil-line",
   "plus",
   "quote",
+  "rotate-ccw",
   "rows-3",
   "search",
   "send",
@@ -102,6 +103,7 @@ declare module "@lattice-php/lattice" {
     "pencil-line": true;
     plus: true;
     quote: true;
+    "rotate-ccw": true;
     "rows-3": true;
     search: true;
     send: true;


### PR DESCRIPTION
Adds a subtle reset affordance to resizable tables once a user has customized column widths (the widths persist in localStorage but previously had no way to reset).

## What
- `useColumnResizing` gains `hasOverrides` (any column has a custom width) and `resetColumns()` (clears all overrides + removes the localStorage entry).
- The table renders a muted, icon-only button (`rotate-ccw`) pinned to the top-right corner, shown only when `resizableColumns` is on **and** the user has resized at least one column. Click → all widths revert, the localStorage key is removed, and the button disappears. Desktop-only (`md:`), matching the resize handles.
- Added the `rotate-ccw` lucide icon to the vendored sprite allow-list; `a11y.resetColumnWidths` translation (en + de).

Per-column reset already existed (double-click a resize handle); this is the "reset all" complement.

## Test plan
- [ ] `composer check` — 571 pass, PHPStan 0, Pint clean
- [ ] `npm run check` — lint/format/tsc/vitest/build green (hook unit test covers `hasOverrides` toggle + `resetColumns` clearing state and localStorage)
- [ ] `composer test:browser` — new test: button absent → resize a column → button appears → click → widths revert + localStorage cleared + button gone