### PR TITLE
Enable Codecov test and bundle analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,12 @@ jobs:
 
       - run: npm run type-coverage
 
-      - run: npm run test:coverage
+      - run: |
+          mkdir -p coverage_vitest
+          npm run test:coverage -- --reporter=default --reporter=junit --outputFile.junit=coverage_vitest/junit.xml
 
       - name: Upload Vitest coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
@@ -47,7 +50,24 @@ jobs:
           disable_search: true
           fail_ci_if_error: true
 
+      - name: Upload Vitest test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage_vitest/junit.xml
+          flags: vitest
+          name: vitest-tests
+          report_type: test_results
+          disable_search: true
+          fail_ci_if_error: true
+
       - run: npm run build:lib
+
+      - name: Upload workbench bundle analysis to Codecov
+        env:
+          CODECOV_BUNDLE: "1"
+        run: npm run build
 
   php:
     name: PHP (pint, phpstan, pest)
@@ -103,13 +123,25 @@ jobs:
         run: composer test:coverage
 
       - name: Upload Pest coverage to Codecov
-        if: ${{ matrix.php-version == '8.4' }}
+        if: ${{ !cancelled() && matrix.php-version == '8.4' }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
           files: coverage_phpunit/clover.xml
           flags: pest
           name: pest
+          disable_search: true
+          fail_ci_if_error: true
+
+      - name: Upload Pest test results to Codecov
+        if: ${{ !cancelled() && matrix.php-version == '8.4' }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage_phpunit/pest.junit.xml
+          flags: pest
+          name: pest-tests
+          report_type: test_results
           disable_search: true
           fail_ci_if_error: true
 
@@ -193,12 +225,25 @@ jobs:
         run: composer test:browser:coverage
 
       - name: Upload Pest browser coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
           files: coverage_phpunit/browser-clover.xml
           flags: pest
           name: pest-browser
+          disable_search: true
+          fail_ci_if_error: true
+
+      - name: Upload Pest browser test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage_phpunit/pest-browser.junit.xml
+          flags: pest-browser
+          name: pest-browser-tests
+          report_type: test_results
           disable_search: true
           fail_ci_if_error: true
 

--- a/composer.json
+++ b/composer.json
@@ -83,10 +83,10 @@
         ],
         "test": "./vendor/bin/pest --testsuite Arch,Unit,Feature",
         "test:parallel": "./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel",
-        "test:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; $runner ./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel --coverage --coverage-clover coverage_phpunit/clover.xml",
+        "test:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel --coverage --coverage-clover coverage_phpunit/clover.xml --log-junit coverage_phpunit/pest.junit.xml",
         "test:browser": "./vendor/bin/pest --testsuite Browser",
         "test:browser:parallel": "./vendor/bin/pest --testsuite Browser --parallel",
-        "test:browser:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; $runner ./vendor/bin/pest --testsuite Browser --parallel --coverage --coverage-clover coverage_phpunit/browser-clover.xml",
+        "test:browser:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Browser --parallel --coverage --coverage-clover coverage_phpunit/browser-clover.xml --log-junit coverage_phpunit/pest-browser.junit.xml",
         "post-autoload-dump": [
             "@clear",
             "@prepare"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@astrojs/react": "^5.0.7",
         "@astrojs/starlight": "^0.40.0",
         "@astrojs/starlight-tailwind": "^5.0.0",
+        "@codecov/vite-plugin": "^2.0.1",
         "@inertiajs/react": "^3.0.0",
         "@inertiajs/vite": "^3.0.0",
         "@tailwindcss/vite": "^4.1.11",
@@ -68,6 +69,92 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
@@ -1501,6 +1588,51 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@codecov/bundler-plugin-core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@codecov/bundler-plugin-core/-/bundler-plugin-core-2.0.1.tgz",
+      "integrity": "sha512-TkdKn/rEwZQ723M7DDUmHe5r0IJa23rUT4TAx5jXmg12wGZGAHGWWU7LKeQsYCsKdLMxK7bLaGk9M++4wSRD5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^3.0.0",
+        "@actions/github": "^9.0.0",
+        "chalk": "4.1.2",
+        "semver": "^7.5.4",
+        "unplugin": "^1.10.1",
+        "zod": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@codecov/bundler-plugin-core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@codecov/vite-plugin": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@codecov/vite-plugin/-/vite-plugin-2.0.1.tgz",
+      "integrity": "sha512-w7nGA9SSc0WECzn05yRrw3uN8293I620Kd9x97I0kyyxUjtWxCMmlgmAbS364gJZYvljd0A6iQyAigVV2dOX9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codecov/bundler-plugin-core": "^2.0.1",
+        "unplugin": "^1.10.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "4.x || 5.x || 6.x"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -3059,6 +3191,144 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -7210,6 +7480,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -7513,6 +7790,20 @@
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -9424,6 +9715,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "dev": true,
       "license": "MIT"
     },
@@ -13230,6 +13528,16 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
@@ -13502,6 +13810,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -13510,6 +13825,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.1.tgz",
+      "integrity": "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/unstorage": {
@@ -14084,6 +14413,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "@astrojs/react": "^5.0.7",
     "@astrojs/starlight": "^0.40.0",
     "@astrojs/starlight-tailwind": "^5.0.0",
+    "@codecov/vite-plugin": "^2.0.1",
     "@inertiajs/react": "^3.0.0",
     "@inertiajs/vite": "^3.0.0",
     "@tailwindcss/vite": "^4.1.11",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import inertia from "@inertiajs/vite";
+import { codecovVitePlugin } from "@codecov/vite-plugin";
 import { svgSprite, writePhpEnum } from "@lattice-php/vite-svg-sprite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -64,6 +65,7 @@ export default defineConfig(({ mode }) => {
   // env flag so it only runs for `npm run analyze` / the docs build, writing an
   // interactive report + JSON the bundle-size docs page reads at build time.
   const isSonda = !isLibrary && process.env.SONDA === "1";
+  const isCodecovBundle = !isLibrary && !isVitest && process.env.CODECOV_BUNDLE === "1";
 
   return {
     publicDir: isLibrary ? false : undefined,
@@ -131,6 +133,17 @@ export default defineConfig(({ mode }) => {
               open: false,
             }),
           ]
+        : []),
+      ...(isCodecovBundle
+        ? codecovVitePlugin({
+            enableBundleAnalysis: true,
+            bundleName: "lattice-workbench",
+            oidc: {
+              useGitHubOIDC: true,
+            },
+            dryRun: process.env.CODECOV_BUNDLE_DRY_RUN === "1",
+            telemetry: false,
+          })
         : []),
     ],
     resolve: {


### PR DESCRIPTION
## Summary

- Emit and upload JUnit test results for Vitest, Pest coverage, and Pest browser coverage.
- Add gated Codecov bundle analysis for the workbench Vite build.
- Keep the PHP non-coverage matrix on the existing plain parallel Pest run.

## Validation

- `npm run check`
- `composer check`
- `npm run test:coverage -- --reporter=default --reporter=junit --outputFile.junit=coverage_vitest/junit.xml`
- `composer test:coverage`
- `CODECOV_BUNDLE=1 CODECOV_BUNDLE_DRY_RUN=1 npm run build`
- `composer validate --no-check-publish --strict`
- `git diff --check`
