### PR TITLE
feat: dedicated table filters

### DIFF
--- a/docs/content/docs/tables/sorting-filtering-pagination.mdx
+++ b/docs/content/docs/tables/sorting-filtering-pagination.mdx
@@ -4,6 +4,7 @@ description: Make columns sortable and filterable, choose filter operators per v
 ---
 
 import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
 
 Sorting, filtering, and pagination are handled for you once a column opts in. The table sends the
 current sort and filters to its [endpoint](/advanced/security/), and the [data source](/tables/overview/#data-sources)
@@ -65,6 +66,65 @@ TextColumn::make('sku')->filterable(Op::Equals, [Op::Equals, Op::NotEquals]);
 A column's filter capability serializes as a `ColumnFilter` (`{ enabled, type, operators,
 defaultOperator }`) so the React filter control knows which inputs and operators to render. Open the
 **Tree** tab on the example above to see it.
+
+## Dedicated filters
+
+Per-column filters compare a single column with an operator. **Dedicated filters** are named,
+table-level controls rendered in a filter bar above the table — each owns its own control and query
+logic, and isn't tied to a column. Declare them by overriding `filters()`:
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Tables\Filters\DateRangeFilter;
+use Lattice\Lattice\Tables\Filters\Filter;
+use Lattice\Lattice\Tables\Filters\SelectFilter;
+use Lattice\Lattice\Tables\Filters\TernaryFilter;
+
+public function filters(): array
+{
+    return [
+        SelectFilter::make('status')
+            ->options([
+                SelectFilter::option('Draft', 'draft'),
+                SelectFilter::option('Active', 'active'),
+            ])
+            ->multiple(),                          // match any selected → whereIn
+
+        TernaryFilter::make('featured')            // yes / no / all
+            ->trueLabel('Featured')
+            ->falseLabel('Not featured'),
+
+        DateRangeFilter::make('created_at'),       // from / until, inclusive
+
+        Filter::make('high_value')                 // custom toggle + query
+            ->query(fn (Builder $query): Builder => $query->where('price', '>', 1000)),
+    ];
+}
+```
+
+| Filter             | Control          | Applies                                                                 |
+| ------------------ | ---------------- | ----------------------------------------------------------------------- |
+| `SelectFilter`     | dropdown         | `where` (single) or `whereIn` (`->multiple()`); `->attribute()` to remap |
+| `TernaryFilter`    | yes / no / all   | boolean `where`, or custom `->queries(true: …, false: …)`                |
+| `DateRangeFilter`  | from / until     | inclusive `whereDate` on each provided bound                            |
+| `Filter`           | toggle           | your `->query()` closure when on                                        |
+
+Active values show as removable chips with a **Reset all** that clears every filter — dedicated and
+column alike.
+
+### How values reach the server
+
+Dedicated filter values post as Laravel bracket params — `tf[status]=active`, repeated
+`tf[status][]=…` for multi-select, and `tf[created][from]=…` / `[until]` for a range. They're
+validated against the declared filters, then applied by the [data source](/tables/overview/#data-sources).
+A custom `Filter::query()` closure runs server-side with utility injection — type-hint `Builder` to
+receive the query.
+
+<Info>
+Dedicated filters are independent of a column's `->filterable()`: column filters compare one column
+with an operator and render in the column header; dedicated filters are named, drive their own query,
+and live in the filter bar.
+</Info>
 
 ## Pagination
 

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -91,6 +91,7 @@
             ],
             "emptyLabel": "No results",
             "endpoint": null,
+            "filters": [],
             "layout": null,
             "lazy": null,
             "pagination": {
@@ -110,7 +111,8 @@
                 "filters": [],
                 "page": 1,
                 "perPage": 25,
-                "sorts": []
+                "sorts": [],
+                "tableFilters": []
             },
             "striped": null
         },

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -113,6 +113,7 @@
             ],
             "emptyLabel": "No results",
             "endpoint": null,
+            "filters": [],
             "layout": null,
             "lazy": null,
             "pagination": {
@@ -132,7 +133,8 @@
                 "filters": [],
                 "page": 1,
                 "perPage": 25,
-                "sorts": []
+                "sorts": [],
+                "tableFilters": []
             },
             "striped": true
         },

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -73,6 +73,7 @@
             ],
             "emptyLabel": "No results",
             "endpoint": null,
+            "filters": [],
             "layout": null,
             "lazy": null,
             "pagination": {
@@ -92,7 +93,8 @@
                 "filters": [],
                 "page": 1,
                 "perPage": 25,
-                "sorts": []
+                "sorts": [],
+                "tableFilters": []
             },
             "striped": null
         },

--- a/lang/de/lattice.php
+++ b/lang/de/lattice.php
@@ -57,6 +57,10 @@ return [
         'remove' => ':label-Filter entfernen',
         'value' => ':label-Filterwert',
         'add' => 'Filter hinzufügen',
+        'from' => ':label ab',
+        'until' => ':label bis',
+        'selectedCount' => ':amount ausgewählt',
+        'resetAll' => 'Alle zurücksetzen',
     ],
     'operators' => [
         'contains' => 'enthält',

--- a/lang/en/lattice.php
+++ b/lang/en/lattice.php
@@ -57,6 +57,10 @@ return [
         'remove' => 'Remove :label filter',
         'value' => ':label filter value',
         'add' => 'Add filter',
+        'from' => ':label from',
+        'until' => ':label until',
+        'selectedCount' => ':amount selected',
+        'resetAll' => 'Reset all',
     ],
     'operators' => [
         'contains' => 'contains',

--- a/resources/js/table/components/filter-bar.test.tsx
+++ b/resources/js/table/components/filter-bar.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { FilterData } from "@lattice-php/lattice/types/generated";
+import { FilterBar } from "./filter-bar";
+
+const selectFilter: FilterData = {
+  key: "status",
+  label: "Status",
+  type: "select",
+  props: {
+    options: [
+      { label: "Active", value: "active" },
+      { label: "Draft", value: "draft" },
+    ],
+    multiple: false,
+    searchable: false,
+    placeholder: null,
+  },
+};
+
+const toggleFilter: FilterData = {
+  key: "high_value",
+  label: "High value",
+  type: "toggle",
+  props: {},
+};
+
+function renderBar(props: Partial<Parameters<typeof FilterBar>[0]> = {}) {
+  const onChange = vi.fn<(key: string, value: unknown) => void>();
+  const onReset = vi.fn<() => void>();
+
+  render(
+    <FilterBar
+      filters={[selectFilter, toggleFilter]}
+      values={{}}
+      processing={false}
+      hasActiveFilters={false}
+      onChange={onChange}
+      onReset={onReset}
+      {...props}
+    />,
+  );
+
+  return { onChange, onReset };
+}
+
+describe("FilterBar", () => {
+  it("emits a value when a select option is chosen", () => {
+    const { onChange } = renderBar();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Status" }), {
+      target: { value: "active" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("status", "active");
+  });
+
+  it("emits the on state when a toggle is checked", () => {
+    const { onChange } = renderBar();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "High value" }));
+
+    expect(onChange).toHaveBeenCalledWith("high_value", "1");
+  });
+
+  it("renders an active-value chip whose remove clears the filter", () => {
+    const { onChange } = renderBar({ values: { status: "active" }, hasActiveFilters: true });
+
+    const remove = screen.getByRole("button", { name: "Remove Status filter" });
+    expect(remove).toBeInTheDocument();
+
+    fireEvent.click(remove);
+
+    expect(onChange).toHaveBeenCalledWith("status", undefined);
+  });
+
+  it("resets all filters", () => {
+    const { onReset } = renderBar({ values: { status: "active" }, hasActiveFilters: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset all" }));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/resources/js/table/components/filter-bar.tsx
+++ b/resources/js/table/components/filter-bar.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@lattice-php/lattice/icons";
 import { useT } from "@lattice-php/lattice/i18n";
-import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
+import type { FilterData } from "@lattice-php/lattice/types/generated";
+import { filterOptions, isActiveFilterValue, stringProp } from "../filter-values";
 import { TableFilterControl } from "./filter-controls";
 
 /**
@@ -24,7 +25,7 @@ export function FilterBar({
   onReset: () => void;
 }) {
   const { t } = useT("lattice");
-  const active = filters.filter((filter) => isActive(values[filter.key]));
+  const active = filters.filter((filter) => isActiveFilterValue(values[filter.key]));
 
   return (
     <div className="flex flex-col gap-2 border-b border-lt-border px-4 py-3">
@@ -43,7 +44,7 @@ export function FilterBar({
           </div>
         ))}
       </div>
-      {(active.length > 0 || hasActiveFilters) && (
+      {hasActiveFilters && (
         <div className="flex flex-wrap items-center gap-2 text-sm">
           {active.map((filter) => (
             <span
@@ -83,26 +84,8 @@ export function FilterBar({
   );
 }
 
-function isActive(value: unknown): boolean {
-  if (value == null || value === "") {
-    return false;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length > 0;
-  }
-
-  if (typeof value === "object") {
-    return Object.values(value).some((member) => member != null && member !== "");
-  }
-
-  return true;
-}
-
 function optionLabel(filter: FilterData, value: string): string {
-  const options = Array.isArray(filter.props.options) ? (filter.props.options as Option[]) : [];
-
-  return options.find((option) => option.value === value)?.label ?? value;
+  return filterOptions(filter).find((option) => option.value === value)?.label ?? value;
 }
 
 function displayValue(filter: FilterData, value: unknown): string {
@@ -115,11 +98,9 @@ function displayValue(filter: FilterData, value: unknown): string {
   }
 
   if (filter.type === "ternary") {
-    const trueLabel = typeof filter.props.trueLabel === "string" ? filter.props.trueLabel : "True";
-    const falseLabel =
-      typeof filter.props.falseLabel === "string" ? filter.props.falseLabel : "False";
-
-    return value === "true" ? trueLabel : falseLabel;
+    return value === "true"
+      ? stringProp(filter, "trueLabel", "True")
+      : stringProp(filter, "falseLabel", "False");
   }
 
   if (filter.type === "date-range" && value && typeof value === "object") {

--- a/resources/js/table/components/filter-bar.tsx
+++ b/resources/js/table/components/filter-bar.tsx
@@ -1,0 +1,132 @@
+import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
+import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
+import { TableFilterControl } from "./filter-controls";
+
+/**
+ * The dedicated-filter toolbar above the table: a control per declared filter
+ * plus a row of active-value indicator chips with individual remove and a
+ * "Reset all" that clears every filter (column and dedicated alike).
+ */
+export function FilterBar({
+  filters,
+  values,
+  processing,
+  hasActiveFilters,
+  onChange,
+  onReset,
+}: {
+  filters: FilterData[];
+  values: Record<string, unknown>;
+  processing: boolean;
+  hasActiveFilters: boolean;
+  onChange: (key: string, value: unknown) => void;
+  onReset: () => void;
+}) {
+  const { t } = useT("lattice");
+  const active = filters.filter((filter) => isActive(values[filter.key]));
+
+  return (
+    <div className="flex flex-col gap-2 border-b border-lt-border px-4 py-3">
+      <div className="flex flex-wrap items-end gap-3">
+        {filters.map((filter) => (
+          <div key={filter.key} className="flex flex-col gap-1">
+            {filter.type !== "toggle" && (
+              <span className="text-xs font-medium text-lt-muted-fg">{filter.label}</span>
+            )}
+            <TableFilterControl
+              filter={filter}
+              value={values[filter.key]}
+              processing={processing}
+              onChange={(value) => onChange(filter.key, value)}
+            />
+          </div>
+        ))}
+      </div>
+      {(active.length > 0 || hasActiveFilters) && (
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          {active.map((filter) => (
+            <span
+              key={filter.key}
+              className="inline-flex items-center gap-1.5 rounded-lt-sm bg-lt-muted px-2 py-1"
+            >
+              <span>
+                {`${filter.label}: `}
+                <span className="font-semibold">{displayValue(filter, values[filter.key])}</span>
+              </span>
+              <button
+                type="button"
+                data-test={`table-filter-chip-${filter.key}-remove`}
+                className="inline-flex size-5 items-center justify-center rounded text-lt-muted-fg hover:bg-lt-border disabled:opacity-50"
+                disabled={processing}
+                aria-label={t("filter.remove", "Remove {{label}} filter", { label: filter.label })}
+                onClick={() => onChange(filter.key, undefined)}
+              >
+                <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
+              </button>
+            </span>
+          ))}
+          {hasActiveFilters && (
+            <button
+              type="button"
+              data-test="table-filters-reset"
+              className="text-lt-muted-fg underline-offset-2 hover:underline disabled:opacity-50"
+              disabled={processing}
+              onClick={onReset}
+            >
+              {t("filter.resetAll", "Reset all")}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isActive(value: unknown): boolean {
+  if (value == null || value === "") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value).some((member) => member != null && member !== "");
+  }
+
+  return true;
+}
+
+function optionLabel(filter: FilterData, value: string): string {
+  const options = Array.isArray(filter.props.options) ? (filter.props.options as Option[]) : [];
+
+  return options.find((option) => option.value === value)?.label ?? value;
+}
+
+function displayValue(filter: FilterData, value: unknown): string {
+  if (filter.type === "select") {
+    if (Array.isArray(value)) {
+      return value.map((item) => optionLabel(filter, String(item))).join(", ");
+    }
+
+    return optionLabel(filter, String(value));
+  }
+
+  if (filter.type === "ternary") {
+    const trueLabel = typeof filter.props.trueLabel === "string" ? filter.props.trueLabel : "True";
+    const falseLabel =
+      typeof filter.props.falseLabel === "string" ? filter.props.falseLabel : "False";
+
+    return value === "true" ? trueLabel : falseLabel;
+  }
+
+  if (filter.type === "date-range" && value && typeof value === "object") {
+    const range = value as { from?: string; until?: string };
+
+    return [range.from, range.until].filter((part) => part).join(" – ");
+  }
+
+  return String(value);
+}

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -1,0 +1,281 @@
+import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
+import { useState } from "react";
+import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
+
+const fieldClass =
+  "h-9 w-full min-w-0 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal";
+
+export type DateRangeValue = { from?: string; until?: string };
+
+function options(filter: FilterData): Option[] {
+  const value = filter.props.options;
+
+  return Array.isArray(value) ? (value as Option[]) : [];
+}
+
+/**
+ * Renders the control for a single dedicated table filter, dispatching on the
+ * filter's `type`. The current value comes from the table state; `onChange`
+ * pushes a new value (an empty value clears the filter).
+ */
+export function TableFilterControl({
+  filter,
+  value,
+  processing,
+  onChange,
+}: {
+  filter: FilterData;
+  value: unknown;
+  processing: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  switch (filter.type) {
+    case "select":
+      return filter.props.multiple === true ? (
+        <MultiSelectControl
+          filter={filter}
+          value={value}
+          processing={processing}
+          onChange={onChange}
+        />
+      ) : (
+        <SelectControl filter={filter} value={value} processing={processing} onChange={onChange} />
+      );
+    case "ternary":
+      return (
+        <TernaryControl filter={filter} value={value} processing={processing} onChange={onChange} />
+      );
+    case "date-range":
+      return (
+        <DateRangeControl
+          filter={filter}
+          value={value}
+          processing={processing}
+          onChange={onChange}
+        />
+      );
+    case "toggle":
+      return (
+        <ToggleControl filter={filter} value={value} processing={processing} onChange={onChange} />
+      );
+    default:
+      return null;
+  }
+}
+
+function SelectControl({
+  filter,
+  value,
+  processing,
+  onChange,
+}: {
+  filter: FilterData;
+  value: unknown;
+  processing: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const { t } = useT("lattice");
+  const placeholder =
+    typeof filter.props.placeholder === "string"
+      ? filter.props.placeholder
+      : t("filter.all", "All");
+
+  return (
+    <select
+      aria-label={filter.label}
+      data-test={`table-filter-${filter.key}`}
+      className={fieldClass}
+      disabled={processing}
+      value={typeof value === "string" ? value : ""}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">{placeholder}</option>
+      {options(filter).map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function MultiSelectControl({
+  filter,
+  value,
+  processing,
+  onChange,
+}: {
+  filter: FilterData;
+  value: unknown;
+  processing: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const { t } = useT("lattice");
+  const [open, setOpen] = useState(false);
+  const selected = Array.isArray(value) ? (value as string[]) : [];
+
+  function toggle(optionValue: string): void {
+    const next = selected.includes(optionValue)
+      ? selected.filter((item) => item !== optionValue)
+      : [...selected, optionValue];
+
+    onChange(next);
+  }
+
+  const summary =
+    selected.length === 0
+      ? typeof filter.props.placeholder === "string"
+        ? filter.props.placeholder
+        : t("filter.all", "All")
+      : t("filter.selectedCount", "{{amount}} selected", { amount: selected.length });
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label={filter.label}
+        aria-expanded={open}
+        data-test={`table-filter-${filter.key}`}
+        className={`${fieldClass} flex items-center justify-between gap-2`}
+        disabled={processing}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="truncate">{summary}</span>
+        <Icon name="chevron-down" aria-hidden="true" className="size-lt-icon-sm shrink-0" />
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-1 min-w-full rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-md">
+          {options(filter).map((option) => (
+            <label
+              key={option.value}
+              className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-lt-muted"
+            >
+              <input
+                type="checkbox"
+                aria-label={option.label}
+                data-test={`table-filter-${filter.key}-${option.value}`}
+                checked={selected.includes(option.value)}
+                disabled={processing}
+                onChange={() => toggle(option.value)}
+              />
+              <span className="truncate">{option.label}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TernaryControl({
+  filter,
+  value,
+  processing,
+  onChange,
+}: {
+  filter: FilterData;
+  value: unknown;
+  processing: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const { t } = useT("lattice");
+  const placeholder =
+    typeof filter.props.placeholder === "string"
+      ? filter.props.placeholder
+      : t("filter.all", "All");
+  const trueLabel =
+    typeof filter.props.trueLabel === "string" ? filter.props.trueLabel : t("filter.true", "True");
+  const falseLabel =
+    typeof filter.props.falseLabel === "string"
+      ? filter.props.falseLabel
+      : t("filter.false", "False");
+
+  return (
+    <select
+      aria-label={filter.label}
+      data-test={`table-filter-${filter.key}`}
+      className={fieldClass}
+      disabled={processing}
+      value={typeof value === "string" ? value : ""}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      <option value="">{placeholder}</option>
+      <option value="true">{trueLabel}</option>
+      <option value="false">{falseLabel}</option>
+    </select>
+  );
+}
+
+function DateRangeControl({
+  filter,
+  value,
+  processing,
+  onChange,
+}: {
+  filter: FilterData;
+  value: unknown;
+  processing: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const { t } = useT("lattice");
+  const range: DateRangeValue = value && typeof value === "object" ? (value as DateRangeValue) : {};
+
+  function commit(next: DateRangeValue): void {
+    onChange({ from: next.from ?? "", until: next.until ?? "" });
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <input
+        type="date"
+        aria-label={t("filter.from", "{{label}} from", { label: filter.label })}
+        data-test={`table-filter-${filter.key}-from`}
+        className={fieldClass}
+        disabled={processing}
+        value={range.from ?? ""}
+        onChange={(event) => commit({ ...range, from: event.target.value })}
+      />
+      <span className="text-lt-muted-fg" aria-hidden="true">
+        –
+      </span>
+      <input
+        type="date"
+        aria-label={t("filter.until", "{{label}} until", { label: filter.label })}
+        data-test={`table-filter-${filter.key}-until`}
+        className={fieldClass}
+        disabled={processing}
+        value={range.until ?? ""}
+        onChange={(event) => commit({ ...range, until: event.target.value })}
+      />
+    </div>
+  );
+}
+
+function ToggleControl({
+  filter,
+  value,
+  processing,
+  onChange,
+}: {
+  filter: FilterData;
+  value: unknown;
+  processing: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const checked = value === "1" || value === true || value === "true";
+
+  return (
+    <label className="flex h-9 cursor-pointer items-center gap-2 text-sm">
+      <input
+        type="checkbox"
+        aria-label={filter.label}
+        data-test={`table-filter-${filter.key}`}
+        checked={checked}
+        disabled={processing}
+        onChange={(event) => onChange(event.target.checked ? "1" : "")}
+      />
+      <span>{filter.label}</span>
+    </label>
+  );
+}

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -1,18 +1,11 @@
 import { Icon } from "@lattice-php/lattice/icons";
 import { useT } from "@lattice-php/lattice/i18n";
 import { useState } from "react";
-import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
-
-const fieldClass =
-  "h-9 w-full min-w-0 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal";
+import type { FilterData } from "@lattice-php/lattice/types/generated";
+import { filterOptions, stringProp } from "../filter-values";
+import { fieldClass } from "./filter-value-input";
 
 export type DateRangeValue = { from?: string; until?: string };
-
-function options(filter: FilterData): Option[] {
-  const value = filter.props.options;
-
-  return Array.isArray(value) ? (value as Option[]) : [];
-}
 
 /**
  * Renders the control for a single dedicated table filter, dispatching on the
@@ -76,10 +69,7 @@ function SelectControl({
   onChange: (value: unknown) => void;
 }) {
   const { t } = useT("lattice");
-  const placeholder =
-    typeof filter.props.placeholder === "string"
-      ? filter.props.placeholder
-      : t("filter.all", "All");
+  const placeholder = stringProp(filter, "placeholder", t("filter.all", "All"));
 
   return (
     <select
@@ -91,7 +81,7 @@ function SelectControl({
       onChange={(event) => onChange(event.target.value)}
     >
       <option value="">{placeholder}</option>
-      {options(filter).map((option) => (
+      {filterOptions(filter).map((option) => (
         <option key={option.value} value={option.value}>
           {option.label}
         </option>
@@ -125,9 +115,7 @@ function MultiSelectControl({
 
   const summary =
     selected.length === 0
-      ? typeof filter.props.placeholder === "string"
-        ? filter.props.placeholder
-        : t("filter.all", "All")
+      ? stringProp(filter, "placeholder", t("filter.all", "All"))
       : t("filter.selectedCount", "{{amount}} selected", { amount: selected.length });
 
   return (
@@ -146,7 +134,7 @@ function MultiSelectControl({
       </button>
       {open && (
         <div className="absolute z-10 mt-1 min-w-full rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-md">
-          {options(filter).map((option) => (
+          {filterOptions(filter).map((option) => (
             <label
               key={option.value}
               className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-lt-muted"
@@ -180,16 +168,9 @@ function TernaryControl({
   onChange: (value: unknown) => void;
 }) {
   const { t } = useT("lattice");
-  const placeholder =
-    typeof filter.props.placeholder === "string"
-      ? filter.props.placeholder
-      : t("filter.all", "All");
-  const trueLabel =
-    typeof filter.props.trueLabel === "string" ? filter.props.trueLabel : t("filter.true", "True");
-  const falseLabel =
-    typeof filter.props.falseLabel === "string"
-      ? filter.props.falseLabel
-      : t("filter.false", "False");
+  const placeholder = stringProp(filter, "placeholder", t("filter.all", "All"));
+  const trueLabel = stringProp(filter, "trueLabel", t("filter.true", "True"));
+  const falseLabel = stringProp(filter, "falseLabel", t("filter.false", "False"));
 
   return (
     <select

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { FilterType } from "@lattice-php/lattice/types/generated";
 
-const baseClass =
+export const fieldClass =
   "h-9 w-full min-w-0 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal";
 
 export function FilterValueInput({
@@ -43,7 +43,7 @@ export function FilterValueInput({
       <select
         aria-label={inputLabel}
         data-test={testId}
-        className={`${baseClass} ${groupedClass}`}
+        className={`${fieldClass} ${groupedClass}`}
         disabled={processing}
         value={value}
         onChange={(event) => onCommit(event.target.value)}
@@ -61,7 +61,7 @@ export function FilterValueInput({
         type="date"
         aria-label={inputLabel}
         data-test={testId}
-        className={`${baseClass} ${groupedClass}`}
+        className={`${fieldClass} ${groupedClass}`}
         disabled={processing}
         value={draft}
         onChange={(event) => {
@@ -85,7 +85,7 @@ export function FilterValueInput({
         type={type === "number" ? "number" : "text"}
         aria-label={inputLabel}
         data-test={testId}
-        className={`${baseClass} ${groupedClass} ${withSearchIcon ? "pl-8" : ""} ${onClear ? "pr-8" : ""}`}
+        className={`${fieldClass} ${groupedClass} ${withSearchIcon ? "pl-8" : ""} ${onClear ? "pr-8" : ""}`}
         disabled={processing}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}

--- a/resources/js/table/components/table-filters.test.tsx
+++ b/resources/js/table/components/table-filters.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ColumnData, FilterData } from "@lattice-php/lattice/types/generated";
+import type { TableNode } from "../types";
+import TableComponent from "./table";
+
+function col(key: string, label: string): ColumnData {
+  return {
+    key,
+    label,
+    type: "text",
+    width: "md",
+    sortable: null,
+    filter: null,
+    columns: null,
+    props: null,
+  };
+}
+
+const filters: FilterData[] = [
+  {
+    key: "status",
+    label: "Status",
+    type: "select",
+    props: {
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Draft", value: "draft" },
+      ],
+      multiple: true,
+      searchable: false,
+      placeholder: null,
+    },
+  },
+  {
+    key: "featured",
+    label: "Featured",
+    type: "ternary",
+    props: { trueLabel: "Yes", falseLabel: "No", placeholder: "All" },
+  },
+  { key: "created", label: "Created", type: "date-range", props: {} },
+  { key: "high", label: "High value", type: "toggle", props: {} },
+];
+
+function stubFetch() {
+  const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+    Response.json({
+      data: [{ name: "Alpha" }],
+      pagination: {},
+      state: { filters: [], page: 1, perPage: 25, sorts: [], tableFilters: {} },
+    }),
+  );
+
+  vi.stubGlobal("fetch", fetch);
+
+  return fetch;
+}
+
+function node(tableFilters: Record<string, unknown>): TableNode {
+  return {
+    id: "workbench.products",
+    type: "table",
+    props: {
+      columns: [col("name", "Name")],
+      filters,
+      data: [{ name: "Alpha" }],
+      endpoint: "/lattice/tables/workbench.products",
+      state: { filters: [], page: 1, perPage: 25, sorts: [], tableFilters },
+    },
+  } satisfies TableNode;
+}
+
+describe("dedicated table filters in the table component", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders an active-value chip per dedicated filter type", () => {
+    stubFetch();
+
+    render(
+      <TableComponent
+        node={node({
+          status: ["active", "draft"],
+          featured: "true",
+          created: { from: "2026-01-01", until: "" },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Active, Draft")).toBeInTheDocument();
+    expect(screen.getByText("2026-01-01")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove Featured filter" })).toBeInTheDocument();
+  });
+
+  it("applies a ternary selection through the endpoint", async () => {
+    const fetch = stubFetch();
+
+    render(<TableComponent node={node({})} />);
+
+    fireEvent.change(screen.getByLabelText("Featured"), { target: { value: "false" } });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("tf%5Bfeatured%5D=false"),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("toggles a single value off the multi-select through the endpoint", async () => {
+    const fetch = stubFetch();
+
+    render(<TableComponent node={node({ status: ["active", "draft"] })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Status" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Active" }));
+
+    await waitFor(() => {
+      const url = fetch.mock.calls.at(-1)?.[0];
+      expect(url).toContain("tf%5Bstatus%5D%5B%5D=draft");
+      expect(url).not.toContain("active");
+    });
+  });
+
+  it("applies a date-range bound through the endpoint", async () => {
+    const fetch = stubFetch();
+
+    render(<TableComponent node={node({})} />);
+
+    fireEvent.change(screen.getByLabelText("Created from"), { target: { value: "2026-03-01" } });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("tf%5Bcreated%5D%5Bfrom%5D=2026-03-01"),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("turns a toggle filter on through the endpoint", async () => {
+    const fetch = stubFetch();
+
+    render(<TableComponent node={node({})} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "High value" }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("tf%5Bhigh%5D=1"),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("clears one filter through its indicator chip", async () => {
+    const fetch = stubFetch();
+
+    render(<TableComponent node={node({ featured: "true", status: ["active"] })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Featured filter" }));
+
+    await waitFor(() => {
+      const url = fetch.mock.calls.at(-1)?.[0];
+      expect(url).not.toContain("tf%5Bfeatured%5D");
+      expect(url).toContain("tf%5Bstatus%5D%5B%5D=active");
+    });
+  });
+
+  it("resets every filter", async () => {
+    const fetch = stubFetch();
+
+    render(<TableComponent node={node({ featured: "true" })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset all" }));
+
+    await waitFor(() => {
+      const url = fetch.mock.calls.at(-1)?.[0];
+      expect(url).not.toContain("tf%5B");
+    });
+  });
+});

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -17,6 +17,7 @@ import { useTableSelection } from "../use-table-selection";
 import { BulkBar } from "./bulk-bar";
 import { ColumnFilterControl } from "./column-filter-control";
 import { ColumnHeader } from "./column-header";
+import { FilterBar } from "./filter-bar";
 import { FilterStackBar } from "./filter-stack-bar";
 import { TablePagination } from "./pagination";
 import { SortBar } from "./sort-bar";
@@ -31,9 +32,12 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
     pagination,
     state,
     filters,
+    tableFilters,
     addFilter,
     updateFilter,
     removeFilter,
+    setTableFilter,
+    resetFilters,
     processing,
     hasLoaded,
     infiniteLoaderRef,
@@ -68,6 +72,11 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   const striped = node.props?.striped === true;
   const hasFilters = columns.some((column) => column.filter?.enabled);
   const filterEntries = filters.map((clause, index) => ({ clause, index }));
+  const filterDefinitions = useMemo(
+    () => (Array.isArray(node.props?.filters) ? node.props.filters : []),
+    [node.props?.filters],
+  );
+  const hasActiveFilters = filters.length > 0 || Object.keys(tableFilters).length > 0;
   const sizingColumns = useMemo(() => getTableSizingColumns(columns), [columns]);
   const utilityTracks = useMemo(
     () => getTableUtilityTracks(hasActions, hasBulkActions),
@@ -103,6 +112,16 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
         </button>
       )}
       <div className="overflow-x-auto rounded-lt-sm border border-lt-border">
+        {filterDefinitions.length > 0 && (
+          <FilterBar
+            filters={filterDefinitions}
+            values={tableFilters}
+            processing={processing}
+            hasActiveFilters={hasActiveFilters}
+            onChange={setTableFilter}
+            onReset={resetFilters}
+          />
+        )}
         {hasBulkActions && selection.active && (
           <BulkBar
             actions={bulkActions}

--- a/resources/js/table/filter-params.test.ts
+++ b/resources/js/table/filter-params.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildEndpoint } from "./query";
+import type { TableState } from "./types";
+
+function state(overrides: Partial<TableState>): TableState {
+  return { filters: [], sorts: [], page: 1, perPage: 25, tableFilters: {}, ...overrides };
+}
+
+describe("buildEndpoint with table filters", () => {
+  it("serializes a scalar table filter as tf[key]", () => {
+    const endpoint = buildEndpoint("/t", state({ tableFilters: { status: "active" } }));
+
+    expect(endpoint).toContain("tf%5Bstatus%5D=active");
+  });
+
+  it("serializes a multi-value table filter as repeated tf[key][]", () => {
+    const endpoint = buildEndpoint("/t", state({ tableFilters: { status: ["active", "draft"] } }));
+
+    expect(endpoint).toContain("tf%5Bstatus%5D%5B%5D=active");
+    expect(endpoint).toContain("tf%5Bstatus%5D%5B%5D=draft");
+  });
+
+  it("serializes an object table filter as tf[key][subkey]", () => {
+    const endpoint = buildEndpoint(
+      "/t",
+      state({ tableFilters: { created: { from: "2026-01-01" } } }),
+    );
+
+    expect(endpoint).toContain("tf%5Bcreated%5D%5Bfrom%5D=2026-01-01");
+  });
+
+  it("omits empty table filter values", () => {
+    const endpoint = buildEndpoint(
+      "/t",
+      state({ tableFilters: { status: "", created: { from: "", until: "" } } }),
+    );
+
+    expect(endpoint).not.toContain("tf%5B");
+  });
+});

--- a/resources/js/table/filter-values.test.ts
+++ b/resources/js/table/filter-values.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { FilterData } from "@lattice-php/lattice/types/generated";
+import {
+  filterOptions,
+  isActiveFilterValue,
+  isEmptyFilterValue,
+  stringProp,
+} from "./filter-values";
+
+describe("isEmptyFilterValue", () => {
+  it.each([
+    ["null", null, true],
+    ["empty string", "", true],
+    ["empty array", [], true],
+    ["all-empty object", { from: "", until: "" }, true],
+    ["non-empty string", "x", false],
+    ["non-empty array", ["a"], false],
+    ["partial object", { from: "2026-01-01", until: "" }, false],
+  ])("treats %s as empty=%s", (_label, value, expected) => {
+    expect(isEmptyFilterValue(value)).toBe(expected);
+    expect(isActiveFilterValue(value)).toBe(!expected);
+  });
+});
+
+const filter: FilterData = {
+  key: "status",
+  label: "Status",
+  type: "select",
+  props: { placeholder: "Pick", options: [{ label: "Active", value: "active" }] },
+};
+
+describe("stringProp", () => {
+  it("returns the string prop when present", () => {
+    expect(stringProp(filter, "placeholder", "fallback")).toBe("Pick");
+  });
+
+  it("falls back when the prop is absent or not a string", () => {
+    expect(stringProp(filter, "missing", "fallback")).toBe("fallback");
+    expect(stringProp({ ...filter, props: { placeholder: 3 } }, "placeholder", "fallback")).toBe(
+      "fallback",
+    );
+  });
+});
+
+describe("filterOptions", () => {
+  it("returns the options array", () => {
+    expect(filterOptions(filter)).toEqual([{ label: "Active", value: "active" }]);
+  });
+
+  it("returns an empty array when options are absent", () => {
+    expect(filterOptions({ ...filter, props: {} })).toEqual([]);
+  });
+});

--- a/resources/js/table/filter-values.ts
+++ b/resources/js/table/filter-values.ts
@@ -1,0 +1,41 @@
+import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
+
+/**
+ * Whether a table-filter value should clear the filter rather than apply it —
+ * an empty string, empty list, or an object whose every member is empty.
+ */
+export function isEmptyFilterValue(value: unknown): boolean {
+  if (value == null || value === "") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value).every((member) => member == null || member === "");
+  }
+
+  return false;
+}
+
+export function isActiveFilterValue(value: unknown): boolean {
+  return !isEmptyFilterValue(value);
+}
+
+/**
+ * Read a string entry from a filter's loose `props` bag, falling back when the
+ * key is absent or not a string.
+ */
+export function stringProp(filter: FilterData, key: string, fallback: string): string {
+  const value = filter.props[key];
+
+  return typeof value === "string" ? value : fallback;
+}
+
+export function filterOptions(filter: FilterData): Option[] {
+  const value = filter.props.options;
+
+  return Array.isArray(value) ? (value as Option[]) : [];
+}

--- a/resources/js/table/payload.ts
+++ b/resources/js/table/payload.ts
@@ -73,6 +73,7 @@ export function getState(value: unknown): TableState {
       sorts: [],
       page: 1,
       perPage: 25,
+      tableFilters: {},
     };
   }
 
@@ -83,7 +84,20 @@ export function getState(value: unknown): TableState {
     sorts: Array.isArray(state.sorts) ? state.sorts : [],
     page: typeof state.page === "number" ? state.page : 1,
     perPage: typeof state.perPage === "number" ? state.perPage : 25,
+    tableFilters: getTableFilters(state.tableFilters),
   };
+}
+
+/**
+ * The wire serializes an empty filter map as `[]` and a populated one as an
+ * object, so coerce both to a plain `key => value` record.
+ */
+function getTableFilters(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
 }
 
 export function getRowKey(row: TableRow, index: number): string {

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -32,10 +32,48 @@ export function buildEndpoint(endpoint: string, state: TableState): string {
     url.searchParams.set("sort", serializeSorts(state));
   }
 
+  appendTableFilters(url, state.tableFilters);
+
   url.searchParams.set("page", String(state.page));
   url.searchParams.set("per_page", String(state.perPage));
 
   return `${url.pathname}${url.search}`;
+}
+
+/**
+ * Serialize the dedicated table filters as Laravel-native bracket params:
+ * `tf[key]=v`, repeated `tf[key][]=v` for multi-value, and `tf[key][sub]=v`
+ * for structured values (e.g. a date range's from/until). Empty values are
+ * dropped so an unset filter never reaches the server.
+ */
+function appendTableFilters(url: URL, tableFilters: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(tableFilters)) {
+    if (typeof value === "string") {
+      if (value !== "") {
+        url.searchParams.set(`tf[${key}]`, value);
+      }
+
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item != null && item !== "") {
+          url.searchParams.append(`tf[${key}][]`, String(item));
+        }
+      }
+
+      continue;
+    }
+
+    if (value != null && typeof value === "object") {
+      for (const [subKey, subValue] of Object.entries(value as Record<string, unknown>)) {
+        if (typeof subValue === "string" && subValue !== "") {
+          url.searchParams.set(`tf[${key}][${subKey}]`, subValue);
+        }
+      }
+    }
+  }
 }
 
 export function getQueryParams(state: TableState): Record<string, unknown> {

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -91,6 +91,28 @@ export function useTable(node: TableNode) {
     applyFilters(state.filters.filter((_, current) => current !== index));
   }
 
+  function setTableFilter(key: string, value: unknown): void {
+    const next = { ...state.tableFilters };
+
+    if (isEmptyFilterValue(value)) {
+      delete next[key];
+    } else {
+      next[key] = value;
+    }
+
+    const nextState = { ...state, tableFilters: next, page: 1 };
+
+    setState(nextState);
+    void load(nextState);
+  }
+
+  function resetFilters(): void {
+    const nextState = { ...state, filters: [], tableFilters: {}, page: 1 };
+
+    setState(nextState);
+    void load(nextState);
+  }
+
   function goToPage(page: number): void {
     void load({
       ...state,
@@ -169,9 +191,12 @@ export function useTable(node: TableNode) {
     pagination,
     state,
     filters: state.filters,
+    tableFilters: state.tableFilters,
     addFilter,
     updateFilter,
     removeFilter,
+    setTableFilter,
+    resetFilters,
     processing,
     hasLoaded,
     infiniteLoaderRef,
@@ -180,4 +205,24 @@ export function useTable(node: TableNode) {
     goToPage,
     loadMore,
   };
+}
+
+/**
+ * Whether a table-filter value should clear the filter rather than apply it —
+ * an empty string, empty list, or an object whose every member is empty.
+ */
+function isEmptyFilterValue(value: unknown): boolean {
+  if (value == null || value === "") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value).every((member) => member == null || member === "");
+  }
+
+  return false;
 }

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -1,6 +1,7 @@
 import { withHeaders } from "@lattice-php/lattice/core/headers";
 import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice-php/lattice/events/event-names";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { isEmptyFilterValue } from "./filter-values";
 import { getColumns, getPagination, getRows, getState } from "./payload";
 import { buildEndpoint, nextSort } from "./query";
 import type {
@@ -205,24 +206,4 @@ export function useTable(node: TableNode) {
     goToPage,
     loadMore,
   };
-}
-
-/**
- * Whether a table-filter value should clear the filter rather than apply it —
- * an empty string, empty list, or an object whose every member is empty.
- */
-function isEmptyFilterValue(value: unknown): boolean {
-  if (value == null || value === "") {
-    return true;
-  }
-
-  if (Array.isArray(value)) {
-    return value.length === 0;
-  }
-
-  if (typeof value === "object") {
-    return Object.values(value).every((member) => member == null || member === "");
-  }
-
-  return false;
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -402,6 +402,13 @@ export type FilterClause = {
   readonly operator: string;
   readonly value: string;
 };
+export type FilterControl = "select" | "ternary" | "date-range" | "toggle";
+export type FilterData = {
+  readonly key: string;
+  readonly label: string;
+  readonly type: FilterControl;
+  readonly props: Record<string, unknown>;
+};
 export type FilterType = "text" | "number" | "date" | "boolean";
 export type FloatingPanel = {
   label: string | null;
@@ -871,6 +878,7 @@ export type Table = {
   columns: ColumnData[];
   emptyLabel: string;
   endpoint: string | null;
+  filters: FilterData[];
   layout: string | null;
   lazy: boolean | null;
   ref: string | null;
@@ -900,6 +908,7 @@ export type TableQuery = {
   readonly sorts: TableSort[];
   readonly page: number;
   readonly perPage: number;
+  readonly tableFilters: Record<string, unknown>;
 };
 export type TableSort = {
   readonly key: string;

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -10,6 +10,8 @@ use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\IsInteractive;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\ColumnData;
+use Lattice\Lattice\Tables\Filters\BaseFilter;
+use Lattice\Lattice\Tables\Filters\FilterData;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableRegistry;
@@ -26,6 +28,11 @@ class Table extends Component
      * @var array<int, ColumnData>
      */
     public array $columns = [];
+
+    /**
+     * @var array<int, FilterData>
+     */
+    public array $filters = [];
 
     public ?string $layout = null;
 
@@ -95,6 +102,16 @@ class Table extends Component
     public function columns(array $columns): static
     {
         $this->columns = array_map(fn (Column $column): ColumnData => $column->toData(), $columns);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, BaseFilter>  $filters
+     */
+    public function filters(array $filters): static
+    {
+        $this->filters = array_map(fn (BaseFilter $filter): FilterData => $filter->toData(), $filters);
 
         return $this;
     }

--- a/src/Tables/EloquentTableDefinition.php
+++ b/src/Tables/EloquentTableDefinition.php
@@ -23,6 +23,7 @@ abstract class EloquentTableDefinition extends TableDefinition
             fn (TableQuery $query): Builder => $this->builder($query),
             $this->columns(),
             $this->paginationType(),
+            $this->filters(),
         );
     }
 }

--- a/src/Tables/EloquentTableSource.php
+++ b/src/Tables/EloquentTableSource.php
@@ -12,6 +12,7 @@ use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\Filterable;
 use Lattice\Lattice\Tables\Contracts\TableSource;
 use Lattice\Lattice\Tables\Enums\PaginationType;
+use Lattice\Lattice\Tables\Filters\BaseFilter;
 
 /**
  * The built-in Eloquent table source. Applies a TableQuery's filters and sorts
@@ -24,11 +25,13 @@ final readonly class EloquentTableSource implements TableSource
     /**
      * @param  Closure(TableQuery): Builder<TModel>  $builder  produces a fresh base query per request
      * @param  array<int, Column>  $columns
+     * @param  array<int, BaseFilter>  $filters
      */
     public function __construct(
         private Closure $builder,
         private array $columns,
         private PaginationType $pagination,
+        private array $filters = [],
         private FilterApplier $filterApplier = new FilterApplier,
     ) {}
 
@@ -90,6 +93,16 @@ final readonly class EloquentTableSource implements TableSource
                     $clause->field,
                     $clause->value,
                 );
+            }
+        }
+
+        $filters = collect($this->filters)->keyBy(fn (BaseFilter $filter): string => $filter->key);
+
+        foreach ($query->tableFilters as $key => $value) {
+            $filter = $filters->get($key);
+
+            if ($filter instanceof BaseFilter) {
+                $filter->apply($builder, $value);
             }
         }
 

--- a/src/Tables/Enums/FilterControl.php
+++ b/src/Tables/Enums/FilterControl.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+/**
+ * The control style a dedicated table filter renders as on the client. The
+ * value type ({@see FilterType}) describes a column's value; this describes a
+ * table-level filter's UI.
+ */
+#[TypeScript]
+enum FilterControl: string
+{
+    case Select = 'select';
+    case Ternary = 'ternary';
+    case DateRange = 'date-range';
+    case Toggle = 'toggle';
+}

--- a/src/Tables/Filters/BaseFilter.php
+++ b/src/Tables/Filters/BaseFilter.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use JsonSerializable;
+
+/**
+ * A dedicated, table-level filter — named, not bound to a column, owning its own
+ * control and query logic. The Tables-side analogue of a form field: the wire
+ * descriptor ({@see toData}) renders a control, and {@see apply} constrains the
+ * query from the value the client posts back.
+ *
+ * @phpstan-consistent-constructor
+ */
+abstract class BaseFilter implements JsonSerializable
+{
+    protected string $label;
+
+    protected ?string $attribute = null;
+
+    public function __construct(public readonly string $key)
+    {
+        $this->label = str($key)->headline()->toString();
+    }
+
+    public static function make(string $key): static
+    {
+        return new static($key);
+    }
+
+    public function label(string $label): static
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Override the database column this filter constrains; defaults to the key.
+     */
+    public function attribute(string $attribute): static
+    {
+        $this->attribute = $attribute;
+
+        return $this;
+    }
+
+    abstract public function toData(): FilterData;
+
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $builder
+     */
+    abstract public function apply(Builder $builder, mixed $value): void;
+
+    /**
+     * Whether a posted value is well-formed for this filter. Rejected values are
+     * dropped during request parsing rather than applied.
+     */
+    public function accepts(mixed $value): bool
+    {
+        return true;
+    }
+
+    protected function column(): string
+    {
+        return $this->attribute ?? $this->key;
+    }
+
+    public function jsonSerialize(): FilterData
+    {
+        return $this->toData();
+    }
+}

--- a/src/Tables/Filters/DateRangeFilter.php
+++ b/src/Tables/Filters/DateRangeFilter.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Tables\Enums\FilterControl;
+
+/**
+ * A from/until date-range filter. Each bound is optional; a present bound adds an
+ * inclusive `whereDate` comparison against the column.
+ */
+class DateRangeFilter extends BaseFilter
+{
+    public function toData(): FilterData
+    {
+        return new FilterData(
+            $this->key,
+            $this->label,
+            FilterControl::DateRange,
+            [],
+        );
+    }
+
+    public function accepts(mixed $value): bool
+    {
+        return is_array($value);
+    }
+
+    public function apply(Builder $builder, mixed $value): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        $from = $value['from'] ?? null;
+        $until = $value['until'] ?? null;
+
+        if (is_string($from) && $from !== '') {
+            $builder->whereDate($this->column(), '>=', $from);
+        }
+
+        if (is_string($until) && $until !== '') {
+            $builder->whereDate($this->column(), '<=', $until);
+        }
+    }
+}

--- a/src/Tables/Filters/Filter.php
+++ b/src/Tables/Filters/Filter.php
@@ -19,11 +19,6 @@ class Filter extends BaseFilter
 {
     private ?Closure $query = null;
 
-    public function toggle(): static
-    {
-        return $this;
-    }
-
     /**
      * Constrain the query when the toggle is on.
      *

--- a/src/Tables/Filters/Filter.php
+++ b/src/Tables/Filters/Filter.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Filters;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Lattice\Lattice\Facades\Evaluate;
+use Lattice\Lattice\Tables\Enums\FilterControl;
+
+/**
+ * The generic, custom filter: a toggle whose query logic the consumer supplies
+ * via {@see query}. The closure is resolved with utility injection — a `Builder`
+ * parameter receives the query, `$value` the toggle state, and any type-hinted
+ * service resolves from the container.
+ */
+class Filter extends BaseFilter
+{
+    private ?Closure $query = null;
+
+    public function toggle(): static
+    {
+        return $this;
+    }
+
+    /**
+     * Constrain the query when the toggle is on.
+     *
+     * @param  Closure(Builder<Model>): mixed  $query
+     */
+    public function query(Closure $query): static
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function toData(): FilterData
+    {
+        return new FilterData(
+            $this->key,
+            $this->label,
+            FilterControl::Toggle,
+            [],
+        );
+    }
+
+    public function accepts(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null;
+    }
+
+    public function apply(Builder $builder, mixed $value): void
+    {
+        if (filter_var($value, FILTER_VALIDATE_BOOLEAN) !== true) {
+            return;
+        }
+
+        if ($this->query !== null) {
+            Evaluate::resolve(
+                $this->query,
+                Evaluate::context()->typed($builder::class, $builder)->named('value', $value),
+            );
+
+            return;
+        }
+
+        $builder->where($this->column(), true);
+    }
+}

--- a/src/Tables/Filters/FilterData.php
+++ b/src/Tables/Filters/FilterData.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Filters;
+
+use JsonSerializable;
+use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Tables\Enums\FilterControl;
+
+/**
+ * The wire shape of a dedicated table filter. Built by a {@see Filter} and
+ * generated to TypeScript; the client dispatches on `type` to render the
+ * matching control from `props`.
+ */
+#[TypeScript]
+final readonly class FilterData implements JsonSerializable
+{
+    /**
+     * @param  array<string, mixed>  $props
+     */
+    public function __construct(
+        public string $key,
+        public string $label,
+        public FilterControl $type,
+        public array $props,
+    ) {}
+
+    /**
+     * @return array{key: string, label: string, type: string, props: array<string, mixed>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'key' => $this->key,
+            'label' => $this->label,
+            'type' => $this->type->value,
+            'props' => $this->props,
+        ];
+    }
+}

--- a/src/Tables/Filters/SelectFilter.php
+++ b/src/Tables/Filters/SelectFilter.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Core\Concerns\HasOptions;
+use Lattice\Lattice\Core\Concerns\HasPlaceholder;
+use Lattice\Lattice\Tables\Enums\FilterControl;
+
+/**
+ * A dropdown filter. Single by default ({@see Builder::where}); `multiple()`
+ * matches any of the selected values ({@see Builder::whereIn}).
+ */
+class SelectFilter extends BaseFilter
+{
+    use HasOptions;
+    use HasPlaceholder;
+
+    public bool $multiple = false;
+
+    public function multiple(bool $multiple = true): static
+    {
+        $this->multiple = $multiple;
+
+        return $this;
+    }
+
+    public function toData(): FilterData
+    {
+        return new FilterData(
+            $this->key,
+            $this->label,
+            FilterControl::Select,
+            [
+                'options' => $this->options,
+                'multiple' => $this->multiple,
+                'searchable' => false,
+                'placeholder' => $this->placeholder,
+            ],
+        );
+    }
+
+    public function apply(Builder $builder, mixed $value): void
+    {
+        if ($this->multiple) {
+            $values = $this->normalizeValues($value);
+
+            if ($values !== []) {
+                $builder->whereIn($this->column(), $values);
+            }
+
+            return;
+        }
+
+        if (is_string($value) && $value !== '') {
+            $builder->where($this->column(), $value);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeValues(mixed $value): array
+    {
+        return array_values(array_filter(
+            array_map(static fn (mixed $item): string => (string) $item, is_array($value) ? $value : [$value]),
+            static fn (string $item): bool => $item !== '',
+        ));
+    }
+}

--- a/src/Tables/Filters/TernaryFilter.php
+++ b/src/Tables/Filters/TernaryFilter.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Filters;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Lattice\Lattice\Facades\Evaluate;
+use Lattice\Lattice\Tables\Enums\FilterControl;
+
+/**
+ * A three-state filter: true / false / all (unset). Defaults to a boolean column
+ * constraint; pass {@see queries} to drive each state with a custom query (e.g.
+ * null-existence checks). Custom queries receive the `Builder` by type injection.
+ */
+class TernaryFilter extends BaseFilter
+{
+    public string $trueLabel = 'Yes';
+
+    public string $falseLabel = 'No';
+
+    public string $placeholder = 'All';
+
+    private ?Closure $trueQuery = null;
+
+    private ?Closure $falseQuery = null;
+
+    public function trueLabel(string $label): static
+    {
+        $this->trueLabel = $label;
+
+        return $this;
+    }
+
+    public function falseLabel(string $label): static
+    {
+        $this->falseLabel = $label;
+
+        return $this;
+    }
+
+    public function placeholder(string $label): static
+    {
+        $this->placeholder = $label;
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(Builder<Model>): mixed  $true
+     * @param  Closure(Builder<Model>): mixed  $false
+     */
+    public function queries(Closure $true, Closure $false): static
+    {
+        $this->trueQuery = $true;
+        $this->falseQuery = $false;
+
+        return $this;
+    }
+
+    public function toData(): FilterData
+    {
+        return new FilterData(
+            $this->key,
+            $this->label,
+            FilterControl::Ternary,
+            [
+                'trueLabel' => $this->trueLabel,
+                'falseLabel' => $this->falseLabel,
+                'placeholder' => $this->placeholder,
+            ],
+        );
+    }
+
+    public function accepts(mixed $value): bool
+    {
+        return is_scalar($value) && filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null;
+    }
+
+    public function apply(Builder $builder, mixed $value): void
+    {
+        $state = is_scalar($value) ? filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : null;
+
+        if ($state === null) {
+            return;
+        }
+
+        $query = $state ? $this->trueQuery : $this->falseQuery;
+
+        if ($query !== null) {
+            Evaluate::resolve($query, Evaluate::context()->typed($builder::class, $builder));
+
+            return;
+        }
+
+        $builder->where($this->column(), $state);
+    }
+}

--- a/src/Tables/TableDefinition.php
+++ b/src/Tables/TableDefinition.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Core\Definition;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Contracts\TableSource;
 use Lattice\Lattice\Tables\Enums\PaginationType;
+use Lattice\Lattice\Tables\Filters\BaseFilter;
 
 abstract class TableDefinition extends Definition
 {
@@ -16,6 +17,16 @@ abstract class TableDefinition extends Definition
      * @return array<int, Column>
      */
     abstract public function columns(): array;
+
+    /**
+     * Dedicated, table-level filters rendered above the table.
+     *
+     * @return array<int, BaseFilter>
+     */
+    public function filters(): array
+    {
+        return [];
+    }
 
     public function perPage(): int
     {

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -12,6 +12,7 @@ use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\Filterable;
 use Lattice\Lattice\Tables\Columns\Sortable;
+use Lattice\Lattice\Tables\Filters\BaseFilter;
 
 #[TypeScript]
 final readonly class TableQuery implements JsonSerializable
@@ -19,36 +20,40 @@ final readonly class TableQuery implements JsonSerializable
     /**
      * @param  array<int, FilterClause>  $filters
      * @param  array<int, TableSort>  $sorts
+     * @param  array<string, mixed>  $tableFilters
      */
     private function __construct(
         public array $filters,
         public array $sorts,
         public int $page,
         public int $perPage,
+        public array $tableFilters = [],
     ) {}
 
     public static function empty(int $defaultPerPage = 25): self
     {
-        return new self([], [], 1, self::clampPerPage($defaultPerPage));
+        return new self([], [], 1, self::clampPerPage($defaultPerPage), []);
     }
 
     /**
      * @param  array<int, Column>  $columns
+     * @param  array<int, BaseFilter>  $filters
      */
-    public static function fromRequest(Request $request, array $columns, string $table, int $defaultPerPage = 25): self
+    public static function fromRequest(Request $request, array $columns, string $table, int $defaultPerPage = 25, array $filters = []): self
     {
-        $filters = self::parseFilters($request->input('filter'));
+        $clauses = self::parseFilters($request->input('filter'));
         $sorts = self::parseSorts($request->input('sort'));
         $index = Column::index($columns);
 
-        self::validateFilters($filters, $index, $table);
+        self::validateFilters($clauses, $index, $table);
         self::validateSorts($sorts, $index, $table);
 
         return new self(
-            $filters,
+            $clauses,
             $sorts,
             max(1, $request->integer('page', 1)),
             self::clampPerPage($request->integer('per_page', $defaultPerPage)),
+            self::parseTableFilters($request->input('tf'), $filters, $table),
         );
     }
 
@@ -58,7 +63,7 @@ final readonly class TableQuery implements JsonSerializable
     }
 
     /**
-     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int}
+     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int, tableFilters: array<string, mixed>}
      */
     public function jsonSerialize(): array
     {
@@ -67,7 +72,39 @@ final readonly class TableQuery implements JsonSerializable
             'sorts' => $this->sorts,
             'page' => $this->page,
             'perPage' => $this->perPage,
+            'tableFilters' => $this->tableFilters,
         ];
+    }
+
+    /**
+     * Parse and validate the `tf` request param (a `key => value` map) against
+     * the table's declared filters, keeping only values the filter accepts.
+     *
+     * @param  array<int, BaseFilter>  $filters
+     * @return array<string, mixed>
+     */
+    private static function parseTableFilters(mixed $tableFilters, array $filters, string $table): array
+    {
+        if (! is_array($tableFilters) || $tableFilters === []) {
+            return [];
+        }
+
+        $index = collect($filters)->keyBy(fn (BaseFilter $filter): string => $filter->key);
+        $parsed = [];
+
+        foreach ($tableFilters as $key => $value) {
+            $filter = $index->get($key);
+
+            if (! $filter instanceof BaseFilter) {
+                throw InvalidTableQuery::filter((string) $key, $table);
+            }
+
+            if ($filter->accepts($value)) {
+                $parsed[$key] = $value;
+            }
+        }
+
+        return $parsed;
     }
 
     /**

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -57,6 +57,7 @@ final class TableRegistry extends DefinitionRegistry
         $component = TableComponent::make($key)
             ->endpoint($this->endpointFor($key))
             ->columns($columns)
+            ->filters($definition->filters())
             ->layout($definition->layout())
             ->striped($definition->striped())
             ->resizableColumns($definition->resizableColumns(), $definition->resizeIndicator())
@@ -76,7 +77,7 @@ final class TableRegistry extends DefinitionRegistry
     {
         $definition ??= $this->resolve($key);
         $columns = $definition->columns();
-        $query = TableQuery::fromRequest($request, $columns, $key, $definition->perPage());
+        $query = TableQuery::fromRequest($request, $columns, $key, $definition->perPage(), $definition->filters());
 
         return $this->decorateResult($definition, $definition->source()->query($query), $columns)->forQuery($query);
     }

--- a/tests/Browser/Tables/DedicatedFilterTest.php
+++ b/tests/Browser/Tables/DedicatedFilterTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use Workbench\App\Models\Product;
+
+function seedFilterProducts(): void
+{
+    Product::factory()->create([
+        'name' => 'Active Featured',
+        'status' => 'active',
+        'featured' => true,
+        'price' => 1500,
+    ]);
+    Product::factory()->create([
+        'name' => 'Draft Plain',
+        'status' => 'draft',
+        'featured' => false,
+        'price' => 50,
+    ]);
+}
+
+it('narrows rows with the ternary featured filter and restores them via reset', function (): void {
+    seedFilterProducts();
+
+    visit('/products')
+        ->assertSee('Active Featured')
+        ->assertSee('Draft Plain')
+        ->select('@table-filter-featured', 'true')
+        ->assertSee('Active Featured')
+        ->assertDontSee('Draft Plain')
+        ->click('@table-filters-reset')
+        ->assertSee('Draft Plain')
+        ->assertNoSmoke();
+});
+
+it('narrows rows with a custom toggle filter', function (): void {
+    seedFilterProducts();
+
+    visit('/products')
+        ->click('@table-filter-high_value')
+        ->assertSee('Active Featured')
+        ->assertDontSee('Draft Plain')
+        ->assertNoSmoke();
+});
+
+it('narrows rows with the multi-select status filter', function (): void {
+    seedFilterProducts();
+
+    visit('/products')
+        ->click('@table-filter-status')
+        ->click('@table-filter-status-active')
+        ->assertSee('Active Featured')
+        ->assertDontSee('Draft Plain')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -46,6 +46,7 @@ test('registered tables serialize their configured endpoint columns state and in
                 'resizeIndicator' => false,
                 'actionsLabel' => 'Actions',
                 'emptyLabel' => 'No results',
+                'filters' => [],
                 'columns' => [
                     [
                         'key' => 'name',
@@ -98,6 +99,7 @@ test('registered tables serialize their configured endpoint columns state and in
                     'sorts' => [],
                     'page' => 1,
                     'perPage' => 25,
+                    'tableFilters' => [],
                 ],
                 'pagination' => null,
             ],
@@ -126,6 +128,7 @@ test('registered tables can serialize lazily without running their query', funct
                 'resizeIndicator' => false,
                 'actionsLabel' => 'Actions',
                 'emptyLabel' => 'No results',
+                'filters' => [],
                 'columns' => [
                     [
                         'key' => 'name',
@@ -144,6 +147,7 @@ test('registered tables can serialize lazily without running their query', funct
                     'sorts' => [],
                     'page' => 1,
                     'perPage' => 25,
+                    'tableFilters' => [],
                 ],
                 'pagination' => [
                     'mode' => 'table',

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Attributes\Table as TableAttribute;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Components\Table;
+use Lattice\Lattice\Tables\EloquentTableDefinition;
+use Lattice\Lattice\Tables\Filters\SelectFilter;
+use Lattice\Lattice\Tables\TableQuery;
+use Workbench\App\Models\Product;
+
+test('a table serializes its declared filters and starts with no active values', function () {
+    Lattice::tables([WorkbenchFilteredProductsTable::class]);
+
+    $table = wire(Table::use(WorkbenchFilteredProductsTable::class));
+
+    expect($table['props']['filters'])->toBe([
+        [
+            'key' => 'status',
+            'label' => 'Status',
+            'type' => 'select',
+            'props' => [
+                'options' => [
+                    ['label' => 'Draft', 'value' => 'draft'],
+                    ['label' => 'Active', 'value' => 'active'],
+                ],
+                'multiple' => false,
+                'searchable' => false,
+                'placeholder' => null,
+            ],
+        ],
+    ])
+        ->and($table['props']['state']['tableFilters'])->toBe([]);
+});
+
+test('a table applies a dedicated select filter from the request', function () {
+    Lattice::tables([WorkbenchFilteredProductsTable::class]);
+
+    Product::factory()->create(['name' => 'Active One', 'status' => 'active']);
+    Product::factory()->create(['name' => 'Draft One', 'status' => 'draft']);
+
+    $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
+
+    $response = latticeGet('/lattice/tables/workbench.filtered-products?tf[status]=active', $ref)
+        ->assertOk()
+        ->assertJsonPath('data.0.name', 'Active One')
+        ->assertJsonPath('state.tableFilters.status', 'active');
+
+    expect($response->json('data'))->toHaveCount(1);
+});
+
+test('a table rejects a filter key that is not declared', function () {
+    Lattice::tables([WorkbenchFilteredProductsTable::class]);
+
+    $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
+
+    latticeGet('/lattice/tables/workbench.filtered-products?tf[unknown]=x', $ref)
+        ->assertUnprocessable()
+        ->assertJsonPath('message', 'Filter [unknown] is not allowed for table [workbench.filtered-products].');
+});
+
+/**
+ * @extends EloquentTableDefinition<Product>
+ */
+#[TableAttribute('workbench.filtered-products')]
+class WorkbenchFilteredProductsTable extends EloquentTableDefinition
+{
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->label('Name'),
+        ];
+    }
+
+    public function filters(): array
+    {
+        return [
+            SelectFilter::make('status')->label('Status')->options([
+                SelectFilter::option('Draft', 'draft'),
+                SelectFilter::option('Active', 'active'),
+            ]),
+        ];
+    }
+
+    /**
+     * @return Builder<Product>
+     */
+    public function builder(TableQuery $query): Builder
+    {
+        return Product::query()->select(['id', 'name', 'status'])->orderBy('id');
+    }
+}

--- a/tests/Unit/Tables/Components/TableWireShapeTest.php
+++ b/tests/Unit/Tables/Components/TableWireShapeTest.php
@@ -44,8 +44,10 @@ it('serializes the table component wire shape', function (): void {
         'sorts' => [],
         'page' => 1,
         'perPage' => 25,
+        'tableFilters' => [],
     ]);
     expect($payload['props']['bulkActions'])->toBe([]);
+    expect($payload['props']['filters'])->toBe([]);
 });
 
 it('serializes visible resize indicators on table components', function (): void {

--- a/tests/Unit/Tables/Filters/FilterTypesTest.php
+++ b/tests/Unit/Tables/Filters/FilterTypesTest.php
@@ -2,9 +2,12 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
 use Lattice\Lattice\Tables\Filters\DateRangeFilter;
 use Lattice\Lattice\Tables\Filters\Filter;
+use Lattice\Lattice\Tables\Filters\SelectFilter;
 use Lattice\Lattice\Tables\Filters\TernaryFilter;
+use Lattice\Lattice\Tables\TableQuery;
 use Workbench\App\Models\Product;
 
 test('ternary filter serializes its wire shape', function () {
@@ -112,4 +115,61 @@ test('a generic filter is a no-op when toggled off', function () {
         ->apply($builder, '0');
 
     expect($builder->toSql())->not->toContain('where');
+});
+
+test('a generic filter without a query applies a boolean constraint on its column', function () {
+    $builder = Product::query();
+
+    Filter::make('featured')->apply($builder, '1');
+
+    expect($builder->toSql())->toContain('"featured" = ?')
+        ->and($builder->getBindings())->toBe([true]);
+});
+
+test('a ternary filter runs the false query branch', function () {
+    $builder = Product::query();
+
+    TernaryFilter::make('verified')
+        ->queries(
+            true: fn (Builder $query) => $query->whereNotNull('verified_at'),
+            false: fn (Builder $query) => $query->whereNull('verified_at'),
+        )
+        ->apply($builder, 'false');
+
+    expect($builder->toSql())->toContain('"verified_at" is null');
+});
+
+test('a ternary filter ignores an unparseable value', function () {
+    $builder = Product::query();
+
+    TernaryFilter::make('featured')->apply($builder, 'garbage');
+
+    expect($builder->toSql())->not->toContain('where');
+});
+
+test('a date range filter ignores a non-array value', function () {
+    $filter = DateRangeFilter::make('created_at');
+    $builder = Product::query();
+
+    $filter->apply($builder, 'not-an-array');
+
+    expect($filter->accepts('not-an-array'))->toBeFalse()
+        ->and($builder->toSql())->not->toContain('where');
+});
+
+test('a filter constrains the column named by attribute()', function () {
+    $builder = Product::query();
+
+    SelectFilter::make('state')->attribute('status')->apply($builder, 'active');
+
+    expect($builder->toSql())->toContain('"status" = ?')
+        ->and($builder->getBindings())->toBe(['active']);
+});
+
+test('table query drops a table-filter value the filter rejects', function () {
+    $request = Request::create('/', 'GET', ['tf' => ['featured' => 'garbage']]);
+
+    $query = TableQuery::fromRequest($request, [], 'demo', 25, [TernaryFilter::make('featured')]);
+
+    expect($query->tableFilters)->toBe([]);
 });

--- a/tests/Unit/Tables/Filters/FilterTypesTest.php
+++ b/tests/Unit/Tables/Filters/FilterTypesTest.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Tables\Filters\DateRangeFilter;
+use Lattice\Lattice\Tables\Filters\Filter;
+use Lattice\Lattice\Tables\Filters\TernaryFilter;
+use Workbench\App\Models\Product;
+
+test('ternary filter serializes its wire shape', function () {
+    expect(wire(TernaryFilter::make('featured')
+        ->trueLabel('Featured')
+        ->falseLabel('Not featured')))
+        ->toBe([
+            'key' => 'featured',
+            'label' => 'Featured',
+            'type' => 'ternary',
+            'props' => [
+                'trueLabel' => 'Featured',
+                'falseLabel' => 'Not featured',
+                'placeholder' => 'All',
+            ],
+        ]);
+});
+
+test('a ternary filter applies a boolean constraint', function () {
+    $builder = Product::query();
+    TernaryFilter::make('featured')->apply($builder, 'true');
+    expect($builder->toSql())->toContain('"featured" = ?')
+        ->and($builder->getBindings())->toBe([true]);
+
+    $other = Product::query();
+    TernaryFilter::make('featured')->apply($other, 'false');
+    expect($other->getBindings())->toBe([false]);
+});
+
+test('a ternary filter runs custom queries when provided', function () {
+    $builder = Product::query();
+
+    TernaryFilter::make('verified')
+        ->queries(
+            true: fn (Builder $query) => $query->whereNotNull('verified_at'),
+            false: fn (Builder $query) => $query->whereNull('verified_at'),
+        )
+        ->apply($builder, 'true');
+
+    expect($builder->toSql())->toContain('"verified_at" is not null');
+});
+
+test('a ternary filter rejects non-boolean values', function () {
+    $filter = TernaryFilter::make('featured');
+    expect($filter->accepts('true'))->toBeTrue()
+        ->and($filter->accepts('false'))->toBeTrue()
+        ->and($filter->accepts('garbage'))->toBeFalse();
+});
+
+test('date range filter serializes its wire shape', function () {
+    expect(wire(DateRangeFilter::make('created_at')->label('Created')))
+        ->toBe([
+            'key' => 'created_at',
+            'label' => 'Created',
+            'type' => 'date-range',
+            'props' => [],
+        ]);
+});
+
+test('a date range filter applies from and until bounds', function () {
+    $builder = Product::query();
+
+    DateRangeFilter::make('created_at')->apply($builder, ['from' => '2026-01-01', 'until' => '2026-06-30']);
+
+    expect($builder->toSql())->toContain('"created_at')->and($builder->toSql())->toContain('>=')
+        ->and($builder->toSql())->toContain('<=')
+        ->and($builder->getBindings())->toBe(['2026-01-01', '2026-06-30']);
+});
+
+test('a date range filter applies only the provided bound', function () {
+    $builder = Product::query();
+
+    DateRangeFilter::make('created_at')->apply($builder, ['from' => '2026-01-01']);
+
+    expect($builder->getBindings())->toBe(['2026-01-01'])
+        ->and($builder->toSql())->not->toContain('<=');
+});
+
+test('a generic filter serializes as a toggle', function () {
+    expect(wire(Filter::make('high_value')->label('High value')->toggle()))
+        ->toBe([
+            'key' => 'high_value',
+            'label' => 'High value',
+            'type' => 'toggle',
+            'props' => [],
+        ]);
+});
+
+test('a generic filter runs its query closure when toggled on', function () {
+    $builder = Product::query();
+
+    Filter::make('high_value')
+        ->query(fn (Builder $query) => $query->where('price', '>', 1000))
+        ->apply($builder, '1');
+
+    expect($builder->toSql())->toContain('"price" > ?')
+        ->and($builder->getBindings())->toBe([1000]);
+});
+
+test('a generic filter is a no-op when toggled off', function () {
+    $builder = Product::query();
+
+    Filter::make('high_value')
+        ->query(fn (Builder $query) => $query->where('price', '>', 1000))
+        ->apply($builder, '0');
+
+    expect($builder->toSql())->not->toContain('where');
+});

--- a/tests/Unit/Tables/Filters/FilterTypesTest.php
+++ b/tests/Unit/Tables/Filters/FilterTypesTest.php
@@ -84,7 +84,7 @@ test('a date range filter applies only the provided bound', function () {
 });
 
 test('a generic filter serializes as a toggle', function () {
-    expect(wire(Filter::make('high_value')->label('High value')->toggle()))
+    expect(wire(Filter::make('high_value')->label('High value')))
         ->toBe([
             'key' => 'high_value',
             'label' => 'High value',

--- a/tests/Unit/Tables/Filters/SelectFilterTest.php
+++ b/tests/Unit/Tables/Filters/SelectFilterTest.php
@@ -56,3 +56,11 @@ test('a select filter without a value applies no constraint', function () {
 
     expect($builder->toSql())->not->toContain('where');
 });
+
+test('a multiple select filter with no selected values applies no constraint', function () {
+    $builder = Product::query();
+
+    SelectFilter::make('status')->multiple()->apply($builder, []);
+
+    expect($builder->toSql())->not->toContain('where');
+});

--- a/tests/Unit/Tables/Filters/SelectFilterTest.php
+++ b/tests/Unit/Tables/Filters/SelectFilterTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Tables\Filters\SelectFilter;
+use Workbench\App\Models\Product;
+
+test('select filter serializes its wire shape', function () {
+    expect(wire(SelectFilter::make('status')
+        ->label('Status')
+        ->options([
+            SelectFilter::option('Draft', 'draft'),
+            SelectFilter::option('Active', 'active'),
+        ])))
+        ->toBe([
+            'key' => 'status',
+            'label' => 'Status',
+            'type' => 'select',
+            'props' => [
+                'options' => [
+                    ['label' => 'Draft', 'value' => 'draft'],
+                    ['label' => 'Active', 'value' => 'active'],
+                ],
+                'multiple' => false,
+                'searchable' => false,
+                'placeholder' => null,
+            ],
+        ]);
+});
+
+test('select filter defaults its label from the key', function () {
+    expect(wire(SelectFilter::make('order_status'))['label'])->toBe('Order Status');
+});
+
+test('a single select filter applies an equality constraint', function () {
+    $builder = Product::query();
+
+    SelectFilter::make('status')->apply($builder, 'active');
+
+    expect($builder->toSql())->toContain('"status" = ?')
+        ->and($builder->getBindings())->toBe(['active']);
+});
+
+test('a multiple select filter applies a whereIn constraint', function () {
+    $builder = Product::query();
+
+    SelectFilter::make('status')->multiple()->apply($builder, ['active', 'draft']);
+
+    expect($builder->toSql())->toContain('"status" in (?, ?)')
+        ->and($builder->getBindings())->toBe(['active', 'draft']);
+});
+
+test('a select filter without a value applies no constraint', function () {
+    $builder = Product::query();
+
+    SelectFilter::make('status')->apply($builder, '');
+
+    expect($builder->toSql())->not->toContain('where');
+});

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -13,6 +13,11 @@ use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 use Lattice\Lattice\Tables\EloquentTableDefinition;
+use Lattice\Lattice\Tables\Filters\BaseFilter;
+use Lattice\Lattice\Tables\Filters\DateRangeFilter;
+use Lattice\Lattice\Tables\Filters\Filter;
+use Lattice\Lattice\Tables\Filters\SelectFilter;
+use Lattice\Lattice\Tables\Filters\TernaryFilter;
 use Lattice\Lattice\Tables\TableQuery;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
@@ -40,6 +45,30 @@ class ProductsTable extends EloquentTableDefinition
             StatusBadgeColumn::make('status')->label(__('workbench.tables.columns.status'))->filterable(Op::Equals)->colorMap(['draft' => 'gray', 'active' => 'green', 'archived' => 'red']),
             TextColumn::make('featured')->label(__('workbench.tables.columns.featured'))->sortable()->boolean()->filterable(),
             TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->date('Y-m-d H:i:s')->filterable(),
+        ];
+    }
+
+    /**
+     * @return array<int, BaseFilter>
+     */
+    public function filters(): array
+    {
+        return [
+            SelectFilter::make('status')
+                ->label(__('workbench.tables.columns.status'))
+                ->options([
+                    SelectFilter::option('Draft', 'draft'),
+                    SelectFilter::option('Active', 'active'),
+                    SelectFilter::option('Archived', 'archived'),
+                ])
+                ->multiple(),
+            TernaryFilter::make('featured')
+                ->label(__('workbench.tables.columns.featured')),
+            DateRangeFilter::make('updated_at')
+                ->label(__('workbench.tables.columns.updated-at')),
+            Filter::make('high_value')
+                ->label('High value')
+                ->query(fn (Builder $query): Builder => $query->where('price', '>', 1000)),
         ];
     }
 


### PR DESCRIPTION
## What

Adds **dedicated, table-level filters** alongside the existing per-column filtering. A table declares them via `TableDefinition::filters()`:

```php
public function filters(): array
{
    return [
        SelectFilter::make('status')
            ->options([SelectFilter::option('Active', 'active')])
            ->multiple(),                 // where / whereIn
        TernaryFilter::make('featured')   // yes / no / all
            ->trueLabel('Featured')->falseLabel('Not featured'),
        DateRangeFilter::make('created_at'),  // from / until
        Filter::make('high_value')            // custom toggle + query
            ->query(fn (Builder $q) => $q->where('price', '>', 1000)),
    ];
}
```

## How

- **Backend** — `BaseFilter` + `Filter`/`SelectFilter`/`TernaryFilter`/`DateRangeFilter`, a `FilterControl` enum and `FilterData` wire VO. Active values ride a Laravel bracket-array `tf[...]` param, are validated against the declared filters in `TableQuery::fromRequest`, and applied by `EloquentTableSource`. Custom `Filter::query()` closures resolve through `Evaluate` (type-hint `Builder`).
- **Frontend** — `tf[]` serialization, `tableFilters` state + `setTableFilter`/`resetFilters` in `useTable`, a filter bar with a control per filter (select, multi-select, ternary, date range, toggle), active-value chips with per-filter remove, and **Reset all**.
- Workbench `ProductsTable` demo + docs section; translation keys for `en`/`de`.

## Why

Dedicated filters cover the largest table-side UX gap: named filters with their own controls and query logic, not tied to a single column/operator. Column filtering is unchanged.

## Verification

- `composer check` — 606 passed (2205 assertions)
- `npm run check` — 367 Vitest passed + lib build
- Browser `DedicatedFilterTest` — 3 passed
- `npm run docs:build` — clean

## Not included (follow-up)

`SelectFilter->options(EloquentOptions…)` relationship-backed options and `optionsFrom` on column filters — tracked separately.