### PR TITLE
docs: document FileUpload and fix reference drift

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -80,6 +80,7 @@ export default defineConfig({
                 { label: "Number input", link: "/forms/fields/number-input/" },
                 { label: "Password input", link: "/forms/fields/password-input/" },
                 { label: "Hidden input", link: "/forms/fields/hidden-input/" },
+                { label: "File upload", link: "/forms/fields/file-upload/" },
                 { label: "Rich editor", link: "/forms/fields/rich-editor/" },
                 { label: "Repeater", link: "/forms/fields/repeater/" },
                 { label: "Builder", link: "/forms/fields/builder/" },

--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -3,6 +3,9 @@ title: Effects & results
 description: What an action returns — a success or failure result carrying effects the client dispatches.
 ---
 
+import Info from "@components/Info.astro";
+import Warning from "@components/Warning.astro";
+
 `handle()` returns an `ActionResult`: a success/failure flag, optional data, and a list of **effects**
 the client runs in order once the action responds.
 
@@ -102,10 +105,10 @@ public function schema(): array
 }
 ```
 
-:::caution
-A page or layout that does not include `Callouts::make()` silently drops any callout effect. If a
-callout does not appear, check that the active layout's `schema()` contains the slot.
-:::
+<Warning>
+  A page or layout that does not include `Callouts::make()` silently drops any callout effect. If a
+  callout does not appear, check that the active layout's `schema()` contains the slot.
+</Warning>
 
 **Callout vs. toast**
 
@@ -163,10 +166,10 @@ Effects::flash(
 The flashed effects are stored in the `latticeEffects` session bag, drained on the next request, and
 run through the normal client-side effect pipeline in order.
 
-:::note
-`Effects::flash()` replaces the old toast-only flash helper (`CreatesToastMessages` trait and
-`flash.toast` bag). Any code using that trait should switch to `Effects::flash(Effect::toast(...))`.
-:::
+<Info>
+  `Effects::flash()` replaces the old toast-only flash helper (`CreatesToastMessages` trait and
+  `flash.toast` bag). Any code using that trait should switch to `Effects::flash(Effect::toast(...))`.
+</Info>
 
 ## How effects reach the client
 

--- a/docs/content/docs/advanced/enums.md
+++ b/docs/content/docs/advanced/enums.md
@@ -75,6 +75,7 @@ The icon names a `Lattice\Lattice\Core\Enums\Icon` accepts are listed on the [Ic
 | ---------------- | ------------------------------------------------------------------------ |
 | `ColumnType`     | `Text` (text), `Stack` (stack), `Badge` (badge), `Icon` (icon), `Image` (image) |
 | `FilterType`     | `Text` (text), `Number` (number), `Date` (date), `Boolean` (boolean)     |
+| `FilterControl`  | `Select` (select), `Ternary` (ternary), `DateRange` (date-range), `Toggle` (toggle) |
 | `PaginationType` | `None` (none), `Simple` (simple), `Table` (table), `Infinite` (infinite) |
 | `SortDirection`  | `Asc` (asc), `Desc` (desc)                                               |
 
@@ -95,4 +96,3 @@ fields.
 `Toast` (toast), `Callout` (callout), `ReloadComponent` (reloadComponent), `ReloadPage` (reloadPage),
 `Redirect` (redirect), `Download` (download), `OpenModal` (openModal), `CloseModal` (closeModal),
 `ResetForm` (resetForm), `LocaleChange` (localeChange).
-</content>

--- a/docs/content/docs/forms/conditional-fields.mdx
+++ b/docs/content/docs/forms/conditional-fields.mdx
@@ -4,6 +4,7 @@ description: Show, require, or disable fields based on other fields, and compute
 ---
 
 import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
 
 Fields can react to the rest of the form. A condition compares another field's value and toggles this
 field's visibility, required, read-only, or disabled state. Conditions are evaluated on the client as
@@ -123,3 +124,33 @@ TextInput::make('total', 'Total')
         fn (TextInput $field, FormData $data) => $field->value($data->float('qty') * $data->float('price')),
     );
 ```
+
+A computed value is **authoritative** by default: the closure result overwrites whatever the user
+typed on every resolve and on submit, so the field reads as derived.
+
+## Editable defaults
+
+Pass `editable: true` to compute a **suggestion** instead — the value is applied as a default the user
+can then override by typing. Once a field is manually edited it stops tracking the computed value.
+
+```php
+TextInput::make('price', 'Price')
+    ->value(fn (FormData $data) => priceFor($data->get('product')), editable: true);
+```
+
+Two lists control when the suggestion re-applies:
+
+- `resetOn` — naming a field here **clears a manual override** when that field changes, so the
+  suggestion takes over again.
+- `refreshOn` — naming a field here **recomputes** the suggestion when that field changes, but only
+  while the user has not overridden it.
+
+```php
+TextInput::make('price', 'Price')
+    ->value(fn (FormData $data) => priceFor($data->get('product')), editable: true, resetOn: ['product']);
+```
+
+<Info>
+  Inside a [repeater or builder](/forms/fields/repeater/) row, a bare dependency name is row-relative;
+  prefix it with `@` (e.g. `@customer`) to watch a form-level field instead.
+</Info>

--- a/docs/content/docs/forms/fields/file-upload.mdx
+++ b/docs/content/docs/forms/fields/file-upload.mdx
@@ -1,0 +1,123 @@
+---
+title: File upload
+description: Upload files and images to a filesystem disk, with optional direct-to-S3 signed uploads.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
+import Warning from "@components/Warning.astro";
+
+The file upload field stores uploaded files on a filesystem disk and submits their paths. It supports
+single or multiple files, image-only mode, size and count limits, and direct-to-storage signed uploads.
+Create one with `FileUpload::make()`.
+
+<ComponentExample
+  php={`FileUpload::make('avatar', 'Avatar')
+    ->image()
+    ->maxSize(2048)`}
+  fixture="file-upload.basic"
+  values={{ avatar: null }}
+/>
+
+## Disk
+
+`->disk()` chooses the filesystem disk the field reads and writes. Without it the field uses the
+`lattice.files.disk` config value (defaulting to `public`).
+
+```php
+FileUpload::make('document')->disk('s3');
+```
+
+## Images
+
+`->image()` restricts the picker to images and renders an image-aware preview. It also defaults the
+accepted types to `image/*` unless you set them explicitly.
+
+```php
+FileUpload::make('avatar')->image();
+```
+
+## Accepted types and size
+
+`->acceptedFileTypes()` takes a list of MIME types or extensions for the file picker's `accept`
+attribute. `->maxSize()` caps each file's size in **kilobytes**.
+
+```php
+FileUpload::make('attachment')
+    ->acceptedFileTypes(['application/pdf', 'image/png'])
+    ->maxSize(5120);
+```
+
+## Multiple files
+
+`->multiple()` lets the field accept more than one file; it then submits an array of paths. `->maxFiles()`
+caps how many the form accepts.
+
+```php
+FileUpload::make('gallery', 'Gallery')
+    ->image()
+    ->multiple()
+    ->maxFiles(8);
+```
+
+## Signed (direct-to-storage) uploads
+
+By default files are uploaded through your form endpoint. `->signedUpload()` switches to **direct
+uploads**: the client asks the form endpoint for a short-lived signed URL, uploads straight to the
+disk (for example S3), and submits the resulting object key. This keeps large files off your PHP
+process. The disk must support temporary upload URLs.
+
+```php
+FileUpload::make('document')
+    ->disk('s3')
+    ->signedUpload();
+```
+
+<Info>
+  Signed-URL lifetime comes from `lattice.files.url_ttl` (minutes, default `5`) and temporary objects
+  are keyed under `lattice.files.temp_prefix` (default `tmp`).
+</Info>
+
+## Reading the value in `handle()`
+
+A submitted file arrives as an `UploadedFile` (or an array of them for `->multiple()`); a signed upload
+arrives as the object key string. Store it however you like:
+
+```php
+public function handle(Request $request): Response
+{
+    $data = $this->validate($request);
+
+    if (($data['avatar'] ?? null) instanceof UploadedFile) {
+        $data['avatar'] = $data['avatar']->store('avatars', 'public');
+    }
+
+    // persist $data['avatar'] ...
+}
+```
+
+## Removing existing files
+
+When a form is bound to a record, stored paths render as existing files the user can remove. Each
+existing file carries a **sealed token**, and the client posts the tokens of removed files under
+`{name}__removed[]`. Resolve them server-side with the static `FileUpload::removed()` helper, which
+unseals each token (skipping any forged, expired, or mismatched one) and returns the trusted disk
+paths to delete:
+
+```php
+foreach (FileUpload::removed($request, 'avatar') as $path) {
+    Storage::disk('public')->delete($path);
+}
+```
+
+<Warning title="Authorization">
+  `FileUpload::removed()` only returns paths whose token the server itself sealed for this field, so a
+  client cannot forge a path to delete. Always delete through it rather than trusting raw request input.
+  See [Security](/advanced/security/) for how sealed references work.
+</Warning>
+
+## Common options
+
+`FileUpload` shares label, required, disabled, read-only, and visibility options with every field — see
+[Fields](/forms/fields/overview/). For validation and conditional behavior, see
+[Validation](/forms/validation/) and [Conditional fields](/forms/conditional-fields/).

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -10,8 +10,9 @@ Fields are the building blocks of a form. Lattice ships
 [Select](/forms/fields/select/), [Choice](/forms/fields/choice/),
 [Checkbox](/forms/fields/checkbox/), [Date input](/forms/fields/date-input/),
 [Number input](/forms/fields/number-input/), [Password input](/forms/fields/password-input/),
-[Hidden input](/forms/fields/hidden-input/), [Rich editor](/forms/fields/rich-editor/),
-[Repeater](/forms/fields/repeater/), and [Builder](/forms/fields/builder/) — and you can add your own. Each field type has its own page for the options unique to it; this page covers the
+[Hidden input](/forms/fields/hidden-input/), [File upload](/forms/fields/file-upload/),
+[Rich editor](/forms/fields/rich-editor/), [Repeater](/forms/fields/repeater/), and
+[Builder](/forms/fields/builder/) — and you can add your own. Each field type has its own page for the options unique to it; this page covers the
 options every field shares.
 
 The submit button is not a field: the form renders it for you from `->submitLabel()`. See

--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -78,6 +78,19 @@ once a row carries more than one action they collapse into a ⋯ menu. Reorderin
 new position, and the table scrolls horizontally on narrow screens. The slide animation is skipped when
 the viewer prefers reduced motion.
 
+Call `->resizableColumns()` to let the user drag column borders to resize them; pass
+`showIndicator: true` to surface a drag handle on each border.
+
+```php
+Repeater::make('items', 'Line items')
+    ->schema([
+        TextInput::make('name', 'Name'),
+        TextInput::make('qty', 'Qty')->rules(['numeric']),
+    ])
+    ->table()
+    ->resizableColumns(showIndicator: true);
+```
+
 ## Row actions
 
 Every row carries an action menu. By default it holds just **Remove** (hidden while the row is at
@@ -122,13 +135,28 @@ Each child field's rules apply to every row through the `items.*.field` wildcard
 `minItems`/`maxItems` rules validate the number of rows independently of the per-row rules. See
 [Validation](/forms/validation/) for how field rules are resolved.
 
+## Row-scoped conditions
+
+Conditional rules on a child field resolve against the **other fields in the same row** first, falling
+back to form-level values. So `visibleWhen`, `requiredWhen`, `readOnlyWhen`, and `disabledWhen` on a
+row field compare against its siblings, and each row evaluates independently — the same client-side and
+on the server. See [Conditional fields](/forms/conditional-fields/) for the condition DSL.
+
+```php
+Repeater::make('items', 'Line items')
+    ->schema([
+        Select::make('type', 'Type')->options(['Fixed' => 'fixed', 'Hourly' => 'hourly']),
+        NumberInput::make('hours', 'Hours')
+            ->visibleWhen('type', 'hourly')
+            ->requiredWhen('type', 'hourly'),
+    ]);
+```
+
 ## Not yet supported (v1)
 
 These are follow-ups, not part of the first release:
 
 - Nested repeaters (a repeater inside a repeater row).
-- Row-scoped conditions — `visibleWhen`/`requiredWhen` evaluated against sibling fields inside the
-  same row.
 - Relationship auto-save (persisting rows straight to a related model).
 
 ## Common options

--- a/docs/content/docs/tables/columns.mdx
+++ b/docs/content/docs/tables/columns.mdx
@@ -90,3 +90,16 @@ sort and filter for that column. They are covered in detail under
 ```php
 TextColumn::make('name')->sortable()->filterable();
 ```
+
+## Column width
+
+Every column carries a width hint the table uses to size its column. `->width()` overrides the default
+with a [`ColumnWidth`](/advanced/enums/#text--sizing) case (`Lattice\Lattice\Core\Enums\ColumnWidth` —
+`Xs`, `Sm`, `Md`, `Lg`, `Xl`).
+
+```php
+use Lattice\Lattice\Core\Enums\ColumnWidth;
+
+TextColumn::make('id')->width(ColumnWidth::Xs);
+TextColumn::make('description')->width(ColumnWidth::Xl);
+```

--- a/docs/content/docs/tables/eloquent-tables.mdx
+++ b/docs/content/docs/tables/eloquent-tables.mdx
@@ -65,7 +65,7 @@ default order only when the user hasn't chosen a sort.
 your builder automatically, driven by the columns' capabilities:
 
 - A **filter** is applied only for a column that is [`filterable()`](/tables/sorting-filtering-pagination/#filtering),
-  using the column's [`FilterType`](/tables/sorting-filtering-pagination/#filter-types) to build the right `where`.
+  using the column's [`FilterType`](/tables/sorting-filtering-pagination/#filter-types-and-operators) to build the right `where`.
 - A **sort** becomes an `orderBy` on the column key.
 
 Because both map to the column **key**, a filterable or sortable column key must be a real database

--- a/docs/fixtures/file-upload.basic.json
+++ b/docs/fixtures/file-upload.basic.json
@@ -1,0 +1,29 @@
+[
+    {
+        "props": {
+            "accept": "image/*",
+            "columnWidth": "md",
+            "conditions": null,
+            "dependsOnAny": false,
+            "dependsOnKeys": null,
+            "disabled": false,
+            "files": null,
+            "helperText": null,
+            "hidden": false,
+            "image": true,
+            "label": "Avatar",
+            "maxFiles": null,
+            "maxSize": 2048,
+            "multiple": false,
+            "name": "avatar",
+            "prefill": false,
+            "prefillRefreshOn": null,
+            "prefillResetOn": null,
+            "readOnly": false,
+            "required": false,
+            "signed": false,
+            "value": null
+        },
+        "type": "form.file-upload"
+    }
+]

--- a/tests/Unit/Forms/Components/FileUploadTest.php
+++ b/tests/Unit/Forms/Components/FileUploadTest.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\FileUpload;
+
+describe('docs fixtures', function (): void {
+    it('dumps the file upload example', function (): void {
+        dumpFixture('file-upload.basic', [
+            FileUpload::make('avatar', 'Avatar')->image()->maxSize(2048),
+        ]);
+
+        expect('docs/fixtures/file-upload.basic.json')->toBeReadableFile();
+    });
+});


### PR DESCRIPTION
Fills documentation gaps for shipped features and fixes drift surfaced by a docs audit. Docs-only, plus one fixture-generating unit test.

## New
- **FileUpload field** — a full reference page (disk, image, accepted types/size, multiple, signed direct-to-storage uploads, reading the value in `handle()`, and the sealed-token `FileUpload::removed()` handler), wired into the sidebar and fields overview, backed by a generated fixture.

## Documented (were shipped but undocumented)
- `Column->width()` with the `ColumnWidth` enum.
- Repeater `->resizableColumns()`.
- Editable computed `->value()` (`editable`/`resetOn`/`refreshOn`), and that a plain computed value is authoritative.
- Repeater **row-scoped conditions** (previously listed as "not yet supported").

## Fixed drift
- Added the `FilterControl` enum to the enums reference and removed a stray `</content>` tag that rendered literally.
- Fixed the broken `#filter-types` anchor in the Eloquent tables page.
- Converted the effects reference to `.mdx` and switched raw `:::caution`/`:::note` asides to the `Info`/`Warning` components.

## Verification
- `npm run docs:build` passes.
- New `FileUploadTest` docs-fixture test passes; Pint + PHPStan clean.