### PR TITLE
refactor: drop redundant "lattice" from internal identifiers

### DIFF
--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -6,7 +6,7 @@ import type { Plugin, PluginOption, UserConfig } from "vite";
 
 type InlineDependency = string | RegExp;
 
-type LatticeUserConfig = UserConfig & {
+type ConfigWithTest = UserConfig & {
   test?: {
     server?: {
       deps?: {
@@ -28,14 +28,14 @@ export type LatticeViteOptions = {
   source?: boolean;
 };
 
-type LatticeRoots = {
+type Roots = {
   appRoot: string;
   root: string;
 };
 
 export function lattice(options: LatticeViteOptions = {}): PluginOption[] {
-  const plugins: PluginOption[] = [latticePlugin(options)];
-  const iconOptions = latticeIconOptions(options);
+  const plugins: PluginOption[] = [corePlugin(options)];
+  const iconOptions = resolveIconOptions(options);
 
   if (iconOptions) {
     plugins.push(svgSprite(iconOptions));
@@ -44,8 +44,8 @@ export function lattice(options: LatticeViteOptions = {}): PluginOption[] {
   return plugins;
 }
 
-export function latticeConfig(options: LatticeViteOptions = {}): LatticeUserConfig {
-  const { appRoot, root } = latticeRoots(options);
+export function latticeConfig(options: LatticeViteOptions = {}): ConfigWithTest {
+  const { appRoot, root } = resolveRoots(options);
 
   return {
     resolve: {
@@ -83,7 +83,7 @@ export function latticeConfig(options: LatticeViteOptions = {}): LatticeUserConf
   };
 }
 
-function latticePlugin(options: LatticeViteOptions): Plugin {
+function corePlugin(options: LatticeViteOptions): Plugin {
   return {
     name: "lattice",
     config() {
@@ -92,14 +92,14 @@ function latticePlugin(options: LatticeViteOptions): Plugin {
   };
 }
 
-function latticeIconOptions(options: LatticeViteOptions): SvgSpriteOptions | null {
+function resolveIconOptions(options: LatticeViteOptions): SvgSpriteOptions | null {
   const icons = options.icons ?? true;
 
   if (icons === false) {
     return null;
   }
 
-  const { root } = latticeRoots(options);
+  const { root } = resolveRoots(options);
   const iconOptions = icons === true ? {} : icons;
   const { dirs = [], dts, ...spriteOptions } = iconOptions;
   const defaultTypes = {
@@ -115,7 +115,7 @@ function latticeIconOptions(options: LatticeViteOptions): SvgSpriteOptions | nul
   };
 }
 
-function latticeRoots(options: LatticeViteOptions): LatticeRoots {
+function resolveRoots(options: LatticeViteOptions): Roots {
   const appRoot = options.appRoot ?? process.cwd();
   const root = options.root ?? path.resolve(appRoot, "vendor/lattice-php/lattice");
 

--- a/src/Core/Concerns/InteractsWithComponents.php
+++ b/src/Core/Concerns/InteractsWithComponents.php
@@ -7,9 +7,9 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Core\Contracts\DefinitionRegistry;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Core\Definition;
-use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Core\Exceptions\UnknownComponent;
 
-trait InteractsWithLatticeComponents
+trait InteractsWithComponents
 {
     /**
      * @template TDefinition of Definition
@@ -28,7 +28,7 @@ trait InteractsWithLatticeComponents
 
         try {
             $definition = $registry->resolve($key);
-        } catch (UnknownLatticeComponent) {
+        } catch (UnknownComponent) {
             abort(404);
         }
 

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 use Lattice\Lattice\Attributes\ComponentAttribute;
 use Lattice\Lattice\Core\Contracts\DefinitionRegistry as DefinitionRegistryContract;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
-use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Core\Exceptions\UnknownComponent;
 use Spatie\Attributes\Attributes;
 
 /**
@@ -61,7 +61,7 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract
         $definitions = $this->definitions();
 
         if (! array_key_exists($key, $definitions)) {
-            throw new UnknownLatticeComponent($this->name(), $key);
+            throw new UnknownComponent($this->name(), $key);
         }
 
         return $this->make($definitions[$key]);

--- a/src/Core/Exceptions/UnknownComponent.php
+++ b/src/Core/Exceptions/UnknownComponent.php
@@ -5,7 +5,7 @@ namespace Lattice\Lattice\Core\Exceptions;
 
 use InvalidArgumentException;
 
-final class UnknownLatticeComponent extends InvalidArgumentException
+final class UnknownComponent extends InvalidArgumentException
 {
     public function __construct(
         public readonly string $type,

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -5,7 +5,7 @@ namespace Lattice\Lattice\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\ActionRegistry;
-use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
+use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
@@ -15,7 +15,7 @@ final class ActionController
 {
     use HandlesFormSubRequests;
     use HandlesPrecognition;
-    use InteractsWithLatticeComponents;
+    use InteractsWithComponents;
 
     public function __construct(
         private readonly ActionRegistry $actions,

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -6,9 +6,9 @@ namespace Lattice\Lattice\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\BulkActionRegistry;
-use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
+use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
-use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Core\Exceptions\UnknownComponent;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
 use Lattice\Lattice\Tables\TableDefinition;
@@ -20,7 +20,7 @@ final class BulkActionController
 {
     use HandlesFormSubRequests;
     use HandlesPrecognition;
-    use InteractsWithLatticeComponents;
+    use InteractsWithComponents;
 
     public function __construct(
         private readonly BulkActionRegistry $bulkActions,
@@ -81,7 +81,7 @@ final class BulkActionController
     {
         try {
             return $this->tables->resolve($key);
-        } catch (UnknownLatticeComponent) {
+        } catch (UnknownComponent) {
             abort(404);
         }
     }

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -6,7 +6,7 @@ namespace Lattice\Lattice\Http\Controllers;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
+use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Http\Controllers\Concerns\HandlesPrecognition;
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 final class FormController
 {
     use HandlesPrecognition;
-    use InteractsWithLatticeComponents;
+    use InteractsWithComponents;
 
     public function __construct(
         private readonly FormRegistry $forms,

--- a/src/Http/Controllers/FragmentController.php
+++ b/src/Http/Controllers/FragmentController.php
@@ -5,13 +5,13 @@ namespace Lattice\Lattice\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
+use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 
 final class FragmentController
 {
-    use InteractsWithLatticeComponents;
+    use InteractsWithComponents;
 
     public function __construct(
         private readonly FragmentRegistry $fragments,

--- a/src/Http/Controllers/TableController.php
+++ b/src/Http/Controllers/TableController.php
@@ -5,13 +5,13 @@ namespace Lattice\Lattice\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Lattice\Lattice\Core\Concerns\InteractsWithLatticeComponents;
+use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Tables\TableRegistry;
 
 final class TableController
 {
-    use InteractsWithLatticeComponents;
+    use InteractsWithComponents;
 
     public function __construct(
         private readonly TableRegistry $tables,

--- a/tests/Feature/Http/LatticeLayoutTest.php
+++ b/tests/Feature/Http/LatticeLayoutTest.php
@@ -7,7 +7,7 @@ use Lattice\Lattice\Attributes\Page as PageAttr;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
-use Lattice\Lattice\Core\Exceptions\UnknownLatticeComponent;
+use Lattice\Lattice\Core\Exceptions\UnknownComponent;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Http\Page;
@@ -61,7 +61,7 @@ test('the layout registry resolves a registered layout to its wire schema', func
 
 test('the layout registry rejects an unregistered layout key', function () {
     expect(fn () => app(LayoutRegistry::class)->render('missing', new Request))
-        ->toThrow(UnknownLatticeComponent::class);
+        ->toThrow(UnknownComponent::class);
 });
 
 test('a page serializes its layout as key and schema with an outlet', function () {


### PR DESCRIPTION
Naming cleanup: remove the word "lattice" from identifiers where the namespace already supplies the context. We're in alpha, so public-API breakage is acceptable — but a full review showed almost all `lattice` usage is **legitimate namespacing** and was deliberately left intact.

## Renamed (redundant internal)
- `UnknownLatticeComponent` → `UnknownComponent`
- `InteractsWithLatticeComponents` → `InteractsWithComponents`
- `vite.ts` internals: `LatticeUserConfig`→`ConfigWithTest`, `LatticeRoots`→`Roots`, `latticeRoots`→`resolveRoots`, `latticePlugin`→`corePlugin`, `latticeIconOptions`→`resolveIconOptions`

## Deliberately kept (legitimate namespacing / public / wire contracts)
- The `Lattice\Lattice` namespace and `X-Lattice-Ref` header (hard constraints).
- Public API: the `Lattice` facade, `LatticeServiceProvider`, the Vite plugin `lattice()`/`latticeConfig()` + option types, the public test trait `AssertsLatticeComponents` + `assertLattice*` (prefix disambiguates in consumer suites).
- Wire/namespacing tokens: `lattice` config key, `/lattice/*` routes, `lattice:*` artisan commands, `@lattice-php/lattice` package, `latticeEffects`/`lattice` Inertia keys, `lattice:*` events, `lt-`/`data-lattice-*` DOM+CSS prefixes, the i18n namespace, and user-facing message strings.

## Verification
- `composer check`: Pint, PHPStan (no errors), Pest 682 passed.
- `npm run check`: lint, format, tsc, type-coverage, Vitest, build — all pass.