### PR TITLE
refactor(frontend): add a shared Skeleton primitive

### DIFF
--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { withHeaders } from "@lattice-php/lattice/core/headers";
 import { Button } from "@lattice-php/lattice/core/components/button";
 import { Dialog, DialogContent, DialogHeader } from "@lattice-php/lattice/core/components/dialog";
+import { Skeleton } from "@lattice-php/lattice/core/components/skeleton";
 import { Spinner } from "@lattice-php/lattice/core/components/spinner";
 import { Renderer, useRendererContext } from "@lattice-php/lattice/core/renderer";
 import type { Node } from "@lattice-php/lattice/core/types";
@@ -95,9 +96,9 @@ function firstErrors(errors: Record<string, string[] | string> | undefined): Fie
 function ActionFormSkeleton() {
   return (
     <div className="space-y-4" data-lattice-action-form-loading>
-      <div className="h-4 w-24 animate-pulse rounded bg-lt-muted" />
-      <div className="h-10 w-full animate-pulse rounded bg-lt-muted" />
-      <div className="h-10 w-full animate-pulse rounded bg-lt-muted" />
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
     </div>
   );
 }

--- a/resources/js/core/components/fragment.tsx
+++ b/resources/js/core/components/fragment.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { withHeaders } from "@lattice-php/lattice/core/headers";
+import { Skeleton } from "@lattice-php/lattice/core/components/skeleton";
 import { Renderer, useRendererContext } from "@lattice-php/lattice/core/renderer";
 import type { Node, RendererComponent, Schema } from "@lattice-php/lattice/core/types";
 import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice-php/lattice/events/event-names";
@@ -77,7 +78,7 @@ const FragmentComponent: RendererComponent<"fragment"> = ({ node }) => {
   return (
     <div data-lattice-fragment={node.id}>
       {processing && components.length === 0 ? (
-        <div className="h-16 animate-pulse rounded-lt-sm bg-lt-muted" />
+        <Skeleton className="h-16" />
       ) : (
         <Renderer
           fallback={fallback}

--- a/resources/js/core/components/modal-fragment.test.tsx
+++ b/resources/js/core/components/modal-fragment.test.tsx
@@ -67,6 +67,34 @@ describe("Lattice modal and fragment components", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("shows a skeleton while a lazy fragment is loading", () => {
+    const fetch = vi.fn<() => Promise<Response>>(() => new Promise<Response>(() => {}));
+    vi.stubGlobal("fetch", fetch);
+
+    const { components: registry } = createRegistry({
+      components: {
+        fragment: eagerComponent(FragmentComponent),
+        text: eagerComponent(TextComponent),
+      },
+      name: "test/fragment",
+    });
+
+    const { container } = render(
+      <Renderer
+        nodes={[
+          {
+            id: "settings.two-factor-setup",
+            props: { endpoint: "/lattice/fragments/settings.two-factor-setup", lazy: true },
+            type: "fragment",
+          },
+        ]}
+        registry={registry}
+      />,
+    );
+
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+  });
+
   it("loads fragment schemas and renders them with the current registry", async () => {
     const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
 

--- a/resources/js/core/components/skeleton.test.tsx
+++ b/resources/js/core/components/skeleton.test.tsx
@@ -1,0 +1,14 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton } from "./skeleton";
+
+describe("Skeleton", () => {
+  it("merges custom classes onto the pulsing surface", () => {
+    const { container } = render(<Skeleton className="h-10 w-full" />);
+
+    const skeleton = container.querySelector('[data-slot="skeleton"]');
+    expect(skeleton).not.toBeNull();
+    expect(skeleton).toHaveClass("animate-pulse", "bg-lt-muted", "h-10", "w-full");
+    expect(skeleton).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/resources/js/core/components/skeleton.tsx
+++ b/resources/js/core/components/skeleton.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { cn } from "@lattice-php/lattice/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-lt-sm bg-lt-muted", className)}
+      data-slot="skeleton"
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/resources/js/form/skeleton.test.tsx
+++ b/resources/js/form/skeleton.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import { FormSkeletonComponent } from "./skeleton";
+
+describe("FormSkeletonComponent", () => {
+  it("renders a label and input placeholder per visible field plus a submit row", () => {
+    const node = fakeNode({
+      type: "form",
+      schema: [
+        {
+          type: "grid",
+          schema: [
+            { type: "form.text-input", props: {} },
+            { type: "form.text-input", props: {} },
+            { type: "form.hidden-input", props: {} },
+          ],
+        },
+      ],
+    });
+
+    const { container } = render(<FormSkeletonComponent node={node}>{null}</FormSkeletonComponent>);
+
+    // 2 visible fields × (label + input) + 1 submit placeholder.
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(5);
+  });
+});

--- a/resources/js/form/skeleton.tsx
+++ b/resources/js/form/skeleton.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from "@lattice-php/lattice/core/components/skeleton";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 
 export const FormSkeletonComponent: RendererComponent<"form"> = ({ node }) => {
@@ -14,18 +15,18 @@ export const FormSkeletonComponent: RendererComponent<"form"> = ({ node }) => {
   return (
     <div
       aria-hidden="true"
-      className="mx-auto flex w-full max-w-md animate-pulse flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface p-6 shadow-xs"
+      className="mx-auto flex w-full max-w-md flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface p-6 shadow-xs"
       data-lattice-skeleton={node.id ?? node.type}
     >
       <div className="grid gap-6">
         {Array.from({ length: fieldCount }).map((_, index) => (
           <div className="grid gap-2" key={index}>
-            <div className="h-4 w-28 rounded bg-lt-muted" />
-            <div className="h-10 rounded-lt-sm bg-lt-muted" />
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-10" />
           </div>
         ))}
 
-        <div className="mt-4 h-10 rounded-lt-sm bg-lt-muted" />
+        <Skeleton className="mt-4 h-10" />
       </div>
     </div>
   );


### PR DESCRIPTION
## What & why

The pulsing loading placeholder (`animate-pulse … bg-lt-muted`) was hand-rolled in three places with drifting classes: `ActionFormSkeleton` (3 blocks), the fragment loading state, and the form skeleton (5 blocks). This adds a shared `Skeleton` primitive and routes all three through it.

## Changes
- **New** `core/components/skeleton.tsx` — `<Skeleton className>` (pulsing surface + `aria-hidden`, accepts size/shape via className).
- `action-form` `ActionFormSkeleton`, `core/components/fragment.tsx` loading state, and `form/skeleton.tsx` field placeholders now use it. The form skeleton drops its wrapper-level `animate-pulse` (each block pulses in sync).

Visual no-op — same classes, just centralized (the form skeleton's label block normalizes `rounded` → `rounded-lt-sm`).

## Verification
- `npm run check` green: lint, format, `tsc`, type-coverage 99.5%, **414 vitest**, build.
- Browser: `ProductsTableTest` (7) green — includes the lazy edit modal that renders `ActionFormSkeleton`.

## Follow-up dogfooding candidates (not in this PR)
- **Input control-surface**: form `Input` (comfortable) vs table `fieldClass` (compact, and missing the focus-ring) — unifying needs a density decision.
- **NativeSelect**: 4 raw `<select>` already share `fieldClass`; a primitive would remove the boilerplate.
- **Searchable combobox**: `Select` field and the table `SearchableSelectControl` reimplement the same popover+search+listbox (tracked in #114).
- **Icon ghost buttons**: rich-editor toolbar hand-rolls a `size-7` variant of `Button variant="ghost" size="icon"`.