### PR TITLE
refactor: align effect type shape with the node model

### DIFF
--- a/resources/js/chat/types.ts
+++ b/resources/js/chat/types.ts
@@ -7,23 +7,17 @@ import type {
 export type { ChatRole };
 
 /**
- * A chat part is a component node, rendered by `type` through the component
- * registry like any other node. Built-in parts (`chat.part.*`) narrow to their
- * generated props; a consumer's custom part still type-checks as a loose node.
+ * The generated message shape, but `parts` is widened from the generated
+ * `ChatNode` union to open `Node`s — a part is just a component node rendered by
+ * `type`, so a message can also carry a consumer's custom part.
  */
-export type ChatPart = Node;
-
-/**
- * Sourced from the generated message shape but widened to the open `ChatPart`
- * so a message can carry a consumer's custom part.
- */
-export type ChatMessage = Omit<GeneratedChatMessage, "parts"> & { parts: ChatPart[] };
+export type ChatMessage = Omit<GeneratedChatMessage, "parts"> & { parts: Node[] };
 
 export type ChatStatus = "idle" | "submitted" | "streaming" | "error";
 
 export type ChatFrame =
   | { type: "text"; value: string }
-  | { type: "part"; part: ChatPart }
+  | { type: "part"; part: Node }
   | { type: "done" }
   | { type: "error"; message?: string };
 

--- a/resources/js/effects/registry.test-d.ts
+++ b/resources/js/effects/registry.test-d.ts
@@ -1,28 +1,30 @@
 import type { EffectOf, EffectProps } from "./registry";
 
-// 1. Built-in effect resolves from the generated union (redirect carries a url).
+// 1. Built-in effect resolves to { type, ...payload } from the generated union.
 const _redirect: EffectOf<"redirect"> = { type: "redirect", url: "/next" };
 // @ts-expect-error url must be a string, not a number
 const _redirectBad: EffectOf<"redirect"> = { type: "redirect", url: 1 };
 
-// 2. Consumer augmentation: extend EffectProps so "confetti" types its payload.
-//    The declare module is scoped to this module file (which has top-level imports).
+// 2. Consumer augmentation maps the type to its payload; EffectOf adds `type` back,
+//    so a custom effect carries `type` exactly like a built-in one.
 declare module "./registry" {
   interface EffectProps {
     confetti: { color: string };
   }
 }
-const _confetti: EffectOf<"confetti"> = { color: "gold" };
+const _confetti: EffectOf<"confetti"> = { type: "confetti", color: "gold" };
 // @ts-expect-error color must be a string, not a number
-const _confettiBad: EffectOf<"confetti"> = { color: 1 };
+const _confettiBad: EffectOf<"confetti"> = { type: "confetti", color: 1 };
+const _confettiType: "confetti" = _confetti.type;
 
-// 3. Unaugmented unknown effect falls back to the loose Effect union.
-const _loose: EffectOf<"totally.unknown"> = { type: "redirect", url: "/x" };
+// 3. Unaugmented unknown effect resolves to a loose { type } & bag.
+const _loose: EffectOf<"totally.unknown"> = { type: "totally.unknown", anything: true };
 
 void _redirect;
 void _redirectBad;
 void _confetti;
 void _confettiBad;
+void _confettiType;
 void _loose;
 
 type _EffectProps = EffectProps;

--- a/resources/js/effects/registry.ts
+++ b/resources/js/effects/registry.ts
@@ -5,20 +5,31 @@ import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
 import { setLocale } from "@lattice-php/lattice/i18n/locale";
 
 /**
- * Augmentable map of effect `type` → effect shape. Consumer apps extend it via
- * `declare module "@lattice-php/lattice"` so their custom effects type their
- * handler's payload; built-ins resolve through the generated `Effect` union.
+ * Augmentable map of effect `type` → payload (the effect's fields minus `type`).
+ * Consumer apps extend it via `declare module "@lattice-php/lattice"` so their
+ * custom effects type their handler's payload; built-ins resolve through the
+ * generated `Effect` union.
  */
 export interface EffectProps {}
 
-// The generated built-in effects, keyed by their `type` discriminant.
-type EffectMap = { [TEffect in Effect as TEffect["type"]]: TEffect };
+// The generated built-in effect payloads, keyed by `type` (the discriminant stripped).
+type EffectPayloads = { [TEffect in Effect as TEffect["type"]]: Omit<TEffect, "type"> };
+
+type EffectPayloadOf<TType extends string> = ResolveProps<
+  EffectProps,
+  EffectPayloads,
+  TType,
+  Record<string, unknown>
+>;
 
 /**
- * Resolves an effect `type` to its shape: consumer augmentations (`EffectProps`)
- * first, then the generated built-ins, then the loose `Effect` union.
+ * Resolves an effect `type` to its full shape — `{ type, ...payload }` — the way
+ * `Node<T>` pairs a type with its props, so built-ins and consumer effects alike
+ * always carry `type`. An unknown type falls back to the loose `Effect` union.
  */
-export type EffectOf<TType extends string> = ResolveProps<EffectProps, EffectMap, TType, Effect>;
+export type EffectOf<TType extends string> = string extends TType
+  ? Effect
+  : { type: TType } & EffectPayloadOf<TType>;
 
 export type EffectHandler<TType extends string = string> = (effect: EffectOf<TType>) => void;
 
@@ -33,7 +44,7 @@ export function effectHandler<TType extends string>(
   _type: TType,
   fn: EffectHandler<TType>,
 ): EffectHandler {
-  return fn as EffectHandler;
+  return fn as unknown as EffectHandler;
 }
 
 function triggerDownload(url: string): void {

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -41,7 +41,6 @@ export type { UseChatOptions } from "./chat/use-chat";
 export type {
   ChatFrame,
   ChatMessage,
-  ChatPart,
   ChatRole,
   ChatStatus,
   ChatTransport,


### PR DESCRIPTION
Follow-up TS-ergonomics pass on the registry kinds. Two small alignments:

## `EffectOf` now mirrors `Node<T>`

`EffectOf<T>` resolved to the whole *flat* effect, built from a union where the built-in members carry `type` but the consumer augmentation (`EffectProps`) does not. So:

```ts
const a: EffectOf<"redirect">     = { type: "redirect", url: "/x" }; // built-in: has type
const b: EffectOf<"app.confetti"> = { color: "gold" };               // custom: NO type ✗
```

A custom-effect handler couldn't read `effect.type`, while a built-in one could — an inconsistent handler shape. Now `EffectProps` maps `type → payload` (consistent with `ComponentProps`/`ColumnProps`) and `EffectOf<T>` adds `{ type: T }` back, exactly the way `Node<T> = { type: T; props: PropsOf<T> }` pairs type + props:

```ts
type EffectOf<T> = string extends T ? Effect : { type: T } & EffectPayloadOf<T>;
```

Every handler — built-in or custom — now sees `{ type, ...payload }`. The dispatcher is unaffected: the erased `EffectOf<string>` stays the loose `Effect` union.

## Inline `ChatPart`

`ChatPart = Node` added no type information beyond `Node`; use `Node` directly in `ChatMessage.parts`/`ChatFrame` and drop the alias + export.

Frontend-only, no generated-type change. `npm run check` green (lint, tsc, type-coverage, Vitest, build).