### PR TITLE
feat(frontend): unify control surface + extract a Combobox primitive

### DIFF
--- a/resources/js/core/components/combobox.test.tsx
+++ b/resources/js/core/components/combobox.test.tsx
@@ -73,6 +73,25 @@ describe("Combobox", () => {
     expect(red).toHaveAttribute("aria-selected", "true");
   });
 
+  it("omits test ids and shows the empty label when no options match", () => {
+    render(
+      <Combobox
+        emptyLabel="No matches"
+        onOpenChange={() => {}}
+        onSelect={() => {}}
+        open
+        options={[]}
+        selected={[]}
+        trigger={<span>Open</span>}
+      />,
+    );
+
+    expect(screen.getByText("No matches")).toBeVisible();
+    expect(document.querySelector('[data-slot="combobox-search"]')).not.toHaveAttribute(
+      "data-test",
+    );
+  });
+
   it("debounces a remote search instead of filtering locally", () => {
     vi.useFakeTimers();
     const onSearch = vi.fn<(q: string) => void>();

--- a/resources/js/core/components/combobox.test.tsx
+++ b/resources/js/core/components/combobox.test.tsx
@@ -1,0 +1,90 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Option } from "@lattice-php/lattice/core/types";
+import { Combobox } from "./combobox";
+
+const OPTIONS: Option[] = [
+  { label: "Red", value: "red" },
+  { label: "Blue", value: "blue" },
+];
+
+function Harness({
+  multiple = false,
+  onSearch,
+  onSelect,
+  options = OPTIONS,
+}: {
+  multiple?: boolean;
+  onSearch?: (q: string) => void;
+  onSelect?: (v: string) => void;
+  options?: Option[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <Combobox
+      multiple={multiple}
+      onSearch={onSearch}
+      onSelect={(value) => {
+        setSelected((current) =>
+          current.includes(value) ? current.filter((v) => v !== value) : [...current, value],
+        );
+        onSelect?.(value);
+      }}
+      open={open}
+      onOpenChange={setOpen}
+      options={options}
+      selected={selected}
+      testId="cb"
+      trigger={<span>Open</span>}
+    />
+  );
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("Combobox", () => {
+  it("opens, filters locally, and closes after a single select", () => {
+    const onSelect = vi.fn<(v: string) => void>();
+    render(<Harness onSelect={onSelect} />);
+
+    expect(screen.queryByRole("option", { name: "Red" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Open"));
+    expect(screen.getByRole("option", { name: "Red" })).toBeVisible();
+
+    fireEvent.change(screen.getByTestId("cb-search"), { target: { value: "blu" } });
+    expect(screen.queryByRole("option", { name: "Red" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "Blue" }));
+    expect(onSelect).toHaveBeenCalledWith("blue");
+    expect(screen.queryByRole("option", { name: "Blue" })).not.toBeInTheDocument();
+  });
+
+  it("stays open and marks selection for a multi-select", () => {
+    render(<Harness multiple />);
+
+    fireEvent.click(screen.getByText("Open"));
+    fireEvent.click(screen.getByRole("option", { name: "Red" }));
+
+    const red = screen.getByRole("option", { name: "Red" });
+    expect(red).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("debounces a remote search instead of filtering locally", () => {
+    vi.useFakeTimers();
+    const onSearch = vi.fn<(q: string) => void>();
+    render(<Harness onSearch={onSearch} />);
+
+    fireEvent.click(screen.getByText("Open"));
+    fireEvent.change(screen.getByTestId("cb-search"), { target: { value: "x" } });
+
+    act(() => vi.advanceTimersByTime(250));
+
+    expect(onSearch).toHaveBeenCalledWith("x");
+    // Remote mode shows options as given (no local filtering).
+    expect(screen.getByRole("option", { name: "Red" })).toBeVisible();
+  });
+});

--- a/resources/js/core/components/combobox.tsx
+++ b/resources/js/core/components/combobox.tsx
@@ -1,0 +1,159 @@
+import { Icon } from "@lattice-php/lattice/icons";
+import * as React from "react";
+import { useEffect, useState } from "react";
+import { useT } from "@lattice-php/lattice/i18n";
+import type { Option } from "@lattice-php/lattice/core/types";
+import { cn } from "@lattice-php/lattice/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+/**
+ * A popover select list with an optional search box and single/multi selection.
+ *
+ * Selection state is controlled by the consumer (`selected` + `onSelect`); the
+ * consumer also owns option fetching. Pass `onSearch` for remote search (the
+ * combobox debounces the query and renders `options` as given); omit it to
+ * filter the provided `options` locally by label. The combobox closes itself
+ * after a single-select.
+ */
+function Combobox({
+  contentClassName,
+  emptyLabel,
+  loading = false,
+  multiple = false,
+  onSearch,
+  onSelect,
+  open,
+  onOpenChange,
+  options,
+  searchLabel,
+  searchPlaceholder,
+  selected,
+  showSearch = true,
+  testId,
+  trigger,
+  triggerClassName,
+  triggerProps,
+}: {
+  contentClassName?: string;
+  emptyLabel?: string;
+  loading?: boolean;
+  multiple?: boolean;
+  onSearch?: (query: string) => void;
+  onSelect: (value: string) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  options: Option[];
+  searchLabel?: string;
+  searchPlaceholder?: string;
+  selected: string[];
+  showSearch?: boolean;
+  testId?: string;
+  trigger: React.ReactNode;
+  triggerClassName?: string;
+  triggerProps?: React.ComponentProps<"button"> & { "data-test"?: string };
+}) {
+  const { t } = useT("lattice");
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!onSearch || !open) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => onSearch(query), SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [query, onSearch, open]);
+
+  const visibleOptions = onSearch
+    ? options
+    : options.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()));
+
+  function close(): void {
+    setQuery("");
+    onOpenChange(false);
+  }
+
+  function choose(value: string): void {
+    onSelect(value);
+
+    if (!multiple) {
+      close();
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+      <PopoverTrigger asChild>
+        <button type="button" className={triggerClassName} {...triggerProps}>
+          {trigger}
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="start"
+        className={cn(
+          "w-[var(--radix-popover-trigger-width)] overflow-hidden p-0",
+          contentClassName,
+        )}
+      >
+        {showSearch && (
+          <div className="flex items-center gap-2 border-b border-lt-border px-3 py-2">
+            <input
+              aria-label={searchLabel ?? t("a11y.searchOptions", "Search options")}
+              data-slot="combobox-search"
+              data-test={testId ? `${testId}-search` : undefined}
+              className="w-full bg-transparent text-sm outline-none placeholder:text-lt-muted-fg"
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={searchPlaceholder}
+              value={query}
+            />
+            {loading && (
+              <Icon
+                name="loader-2"
+                aria-hidden="true"
+                className="size-lt-icon-md shrink-0 animate-spin text-lt-muted-fg"
+              />
+            )}
+          </div>
+        )}
+
+        <div className="max-h-60 overflow-y-auto p-1" role="listbox">
+          {visibleOptions.length === 0 ? (
+            <p className="px-3 py-2 text-sm text-lt-muted-fg">{emptyLabel}</p>
+          ) : (
+            visibleOptions.map((option) => {
+              const isSelected = selected.includes(option.value);
+
+              return (
+                <button
+                  aria-selected={isSelected}
+                  className={cn(
+                    "flex w-full items-center justify-between gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-lt-accent hover:text-lt-accent-fg",
+                    isSelected && "bg-lt-accent/60",
+                  )}
+                  data-slot="combobox-option"
+                  data-test={testId ? `${testId}-option-${option.value}` : undefined}
+                  data-value={option.value}
+                  key={option.value}
+                  onClick={() => choose(option.value)}
+                  role="option"
+                  type="button"
+                >
+                  {option.label}
+                  {isSelected && (
+                    <Icon name="check" aria-hidden="true" className="size-lt-icon-md shrink-0" />
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export { Combobox };

--- a/resources/js/core/components/control.test.ts
+++ b/resources/js/core/components/control.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { controlSurface, FOCUS_RING } from "./control";
+
+describe("controlSurface", () => {
+  it("shares the border and focus ring across densities", () => {
+    const comfortable = controlSurface({ density: "comfortable" });
+    const compact = controlSurface();
+
+    for (const classes of [comfortable, compact]) {
+      expect(classes).toContain("border-lt-input");
+      expect(classes).toContain("focus-visible:ring-[3px]");
+    }
+  });
+
+  it("varies padding, text size, and background by density", () => {
+    expect(controlSurface({ density: "comfortable" })).toContain("px-3");
+    expect(controlSurface({ density: "comfortable" })).toContain("bg-transparent");
+    expect(controlSurface({ density: "compact" })).toContain("px-2");
+    expect(controlSurface({ density: "compact" })).toContain("bg-lt-bg");
+  });
+
+  it("exposes the focus ring constant", () => {
+    expect(FOCUS_RING).toContain("focus-visible:border-lt-ring");
+  });
+});

--- a/resources/js/core/components/control.ts
+++ b/resources/js/core/components/control.ts
@@ -1,0 +1,32 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+/** The focus-visible ring shared by every interactive control surface. */
+export const FOCUS_RING =
+  "focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]";
+
+/**
+ * The shared chrome for single-line form/table controls (text inputs, native
+ * selects, and the Select/filter trigger buttons). `density` is the only axis
+ * that differs between forms (comfortable) and table filters (compact); the
+ * border, focus ring, invalid, and disabled treatment are unified.
+ */
+export const controlSurface = cva(
+  [
+    "w-full min-w-0 rounded-lt-sm border border-lt-input shadow-xs outline-none transition-[color,box-shadow]",
+    "placeholder:text-lt-muted-fg",
+    FOCUS_RING,
+    "aria-invalid:border-lt-danger aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40",
+    "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+  ],
+  {
+    variants: {
+      density: {
+        comfortable: "h-9 bg-transparent px-3 py-1 text-base md:text-sm",
+        compact: "h-9 bg-lt-bg px-2 text-sm font-normal",
+      },
+    },
+    defaultVariants: { density: "comfortable" },
+  },
+);
+
+export type ControlSurfaceVariants = VariantProps<typeof controlSurface>;

--- a/resources/js/form/components/base/input.tsx
+++ b/resources/js/form/components/base/input.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { controlSurface } from "@lattice-php/lattice/core/components/control";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
@@ -8,9 +9,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "border-lt-input file:text-lt-fg placeholder:text-lt-muted-fg selection:bg-lt-primary selection:text-lt-primary-fg flex h-9 w-full min-w-0 rounded-lt-sm border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
+        controlSurface(),
+        "file:text-lt-fg selection:bg-lt-primary selection:text-lt-primary-fg file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium",
         className,
       )}
       {...props}

--- a/resources/js/form/components/base/textarea.tsx
+++ b/resources/js/form/components/base/textarea.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { FOCUS_RING } from "@lattice-php/lattice/core/components/control";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
@@ -8,7 +9,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       data-slot="textarea"
       className={cn(
         "border-lt-input placeholder:text-lt-muted-fg flex field-sizing-content min-h-16 w-full rounded-lt-sm border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]",
+        FOCUS_RING,
         "aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
         className,
       )}

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -184,4 +184,23 @@ describe("SelectComponent options", () => {
 
     expect(screen.queryByText("Red")).not.toBeInTheDocument();
   });
+
+  it("toggles options without closing in a multiple select", () => {
+    renderStaticSelect({
+      multiple: true,
+      options: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+      ],
+    });
+
+    fireEvent.click(screen.getByTestId("select-color"));
+    fireEvent.click(screen.getByTestId("select-color-option-red"));
+
+    // The popover stays open for multi-select, so the second option is clickable.
+    fireEvent.click(screen.getByTestId("select-color-option-blue"));
+
+    expect(screen.getByTestId("select-color-option-red")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("select-color-option-blue")).toHaveAttribute("aria-selected", "true");
+  });
 });

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -13,7 +13,7 @@ const { postFormAction } = vi.hoisted(() => ({
       componentRef: string,
       body: Record<string, unknown>,
       signal: AbortSignal,
-    ) => Promise<{ options: [] }>
+    ) => Promise<{ options: { label: string; value: string }[] }>
   >(() => Promise.resolve({ options: [] })),
 }));
 
@@ -113,6 +113,32 @@ describe("SelectComponent search", () => {
       { _search: "items.0.product", q: "desk", ...initial },
       expect.any(AbortSignal),
     );
+  });
+
+  it("loads on open, fetches matches, and selects a searched option", async () => {
+    vi.useFakeTimers();
+    postFormAction.mockResolvedValue({ options: [{ label: "Desk", value: "desk" }] });
+
+    renderSelect({ initial: {} });
+
+    fireEvent.click(screen.getByTestId("select-product"));
+
+    // Opening fires an empty search that clears results without a request.
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+      await Promise.resolve();
+    });
+    expect(postFormAction).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId("select-product-search"), { target: { value: "de" } });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByTestId("select-product-option-desk"));
+
+    expect(screen.getByTestId("select-product")).toHaveTextContent("Desk");
   });
 });
 

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -1,16 +1,13 @@
 import { Icon } from "@lattice-php/lattice/icons";
-import { useEffect, useMemo, useState } from "react";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@lattice-php/lattice/core/components/popover";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Combobox } from "@lattice-php/lattice/core/components/combobox";
+import { controlSurface } from "@lattice-php/lattice/core/components/control";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { Option, RendererComponent } from "@lattice-php/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
-import { FORM_DEBOUNCE_MS, postFormAction } from "../form-transport";
+import { postFormAction } from "../form-transport";
 import { useResolvedNode } from "../resolved-nodes";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
@@ -53,17 +50,19 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
 
   const globalValue = useFormValue(name);
   const values = useFormValues();
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
   const storedValue = scope ? scope.getValue(name) : globalValue;
   const selected = useMemo(() => toValues(storedValue, props.value), [storedValue, props.value]);
 
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState<Option[]>([]);
+  const [results, setResults] = useState<Option[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const searchAbort = useRef<AbortController | null>(null);
 
   const labels = useMemo(() => {
     const map = new Map<string, string>();
-    for (const option of [...staticOptions, ...results]) {
+    for (const option of [...staticOptions, ...(results ?? [])]) {
       map.set(option.value, option.label);
     }
     return map;
@@ -72,26 +71,25 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
 
   const locked = readOnly || disabled;
 
-  useEffect(() => {
-    if (!searchable) {
-      return;
-    }
+  const search = useCallback(
+    (query: string) => {
+      searchAbort.current?.abort();
 
-    if (query.trim() === "") {
-      setResults([]);
-      setLoading(false);
+      if (query.trim() === "") {
+        setResults(null);
+        setLoading(false);
 
-      return;
-    }
+        return;
+      }
 
-    const controller = new AbortController();
-    setLoading(true);
+      const controller = new AbortController();
+      searchAbort.current = controller;
+      setLoading(true);
 
-    const timer = window.setTimeout(() => {
       void postFormAction<{ options?: Option[] }>(
         action,
         componentRef,
-        { ...values, _search: searchKey, q: query },
+        { ...valuesRef.current, _search: searchKey, q: query },
         controller.signal,
       )
         .then((response) => {
@@ -99,36 +97,24 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
           setLoading(false);
         })
         .catch(() => {});
-    }, FORM_DEBOUNCE_MS);
-
-    return () => {
-      window.clearTimeout(timer);
-      controller.abort();
-    };
-  }, [query, searchable, action, componentRef, searchKey, values]);
+    },
+    [action, componentRef, searchKey],
+  );
 
   function commit(next: string[]): void {
     change(name, multiple ? next : (next[0] ?? ""));
   }
 
-  function close(): void {
-    setOpen(false);
-    setQuery("");
-    blur(name);
-  }
-
-  function pick(option: Option): void {
+  function select(value: string): void {
     if (multiple) {
-      const next = selected.includes(option.value)
-        ? selected.filter((value) => value !== option.value)
-        : [...selected, option.value];
-      commit(next);
+      commit(
+        selected.includes(value) ? selected.filter((item) => item !== value) : [...selected, value],
+      );
 
       return;
     }
 
-    commit([option.value]);
-    close();
+    commit([value]);
   }
 
   function remove(value: string): void {
@@ -139,11 +125,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
     return null;
   }
 
-  const visibleOptions = !searchable
-    ? staticOptions.filter((option) => option.label.toLowerCase().includes(query.toLowerCase()))
-    : query.trim() === ""
-      ? staticOptions
-      : results;
+  const options = searchable ? (results ?? staticOptions) : staticOptions;
 
   return (
     <FormFieldFrame
@@ -188,87 +170,47 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
           </div>
         )}
 
-        <Popover
+        <Combobox
+          emptyLabel={props.emptyLabel ?? undefined}
+          loading={loading}
+          multiple={multiple}
+          onSearch={searchable ? search : undefined}
+          onSelect={select}
           open={open && !locked}
           onOpenChange={(next) => {
-            if (next) {
-              setOpen(true);
-            } else {
-              close();
+            setOpen(next);
+
+            if (!next) {
+              blur(name);
             }
           }}
-        >
-          <PopoverTrigger asChild>
-            <button
-              aria-haspopup="listbox"
-              autoFocus={props.autoFocus ?? undefined}
-              tabIndex={props.tabIndex ?? undefined}
-              data-test={`select-${name}`}
-              className={cn(
-                "flex min-h-9 w-full items-center justify-between gap-2 rounded-lt-sm border border-lt-input bg-transparent px-3 py-1.5 text-left text-sm shadow-xs transition-colors focus:border-lt-ring focus:outline-none focus:ring-[3px] focus:ring-lt-ring/50",
-                locked && "cursor-not-allowed opacity-60",
-              )}
-              disabled={locked}
-              type="button"
-            >
+          options={options}
+          searchPlaceholder={props.searchPlaceholder ?? undefined}
+          selected={selected}
+          testId={`select-${name}`}
+          trigger={
+            <>
               {!multiple && selected.length > 0 ? (
                 <span>{labelFor(selected[0])}</span>
               ) : (
                 <span className="text-lt-muted-fg">{placeholder}</span>
               )}
               <Icon name="chevrons-up-down" className="size-lt-icon-md shrink-0 text-lt-muted-fg" />
-            </button>
-          </PopoverTrigger>
-
-          <PopoverContent
-            align="start"
-            className="w-[var(--radix-popover-trigger-width)] overflow-hidden"
-          >
-            <div className="flex items-center gap-2 border-b border-lt-border px-3 py-2">
-              <input
-                aria-label={t("a11y.searchOptions", "Search options")}
-                data-test={`select-${name}-search`}
-                className="w-full bg-transparent text-sm outline-none placeholder:text-lt-muted-fg"
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder={props.searchPlaceholder}
-                value={query}
-              />
-              {loading && (
-                <Icon
-                  name="loader-2"
-                  className="size-lt-icon-md shrink-0 animate-spin text-lt-muted-fg"
-                />
-              )}
-            </div>
-            <div className="max-h-60 overflow-y-auto p-1" role="listbox">
-              {visibleOptions.length === 0 ? (
-                <p className="px-3 py-2 text-sm text-lt-muted-fg">{props.emptyLabel}</p>
-              ) : (
-                visibleOptions.map((option) => {
-                  const isSelected = selected.includes(option.value);
-
-                  return (
-                    <button
-                      aria-selected={isSelected}
-                      data-test={`select-${name}-option-${option.value}`}
-                      className={cn(
-                        "flex w-full items-center justify-between gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-lt-accent hover:text-lt-accent-fg",
-                        isSelected && "bg-lt-accent/60",
-                      )}
-                      key={option.value}
-                      onClick={() => pick(option)}
-                      role="option"
-                      type="button"
-                    >
-                      {option.label}
-                      {isSelected && <Icon name="check" className="size-lt-icon-md shrink-0" />}
-                    </button>
-                  );
-                })
-              )}
-            </div>
-          </PopoverContent>
-        </Popover>
+            </>
+          }
+          triggerClassName={cn(
+            controlSurface(),
+            "flex items-center justify-between gap-2 text-left",
+            locked && "cursor-not-allowed opacity-60",
+          )}
+          triggerProps={{
+            "aria-haspopup": "listbox",
+            autoFocus: props.autoFocus ?? undefined,
+            "data-test": `select-${name}`,
+            disabled: locked,
+            tabIndex: props.tabIndex ?? undefined,
+          }}
+        />
       </div>
     </FormFieldFrame>
   );

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -6,11 +6,12 @@ import {
   PopoverTrigger,
 } from "@lattice-php/lattice/core/components/popover";
 import { useT } from "@lattice-php/lattice/i18n";
+import { cn } from "@lattice-php/lattice/lib/utils";
 import type { FilterData, FilterType, Op } from "@lattice-php/lattice/types/generated";
 import { operatorLabel, VALUELESS_FILTER_OPERATORS } from "../query";
 import type { FilterClause, TableColumn } from "../types";
 import { type FilterOptionSearch, TableFilterControl } from "./filter-controls";
-import { FilterValueInput } from "./filter-value-input";
+import { fieldClass, FilterValueInput } from "./filter-value-input";
 
 type ColumnClause = { clause: FilterClause; index: number };
 
@@ -318,7 +319,7 @@ function FilterClauseRow({
           <select
             aria-label={t("filter.operator", "{{label}} operator", { label: column.label })}
             data-test={`filter-${column.key}-operator`}
-            className="h-9 flex-1 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal"
+            className={cn(fieldClass, "flex-1")}
             disabled={processing}
             value={clause.operator}
             onChange={(event) => onOperator(event.target.value as Op)}

--- a/resources/js/table/components/column-select-filter.test.tsx
+++ b/resources/js/table/components/column-select-filter.test.tsx
@@ -110,7 +110,7 @@ describe("column select filter", () => {
     render(<TableComponent node={node({ ...selectFilter(false), searchable: true })} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Status" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Active" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Active" }));
 
     await waitFor(() => {
       expect(fetch.mock.calls.at(-1)?.[0]).toContain("filter=status%3Aeq%3Aactive");

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -1,17 +1,12 @@
 import { Icon } from "@lattice-php/lattice/icons";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Checkbox } from "@lattice-php/lattice/core/components/checkbox";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@lattice-php/lattice/core/components/popover";
+import { Combobox } from "@lattice-php/lattice/core/components/combobox";
 import { useT } from "@lattice-php/lattice/i18n";
+import { cn } from "@lattice-php/lattice/lib/utils";
 import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
 import { filterOptions, stringProp } from "../filter-values";
 import { fieldClass } from "./filter-value-input";
-
-const SEARCH_DEBOUNCE_MS = 250;
 
 export type DateRangeValue = { from?: string; until?: string };
 
@@ -195,8 +190,8 @@ function SearchableSelectControl({
   const { t } = useT("lattice");
   const multiple = filter.props.multiple === true;
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
   const [results, setResults] = useState<Option[]>(() => filterOptions(filter));
+  const [loading, setLoading] = useState(false);
 
   const selected = multiple
     ? Array.isArray(value)
@@ -216,87 +211,50 @@ function SearchableSelectControl({
         ? t("filter.selectedCount", "{{amount}} selected", { amount: selected.length })
         : (labels.get(selected[0]) ?? selected[0]);
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    let active = true;
-    const timer = window.setTimeout(() => {
-      void onSearch(query).then((options) => {
-        if (active) {
-          setResults(options);
-        }
-      });
-    }, SEARCH_DEBOUNCE_MS);
-
-    return () => {
-      active = false;
-      window.clearTimeout(timer);
-    };
-  }, [open, query, onSearch]);
+  function search(query: string): void {
+    setLoading(true);
+    void onSearch(query).then((options) => {
+      setResults(options);
+      setLoading(false);
+    });
+  }
 
   function choose(optionValue: string): void {
-    if (multiple) {
-      onChange(
-        selected.includes(optionValue)
+    onChange(
+      multiple
+        ? selected.includes(optionValue)
           ? selected.filter((item) => item !== optionValue)
-          : [...selected, optionValue],
-      );
-
-      return;
-    }
-
-    onChange(optionValue);
-    setOpen(false);
+          : [...selected, optionValue]
+        : optionValue,
+    );
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={filter.label}
-          data-test={`table-filter-${filter.key}`}
-          className={`${fieldClass} flex items-center justify-between gap-2`}
-          disabled={processing}
-        >
+    <Combobox
+      contentClassName="w-60"
+      loading={loading}
+      multiple={multiple}
+      onSearch={search}
+      onSelect={choose}
+      open={open}
+      onOpenChange={setOpen}
+      options={results}
+      searchLabel={t("filter.search", "Search")}
+      selected={selected}
+      testId={`table-filter-${filter.key}`}
+      trigger={
+        <>
           <span className="truncate">{summary}</span>
           <Icon name="chevron-down" aria-hidden="true" className="size-lt-icon-sm shrink-0" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-60 p-2">
-        <input
-          type="text"
-          aria-label={t("filter.search", "Search")}
-          data-test={`table-filter-${filter.key}-search`}
-          className={fieldClass}
-          value={query}
-          disabled={processing}
-          onChange={(event) => setQuery(event.target.value)}
-        />
-        <div className="mt-1 max-h-60 overflow-y-auto" role="listbox">
-          {results.map((option) => (
-            <button
-              type="button"
-              key={option.value}
-              data-test={`table-filter-${filter.key}-${option.value}`}
-              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-lt-muted"
-              onClick={() => choose(option.value)}
-            >
-              {multiple && (
-                <Icon
-                  name="check"
-                  aria-hidden="true"
-                  className={`size-lt-icon-sm shrink-0 ${selected.includes(option.value) ? "" : "invisible"}`}
-                />
-              )}
-              <span className="truncate">{option.label}</span>
-            </button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
+        </>
+      }
+      triggerClassName={cn(fieldClass, "flex items-center justify-between gap-2")}
+      triggerProps={{
+        "aria-label": filter.label,
+        "data-test": `table-filter-${filter.key}`,
+        disabled: processing,
+      }}
+    />
   );
 }
 

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -1,10 +1,10 @@
 import { Icon } from "@lattice-php/lattice/icons";
 import { useEffect, useState } from "react";
+import { controlSurface } from "@lattice-php/lattice/core/components/control";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { FilterType } from "@lattice-php/lattice/types/generated";
 
-export const fieldClass =
-  "h-9 w-full min-w-0 rounded-lt-sm border border-lt-input bg-lt-bg px-2 text-sm font-normal";
+export const fieldClass = controlSurface({ density: "compact" });
 
 export function FilterValueInput({
   type,

--- a/resources/js/table/components/searchable-filter.test.tsx
+++ b/resources/js/table/components/searchable-filter.test.tsx
@@ -75,7 +75,7 @@ describe("searchable select filter", () => {
     render(<TableComponent node={node} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Author" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Ada" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Ada" }));
 
     await waitFor(() => {
       expect(fetch.mock.calls.at(-1)?.[0]).toContain("tf%5Bauthor%5D=1");
@@ -95,7 +95,7 @@ describe("searchable select filter", () => {
     render(<TableComponent node={multiNode} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Author" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Ada" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Ada" }));
 
     await waitFor(() => {
       expect(fetch.mock.calls.at(-1)?.[0]).toContain("tf%5Bauthor%5D%5B%5D=1");


### PR DESCRIPTION
Unifies the duplicated input chrome and the searchable-select UX shared between Forms and Tables. No new dependencies. Follows the deep form/table reusability analysis; respects the CI-enforced Forms⊥Tables boundary (everything shared lives in `core/`).

## 1. Control surface (`core/components/control.ts`)
Three divergent definitions of the same input chrome (form `Input`, the Select trigger, the table `fieldClass` + raw `<select>`s) collapse into one `controlSurface` CVA + a shared `FOCUS_RING` constant. `density` is the only axis that differs (`comfortable` for forms, `compact` for table filters); border / rounding / shadow / focus-ring / invalid / disabled are unified.

Fixes two real bugs uncovered by the analysis:
- **Table filter controls had no focus ring at all** — a keyboard-a11y gap. They now get one.
- The Select trigger used `focus:` instead of `focus-visible:`.

## 2. `Combobox` primitive (`core/components/combobox.tsx`)
The form `Select` and the table `SearchableSelectControl` were ~70% identical (popover + 250ms debounced search + scrollable listbox + multi-toggle). Extracted into one primitive on top of our popover:
- Options + selection stay **controlled** by the consumer; `onSearch` drives remote search (debounced), its absence filters locally; a single-select closes the popover.
- The form `Select` keeps its hidden inputs, multi-select tags, field-scope, and prefill; the table control keeps its clause mapping. Both pass a `testId` so existing per-field test hooks are preserved.
- Advances the column-filter ↔ Select convergence tracked in #114.

The native single `<select>` and the static multi-select dropdown stay as-is (different, appropriate UX).

## Deliberately left alone (from the analysis)
The PHP layer is already well-factored at the right seams (`Op`, `OptionSource`, `HasOptions`, `Definition`, `DefinitionRegistry`, `Discovery` all shared in `core`). `Field` vs `Column` and `ConditionEvaluator` vs `FilterApplier` are intentionally separate — merging would couple or over-abstract. No PHP changes.

## Verification
- `npm run check` green: lint, format, `tsc`, type-coverage 99.5%, **431 vitest**, build.
- **25 browser tests**: form static + searchable-multi selects, modal selects (reject/edit), bulk selection, column + dedicated filters (incl. native status select), builder, dependent fields — all green.