### PR TITLE
refactor(http): funnel raw-fetch through core/api

### DIFF
--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { withHeaders } from "@lattice-php/lattice/core/headers";
+import { apiFetch } from "@lattice-php/lattice/core/api";
 import { Button } from "@lattice-php/lattice/core/components/button";
 import { Dialog, DialogContent, DialogHeader } from "@lattice-php/lattice/core/components/dialog";
 import { Skeleton } from "@lattice-php/lattice/core/components/skeleton";
@@ -8,7 +8,7 @@ import { Renderer, useRendererContext } from "@lattice-php/lattice/core/renderer
 import type { Node } from "@lattice-php/lattice/core/types";
 import { FormProvider } from "@lattice-php/lattice/form/components/context";
 import { walkFields } from "@lattice-php/lattice/form/components/field-props";
-import { FORM_DEBOUNCE_MS, xsrfToken } from "@lattice-php/lattice/form/components/form-transport";
+import { FORM_DEBOUNCE_MS } from "@lattice-php/lattice/form/components/form-transport";
 import { PrefillProvider } from "@lattice-php/lattice/form/components/prefill-context";
 import { ResolvedNodesProvider } from "@lattice-php/lattice/form/components/resolved-nodes";
 import { useFormResolver } from "@lattice-php/lattice/form/components/use-form-resolver";
@@ -35,16 +35,6 @@ type ActionFormProps = {
   title: string;
 };
 
-function jsonHeaders(componentRef: string, extra?: Record<string, string>): Record<string, string> {
-  return withHeaders(componentRef, {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    "X-Requested-With": "XMLHttpRequest",
-    "X-XSRF-TOKEN": xsrfToken(),
-    ...extra,
-  });
-}
-
 /**
  * Fetch a lazily-served form schema from the action endpoint while `enabled`,
  * so it can be prefilled per record. Returns null until it arrives.
@@ -66,12 +56,12 @@ export function useLazyActionForm(
 
     const controller = new AbortController();
 
-    void fetch(endpoint, {
+    void apiFetch(endpoint, {
       body: JSON.stringify({ _form: true }),
-      credentials: "same-origin",
-      headers: jsonHeaders(componentRef),
+      ref: componentRef,
       method: method.toUpperCase(),
       signal: controller.signal,
+      throwOnError: false,
     })
       .then((response) => (response.ok ? (response.json() as Promise<Node>) : null))
       .then((fetched) => setNode(fetched))
@@ -165,13 +155,14 @@ function ActionFormBody({
 
   const request = useCallback(
     (extraHeaders?: Record<string, string>): Promise<Response> =>
-      fetch(endpoint, {
+      apiFetch(endpoint, {
         body: JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
-        credentials: "same-origin",
         // fetch only upper-cases the standardized methods, leaving PATCH/DELETE as
         // given; some servers reject a lower-case method line, so normalize it.
         method: method.toUpperCase(),
-        headers: jsonHeaders(componentRef, extraHeaders),
+        ref: componentRef,
+        headers: extraHeaders,
+        throwOnError: false,
       }),
     [componentRef, endpoint, method],
   );

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -59,7 +59,7 @@ export function useLazyActionForm(
     void apiFetch(endpoint, {
       body: JSON.stringify({ _form: true }),
       ref: componentRef,
-      method: method.toUpperCase(),
+      method,
       signal: controller.signal,
       throwOnError: false,
     })
@@ -157,9 +157,7 @@ function ActionFormBody({
     (extraHeaders?: Record<string, string>): Promise<Response> =>
       apiFetch(endpoint, {
         body: JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
-        // fetch only upper-cases the standardized methods, leaving PATCH/DELETE as
-        // given; some servers reject a lower-case method line, so normalize it.
-        method: method.toUpperCase(),
+        method,
         ref: componentRef,
         headers: extraHeaders,
         throwOnError: false,

--- a/resources/js/chat/components/chat-window.tsx
+++ b/resources/js/chat/components/chat-window.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { apiFetch } from "@lattice-php/lattice/core/api";
 import { testIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { Button } from "@lattice-php/lattice/core/components/button";
@@ -27,11 +28,7 @@ export const ChatWindow: RendererComponent<"chat.window"> = ({ node }) => {
 
     seededRef.current = true;
 
-    const response = await fetch(historyEndpoint, {
-      method: "GET",
-      credentials: "same-origin",
-      headers: { Accept: "application/json" },
-    });
+    const response = await apiFetch(historyEndpoint, { throwOnError: false });
 
     if (!response.ok) {
       return;

--- a/resources/js/chat/transport.ts
+++ b/resources/js/chat/transport.ts
@@ -1,4 +1,4 @@
-import { jsonPostHeaders, withHeaders } from "../core/headers";
+import { apiFetch } from "../core/api";
 import type { ChatFrame, ChatTransportRequest } from "./types";
 
 function parseFrame(line: string): ChatFrame | null {
@@ -14,12 +14,12 @@ export async function* ndjsonChatTransport({
   body,
   signal,
 }: ChatTransportRequest): AsyncGenerator<ChatFrame> {
-  const res = await fetch(url, {
+  const res = await apiFetch(url, {
     method: "POST",
-    credentials: "same-origin",
     signal,
-    headers: withHeaders(undefined, jsonPostHeaders("application/x-ndjson")),
+    headers: { Accept: "application/x-ndjson" },
     body: JSON.stringify(body),
+    throwOnError: false,
   });
 
   if (!res.ok || !res.body) {

--- a/resources/js/core/api.test.ts
+++ b/resources/js/core/api.test.ts
@@ -53,6 +53,15 @@ describe("apiFetch", () => {
     });
   });
 
+  it("sends an empty csrf token on a write when no XSRF-TOKEN cookie is present", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x", { method: "POST" });
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({ "X-XSRF-TOKEN": "" });
+  });
+
   it("lets the caller override a defaulted header", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
     vi.stubGlobal("fetch", fetchMock);

--- a/resources/js/core/api.test.ts
+++ b/resources/js/core/api.test.ts
@@ -65,6 +65,17 @@ describe("apiFetch", () => {
     });
   });
 
+  it("upper-cases the request method so a lower-case verb is normalized", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x", { method: "patch" });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("PATCH");
+    expect(init.headers).toMatchObject({ "X-Requested-With": "XMLHttpRequest" });
+  });
+
   it("passes through body and signal", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
     vi.stubGlobal("fetch", fetchMock);

--- a/resources/js/core/api.test.ts
+++ b/resources/js/core/api.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, apiFetch, apiJson } from "./api";
+
+function okResponse(body: unknown = {}): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.cookie = "XSRF-TOKEN=;path=/;max-age=0";
+});
+
+describe("apiFetch", () => {
+  it("sends same-origin credentials and composes the locale and ref headers", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x", { ref: "sealed-ref" });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.credentials).toBe("same-origin");
+    expect(init.headers).toMatchObject({
+      "Accept-Language": "en",
+      "X-Lattice-Ref": "sealed-ref",
+      Accept: "application/json",
+    });
+  });
+
+  it("defaults a GET to a json Accept without csrf or content-type headers", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x");
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toEqual({
+      "Accept-Language": "en",
+      Accept: "application/json",
+    });
+  });
+
+  it("adds the json content-type, ajax marker, and csrf token for write methods", async () => {
+    document.cookie = "XSRF-TOKEN=tok%20en";
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x", { method: "POST" });
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Requested-With": "XMLHttpRequest",
+      "X-XSRF-TOKEN": "tok en",
+    });
+  });
+
+  it("lets the caller override a defaulted header", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x", { method: "POST", headers: { Accept: "application/x-ndjson" } });
+
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      Accept: "application/x-ndjson",
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("passes through body and signal", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const signal = new AbortController().signal;
+
+    await apiFetch("/x", { method: "POST", body: "payload", signal });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe("payload");
+    expect(init.signal).toBe(signal);
+  });
+
+  it("throws ApiError on a non-ok response by default", async () => {
+    const response = { ok: false, status: 500 } as unknown as Response;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => response),
+    );
+
+    const error = await apiFetch("/x").catch((reason: unknown) => reason);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).response).toBe(response);
+    expect((error as ApiError).message).toBe("HTTP 500");
+  });
+
+  it("returns the response on a non-ok status when throwOnError is false", async () => {
+    const response = { ok: false, status: 404 } as unknown as Response;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => response),
+    );
+
+    await expect(apiFetch("/x", { throwOnError: false })).resolves.toBe(response);
+  });
+});
+
+describe("apiJson", () => {
+  it("parses the response body as json", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => okResponse({ value: 42 })),
+    );
+
+    await expect(apiJson<{ value: number }>("/x")).resolves.toEqual({ value: 42 });
+  });
+
+  it("throws ApiError before parsing when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => ({ ok: false, status: 422 }) as unknown as Response),
+    );
+
+    await expect(apiJson("/x")).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -1,0 +1,64 @@
+/**
+ * The single funnel for raw-fetch HTTP in the package. Callers pass a URL plus
+ * overrides; this owns the cross-cutting header policy so call sites only
+ * declare intent. It always sends same-origin credentials, defaults the Accept
+ * (and, for write methods, the Content-Type) to JSON, adds the AJAX marker and
+ * CSRF token to writes, composes the locale + component-ref headers (via
+ * withHeaders), and throws on a failed response unless opted out.
+ *
+ * Returning a Response keeps one primitive serving JSON, the chat's streaming
+ * getReader(), and multipart uniformly. Any default header can be overridden
+ * through `headers` (e.g. a non-JSON Accept, or a body the browser must type).
+ * Leave the Inertia world (router/useHttp) alone — this is for raw-data fetches.
+ */
+
+import { withHeaders, xsrfToken } from "./headers";
+
+export class ApiError extends Error {
+  constructor(readonly response: Response) {
+    super(`HTTP ${response.status}`);
+  }
+}
+
+export type ApiInit = Omit<RequestInit, "headers"> & {
+  /** Sent as the X-Lattice-Ref header; the locale header is always added. */
+  ref?: string;
+  /** Merged over the defaulted headers, so callers can override any of them. */
+  headers?: Record<string, string>;
+  /** Throw an ApiError on a non-ok response. Defaults to true. */
+  throwOnError?: boolean;
+};
+
+function defaultHeaders(method: string | undefined): Record<string, string> {
+  const isWrite = method !== undefined && !["GET", "HEAD"].includes(method.toUpperCase());
+
+  if (!isWrite) {
+    return { Accept: "application/json" };
+  }
+
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-Requested-With": "XMLHttpRequest",
+    "X-XSRF-TOKEN": xsrfToken(),
+  };
+}
+
+export async function apiFetch(url: string, init: ApiInit = {}): Promise<Response> {
+  const { ref, headers, throwOnError = true, ...rest } = init;
+  const response = await fetch(url, {
+    credentials: "same-origin",
+    ...rest,
+    headers: withHeaders(ref ?? "", { ...defaultHeaders(rest.method), ...headers }),
+  });
+
+  if (throwOnError && !response.ok) {
+    throw new ApiError(response);
+  }
+
+  return response;
+}
+
+export async function apiJson<T>(url: string, init?: ApiInit): Promise<T> {
+  return (await apiFetch(url, init)).json() as Promise<T>;
+}

--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -30,7 +30,7 @@ export type ApiInit = Omit<RequestInit, "headers"> & {
 };
 
 function defaultHeaders(method: string | undefined): Record<string, string> {
-  const isWrite = method !== undefined && !["GET", "HEAD"].includes(method.toUpperCase());
+  const isWrite = method !== undefined && method !== "GET" && method !== "HEAD";
 
   if (!isWrite) {
     return { Accept: "application/json" };
@@ -45,11 +45,15 @@ function defaultHeaders(method: string | undefined): Record<string, string> {
 }
 
 export async function apiFetch(url: string, init: ApiInit = {}): Promise<Response> {
-  const { ref, headers, throwOnError = true, ...rest } = init;
+  const { ref, headers, throwOnError = true, method, ...rest } = init;
+  // fetch only upper-cases the standardized verbs, leaving PATCH/DELETE as given;
+  // some servers reject a lower-case method line, so normalize it here.
+  const normalizedMethod = method?.toUpperCase();
   const response = await fetch(url, {
     credentials: "same-origin",
     ...rest,
-    headers: withHeaders(ref ?? "", { ...defaultHeaders(rest.method), ...headers }),
+    method: normalizedMethod,
+    headers: withHeaders(ref ?? "", { ...defaultHeaders(normalizedMethod), ...headers }),
   });
 
   if (throwOnError && !response.ok) {

--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -12,12 +12,18 @@
  * Leave the Inertia world (router/useHttp) alone — this is for raw-data fetches.
  */
 
-import { withHeaders, xsrfToken } from "./headers";
+import { withHeaders } from "./headers";
 
 export class ApiError extends Error {
   constructor(readonly response: Response) {
     super(`HTTP ${response.status}`);
   }
+}
+
+function xsrfToken(): string {
+  const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+
+  return match ? decodeURIComponent(match[1]) : "";
 }
 
 export type ApiInit = Omit<RequestInit, "headers"> & {

--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -1,15 +1,9 @@
 /**
- * The single funnel for raw-fetch HTTP in the package. Callers pass a URL plus
- * overrides; this owns the cross-cutting header policy so call sites only
- * declare intent. It always sends same-origin credentials, defaults the Accept
- * (and, for write methods, the Content-Type) to JSON, adds the AJAX marker and
- * CSRF token to writes, composes the locale + component-ref headers (via
- * withHeaders), and throws on a failed response unless opted out.
- *
- * Returning a Response keeps one primitive serving JSON, the chat's streaming
- * getReader(), and multipart uniformly. Any default header can be overridden
- * through `headers` (e.g. a non-JSON Accept, or a body the browser must type).
- * Leave the Inertia world (router/useHttp) alone — this is for raw-data fetches.
+ * The single funnel for raw-fetch HTTP, so the cross-cutting header, credential,
+ * and error policy has one home and call sites only declare intent. Returns a
+ * Response (not parsed data) so one primitive serves JSON, the chat's streaming
+ * getReader(), and multipart alike. Not for the Inertia world (router/useHttp),
+ * which carries its own headers.
  */
 
 import { withHeaders } from "./headers";
@@ -27,11 +21,8 @@ function xsrfToken(): string {
 }
 
 export type ApiInit = Omit<RequestInit, "headers"> & {
-  /** Sent as the X-Lattice-Ref header; the locale header is always added. */
   ref?: string;
-  /** Merged over the defaulted headers, so callers can override any of them. */
   headers?: Record<string, string>;
-  /** Throw an ApiError on a non-ok response. Defaults to true. */
   throwOnError?: boolean;
 };
 
@@ -52,8 +43,8 @@ function defaultHeaders(method: string | undefined): Record<string, string> {
 
 export async function apiFetch(url: string, init: ApiInit = {}): Promise<Response> {
   const { ref, headers, throwOnError = true, method, ...rest } = init;
-  // fetch only upper-cases the standardized verbs, leaving PATCH/DELETE as given;
-  // some servers reject a lower-case method line, so normalize it here.
+  // Some servers reject a lower-case method line, and fetch only normalizes the
+  // standard verbs, so upper-case it here.
   const normalizedMethod = method?.toUpperCase();
   const response = await fetch(url, {
     credentials: "same-origin",

--- a/resources/js/core/components/fragment.tsx
+++ b/resources/js/core/components/fragment.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { withHeaders } from "@lattice-php/lattice/core/headers";
+import { apiJson } from "@lattice-php/lattice/core/api";
 import { Skeleton } from "@lattice-php/lattice/core/components/skeleton";
 import { Renderer, useRendererContext } from "@lattice-php/lattice/core/renderer";
 import type { Node, RendererComponent, Schema } from "@lattice-php/lattice/core/types";
@@ -37,12 +37,7 @@ const FragmentComponent: RendererComponent<"fragment"> = ({ node }) => {
     setProcessing(true);
 
     try {
-      const response = await fetch(endpoint, {
-        headers: withHeaders(componentRef, {
-          Accept: "application/json",
-        }),
-      });
-      const result = (await response.json()) as FragmentResponse;
+      const result = await apiJson<FragmentResponse>(endpoint, { ref: componentRef });
 
       setComponents(getComponents(result.schema));
       setHasLoaded(true);

--- a/resources/js/core/components/modal-fragment.test.tsx
+++ b/resources/js/core/components/modal-fragment.test.tsx
@@ -150,6 +150,7 @@ describe("Lattice modal and fragment components", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith("/lattice/fragments/settings.two-factor-setup", {
+      credentials: "same-origin",
       headers: {
         Accept: "application/json",
         "Accept-Language": "en",

--- a/resources/js/core/headers.test.ts
+++ b/resources/js/core/headers.test.ts
@@ -3,7 +3,6 @@ import { afterEach, expect, it, vi } from "vitest";
 afterEach(() => {
   localStorage.clear();
   document.cookie = "locale=;path=/;max-age=0";
-  document.cookie = "XSRF-TOKEN=;path=/;max-age=0";
   document.documentElement.lang = "";
   vi.resetModules();
 });
@@ -25,17 +24,4 @@ it("omits the component reference header when no reference is available", async 
   const { withHeaders } = await import("./headers");
 
   expect(withHeaders()).toEqual({ "Accept-Language": "en" });
-});
-
-it("reads and decodes the XSRF-TOKEN cookie", async () => {
-  document.cookie = "XSRF-TOKEN=ab%20cd";
-  const { xsrfToken } = await import("./headers");
-
-  expect(xsrfToken()).toBe("ab cd");
-});
-
-it("returns an empty token when no XSRF-TOKEN cookie is present", async () => {
-  const { xsrfToken } = await import("./headers");
-
-  expect(xsrfToken()).toBe("");
 });

--- a/resources/js/core/headers.ts
+++ b/resources/js/core/headers.ts
@@ -17,12 +17,3 @@ export function xsrfToken(): string {
 
   return match ? decodeURIComponent(match[1]) : "";
 }
-
-export function jsonPostHeaders(accept: string): Record<string, string> {
-  return {
-    "Content-Type": "application/json",
-    Accept: accept,
-    "X-Requested-With": "XMLHttpRequest",
-    "X-XSRF-TOKEN": xsrfToken(),
-  };
-}

--- a/resources/js/core/headers.ts
+++ b/resources/js/core/headers.ts
@@ -11,9 +11,3 @@ export function withHeaders(
     ...headers,
   };
 }
-
-export function xsrfToken(): string {
-  const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
-
-  return match ? decodeURIComponent(match[1]) : "";
-}

--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -1,11 +1,10 @@
-import { withRefHeader } from "@lattice-php/lattice/core/component-ref";
+import { apiFetch } from "@lattice-php/lattice/core/api";
 import { testIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { useT } from "@lattice-php/lattice/i18n";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
-import { xsrfToken } from "../form-transport";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldScope } from "../field-scope";
 import { useFormValues } from "../values";
@@ -80,22 +79,16 @@ export const FileUploadComponent: RendererComponent<"form.file-upload"> = ({ nod
   });
 
   async function signAndUpload(item: Item, file: File): Promise<void> {
-    const response = await fetch(action, {
+    const response = await apiFetch(action, {
       method: "POST",
-      credentials: "same-origin",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-        "X-Requested-With": "XMLHttpRequest",
-        "X-XSRF-TOKEN": xsrfToken(),
-        ...withRefHeader(componentRef),
-      },
+      ref: componentRef,
       body: JSON.stringify({
         ...values,
         _upload: uploadKey,
         filename: file.name,
         contentType: file.type,
       }),
+      throwOnError: false,
     });
 
     if (!response.ok) {

--- a/resources/js/form/components/form-transport.ts
+++ b/resources/js/form/components/form-transport.ts
@@ -1,7 +1,7 @@
 /**
- * Shared client transport for the lattice form endpoint. Every form sub-action
- * (validation resolve, option search) POSTs to the same signed form URL, so the
- * CSRF header, component-ref header, and request shape live here in one place.
+ * Shared client transport for the lattice form endpoint: every form sub-action
+ * (validation resolve, option search) POSTs to the same signed URL, so the
+ * request shape — notably stripping client-only row ids — lives here once.
  */
 
 import { apiFetch } from "@lattice-php/lattice/core/api";

--- a/resources/js/form/components/form-transport.ts
+++ b/resources/js/form/components/form-transport.ts
@@ -4,12 +4,10 @@
  * CSRF header, component-ref header, and request shape live here in one place.
  */
 
-import { jsonPostHeaders, withHeaders, xsrfToken } from "@lattice-php/lattice/core/headers";
+import { apiFetch } from "@lattice-php/lattice/core/api";
 import { ROW_ID_KEY } from "./fields/repeater-rows";
 
 export const FORM_DEBOUNCE_MS = 250;
-
-export { xsrfToken };
 
 function scrubFormPayload(value: unknown): unknown {
   if (Array.isArray(value)) {
@@ -38,11 +36,11 @@ export function postFormAction<T>(
   body: Record<string, unknown>,
   signal: AbortSignal,
 ): Promise<T | null> {
-  return fetch(action, {
+  return apiFetch(action, {
     method: "POST",
-    credentials: "same-origin",
+    ref: componentRef,
     signal,
-    headers: withHeaders(componentRef, jsonPostHeaders("application/json")),
     body: JSON.stringify(scrubFormPayload(body)),
+    throwOnError: false,
   }).then((response) => (response.ok ? (response.json() as Promise<T>) : null));
 }

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -396,6 +396,7 @@ describe("Lattice table component", () => {
       expect(fetch).toHaveBeenCalledWith(
         "/lattice/tables/workbench.users?sort=name%2Cemail&page=1&per_page=25",
         {
+          credentials: "same-origin",
           headers: {
             Accept: "application/json",
             "Accept-Language": "en",
@@ -412,6 +413,7 @@ describe("Lattice table component", () => {
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.users?sort=name&page=1&per_page=25",
         {
+          credentials: "same-origin",
           headers: {
             Accept: "application/json",
             "Accept-Language": "en",
@@ -468,6 +470,7 @@ describe("Lattice table component", () => {
       expect(fetch).toHaveBeenCalledWith(
         "/lattice/tables/teams.members?sort=name&page=1&per_page=25",
         {
+          credentials: "same-origin",
           headers: {
             Accept: "application/json",
             "Accept-Language": "en",
@@ -532,6 +535,7 @@ describe("Lattice table component", () => {
     await screen.findByRole("cell", { name: "Ada" });
 
     expect(fetch).toHaveBeenCalledWith("/lattice/tables/settings.passkeys?page=1&per_page=25", {
+      credentials: "same-origin",
       headers: {
         Accept: "application/json",
         "Accept-Language": "en",
@@ -619,6 +623,7 @@ describe("Lattice table component", () => {
 
     expect(screen.getByRole("cell", { name: "Taylor" })).toBeVisible();
     expect(fetch).toHaveBeenNthCalledWith(1, "/lattice/tables/workbench.users?page=2&per_page=1", {
+      credentials: "same-origin",
       headers: {
         Accept: "application/json",
         "Accept-Language": "en",
@@ -635,6 +640,7 @@ describe("Lattice table component", () => {
       2,
       "/lattice/tables/workbench.users?sort=name&page=1&per_page=1",
       {
+        credentials: "same-origin",
         headers: {
           Accept: "application/json",
           "Accept-Language": "en",
@@ -741,6 +747,7 @@ describe("Lattice table component", () => {
     await screen.findByRole("cell", { name: "Grace" });
 
     expect(fetch).toHaveBeenCalledWith("/lattice/tables/workbench.users?page=3&per_page=1", {
+      credentials: "same-origin",
       headers: {
         Accept: "application/json",
         "Accept-Language": "en",
@@ -802,6 +809,7 @@ describe("Lattice table component", () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith("/lattice/tables/workbench.users.none?page=1&per_page=25", {
+      credentials: "same-origin",
       headers: {
         Accept: "application/json",
         "Accept-Language": "en",
@@ -883,7 +891,10 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=featured%3Aeq%3Atrue&page=1&per_page=25",
-        { headers: { Accept: "application/json", "Accept-Language": "en" } },
+        {
+          credentials: "same-origin",
+          headers: { Accept: "application/json", "Accept-Language": "en" },
+        },
       ),
     );
 
@@ -893,7 +904,10 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=updated_at%3Aeq%3A2026-06-01&page=1&per_page=25",
-        { headers: { Accept: "application/json", "Accept-Language": "en" } },
+        {
+          credentials: "same-origin",
+          headers: { Accept: "application/json", "Accept-Language": "en" },
+        },
       ),
     );
 
@@ -903,7 +917,10 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=name%3Acontains%3ALamp&page=1&per_page=25",
-        { headers: { Accept: "application/json", "Accept-Language": "en" } },
+        {
+          credentials: "same-origin",
+          headers: { Accept: "application/json", "Accept-Language": "en" },
+        },
       ),
     );
   });
@@ -979,7 +996,10 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=name%3Aneq%3Abar&page=1&per_page=25",
-        { headers: { Accept: "application/json", "Accept-Language": "en" } },
+        {
+          credentials: "same-origin",
+          headers: { Accept: "application/json", "Accept-Language": "en" },
+        },
       ),
     );
   });

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -1,4 +1,4 @@
-import { withHeaders } from "@lattice-php/lattice/core/headers";
+import { apiFetch, apiJson } from "@lattice-php/lattice/core/api";
 import { LATTICE_EVENT, type ReloadComponentEvent } from "@lattice-php/lattice/events/event-names";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Option } from "@lattice-php/lattice/types/generated";
@@ -38,12 +38,9 @@ export function useTable(node: TableNode) {
       setProcessing(true);
 
       try {
-        const response = await fetch(buildEndpoint(endpoint, nextState), {
-          headers: withHeaders(componentRef, {
-            Accept: "application/json",
-          }),
+        const result = await apiJson<TableResponse>(buildEndpoint(endpoint, nextState), {
+          ref: componentRef,
         });
-        const result = (await response.json()) as TableResponse;
         const resultState = getState(result.state);
         const resultRows = getRows(result.data);
 
@@ -125,8 +122,9 @@ export function useTable(node: TableNode) {
       url.searchParams.set("_search", filterKey);
       url.searchParams.set("q", query);
 
-      const response = await fetch(`${url.pathname}${url.search}`, {
-        headers: withHeaders(componentRef, { Accept: "application/json" }),
+      const response = await apiFetch(`${url.pathname}${url.search}`, {
+        ref: componentRef,
+        throwOnError: false,
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## What

Introduce `resources/js/core/api.ts` (`apiFetch` / `apiJson` + `ApiError`) as the single funnel for raw-fetch HTTP, and migrate all 9 raw `fetch()` sites to it. Logical next layer after the recent `core/headers.ts` extraction (closes solo todo #149).

## Why

The 9 sites were inconsistent and carried latent bugs: `credentials: "same-origin"` was set on 5 / omitted on 3; the CSRF+JSON header set was implemented 3 different ways (`jsonPostHeaders`, a local `jsonHeaders`, an inline block); `!ok` handling had 5 different policies including 2 silent "none"s; and chat-window's history fetch dropped the locale header entirely.

## Design

`apiFetch` returns a `Response` (so one primitive serves JSON, the chat's streaming `getReader()`, and multipart uniformly) and **owns the full header policy**:

- always `credentials: "same-origin"`
- locale + component-ref via `withHeaders`
- JSON `Accept` default; for write methods also JSON `Content-Type` + `X-Requested-With` + the CSRF token — all overridable through `headers`
- throws `ApiError` on a failed response unless `throwOnError: false`

`jsonPostHeaders` and the two duplicate header re-impls are deleted; call sites now just declare intent.

## Latent bugs fixed

- fragment + table data fetches now send same-origin credentials and surface failed responses instead of throwing cryptically on `.json()`
- chat-window history now sends the locale header

Silent error policies are preserved where intended (form `→null`, action manual 422/!ok, file-upload error UI, table select-search `→[]`, chat history `→return`) via `throwOnError: false`.

## Caveat for future callers

The write-method `Content-Type: application/json` default is wrong for a FormData body (the browser must set the multipart boundary). No current site hits this; such a caller must override `Content-Type`.

## Verification

- `npm run check` — tsc, type-coverage 99.77%, vitest 491 passed (incl. new `core/api.test.ts`), `build:lib`
- `composer check` — Pint, PHPStan, Pest 686 passed; `composer types` diff-clean
- `composer test:browser` — 74 passed (forms / tables / fragments / chat)