### PR TITLE
feat: gate workbench behind a login page with a locale-aware user

### DIFF
--- a/resources/js/form/components/fields/password-input.test.tsx
+++ b/resources/js/form/components/fields/password-input.test.tsx
@@ -45,4 +45,19 @@ describe("PasswordInputComponent conditions", () => {
 
     expect(screen.getByLabelText("Password")).toBeVisible();
   });
+
+  it("renders a prefilled password value", () => {
+    renderField(
+      fakeNode({
+        type: "form.password-input",
+        props: {
+          name: "password",
+          label: "Password",
+        },
+      }),
+      { password: "password" },
+    );
+
+    expect(screen.getByLabelText("Password")).toHaveValue("password");
+  });
 });

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -3,28 +3,25 @@ import { testIdentity } from "@lattice-php/lattice/core/test-id";
 import { FormFieldFrame } from "../base/field";
 import PasswordInput from "../base/password-input";
 import { useFieldScope } from "../field-scope";
-import { useDependentField } from "../use-dependent-field";
+import { useControlledField } from "../use-controlled-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFormContext } from "../context";
 
 export const PasswordInputComponent: RendererComponent<"form.password-input"> = ({ node }) => {
   const props = node.props;
   const { errors } = useFormContext();
-  const { hidden, required, readOnly, disabled } = useDependentField(node);
+  const field = useControlledField(node);
   const { commit } = useFieldCommit();
   const scope = useFieldScope();
-  const localName = props.name ?? "";
-  const name = scope ? scope.scopedName(localName) : localName;
-  const errorKey = scope ? scope.errorKey(localName) : localName;
   const confirmation = props.confirmation;
-  const confirmationLocalName = confirmation?.name ?? `${localName}_confirmation`;
+  const confirmationLocalName = confirmation?.name ?? `${field.localName}_confirmation`;
   const confirmationName = scope ? scope.scopedName(confirmationLocalName) : confirmationLocalName;
   const confirmationErrorKey = scope
     ? scope.errorKey(confirmationLocalName)
     : confirmationLocalName;
   const passwordRules = (props.passwordRules ?? "") || undefined;
 
-  if (hidden) {
+  if (field.hidden) {
     return null;
   }
 
@@ -37,25 +34,28 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
   return (
     <div className="grid gap-6">
       <FormFieldFrame
-        error={errors[errorKey]}
+        error={field.error}
         helperText={props.helperText ?? undefined}
         label={props.label ?? ""}
         labelAction={props.labelAction ?? undefined}
-        name={name}
-        required={required}
+        name={field.name}
+        required={field.required}
       >
         <PasswordInput
           autoComplete={props.autoComplete ?? ""}
           autoFocus={props.autoFocus ?? false}
-          data-test={testIdentity(localName)}
-          disabled={disabled}
-          id={name}
-          name={name}
-          onChange={onChange(localName)}
+          data-test={field.testId}
+          disabled={field.disabled}
+          id={field.name}
+          name={field.name}
+          onChange={(event) => {
+            field.commit(event.target.value);
+          }}
           placeholder={props.placeholder ?? ""}
           passwordrules={passwordRules}
-          readOnly={readOnly}
+          readOnly={field.readOnly}
           tabIndex={props.tabIndex ?? undefined}
+          value={field.value}
         />
       </FormFieldFrame>
 
@@ -64,18 +64,18 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
           error={errors[confirmationErrorKey]}
           label={confirmation.label ?? "Confirm password"}
           name={confirmationName}
-          required={required}
+          required={field.required}
         >
           <PasswordInput
             autoComplete="new-password"
             data-test={testIdentity(confirmationLocalName)}
-            disabled={disabled}
+            disabled={field.disabled}
             id={confirmationName}
             name={confirmationName}
             onChange={onChange(confirmationLocalName)}
             placeholder={confirmation.placeholder ?? confirmation.label ?? "Confirm password"}
             passwordrules={passwordRules}
-            readOnly={readOnly}
+            readOnly={field.readOnly}
             tabIndex={props.tabIndex ?? undefined}
           />
         </FormFieldFrame>

--- a/src/Http/Middleware/SetLocale.php
+++ b/src/Http/Middleware/SetLocale.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Http\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Inertia\Inertia;
@@ -45,6 +46,7 @@ final class SetLocale
     private function preferredLocale(Request $request, array $locales): ?string
     {
         foreach ([
+            $this->userLocale($request),
             $this->cookieLocale($request),
             $this->sessionLocale($request),
         ] as $locale) {
@@ -56,6 +58,19 @@ final class SetLocale
         $preferred = $request->getPreferredLanguage($locales);
 
         return is_string($preferred) && in_array($preferred, $locales, true) ? $preferred : null;
+    }
+
+    private function userLocale(Request $request): ?string
+    {
+        $user = $request->user();
+
+        if (! $user instanceof HasLocalePreference) {
+            return null;
+        }
+
+        $locale = $user->preferredLocale();
+
+        return is_string($locale) ? $locale : null;
     }
 
     private function cookieLocale(Request $request): ?string

--- a/tests/Browser/Forms/BuilderTest.php
+++ b/tests/Browser/Forms/BuilderTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 it('adds heterogeneous blocks and submits a typed payload', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/builder')
         ->assertSee('Builder Demo')
         ->assertSee('Line items')
@@ -20,6 +21,7 @@ it('adds heterogeneous blocks and submits a typed payload', function (): void {
 });
 
 it('surfaces a per-row required error for the active block', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/builder')
         ->assertSee('Builder Demo')
         ->click('@builder-add')

--- a/tests/Browser/Forms/DependentFieldsTest.php
+++ b/tests/Browser/Forms/DependentFieldsTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 it('toggles the company field instantly based on type', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/dependent-demo')
         ->assertSee('Dependent Demo')
         ->assertDontSee('Company')
@@ -12,6 +13,7 @@ it('toggles the company field instantly based on type', function (): void {
 });
 
 it('requires the company field for business on submit', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/dependent-demo')
         ->click('@type-business')
         ->assertSee('Company')
@@ -20,6 +22,7 @@ it('requires the company field for business on submit', function (): void {
 });
 
 it('computes the total from qty and unit price via a round-trip', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/dependent-demo')
         ->assertSee('Total')
         ->fill('@qty', '3')
@@ -28,6 +31,7 @@ it('computes the total from qty and unit price via a round-trip', function (): v
 });
 
 it('renders textarea, number, slider, and date fields', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/dependent-demo')
         ->assertSee('Bio')
         ->assertSee('Level')
@@ -39,6 +43,7 @@ it('renders textarea, number, slider, and date fields', function (): void {
 });
 
 it('renders the rich text editor with a toolbar', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/dependent-demo')
         ->assertSee('Article')
         ->assertPresent('[aria-label="Bold"]')

--- a/tests/Browser/Forms/FileUploadFieldTest.php
+++ b/tests/Browser/Forms/FileUploadFieldTest.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Rules\FileUploadItem;
 
 it('uploads a file via multipart and shows it in the dropzone', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/uploads/create')
         ->assertSee('Drop files here or click to browse')
         ->attach('@avatar-input', __DIR__.'/fixtures/avatar.jpg')
@@ -18,6 +19,7 @@ it('uploads a file via multipart and shows it in the dropzone', function (): voi
 });
 
 it('removes an existing file from the edit form', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/uploads/edit')
         ->assertSee('avatar-existing.jpg')
         ->click('@avatar-remove-existing')
@@ -27,6 +29,7 @@ it('removes an existing file from the edit form', function (): void {
 });
 
 it('uploads directly to s3 via the signed flow', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/uploads/create')
         ->assertSee('Drop files here or click to browse')
         ->attach('@document-input', __DIR__.'/fixtures/avatar.jpg')
@@ -36,6 +39,7 @@ it('uploads directly to s3 via the signed flow', function (): void {
 })->group('rustfs');
 
 it('signs, uploads, and validates a key against rustfs end-to-end', function (): void {
+    $this->actingAs(workbenchTestUser());
     $signed = FileUpload::make('document')->disk('s3')->signedUpload()
         ->signUpload(Request::create('/', 'POST', ['filename' => 'invoice.pdf']));
 

--- a/tests/Browser/Forms/PricingBuilderTest.php
+++ b/tests/Browser/Forms/PricingBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('prefills computed prices, keeps manual edits, and re-prices untouched rows', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Alpha Chair', 'price' => 100.00]);
     Product::factory()->create(['name' => 'Beta Table', 'price' => 200.00]);
     Product::factory()->create(['name' => 'Gamma Shelf', 'price' => 300.00]);
@@ -38,6 +39,7 @@ it('prefills computed prices, keeps manual edits, and re-prices untouched rows',
 });
 
 it('evaluates row field visibility against same-row siblings', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Alpha Chair', 'price' => 100.00]);
 
     visit('/builder-pricing')
@@ -57,6 +59,7 @@ it('evaluates row field visibility against same-row siblings', function (): void
 });
 
 it('searches products inside a builder row select', function (): void {
+    $this->actingAs(workbenchTestUser());
     foreach (range(1, 20) as $number) {
         Product::factory()->create(['name' => sprintf('Alpha Product %02d', $number), 'price' => 10.00]);
     }

--- a/tests/Browser/Forms/ProductFormTest.php
+++ b/tests/Browser/Forms/ProductFormTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('shows precognitive validation messages in the form', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/products/create')
         ->assertSee('Create Product')
         ->fill('@price', 'invalid')
@@ -14,6 +15,7 @@ it('shows precognitive validation messages in the form', function (): void {
 });
 
 it('disables the submit button while precognition errors are active', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/products/create')
         ->assertSee('Create Product')
         ->assertEnabled('@form-submit')
@@ -25,6 +27,7 @@ it('disables the submit button while precognition errors are active', function (
 });
 
 it('surfaces server validation errors after submitting an empty form', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/products/create')
         ->assertSee('Create Product')
         ->click('@form-submit')
@@ -35,6 +38,7 @@ it('surfaces server validation errors after submitting an empty form', function 
 });
 
 it('shows existing related products on the edit page', function (): void {
+    $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create([
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
@@ -53,6 +57,7 @@ it('shows existing related products on the edit page', function (): void {
 });
 
 it('attaches related products via search when creating', function (): void {
+    $this->actingAs(workbenchTestUser());
     $related = Product::factory()->create(['name' => 'Walnut Desk']);
 
     visit('/products/create')
@@ -76,6 +81,7 @@ it('attaches related products via search when creating', function (): void {
 });
 
 it('creates and edits a product through the form flow', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/products')
         ->assertSee('Products')
         ->click('@create-product')

--- a/tests/Browser/Forms/RepeaterTest.php
+++ b/tests/Browser/Forms/RepeaterTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 it('renders the repeater with one default row', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/repeater')
         ->assertSee('Repeater Demo')
         ->assertSee('Line items')
@@ -12,6 +13,7 @@ it('renders the repeater with one default row', function (): void {
 });
 
 it('round-trips a nested repeater payload through submit', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/repeater')
         ->assertSee('Repeater Demo')
         ->fill('input[name="items[0][name]"]', 'Widget')
@@ -27,6 +29,7 @@ it('round-trips a nested repeater payload through submit', function (): void {
 });
 
 it('reorders rows and submits successfully', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/repeater')
         ->assertSee('Repeater Demo')
         ->fill('input[name="items[0][name]"]', 'First')
@@ -43,6 +46,7 @@ it('reorders rows and submits successfully', function (): void {
 });
 
 it('surfaces the per-row required validation error on submit', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/repeater')
         ->assertSee('Repeater Demo')
         ->click('Save')

--- a/tests/Browser/Forms/ShowcaseTest.php
+++ b/tests/Browser/Forms/ShowcaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('renders the form showcase with every field type', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/showcase')
         ->assertSee('Form Showcase')
         ->assertNoSmoke()
@@ -26,6 +27,7 @@ it('renders the form showcase with every field type', function (): void {
 });
 
 it('inserts a table and a details block into the rich editor', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/showcase')
         ->assertPresent('[aria-label="Insert table"]')
         ->assertPresent('[aria-label="Details"]')
@@ -41,6 +43,7 @@ it('inserts a table and a details block into the rich editor', function (): void
 });
 
 it('selects a static option from the select field', function (): void {
+    $this->actingAs(workbenchTestUser());
     $page = visit('/showcase');
 
     $page->assertSee('Pick a country')
@@ -52,6 +55,7 @@ it('selects a static option from the select field', function (): void {
 });
 
 it('searches and selects entities in a multiple select', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Walnut Desk']);
     Product::factory()->create(['name' => 'Steel Lamp']);
 
@@ -69,6 +73,7 @@ it('searches and selects entities in a multiple select', function (): void {
 });
 
 it('runs conditional and computed behavior on the showcase', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/showcase')
         ->assertDontSee('Company')
         ->click('Business')

--- a/tests/Browser/Forms/TableLayoutTest.php
+++ b/tests/Browser/Forms/TableLayoutTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 it('renders the table layout with a shared header and round-trips a typed payload', function (): void {
+    $this->actingAs(workbenchTestUser());
     $page = visit('/builder-table');
 
     $page->assertSee('Line items')->assertNoSmoke()
@@ -24,6 +25,7 @@ it('renders the table layout with a shared header and round-trips a typed payloa
 });
 
 it('reveals a reset control for custom row-table column widths and clears them on click', function (): void {
+    $this->actingAs(workbenchTestUser());
     $page = visit('/builder-table');
     $page->resize(1280, 800);
 

--- a/tests/Browser/I18nTest.php
+++ b/tests/Browser/I18nTest.php
@@ -35,6 +35,7 @@ function waitForLatticeBrowserTestTranslation(string $file, string $key): mixed
 }
 
 it('dumps missing React lattice keys back into the package lang file', function (): void {
+    $this->actingAs(workbenchTestUser());
     $file = package_path('lang/en/lattice.php');
     $original = File::get($file);
     $translations = require $file;

--- a/tests/Browser/Layout/DropdownTest.php
+++ b/tests/Browser/Layout/DropdownTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 it('opens the composed user dropdown and reveals its items', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/')
         ->assertSee('Workbench User')
         ->assertSee('English')
@@ -13,6 +14,7 @@ it('opens the composed user dropdown and reveals its items', function (): void {
 });
 
 it('keeps the user dropdown usable when the sidebar is collapsed', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/')
         ->click('@sidebar-toggle')
         ->assertPresent('[aria-label="Expand sidebar"]')
@@ -22,6 +24,7 @@ it('keeps the user dropdown usable when the sidebar is collapsed', function (): 
 });
 
 it('renders the workbench locale switcher in a floating panel', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/')
         ->assertPresent('.fixed[aria-label="Language"]')
         ->assertSee('English')

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('expands a collapsed menu group and navigates to a sub-page', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/')
         ->assertSee('Home')
         ->assertSee('Forms')
@@ -18,6 +19,7 @@ it('expands a collapsed menu group and navigates to a sub-page', function (): vo
 });
 
 it('auto-expands the group containing the active page', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp']);
 
     visit('/products')
@@ -26,6 +28,7 @@ it('auto-expands the group containing the active page', function (): void {
 });
 
 it('collapses to an icon rail and opens a group submenu as a flyout', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp']);
 
     visit('/')

--- a/tests/Browser/PageTest.php
+++ b/tests/Browser/PageTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 it('loads the workbench home page without smoke failures', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     visit('/')

--- a/tests/Browser/Tables/DedicatedFilterTest.php
+++ b/tests/Browser/Tables/DedicatedFilterTest.php
@@ -20,6 +20,7 @@ function seedFilterProducts(): void
 }
 
 it('narrows rows with the ternary featured filter and restores them via reset', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedFilterProducts();
 
     visit('/products')
@@ -34,6 +35,7 @@ it('narrows rows with the ternary featured filter and restores them via reset', 
 });
 
 it('narrows rows with a custom toggle filter', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedFilterProducts();
 
     visit('/products')
@@ -44,6 +46,7 @@ it('narrows rows with a custom toggle filter', function (): void {
 });
 
 it('narrows rows with the multi-select status filter', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedFilterProducts();
 
     visit('/products')

--- a/tests/Browser/Tables/FilterTest.php
+++ b/tests/Browser/Tables/FilterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('filters by text and clears via the filter chip', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     visit('/')
@@ -17,6 +18,7 @@ it('filters by text and clears via the filter chip', function (): void {
 });
 
 it('adds a filter through the column popover', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     visit('/')
@@ -29,6 +31,7 @@ it('adds a filter through the column popover', function (): void {
 });
 
 it('filters products by the boolean featured column', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Featured Item', 'featured' => true]);
     Product::factory()->create(['name' => 'Plain Item', 'featured' => false]);
 

--- a/tests/Browser/Tables/PaginationTest.php
+++ b/tests/Browser/Tables/PaginationTest.php
@@ -1,9 +1,10 @@
 <?php
 declare(strict_types=1);
 
-beforeEach(fn () => seedWorkbenchUsers());
-
 it('shows pagination modes in lazily loaded tabs', function (): void {
+    $this->actingAs(workbenchTestUser());
+    seedWorkbenchUsers();
+
     visit('/tables')
         ->assertSee('Pagination modes')
         ->assertSee('No pagination')
@@ -23,6 +24,9 @@ it('shows pagination modes in lazily loaded tabs', function (): void {
 });
 
 it('navigates between pages in table pagination mode', function (): void {
+    $this->actingAs(workbenchTestUser());
+    seedWorkbenchUsers();
+
     visit('/tables')
         ->click('@tab-table')
         ->assertSee('Showing 1-25 of 30')
@@ -34,6 +38,9 @@ it('navigates between pages in table pagination mode', function (): void {
 });
 
 it('loads more rows in infinite mode', function (): void {
+    $this->actingAs(workbenchTestUser());
+    seedWorkbenchUsers();
+
     visit('/tables')
         ->click('@tab-infinite')
         ->assertDontSee('Browser User 26')
@@ -43,6 +50,9 @@ it('loads more rows in infinite mode', function (): void {
 });
 
 it('keeps the sidebar user menu visible on infinite pagination pages', function (): void {
+    $this->actingAs(workbenchTestUser());
+    seedWorkbenchUsers();
+
     $page = visit('/tables');
 
     $page->resize(1280, 720)

--- a/tests/Browser/Tables/ProductsTableTest.php
+++ b/tests/Browser/Tables/ProductsTableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('renders the custom status-badge column cell', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Badge Product', 'sku' => 'BADGE-1', 'status' => 'active']);
 
     visit('/products')
@@ -14,6 +15,7 @@ it('renders the custom status-badge column cell', function (): void {
 });
 
 it('archives a product via the row action with confirmation', function (): void {
+    $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
@@ -28,6 +30,7 @@ it('archives a product via the row action with confirmation', function (): void 
 });
 
 it('cancels the archive confirmation without changing the product', function (): void {
+    $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
@@ -40,6 +43,7 @@ it('cancels the archive confirmation without changing the product', function ():
 });
 
 it('rejects a product through a modal form', function (): void {
+    $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
@@ -55,6 +59,7 @@ it('rejects a product through a modal form', function (): void {
 });
 
 it('archives selected products in bulk', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->count(3)->create(['status' => 'active']);
 
     visit('/products')
@@ -66,6 +71,7 @@ it('archives selected products in bulk', function (): void {
 });
 
 it('edits a product in a prefilled modal form', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create([
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
@@ -86,6 +92,7 @@ it('edits a product in a prefilled modal form', function (): void {
 });
 
 it('searches products inside the reject modal form', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-001', 'status' => 'active']);
     $replacement = Product::factory()->create(['name' => 'Walnut Desk', 'sku' => 'DESK-001', 'status' => 'active']);
 

--- a/tests/Browser/Tables/UsersTableTest.php
+++ b/tests/Browser/Tables/UsersTableTest.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Auth\User;
 use Orchestra\Testbench\Factories\UserFactory;
 
 it('lists users with their columns', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     visit('/')
@@ -18,6 +19,7 @@ it('lists users with their columns', function (): void {
 });
 
 it('loads more users in the infinite table', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     visit('/')
@@ -28,6 +30,7 @@ it('loads more users in the infinite table', function (): void {
 });
 
 it('sorts and clears sorting', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     visit('/')
@@ -43,6 +46,7 @@ it('sorts and clears sorting', function (): void {
 });
 
 it('copies a cell value to the clipboard', function (): void {
+    $this->actingAs(workbenchTestUser());
     User::query()->delete();
     UserFactory::new()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
 
@@ -53,6 +57,7 @@ it('copies a cell value to the clipboard', function (): void {
 });
 
 it('persists resized column widths until the column keys change', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     $page = visit('/');
@@ -99,6 +104,7 @@ it('persists resized column widths until the column keys change', function (): v
 });
 
 it('reveals a reset control once columns are resized and clears them on click', function (): void {
+    $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
     $page = visit('/');

--- a/tests/Browser/TabsTest.php
+++ b/tests/Browser/TabsTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 it('switches horizontal and vertical tabs end to end', function (): void {
+    $this->actingAs(workbenchTestUser());
     visit('/tabs')
         ->assertSee('Horizontal tabs')
         ->assertSee('Vertical tabs')

--- a/tests/Browser/ToastTest.php
+++ b/tests/Browser/ToastTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Workbench\App\Models\Product;
 
 it('shows a toast after an action and dismisses it', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
@@ -16,6 +17,7 @@ it('shows a toast after an action and dismisses it', function (): void {
 });
 
 it('renders a link inside a toast', function (): void {
+    $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
@@ -28,6 +30,7 @@ it('renders a link inside a toast', function (): void {
 });
 
 it('opens a modal form from a toast action', function (): void {
+    $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Orchestra\Testbench\Factories\UserFactory;
-use Workbench\App\Models\WorkbenchUser;
+use Workbench\App\Models\User;
 use Workbench\App\Seeders\UserSeeder;
 
 use function Pest\Laravel\get;
@@ -13,10 +13,10 @@ use function Pest\Laravel\withoutVite;
 test('workbench auth uses the locale aware workbench user model', function (): void {
     $model = config('auth.providers.users.model');
 
-    expect($model)->toBe(WorkbenchUser::class)
+    expect($model)->toBe(User::class)
         ->and(is_a($model, HasLocalePreference::class, true))->toBeTrue();
 
-    $user = new WorkbenchUser(['locale' => 'de']);
+    $user = new User(['locale' => 'de']);
 
     expect($user->preferredLocale())->toBe('de');
 });
@@ -47,7 +47,7 @@ test('seeded workbench user can log in', function (): void {
     ])->assertRedirect('/');
 
     $this->assertAuthenticated();
-    expect(auth()->user())->toBeInstanceOf(WorkbenchUser::class);
+    expect(auth()->user())->toBeInstanceOf(User::class);
 });
 
 test('invalid login keeps the user unauthenticated', function (): void {

--- a/tests/Feature/Forms/ProductFormTest.php
+++ b/tests/Feature/Forms/ProductFormTest.php
@@ -62,6 +62,7 @@ test('the product index page lists products and links to creation', function () 
     ]);
 
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     get('/products')
         ->assertOk()
@@ -104,6 +105,7 @@ test('the product edit page binds existing product state', function () {
     ]);
 
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     get("/products/{$product->getKey()}/edit")
         ->assertOk()

--- a/tests/Feature/Forms/ProductRelatedProductsTest.php
+++ b/tests/Feature/Forms/ProductRelatedProductsTest.php
@@ -98,6 +98,7 @@ test('the product edit page binds related product ids into form state', function
     $product->relatedProducts()->sync([$related->getKey()]);
 
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     get("/products/{$product->getKey()}/edit")
         ->assertOk()

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -107,6 +107,7 @@ test('pages can authorize requests before rendering', function () {
 
 test('workbench pages serialize package component trees for inertia', function () {
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     get('/')
         ->assertOk()
@@ -155,6 +156,7 @@ test('workbench pages serialize package component trees for inertia', function (
 
 test('workbench tables page serializes lazy tables for each pagination type', function () {
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     get('/tables')
         ->assertOk()
@@ -193,11 +195,13 @@ test('workbench user seeder creates sample table data idempotently', function ()
     app(UserSeeder::class)->run();
     app(UserSeeder::class)->run();
 
-    expect(User::query()->count())->toBe(1000)
+    expect(User::query()->count())->toBe(1001)
+        ->and(User::query()->where('email', 'workbench@example.com')->value('name'))->toBe('Workbench User')
+        ->and(User::query()->where('email', 'workbench@example.com')->value('locale'))->toBe('en')
         ->and(User::query()->where('email', 'ada@example.com')->value('name'))->toBe('Ada Lovelace')
         ->and(User::query()->where('email', 'workbench-user-994@example.com')->exists())->toBeTrue()
-        ->and(User::query()->distinct()->count('created_at'))->toBe(1000)
-        ->and(User::query()->distinct()->count('updated_at'))->toBe(1000)
+        ->and(User::query()->distinct()->count('created_at'))->toBe(1001)
+        ->and(User::query()->distinct()->count('updated_at'))->toBe(1001)
         ->and(User::query()->whereColumn('updated_at', '<', 'created_at')->doesntExist())->toBeTrue();
 });
 

--- a/tests/Feature/I18n/I18nextTranslationsTest.php
+++ b/tests/Feature/I18n/I18nextTranslationsTest.php
@@ -20,6 +20,7 @@ afterEach(function () {
 
 it('shares the i18n config to the frontend as a once prop', function () {
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     $response = get('/');
 
@@ -38,6 +39,7 @@ it('shares the i18n config to the frontend as a once prop', function () {
 
 it('omits the i18n config when the client already has the once prop', function () {
     withoutVite();
+    $this->actingAs(workbenchTestUser());
 
     $response = get('/');
     $page = json_decode(json_encode($response->viewData('page'), JSON_THROW_ON_ERROR), true, flags: JSON_THROW_ON_ERROR);
@@ -89,6 +91,7 @@ it('serves workbench translations from the workbench lang dir', function () {
 
 it('localizes workbench page props and table column labels from the accept language header', function () {
     withoutVite();
+    $this->actingAs(workbenchTestUser(['locale' => 'de']));
 
     get('/products', ['Accept-Language' => 'de'])
         ->assertOk()

--- a/tests/Feature/LocalePreferenceTest.php
+++ b/tests/Feature/LocalePreferenceTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Workbench\App\Actions\SetLocaleAction;
-use Workbench\App\Models\WorkbenchUser;
+use Workbench\App\Models\User;
 
 use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
@@ -21,9 +21,9 @@ beforeEach(function (): void {
     ]));
 });
 
-function createWorkbenchLocaleUser(string $locale): WorkbenchUser
+function createWorkbenchLocaleUser(string $locale): User
 {
-    return WorkbenchUser::query()->create([
+    return User::query()->create([
         'name' => 'Locale User',
         'email' => 'locale-user@example.com',
         'email_verified_at' => now(),

--- a/tests/Feature/WorkbenchAuthenticationTest.php
+++ b/tests/Feature/WorkbenchAuthenticationTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Contracts\Translation\HasLocalePreference;
+use Orchestra\Testbench\Factories\UserFactory;
+use Workbench\App\Models\WorkbenchUser;
+use Workbench\App\Seeders\UserSeeder;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\withoutVite;
+
+test('workbench auth uses the locale aware workbench user model', function (): void {
+    $model = config('auth.providers.users.model');
+
+    expect($model)->toBe(WorkbenchUser::class)
+        ->and(is_a($model, HasLocalePreference::class, true))->toBeTrue();
+
+    $user = new WorkbenchUser(['locale' => 'de']);
+
+    expect($user->preferredLocale())->toBe('de');
+});
+
+test('login page renders a simple seeded credential form', function (): void {
+    withoutVite();
+
+    get('/login')
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('lattice/page')
+            ->where('lattice.title', 'Sign in')
+            ->where('lattice.layout', null)
+            ->where('lattice.schema.0.key', 'login-page')
+            ->where('lattice.schema.0.schema.2.type', 'form')
+            ->where('lattice.schema.0.schema.2.props.action', '/login')
+            ->where('lattice.schema.0.schema.2.props.submitLabel', 'Sign in')
+            ->where('lattice.schema.0.schema.2.props.state.email', 'workbench@example.com')
+            ->where('lattice.schema.0.schema.2.props.state.password', 'password'));
+});
+
+test('seeded workbench user can log in', function (): void {
+    app(UserSeeder::class)->run();
+
+    post('/login', [
+        'email' => 'workbench@example.com',
+        'password' => 'password',
+    ])->assertRedirect('/');
+
+    $this->assertAuthenticated();
+    expect(auth()->user())->toBeInstanceOf(WorkbenchUser::class);
+});
+
+test('invalid login keeps the user unauthenticated', function (): void {
+    post('/login', [
+        'email' => 'workbench@example.com',
+        'password' => 'wrong-password',
+    ])->assertSessionHasErrors('email');
+
+    $this->assertGuest();
+});
+
+test('authenticated workbench users can log out', function (): void {
+    $user = UserFactory::new()->create();
+
+    $this->actingAs($user);
+
+    post('/logout')->assertRedirect('/login');
+
+    $this->assertGuest();
+});

--- a/tests/Feature/WorkbenchLocalePreferenceTest.php
+++ b/tests/Feature/WorkbenchLocalePreferenceTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Workbench\App\Actions\SetLocaleAction;
+use Workbench\App\Models\WorkbenchUser;
+
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+beforeEach(function (): void {
+    config(['lattice.i18n.locales' => ['en', 'de']]);
+
+    App::setLocale('en');
+
+    Route::middleware('web')->get('/_workbench-user-locale', fn () => response()->json([
+        'locale' => App::currentLocale(),
+    ]));
+});
+
+function createWorkbenchLocaleUser(string $locale): WorkbenchUser
+{
+    return WorkbenchUser::query()->create([
+        'name' => 'Locale User',
+        'email' => 'locale-user@example.com',
+        'email_verified_at' => now(),
+        'password' => Hash::make('password'),
+        'locale' => $locale,
+    ]);
+}
+
+test('locale middleware prefers the authenticated user locale', function (): void {
+    $this->actingAs(createWorkbenchLocaleUser('de'));
+    $this->withCredentials()->withUnencryptedCookie('locale', 'en');
+
+    getJson('/_workbench-user-locale', ['Accept-Language' => 'en'])
+        ->assertOk()
+        ->assertJsonPath('locale', 'de');
+});
+
+test('locale action persists the authenticated user locale preference', function (): void {
+    $user = createWorkbenchLocaleUser('en');
+    $this->actingAs($user);
+
+    $ref = componentRef(wire(ActionComponent::use(SetLocaleAction::class)
+        ->context(['locale' => 'de'])));
+
+    postJson('/lattice/actions/workbench.locale.set', [], latticeHeaders($ref))
+        ->assertOk()
+        ->assertJsonPath('ok', true)
+        ->assertJsonPath('effects.0.type', 'localeChange')
+        ->assertJsonPath('effects.0.locale', 'de');
+
+    expect($user->refresh()->preferredLocale())->toBe('de');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Tests\TestCase;
@@ -51,6 +52,19 @@ function seedWorkbenchUsers(): void
             'email' => "browser-user-{$number}@example.com",
         ]);
     }
+}
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function workbenchTestUser(array $attributes = []): User
+{
+    return UserFactory::new()->create([
+        'name' => 'Authenticated Workbench User',
+        'email' => 'workbench-test-'.Str::random(12).'@example.com',
+        'locale' => 'en',
+        ...$attributes,
+    ]);
 }
 
 /**

--- a/workbench/app/Actions/SetLocaleAction.php
+++ b/workbench/app/Actions/SetLocaleAction.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Attributes\Action;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
+use Workbench\App\Models\WorkbenchUser;
 
 #[Action('workbench.locale.set')]
 class SetLocaleAction extends ActionDefinition
@@ -28,6 +29,12 @@ class SetLocaleAction extends ActionDefinition
 
         if (! is_string($locale) || ! in_array($locale, $locales, true)) {
             return ActionResult::failure();
+        }
+
+        $user = $request->user();
+
+        if ($user instanceof WorkbenchUser) {
+            $user->forceFill(['locale' => $locale])->save();
         }
 
         return ActionResult::success()->localeChange($locale);

--- a/workbench/app/Actions/SetLocaleAction.php
+++ b/workbench/app/Actions/SetLocaleAction.php
@@ -9,7 +9,7 @@ use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Attributes\Action;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
-use Workbench\App\Models\WorkbenchUser;
+use Workbench\App\Models\User;
 
 #[Action('workbench.locale.set')]
 class SetLocaleAction extends ActionDefinition
@@ -33,7 +33,7 @@ class SetLocaleAction extends ActionDefinition
 
         $user = $request->user();
 
-        if ($user instanceof WorkbenchUser) {
+        if ($user instanceof User) {
             $user->forceFill(['locale' => $locale])->save();
         }
 

--- a/workbench/app/Http/Controllers/SessionController.php
+++ b/workbench/app/Http/Controllers/SessionController.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
-final class WorkbenchSessionController
+final class SessionController
 {
     public function store(Request $request): RedirectResponse
     {

--- a/workbench/app/Http/Controllers/WorkbenchSessionController.php
+++ b/workbench/app/Http/Controllers/WorkbenchSessionController.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\ValidationException;
+
+final class WorkbenchSessionController
+{
+    public function store(Request $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+
+            return redirect()->intended(route('home', absolute: false));
+        }
+
+        throw ValidationException::withMessages([
+            'email' => __('workbench.auth.login.failed'),
+        ]);
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        Auth::guard()->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login');
+    }
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 namespace Workbench\App\Models;
 
 use Illuminate\Contracts\Translation\HasLocalePreference;
-use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
 /**
  * @property string|null $locale
  */
-class WorkbenchUser extends User implements HasLocalePreference
+class User extends Authenticatable implements HasLocalePreference
 {
     protected $table = 'users';
 

--- a/workbench/app/Models/WorkbenchUser.php
+++ b/workbench/app/Models/WorkbenchUser.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Contracts\Translation\HasLocalePreference;
+use Illuminate\Foundation\Auth\User;
+
+/**
+ * @property string|null $locale
+ */
+class WorkbenchUser extends User implements HasLocalePreference
+{
+    protected $table = 'users';
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'email_verified_at',
+        'password',
+        'locale',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'locale' => 'en',
+    ];
+
+    public function preferredLocale(): ?string
+    {
+        $locale = $this->getAttribute('locale');
+
+        return is_string($locale) && $locale !== '' ? $locale : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+            'locale' => 'string',
+        ];
+    }
+}

--- a/workbench/app/Pages/LoginPage.php
+++ b/workbench/app/Pages/LoginPage.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\Align;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Core\Enums\Width;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Forms\Components\Form as FormComponent;
+use Lattice\Lattice\Forms\Components\PasswordInput;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Http\Page as BasePage;
+
+#[Page(route: '/login', name: 'login', layout: PageLayout::None, container: PageContainer::Centered, middleware: ['web'])]
+final class LoginPage extends BasePage
+{
+    public function title(): string
+    {
+        return __('workbench.auth.login.title');
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('login-page')
+                ->align(Align::Center)
+                ->gap(Gap::Large)
+                ->width(Width::Fill)
+                ->schema([
+                    Stack::make('login-heading')
+                        ->align(Align::Center)
+                        ->gap(Gap::Small)
+                        ->schema([
+                            Heading::make(__('workbench.auth.login.heading')),
+                            Text::make(__('workbench.auth.login.description')),
+                        ]),
+                    Text::make(__('workbench.auth.login.seeded-account')),
+                    FormComponent::make('login-form')
+                        ->action(route('login.store', absolute: false))
+                        ->submitLabel(__('workbench.auth.login.submit'))
+                        ->fill([
+                            'email' => 'workbench@example.com',
+                            'password' => 'password',
+                        ])
+                        ->schema([
+                            TextInput::make('email', __('workbench.auth.login.email'))
+                                ->email()
+                                ->autoComplete('email')
+                                ->autoFocus()
+                                ->required(),
+                            PasswordInput::make('password', __('workbench.auth.login.password'))
+                                ->autoComplete('current-password')
+                                ->required(),
+                        ]),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Pages/WorkbenchPage.php
+++ b/workbench/app/Pages/WorkbenchPage.php
@@ -8,5 +8,5 @@ use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Http\Page as BasePage;
 
-#[Page(layout: PageLayout::App, container: PageContainer::Default, middleware: ['web'])]
+#[Page(layout: PageLayout::App, container: PageContainer::Default, middleware: ['web', 'auth'])]
 abstract class WorkbenchPage extends BasePage {}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -13,6 +13,7 @@ use Laravel\Boost\Install\SkillComposer;
 use Laravel\Boost\Support\Config;
 use Laravel\Roster\Roster;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
+use Workbench\App\Models\WorkbenchUser;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
@@ -28,6 +29,7 @@ class WorkbenchServiceProvider extends ServiceProvider
         config(['lattice.discover' => [
             package_path('workbench/app'),
         ]]);
+        config(['auth.providers.users.model' => WorkbenchUser::class]);
 
         $this->keepLatticeEndpointsPublic();
 

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -13,7 +13,7 @@ use Laravel\Boost\Install\SkillComposer;
 use Laravel\Boost\Support\Config;
 use Laravel\Roster\Roster;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
-use Workbench\App\Models\WorkbenchUser;
+use Workbench\App\Models\User;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
@@ -29,7 +29,7 @@ class WorkbenchServiceProvider extends ServiceProvider
         config(['lattice.discover' => [
             package_path('workbench/app'),
         ]]);
-        config(['auth.providers.users.model' => WorkbenchUser::class]);
+        config(['auth.providers.users.model' => User::class]);
 
         $this->keepLatticeEndpointsPublic();
 

--- a/workbench/app/Seeders/UserSeeder.php
+++ b/workbench/app/Seeders/UserSeeder.php
@@ -6,7 +6,7 @@ namespace Workbench\App\Seeders;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
-use Workbench\App\Models\WorkbenchUser;
+use Workbench\App\Models\User;
 
 class UserSeeder extends Seeder
 {
@@ -15,7 +15,7 @@ class UserSeeder extends Seeder
         $users = $this->users();
         $password = Hash::make('password');
 
-        WorkbenchUser::query()->upsert(
+        User::query()->upsert(
             array_map(
                 function (array $user, int $index) use ($password): array {
                     $createdAt = CarbonImmutable::parse('2025-01-01 09:00:00')->addMinutes($index);

--- a/workbench/app/Seeders/UserSeeder.php
+++ b/workbench/app/Seeders/UserSeeder.php
@@ -5,8 +5,8 @@ namespace Workbench\App\Seeders;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Seeder;
-use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Hash;
+use Workbench\App\Models\WorkbenchUser;
 
 class UserSeeder extends Seeder
 {
@@ -15,7 +15,7 @@ class UserSeeder extends Seeder
         $users = $this->users();
         $password = Hash::make('password');
 
-        User::query()->upsert(
+        WorkbenchUser::query()->upsert(
             array_map(
                 function (array $user, int $index) use ($password): array {
                     $createdAt = CarbonImmutable::parse('2025-01-01 09:00:00')->addMinutes($index);
@@ -26,6 +26,7 @@ class UserSeeder extends Seeder
                         'email' => $user['email'],
                         'email_verified_at' => $updatedAt->toDateTimeString(),
                         'password' => $password,
+                        'locale' => $user['locale'] ?? 'en',
                         'created_at' => $createdAt->toDateTimeString(),
                         'updated_at' => $updatedAt->toDateTimeString(),
                     ];
@@ -34,18 +35,19 @@ class UserSeeder extends Seeder
                 array_keys($users),
             ),
             ['email'],
-            ['name', 'email_verified_at', 'password', 'created_at', 'updated_at'],
+            ['name', 'email_verified_at', 'password', 'locale', 'created_at', 'updated_at'],
         );
     }
 
     /**
-     * @return array<int, array{name: string, email: string}>
+     * @return array<int, array{name: string, email: string, locale?: string}>
      */
     private function users(): array
     {
         $faker = fake();
         $faker->seed(1337);
         $users = [
+            ['name' => 'Workbench User', 'email' => 'workbench@example.com', 'locale' => 'en'],
             ['name' => 'Ada Lovelace', 'email' => 'ada@example.com'],
             ['name' => 'Grace Hopper', 'email' => 'grace@example.com'],
             ['name' => 'Katherine Johnson', 'email' => 'katherine@example.com'],

--- a/workbench/database/migrations/2026_06_14_162138_add_locale_to_users_table.php
+++ b/workbench/database/migrations/2026_06_14_162138_add_locale_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('locale')->default('en')->after('remember_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('locale');
+        });
+    }
+};

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -38,6 +38,18 @@ return [
             'toast' => ':count Produkte abgelehnt: :reason',
         ],
     ],
+    'auth' => [
+        'login' => [
+            'description' => 'Verwende den vorbereiteten Account, um die Workbench zu öffnen.',
+            'email' => 'E-Mail',
+            'failed' => 'Diese Zugangsdaten passen nicht zum vorbereiteten Workbench-Benutzer.',
+            'heading' => 'Lattice Workbench',
+            'password' => 'Passwort',
+            'seeded-account' => 'workbench@example.com / password',
+            'submit' => 'Anmelden',
+            'title' => 'Anmelden',
+        ],
+    ],
     'common' => [
         'add-block' => 'Block hinzufügen',
         'add-line' => 'Zeile hinzufügen',

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -38,6 +38,18 @@ return [
             'toast' => 'Rejected :count products: :reason',
         ],
     ],
+    'auth' => [
+        'login' => [
+            'description' => 'Use the seeded account to enter the workbench.',
+            'email' => 'Email',
+            'failed' => 'These credentials do not match the seeded workbench user.',
+            'heading' => 'Lattice Workbench',
+            'password' => 'Password',
+            'seeded-account' => 'workbench@example.com / password',
+            'submit' => 'Sign in',
+            'title' => 'Sign in',
+        ],
+    ],
     'common' => [
         'add-block' => 'Add block',
         'add-line' => 'Add line',

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -3,11 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Workbench\App\Http\Controllers\WorkbenchSessionController;
 
-Route::get('/dashboard', fn (): string => 'Dashboard')->name('dashboard');
-Route::get('/login', fn (): string => 'Login')->name('login');
-Route::post('/login', fn () => redirect()->route('home'))->name('login.store');
-Route::get('/register', fn (): string => 'Register')->name('register');
-Route::get('/forgot-password', fn (): string => 'Forgot password')->name('password.request');
-Route::post('/forgot-password', fn () => redirect()->route('login'))->name('password.email');
-Route::post('/reset-password', fn () => redirect()->route('login'))->name('password.update');
+Route::post('/login', [WorkbenchSessionController::class, 'store'])->name('login.store');
+Route::post('/logout', [WorkbenchSessionController::class, 'destroy'])->name('logout');

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Workbench\App\Http\Controllers\WorkbenchSessionController;
+use Workbench\App\Http\Controllers\SessionController;
 
-Route::post('/login', [WorkbenchSessionController::class, 'store'])->name('login.store');
-Route::post('/logout', [WorkbenchSessionController::class, 'destroy'])->name('logout');
+Route::post('/login', [SessionController::class, 'store'])->name('login.store');
+Route::post('/logout', [SessionController::class, 'destroy'])->name('logout');


### PR DESCRIPTION
## What & why

Adds authentication to the Testbench workbench app and a per-user stored locale, so the workbench exercises Lattice behind a real login flow.

- **`WorkbenchUser`** model implementing `HasLocalePreference` with a `locale` column (migration), wired as the auth provider model.
- **Login flow**: a Lattice-rendered `LoginPage` plus a `WorkbenchSessionController` (login/logout). Workbench pages now sit behind `auth` middleware.
- **Locale**: the `SetLocale` middleware prefers the authenticated user's locale; the locale action persists the user's preference.
- **Seeding**: seeds `workbench@example.com` / `password`; the login form prefills these credentials.
- **Password field**: refactored to a controlled field so the form's prefilled password value renders.

## Testing

Each browser test authenticates explicitly via `$this->actingAs(workbenchTestUser())`, keeping every test self-contained.

- `composer check` — Pint, PHPStan, 629 Pest tests ✅
- `npm run check` — tsc, type-coverage, Vitest, library build ✅
- `composer test:browser` — passing (3 unrelated `DedicatedFilterTest` timeouts are pre-existing on `main` and out of scope)