### PR TITLE
refactor: simplify password onChange and locale persistence

### DIFF
--- a/resources/js/form/components/fields/password-input.test.tsx
+++ b/resources/js/form/components/fields/password-input.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fakeNode } from "@lattice-php/lattice/test-support";
-import { FormValuesProvider } from "../values";
+import { FormValuesProvider, useFormValue } from "../values";
 import { PasswordInputComponent } from "./password-input";
 
 function renderField(node: Node<"form.password-input">, initial: Record<string, unknown> = {}) {
@@ -11,6 +11,10 @@ function renderField(node: Node<"form.password-input">, initial: Record<string, 
       <PasswordInputComponent node={node}>{null}</PasswordInputComponent>
     </FormValuesProvider>,
   );
+}
+
+function CommittedValue({ name }: { name: string }) {
+  return <output data-test={`value-${name}`}>{String(useFormValue(name) ?? "")}</output>;
 }
 
 describe("PasswordInputComponent conditions", () => {
@@ -59,5 +63,35 @@ describe("PasswordInputComponent conditions", () => {
     );
 
     expect(screen.getByLabelText("Password")).toHaveValue("password");
+  });
+
+  it("commits the confirmation field value", () => {
+    render(
+      <FormValuesProvider initial={{}}>
+        <PasswordInputComponent
+          node={fakeNode({
+            type: "form.password-input",
+            props: {
+              name: "password",
+              label: "Password",
+              confirmation: {
+                name: "password_confirmation",
+                label: "Confirm password",
+                placeholder: "Confirm password",
+              },
+            },
+          })}
+        >
+          {null}
+        </PasswordInputComponent>
+        <CommittedValue name="password_confirmation" />
+      </FormValuesProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Confirm password"), {
+      target: { value: "secret" },
+    });
+
+    expect(screen.getByTestId("value-password_confirmation")).toHaveTextContent("secret");
   });
 });

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -25,12 +25,6 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
     return null;
   }
 
-  const onChange =
-    (field: string) =>
-    (event: React.ChangeEvent<HTMLInputElement>): void => {
-      commit(field, event.target.value);
-    };
-
   return (
     <div className="grid gap-6">
       <FormFieldFrame
@@ -72,7 +66,9 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
             disabled={field.disabled}
             id={confirmationName}
             name={confirmationName}
-            onChange={onChange(confirmationLocalName)}
+            onChange={(event) => {
+              commit(confirmationLocalName, event.target.value);
+            }}
             placeholder={confirmation.placeholder ?? confirmation.label ?? "Confirm password"}
             passwordrules={passwordRules}
             readOnly={field.readOnly}

--- a/workbench/app/Actions/SetLocaleAction.php
+++ b/workbench/app/Actions/SetLocaleAction.php
@@ -34,7 +34,7 @@ class SetLocaleAction extends ActionDefinition
         $user = $request->user();
 
         if ($user instanceof User) {
-            $user->forceFill(['locale' => $locale])->save();
+            $user->update(['locale' => $locale]);
         }
 
         return ActionResult::success()->localeChange($locale);


### PR DESCRIPTION
Follow-up cleanups from reviewing #114 (merged). Quality-only, behavior-preserving.

- **Password field:** drop the one-caller `onChange` factory left over from the controlled-field refactor; the confirmation input now commits inline like the main field.
- **SetLocaleAction:** `locale` is fillable and the value is already validated against the configured locales, so persist it with a plain `update()` instead of `forceFill(...)->save()`.

## Verification
- `composer check` — Pint, PHPStan, 629 Pest tests ✅
- `npm run check` — tsc, Vitest, library build ✅