### PR TITLE
chore: drop explanatory comment from codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,3 @@
-# Coverage is uploaded from three separate jobs — vitest (JS), pest (PHP
-# unit/feature), and pest-browser. Without this, Codecov computes the patch /
-# project status after the first report arrives and reports spurious gaps for
-# lines covered by a not-yet-uploaded report. Wait for all three coverage
-# uploads (and for CI to finish) before sending any status or comment.
 codecov:
   notify:
     after_n_builds: 3


### PR DESCRIPTION
Removes the explanatory YAML comment block from `codecov.yml` added in #112. The configuration is unchanged — `codecov.notify.after_n_builds: 3` + `wait_for_ci` (so the patch/project status waits for all three coverage uploads: vitest, pest, pest-browser) and the codecov PR comment is kept (`comment.after_n_builds: 3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)