### PR TITLE
fix(workbench): products-table action dropdown + locale-change flicker

### DIFF
--- a/config/lattice.php
+++ b/config/lattice.php
@@ -18,6 +18,7 @@ return [
 
     'i18n' => [
         'locales' => ['en'],
+        'preload_locales' => [],
     ],
 
     'forms' => [

--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -80,8 +80,15 @@ return [
 ```
 
 Lattice reads whether the routes are serving (`i18next.routes.enabled`), whether missing keys are
-reported back (`i18next.save_missing.enabled`), and the supported locales from
-`config('lattice.i18n.locales')`. It shares those values to the frontend as an Inertia once prop.
+reported back (`i18next.save_missing.enabled`), the supported locales from
+`config('lattice.i18n.locales')`, and which locales to eagerly preload from
+`config('lattice.i18n.preload_locales')`. It shares those values to the frontend as an Inertia once
+prop.
+
+Locales listed in `preload_locales` have their translations fetched once at startup (in the
+background, so the first paint isn't blocked). Switching to a preloaded locale then resolves from the
+store instead of an HTTP round-trip, which avoids a flash of the fallback language. Leave it empty to
+load each locale lazily on first switch.
 
 ### Wire the frontend
 
@@ -310,7 +317,9 @@ options and adds the active `Accept-Language` header.
 ### `LocaleReload`
 
 Listens for `lattice:locale-change` and visits the current URL with `{ preserveScroll: true,
-preserveState: false }`. Override those two options if your app needs a different reload behavior.
+preserveState: true }`. Preserving state means the visit only swaps in the re-localized props without
+remounting the page, so table sort/filter, form input, scroll, and focus survive the switch. Override
+either option if your app needs a different reload behavior.
 
 ### `useLocaleOptions(options?)`
 
@@ -341,9 +350,11 @@ type I18nConfig = {
   enabled: boolean; // are the translation routes serving?
   saveMissing: boolean; // should missing keys be reported back?
   locales: string[]; // supported locale codes from config('lattice.i18n.locales')
+  preloadLocales: string[]; // locales eagerly loaded at startup, from config('lattice.i18n.preload_locales')
 };
 ```
 
-`configureI18n(config)` enables the backend only when `enabled` is true, forwards `saveMissing`, and
-stores `locales` for `useT`, `useLocaleOptions`, and `LocaleSwitcher`. The load and add paths are
-fixed on the frontend, so they never travel in this prop.
+`configureI18n(config)` enables the backend only when `enabled` is true, forwards `saveMissing`,
+stores `locales` for `useT`, `useLocaleOptions`, and `LocaleSwitcher`, and preloads `preloadLocales`
+in the background. The load and add paths are fixed on the frontend, so they never travel in this
+prop.

--- a/resources/js/action/components/action-group.tsx
+++ b/resources/js/action/components/action-group.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@lattice-php/lattice/core/components/dropdown-menu";
+import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
@@ -35,6 +36,7 @@ const ActionGroupComponent: RendererComponent<"action.group"> = ({ children, nod
           <Button
             aria-label={label}
             className="size-8 text-lt-muted-fg shadow-none hover:text-lt-fg"
+            data-test={nodeIdentity(node)}
             size="icon"
             type="button"
             variant="ghost"

--- a/resources/js/i18n/backend.ts
+++ b/resources/js/i18n/backend.ts
@@ -1,7 +1,7 @@
 import type { I18nConfig } from "@lattice-php/lattice/types/generated";
 import HttpBackend from "i18next-http-backend";
 import { setConfig } from "./config";
-import { ensureI18n, i18n } from "./instance";
+import { ensureI18n, i18n, preloadLanguages } from "./instance";
 import { localeHeader } from "./locale";
 
 /** The i18n settings the backend shares to the frontend (Inertia `lattice.i18n`). */
@@ -43,6 +43,9 @@ export async function configureI18n(
   }
 
   await enableBackend({ saveMissing: config.saveMissing, namespaces: options.namespaces });
+
+  // Fire-and-forget so warming the other locales never delays the active one.
+  void preloadLanguages(config.preloadLocales);
 }
 
 /**

--- a/resources/js/i18n/instance.test.tsx
+++ b/resources/js/i18n/instance.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { configureI18n } from "./backend";
-import { i18n, translate, useT } from "./instance";
+import { i18n, preloadLanguages, translate, useT } from "./instance";
 import { setLocale } from "./locale";
 
 const namespace = "test";
@@ -51,8 +51,29 @@ describe("i18n instance", () => {
     expect(await screen.findByText("Hallo")).toBeVisible();
   });
 
+  it("preloads the non-active languages and skips the current one", async () => {
+    const loadLanguages = vi.spyOn(i18n, "loadLanguages").mockResolvedValue(undefined);
+
+    await preloadLanguages(["en", "de"]);
+
+    expect(loadLanguages).toHaveBeenCalledWith(["de"]);
+
+    loadLanguages.mockClear();
+
+    await preloadLanguages(["en"]);
+
+    expect(loadLanguages).not.toHaveBeenCalled();
+
+    loadLanguages.mockRestore();
+  });
+
   it("returns locale controls and configured locales from useT", async () => {
-    await configureI18n({ enabled: false, saveMissing: false, locales: ["en", "de"] });
+    await configureI18n({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en", "de"],
+      preloadLocales: [],
+    });
 
     render(<LocaleProbe />);
 

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -79,6 +79,23 @@ subscribeLocale((locale) => {
   });
 });
 
+/**
+ * Eagerly load the namespaces for the given locales so a later
+ * `changeLanguage` resolves them from the store instead of an HTTP round-trip,
+ * which would otherwise flash the fallback language on switch. The active
+ * locale is already loaded by {@link ensureI18n}, so it is skipped.
+ */
+export async function preloadLanguages(locales: readonly string[]): Promise<void> {
+  const pending = locales.filter((locale) => locale !== currentLocale());
+
+  if (pending.length === 0) {
+    return;
+  }
+
+  await ensureI18n();
+  await i18n.loadLanguages([...pending]);
+}
+
 export function useT(namespace: string): TranslationResult {
   ensureI18n();
   useSyncExternalStore(subscribe, snapshot, snapshot);

--- a/resources/js/i18n/locale-reload.test.tsx
+++ b/resources/js/i18n/locale-reload.test.tsx
@@ -24,18 +24,18 @@ describe("LocaleReload", () => {
 
     expect(router.visit).toHaveBeenCalledWith(href, {
       preserveScroll: true,
-      preserveState: false,
+      preserveState: true,
     });
   });
 
   it("allows the reload visit options to be adjusted", () => {
-    render(<LocaleReload preserveScroll={false} preserveState />);
+    render(<LocaleReload preserveScroll={false} preserveState={false} />);
 
     window.dispatchEvent(new CustomEvent("lattice:locale-change", { detail: { locale: "de" } }));
 
     expect(router.visit).toHaveBeenCalledWith(window.location.href, {
       preserveScroll: false,
-      preserveState: true,
+      preserveState: false,
     });
   });
 });

--- a/resources/js/i18n/locale-reload.tsx
+++ b/resources/js/i18n/locale-reload.tsx
@@ -5,7 +5,10 @@ import { EventBridge } from "../events/event-bridge";
 
 export type LocaleReloadProps = Pick<VisitOptions, "preserveScroll" | "preserveState">;
 
-export function LocaleReload({ preserveScroll = true, preserveState = false }: LocaleReloadProps) {
+// preserveState by default: the visit only re-fetches the re-localized props,
+// so keeping the page mounted avoids remounting the whole tree (and losing
+// table sort/filter, form input, focus) on every locale switch.
+export function LocaleReload({ preserveScroll = true, preserveState = true }: LocaleReloadProps) {
   const reload = useCallback(() => {
     router.visit(window.location.href, { preserveScroll, preserveState });
   }, [preserveScroll, preserveState]);

--- a/resources/js/i18n/locale-switcher.test.tsx
+++ b/resources/js/i18n/locale-switcher.test.tsx
@@ -26,7 +26,12 @@ describe("locale switcher helpers", () => {
   });
 
   it("builds active locale options from the configured locales", async () => {
-    await configureI18n({ enabled: false, saveMissing: false, locales: ["en", "de"] });
+    await configureI18n({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en", "de"],
+      preloadLocales: [],
+    });
 
     render(<LocaleOptionsProbe />);
 
@@ -46,7 +51,12 @@ describe("locale switcher helpers", () => {
   });
 
   it("exposes locale options through a headless render prop component", async () => {
-    await configureI18n({ enabled: false, saveMissing: false, locales: ["en", "de"] });
+    await configureI18n({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en", "de"],
+      preloadLocales: [],
+    });
 
     render(
       <LocaleSwitcher label={(code) => code.toUpperCase()}>

--- a/resources/js/i18n/page-props.test.tsx
+++ b/resources/js/i18n/page-props.test.tsx
@@ -22,18 +22,36 @@ describe("page prop i18n helpers", () => {
     expect(
       i18nConfigFromPageProps({
         lattice: {
-          i18n: { enabled: false, saveMissing: false, locales: ["en", "de"] },
+          i18n: {
+            enabled: false,
+            saveMissing: false,
+            locales: ["en", "de"],
+            preloadLocales: ["en"],
+          },
         },
       }),
-    ).toEqual({ enabled: false, saveMissing: false, locales: ["en", "de"] });
+    ).toEqual({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en", "de"],
+      preloadLocales: ["en"],
+    });
 
     expect(i18nConfigFromPageProps({})).toBeUndefined();
+
+    expect(
+      i18nConfigFromPageProps({
+        lattice: {
+          i18n: { enabled: false, saveMissing: false, locales: ["en"] },
+        },
+      }),
+    ).toBeUndefined();
   });
 
   it("configures the locale store from Inertia page props", async () => {
     await configureI18nFromPageProps({
       lattice: {
-        i18n: { enabled: false, saveMissing: false, locales: ["en", "de"] },
+        i18n: { enabled: false, saveMissing: false, locales: ["en", "de"], preloadLocales: [] },
       },
     });
 

--- a/resources/js/i18n/page-props.ts
+++ b/resources/js/i18n/page-props.ts
@@ -4,13 +4,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
 function isI18nConfig(value: unknown): value is I18nConfig {
   return (
     isRecord(value) &&
     typeof value.enabled === "boolean" &&
     typeof value.saveMissing === "boolean" &&
-    Array.isArray(value.locales) &&
-    value.locales.every((locale) => typeof locale === "string")
+    isStringArray(value.locales) &&
+    isStringArray(value.preloadLocales)
   );
 }
 

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -574,6 +574,7 @@ export type I18nConfig = {
   readonly enabled: boolean;
   readonly saveMissing: boolean;
   readonly locales: string[];
+  readonly preloadLocales: string[];
 };
 export type Icon = {
   class: string | null;

--- a/src/Http/I18nConfig.php
+++ b/src/Http/I18nConfig.php
@@ -11,11 +11,13 @@ final readonly class I18nConfig implements JsonSerializable
 {
     /**
      * @param  array<int, string>  $locales
+     * @param  array<int, string>  $preloadLocales
      */
     public function __construct(
         public bool $enabled,
         public bool $saveMissing,
         public array $locales,
+        public array $preloadLocales,
     ) {}
 
     /**
@@ -26,12 +28,13 @@ final readonly class I18nConfig implements JsonSerializable
         return new self(
             enabled: (bool) config('i18next.routes.enabled', false),
             saveMissing: (bool) config('i18next.save_missing.enabled', false),
-            locales: $locales ?? self::configuredLocales(),
+            locales: $locales ?? self::configuredList('lattice.i18n.locales'),
+            preloadLocales: self::configuredList('lattice.i18n.preload_locales'),
         );
     }
 
     /**
-     * @return array{enabled: bool, saveMissing: bool, locales: array<int, string>}
+     * @return array{enabled: bool, saveMissing: bool, locales: array<int, string>, preloadLocales: array<int, string>}
      */
     public function jsonSerialize(): array
     {
@@ -39,15 +42,16 @@ final readonly class I18nConfig implements JsonSerializable
             'enabled' => $this->enabled,
             'saveMissing' => $this->saveMissing,
             'locales' => $this->locales,
+            'preloadLocales' => $this->preloadLocales,
         ];
     }
 
     /**
      * @return array<int, string>
      */
-    private static function configuredLocales(): array
+    private static function configuredList(string $key): array
     {
-        $configured = config('lattice.i18n.locales', []);
+        $configured = config($key, []);
 
         if (is_string($configured)) {
             $configured = [$configured];

--- a/tests/Browser/Forms/ProductFormTest.php
+++ b/tests/Browser/Forms/ProductFormTest.php
@@ -93,6 +93,7 @@ it('creates and edits a product through the form flow', function (): void {
         ->click('@form-submit')
         ->assertSee('Products')
         ->assertSee('Desk Lamp')
+        ->click('@product-actions')
         ->click('@product-edit')
         ->assertSee('Edit Product')
         ->assertValue('Name', 'Desk Lamp')

--- a/tests/Browser/LocaleSwitchTest.php
+++ b/tests/Browser/LocaleSwitchTest.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+use Workbench\App\Models\Product;
+
+it('switches the server-driven UI language in place when the locale changes', function (): void {
+    $this->actingAs(workbenchTestUser());
+    Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
+
+    visit('/products')
+        ->assertSee('Updated at')
+        ->click('@locale-de')
+        ->assertSee('Aktualisiert am')
+        ->assertDontSee('Updated at')
+        ->assertNoSmoke();
+});

--- a/tests/Browser/Tables/ProductsTableTest.php
+++ b/tests/Browser/Tables/ProductsTableTest.php
@@ -20,6 +20,7 @@ it('archives a product via the row action with confirmation', function (): void 
 
     visit('/products')
         ->assertSee('Desk Lamp')
+        ->click('@product-actions')
         ->click('@action-archive')
         ->assertSee('Archive product?')
         ->click('@confirm-accept')
@@ -34,6 +35,7 @@ it('cancels the archive confirmation without changing the product', function ():
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
+        ->click('@product-actions')
         ->click('@action-archive')
         ->assertSee('Archive product?')
         ->click('@confirm-cancel')
@@ -47,6 +49,7 @@ it('rejects a product through a modal form', function (): void {
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
+        ->click('@product-actions')
         ->click('@action-reject')
         ->assertSee('Reject product?')
         ->click('@action-form-submit')
@@ -80,6 +83,7 @@ it('edits a product in a prefilled modal form', function (): void {
 
     visit('/products')
         ->assertSee('Desk Lamp')
+        ->click('@product-actions')
         ->click('@action-edit-modal')
         ->assertSee('Edit product')
         ->assertValue('#name', 'Desk Lamp')
@@ -97,6 +101,7 @@ it('searches products inside the reject modal form', function (): void {
 
     visit('/products')
         ->assertSee('Desk Lamp')
+        ->click('@product-actions')
         ->click('@action-reject')
         ->assertSee('Reject product?')
         ->click('@select-replacement')

--- a/tests/Browser/ToastTest.php
+++ b/tests/Browser/ToastTest.php
@@ -8,6 +8,7 @@ it('shows a toast after an action and dismisses it', function (): void {
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
+        ->click('@product-actions')
         ->click('@action-archive')
         ->click('@confirm-accept')
         ->assertSee('Product archived.')
@@ -21,6 +22,7 @@ it('renders a link inside a toast', function (): void {
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
+        ->click('@product-actions')
         ->click('@action-archive')
         ->click('@confirm-accept')
         ->assertSee('Product archived.')
@@ -34,10 +36,12 @@ it('opens a modal form from a toast action', function (): void {
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
     visit('/products')
+        ->click('@product-actions')
         ->click('@action-edit-modal')
         ->assertValue('#name', 'Desk Lamp')
         ->click('@action-form-submit')
         ->assertSee('Product updated.')
+        ->click('@product-actions')
         ->click('@action-reject')
         ->assertSee('Reject product?')
         ->fill('@reason', 'Counterfeit listing')

--- a/tests/Feature/I18n/I18nextTranslationsTest.php
+++ b/tests/Feature/I18n/I18nextTranslationsTest.php
@@ -28,6 +28,7 @@ it('shares the i18n config to the frontend as a once prop', function () {
         ->where('lattice.i18n.enabled', true)
         ->where('lattice.i18n.saveMissing', true)
         ->where('lattice.i18n.locales', ['en', 'de'])
+        ->where('lattice.i18n.preloadLocales', ['en', 'de'])
         ->missing('lattice.i18n.loadPath')
         ->missing('lattice.i18n.addPath'),
     );

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -64,6 +64,7 @@ class WorkbenchServiceProvider extends ServiceProvider
             'i18next.namespaces' => true,
             'i18next.output' => 'nested',
             'lattice.i18n.locales' => ['en', 'de'],
+            'lattice.i18n.preload_locales' => ['en', 'de'],
         ]);
 
         // Point lang_path() at the package's lang/ dir so saveMissing dumps land in

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -5,6 +5,7 @@ namespace Workbench\App\Tables;
 
 use Illuminate\Database\Eloquent\Builder;
 use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Components\ActionGroup;
 use Lattice\Lattice\Actions\Components\BulkAction;
 use Lattice\Lattice\Attributes\Table;
 use Lattice\Lattice\Core\Components\Component;
@@ -107,14 +108,19 @@ class ProductsTable extends EloquentTableDefinition
     public function actions(array $row): array
     {
         return [
-            Link::make(__('workbench.tables.products.edit'), 'product-edit')
-                ->href('/products/'.$row['id'].'/edit'),
-            Action::use(EditProductAction::class)
-                ->context(['product_id' => $row['id']]),
-            Action::use(ArchiveProductAction::class)
-                ->context(['product_id' => $row['id']]),
-            Action::use(RejectProductAction::class)
-                ->context(['product_id' => $row['id']]),
+            ActionGroup::make('product-actions-'.$row['id'])
+                ->key('product-actions')
+                ->label(__('workbench.tables.products.actions'))
+                ->actions([
+                    Link::make(__('workbench.tables.products.edit'), 'product-edit')
+                        ->href('/products/'.$row['id'].'/edit'),
+                    Action::use(EditProductAction::class)
+                        ->context(['product_id' => $row['id']]),
+                    Action::use(ArchiveProductAction::class)
+                        ->context(['product_id' => $row['id']]),
+                    Action::use(RejectProductAction::class)
+                        ->context(['product_id' => $row['id']]),
+                ]),
         ];
     }
 

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -437,6 +437,7 @@ return [
             'updated-at' => 'Aktualisiert am',
         ],
         'products' => [
+            'actions' => 'Aktionen',
             'edit' => 'Bearbeiten',
         ],
     ],

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -437,6 +437,7 @@ return [
             'updated-at' => 'Updated at',
         ],
         'products' => [
+            'actions' => 'Actions',
             'edit' => 'Edit',
         ],
     ],


### PR DESCRIPTION
Two UX fixes surfaced while reviewing the commerce workbench.

## 1. Products table — actions overflow (`33ed45b`)
The products table rendered four inline row actions (edit link, edit modal, archive, reject), widening the actions column until it crowded the data columns. They're now wrapped in an `ActionGroup`, so each row shows a single `⋯` trigger that opens the actions in a dropdown.

- Also exposes a `data-test` handle on the `ActionGroup` dropdown trigger (mirroring `link.tsx`) so grouped actions stay reachable from browser tests; product action tests open the dropdown first.

## 2. Locale-change flicker (`c4fff3b`)
Switching locale flickered for two reasons, both fixed:

- **Full-page remount.** `LocaleReload` reloaded with `preserveState: false`, remounting the whole page tree (losing table sort/filter, form input, scroll, focus) just to swap in re-localized props. Defaulted to `preserveState: true` so the visit updates props in place. An audit confirmed no component snapshots translated props into state, so preserving state can't leave stale text; the prop stays overridable.
- **Fallback-language flash.** Client i18next switched language while the target namespace was still being fetched over HTTP. New `lattice.i18n.preload_locales` config (surfaced as `I18nConfig.preloadLocales`) loads those locales once in the background at startup, so a later `changeLanguage` resolves from the store. Empty by default (lazy); the workbench preloads en + de.

Docs updated for both the `LocaleReload` default and `preload_locales`.

## Testing
- `composer check` — Pint, PHPStan, **681 Pest** ✅
- `npm run check` — lint, format, tsc, type-coverage, Vitest, build:lib ✅
- Browser — products-table + toast action tests (10) and a new `LocaleSwitchTest` (DE switches server-driven labels in place, no JS errors) ✅