### PR TITLE
refactor(workbench): dedupe commerce read helpers and simplify address upsert

### DIFF
--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -14,7 +14,6 @@ use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\Product;
-use Workbench\App\Models\SalesPrice;
 
 #[ActionAttribute('workbench.products.edit-modal')]
 class EditProductAction extends FormActionDefinition
@@ -30,22 +29,15 @@ class EditProductAction extends FormActionDefinition
     public function formSchema(Form $form, Request $request): Form
     {
         $product = $this->product($request);
+        $productForm = app(ProductForm::class);
 
         // Reuse the registered form's schema, then prefill the record's values.
-        return app(ProductForm::class)->definition($form, $request)->fill([
+        return $productForm->definition($form, $request)->fill([
             'name' => $product->name,
             'sku' => $product->sku,
             'status' => $product->status,
             'related_products' => $product->relatedProducts()->pluck('products.id')->all(),
-            'sales_prices' => $product->salesPrices()
-                ->orderByRaw('group_id is null desc')
-                ->orderBy('group_id')
-                ->get()
-                ->map(fn (SalesPrice $salesPrice): array => [
-                    'group_id' => $salesPrice->group_id !== null ? (string) $salesPrice->group_id : '',
-                    'amount' => $salesPrice->amount,
-                ])
-                ->all(),
+            'sales_prices' => $productForm->salesPriceRows($product),
         ]);
     }
 

--- a/workbench/app/Forms/BusinessPartnerForm.php
+++ b/workbench/app/Forms/BusinessPartnerForm.php
@@ -66,7 +66,7 @@ class BusinessPartnerForm extends FormDefinition
             if ($addresses->isNotEmpty()) {
                 $addressOptions = $addresses->map(
                     fn (Address $address): Option => Select::option(
-                        $address->label.' — '.$address->city,
+                        $address->displayLabel(),
                         (string) $address->getKey(),
                     ),
                 )->all();
@@ -138,19 +138,13 @@ class BusinessPartnerForm extends FormDefinition
                 'country' => $row['country'],
             ];
 
-            if ($addressId !== null) {
-                $address = $partner->addresses()->find($addressId);
+            $address = $addressId !== null ? $partner->addresses()->find($addressId) : null;
 
-                if ($address instanceof Address) {
-                    $address->update($addressData);
-                    $submittedIds[] = $addressId;
-                } else {
-                    $created = Address::query()->create($addressData);
-                    $submittedIds[] = $created->getKey();
-                }
+            if ($address instanceof Address) {
+                $address->update($addressData);
+                $submittedIds[] = $address->getKey();
             } else {
-                $created = Address::query()->create($addressData);
-                $submittedIds[] = $created->getKey();
+                $submittedIds[] = Address::query()->create($addressData)->getKey();
             }
         }
 

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -20,6 +20,7 @@ use Lattice\Lattice\Forms\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Models\Group;
 use Workbench\App\Models\Product;
+use Workbench\App\Models\SalesPrice;
 
 #[Form('workbench.products.form')]
 class ProductForm extends FormDefinition
@@ -94,6 +95,22 @@ class ProductForm extends FormDefinition
         });
 
         return redirect('/products');
+    }
+
+    /**
+     * @return array<int, array{group_id: string, amount: string}>
+     */
+    public function salesPriceRows(Product $product): array
+    {
+        return $product->salesPrices()
+            ->orderByRaw('group_id is null desc')
+            ->orderBy('group_id')
+            ->get()
+            ->map(fn (SalesPrice $salesPrice): array => [
+                'group_id' => $salesPrice->group_id !== null ? (string) $salesPrice->group_id : '',
+                'amount' => $salesPrice->amount,
+            ])
+            ->all();
     }
 
     /**

--- a/workbench/app/Forms/SalesOrderForm.php
+++ b/workbench/app/Forms/SalesOrderForm.php
@@ -168,7 +168,7 @@ class SalesOrderForm extends FormDefinition
 
         return $partner->addresses()->get()->map(
             fn (Address $address): Option => Select::option(
-                $address->label.' — '.$address->city,
+                $address->displayLabel(),
                 (string) $address->getKey(),
             ),
         )->all();

--- a/workbench/app/Models/Address.php
+++ b/workbench/app/Models/Address.php
@@ -31,6 +31,11 @@ class Address extends Model
         return $this->belongsTo(BusinessPartner::class);
     }
 
+    public function displayLabel(): string
+    {
+        return $this->label.' — '.$this->city;
+    }
+
     protected static function newFactory(): AddressFactory
     {
         return AddressFactory::new();

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -12,7 +12,6 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\Product;
-use Workbench\App\Models\SalesPrice;
 
 #[Page(route: '/products/{product}/edit')]
 class ProductEditPage extends WorkbenchPage
@@ -37,15 +36,7 @@ class ProductEditPage extends WorkbenchPage
                             'sku' => $product->sku,
                             'status' => $product->status,
                             'related_products' => $product->relatedProducts()->pluck('products.id')->all(),
-                            'sales_prices' => $product->salesPrices()
-                                ->orderByRaw('group_id is null desc')
-                                ->orderBy('group_id')
-                                ->get()
-                                ->map(fn (SalesPrice $salesPrice): array => [
-                                    'group_id' => $salesPrice->group_id !== null ? (string) $salesPrice->group_id : '',
-                                    'amount' => $salesPrice->amount,
-                                ])
-                                ->all(),
+                            'sales_prices' => app(ProductForm::class)->salesPriceRows($product),
                         ])
                         ->context([
                             'product_id' => $product->getKey(),

--- a/workbench/app/Pricing/PriceResolver.php
+++ b/workbench/app/Pricing/PriceResolver.php
@@ -11,8 +11,29 @@ final class PriceResolver
 {
     public function lowestFor(BusinessPartner $partner, Product $product): ?string
     {
+        return $this->lowest($partner->groups()->pluck('groups.id')->all(), $product);
+    }
+
+    /**
+     * @return array<int, array{product: Product, price: string|null}>
+     */
+    public function priceList(BusinessPartner $partner): array
+    {
         $groupIds = $partner->groups()->pluck('groups.id')->all();
 
+        return Product::query()->orderBy('name')->get()
+            ->map(fn (Product $product): array => [
+                'product' => $product,
+                'price' => $this->lowest($groupIds, $product),
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  list<int>  $groupIds
+     */
+    private function lowest(array $groupIds, Product $product): ?string
+    {
         $amount = $product->salesPrices()
             ->where(function (Builder $query) use ($groupIds): void {
                 $query->whereNull('group_id');
@@ -24,18 +45,5 @@ final class PriceResolver
             ->min('amount');
 
         return $amount === null ? null : number_format((float) $amount, 2, '.', '');
-    }
-
-    /**
-     * @return array<int, array{product: Product, price: string|null}>
-     */
-    public function priceList(BusinessPartner $partner): array
-    {
-        return Product::query()->orderBy('name')->get()
-            ->map(fn (Product $product): array => [
-                'product' => $product,
-                'price' => $this->lowestFor($partner, $product),
-            ])
-            ->all();
     }
 }


### PR DESCRIPTION
Quality cleanups on the commerce workbench domain (follow-up to the merged #119), surfaced by a review pass.

## Changes
- **Reuse:** extract `ProductForm::salesPriceRows()` and call it from both `ProductEditPage` and `EditProductAction` — the `sales_prices` hydration was previously copy-pasted byte-for-byte. Mirrors the existing shared `syncSalesPrices()` write helper.
- **Reuse:** add `Address::displayLabel()` and use it in `BusinessPartnerForm` and `SalesOrderForm` instead of duplicating the `label — city` formatting (`Select::option` construction stays in the form layer).
- **Simplification:** collapse the duplicated create branch in the `BusinessPartnerForm` address upsert loop.
- **Efficiency:** hoist the partner-groups lookup out of `PriceResolver::priceList()`'s per-product loop — it was re-queried for every product via `lowestFor()`.

All behavior-preserving.

## Testing
- `vendor/bin/pint --dirty` ✅
- `vendor/bin/phpstan analyse` ✅
- `vendor/bin/pest tests/Unit/Pricing tests/Feature/Commerce tests/Feature/Forms/Product*` — 41 passed ✅