### PR TITLE
feat: field tooltips

### DIFF
--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -24,6 +24,7 @@
                             "required": true,
                             "rows": null,
                             "tabIndex": null,
+                            "tooltip": null,
                             "value": null
                         },
                         "type": "form.textarea"
@@ -54,6 +55,7 @@
                             "readOnly": false,
                             "required": true,
                             "tabIndex": null,
+                            "tooltip": null,
                             "type": null,
                             "value": null
                         },
@@ -79,6 +81,7 @@
                             "readOnly": false,
                             "required": false,
                             "tabIndex": null,
+                            "tooltip": null,
                             "type": null,
                             "value": null
                         },
@@ -104,6 +107,7 @@
                             "readOnly": false,
                             "required": false,
                             "tabIndex": null,
+                            "tooltip": null,
                             "type": null,
                             "value": null
                         },
@@ -137,6 +141,7 @@
             "resizableColumns": false,
             "resizeIndicator": false,
             "rowActions": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.builder"

--- a/docs/fixtures/checkbox.basic.json
+++ b/docs/fixtures/checkbox.basic.json
@@ -17,6 +17,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.checkbox"

--- a/docs/fixtures/choice.basic.json
+++ b/docs/fixtures/choice.basic.json
@@ -31,6 +31,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.choice"

--- a/docs/fixtures/date-input.basic.json
+++ b/docs/fixtures/date-input.basic.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.date-input"

--- a/docs/fixtures/field.default-value.json
+++ b/docs/fixtures/field.default-value.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": "Acme Inc"
         },

--- a/docs/fixtures/field.disabled.json
+++ b/docs/fixtures/field.disabled.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": "Acme Inc"
         },

--- a/docs/fixtures/field.helper-text.json
+++ b/docs/fixtures/field.helper-text.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": null
         },

--- a/docs/fixtures/field.read-only.json
+++ b/docs/fixtures/field.read-only.json
@@ -19,6 +19,7 @@
             "readOnly": true,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": "acme-inc"
         },

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -31,6 +31,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.choice"
@@ -63,6 +64,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": null
         },

--- a/docs/fixtures/field.required.json
+++ b/docs/fixtures/field.required.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": true,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": null
         },

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -27,6 +27,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.choice"
@@ -59,6 +60,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": null
         },

--- a/docs/fixtures/file-upload.basic.json
+++ b/docs/fixtures/file-upload.basic.json
@@ -22,6 +22,7 @@
             "readOnly": false,
             "required": false,
             "signed": false,
+            "tooltip": null,
             "value": null
         },
         "type": "form.file-upload"

--- a/docs/fixtures/number-input.basic.json
+++ b/docs/fixtures/number-input.basic.json
@@ -22,6 +22,7 @@
             "slider": false,
             "step": null,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.number-input"

--- a/docs/fixtures/number-input.slider.json
+++ b/docs/fixtures/number-input.slider.json
@@ -22,6 +22,7 @@
             "slider": true,
             "step": null,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.number-input"

--- a/docs/fixtures/password-input.basic.json
+++ b/docs/fixtures/password-input.basic.json
@@ -22,6 +22,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.password-input"

--- a/docs/fixtures/password-input.confirmation.json
+++ b/docs/fixtures/password-input.confirmation.json
@@ -26,6 +26,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.password-input"

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -25,6 +25,7 @@
             "resizableColumns": false,
             "resizeIndicator": false,
             "rowActions": null,
+            "tooltip": null,
             "value": null
         },
         "schema": [
@@ -48,6 +49,7 @@
                     "readOnly": false,
                     "required": true,
                     "tabIndex": null,
+                    "tooltip": null,
                     "type": null,
                     "value": null
                 },
@@ -73,6 +75,7 @@
                     "readOnly": false,
                     "required": false,
                     "tabIndex": null,
+                    "tooltip": null,
                     "type": null,
                     "value": null
                 },

--- a/docs/fixtures/repeater.row-actions.json
+++ b/docs/fixtures/repeater.row-actions.json
@@ -40,6 +40,7 @@
                     "type": "remove"
                 }
             ],
+            "tooltip": null,
             "value": null
         },
         "schema": [
@@ -63,6 +64,7 @@
                     "readOnly": false,
                     "required": false,
                     "tabIndex": null,
+                    "tooltip": null,
                     "type": null,
                     "value": null
                 },
@@ -88,6 +90,7 @@
                     "readOnly": false,
                     "required": false,
                     "tabIndex": null,
+                    "tooltip": null,
                     "type": null,
                     "value": null
                 },

--- a/docs/fixtures/rich-editor.basic.json
+++ b/docs/fixtures/rich-editor.basic.json
@@ -16,6 +16,7 @@
             "prefillResetOn": null,
             "readOnly": false,
             "required": false,
+            "tooltip": null,
             "value": null
         },
         "type": "form.rich-editor"

--- a/docs/fixtures/select.basic.json
+++ b/docs/fixtures/select.basic.json
@@ -40,6 +40,7 @@
             "searchPlaceholder": "Search\u2026",
             "searchable": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.select"

--- a/docs/fixtures/select.multiple.json
+++ b/docs/fixtures/select.multiple.json
@@ -40,6 +40,7 @@
             "searchPlaceholder": "Search\u2026",
             "searchable": false,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.select"

--- a/docs/fixtures/text-input.email.json
+++ b/docs/fixtures/text-input.email.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": false,
             "tabIndex": null,
+            "tooltip": null,
             "type": "email",
             "value": null
         },

--- a/docs/fixtures/text-input.required.json
+++ b/docs/fixtures/text-input.required.json
@@ -19,6 +19,7 @@
             "readOnly": false,
             "required": true,
             "tabIndex": null,
+            "tooltip": null,
             "type": null,
             "value": null
         },

--- a/docs/fixtures/textarea.basic.json
+++ b/docs/fixtures/textarea.basic.json
@@ -19,6 +19,7 @@
             "required": false,
             "rows": 4,
             "tabIndex": null,
+            "tooltip": null,
             "value": null
         },
         "type": "form.textarea"

--- a/lang/de/lattice.php
+++ b/lang/de/lattice.php
@@ -33,6 +33,7 @@ return [
         'removeOption' => ':label entfernen',
         'tabs' => 'Tabs',
         'loading' => 'Lädt',
+        'moreInfo' => 'Mehr Informationen',
         'closeMenu' => 'Menü schließen',
         'dismiss' => 'Schließen',
         'close' => 'Schließen',

--- a/lang/en/lattice.php
+++ b/lang/en/lattice.php
@@ -33,6 +33,7 @@ return [
         'removeOption' => 'Remove :label',
         'tabs' => 'Tabs',
         'loading' => 'Loading',
+        'moreInfo' => 'More information',
         'closeMenu' => 'Close menu',
         'dismiss' => 'Dismiss',
         'close' => 'Close',

--- a/resources/js/core/components/info-tooltip.test.tsx
+++ b/resources/js/core/components/info-tooltip.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InfoTooltip } from "./info-tooltip";
+
+describe("InfoTooltip", () => {
+  it("renders nothing when content is empty", () => {
+    const { container } = render(<InfoTooltip content={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("reveals trusted HTML content only after the trigger is clicked", () => {
+    render(<InfoTooltip content={'See <a href="/docs">the docs</a>.'} />);
+
+    expect(screen.queryByRole("link", { name: "the docs" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+
+    const link = screen.getByRole("link", { name: "the docs" });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute("href", "/docs");
+  });
+});

--- a/resources/js/core/components/info-tooltip.tsx
+++ b/resources/js/core/components/info-tooltip.tsx
@@ -2,11 +2,6 @@ import { Icon } from "@lattice-php/lattice/icons";
 import { useT } from "@lattice-php/lattice/i18n";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
-/**
- * A clickable info icon that opens a popover with trusted, developer-authored
- * HTML. Content is rendered verbatim (no sanitization) — the same trust
- * boundary as raw-block.tsx. Renders nothing when content is empty.
- */
 export function InfoTooltip({ content }: { content?: string | null }) {
   const { t } = useT("lattice");
 

--- a/resources/js/core/components/info-tooltip.tsx
+++ b/resources/js/core/components/info-tooltip.tsx
@@ -1,0 +1,33 @@
+import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+/**
+ * A clickable info icon that opens a popover with trusted, developer-authored
+ * HTML. Content is rendered verbatim (no sanitization) — the same trust
+ * boundary as raw-block.tsx. Renders nothing when content is empty.
+ */
+export function InfoTooltip({ content }: { content?: string | null }) {
+  const { t } = useT("lattice");
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        type="button"
+        aria-label={t("a11y.moreInfo", "More information")}
+        className="ml-1 inline-flex rounded-lt-sm text-lt-muted-fg outline-none hover:text-lt-fg focus-visible:text-lt-fg focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]"
+      >
+        <Icon name="info" className="size-lt-icon-sm" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="max-w-xs p-3 text-sm [&_a]:underline"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    </Popover>
+  );
+}

--- a/resources/js/form/components/base/field.test.tsx
+++ b/resources/js/form/components/base/field.test.tsx
@@ -29,3 +29,21 @@ it("keeps a visually-hidden accessible label inside a table cell", () => {
   // the label is visually hidden
   expect(screen.getByText("Qty")).toHaveClass("sr-only");
 });
+
+it("renders a tooltip trigger when a tooltip is provided", () => {
+  render(
+    <FormFieldFrame label="Qty" name="qty" tooltip="How many units">
+      <input aria-label="qty" />
+    </FormFieldFrame>,
+  );
+  expect(screen.getByRole("button", { name: "More information" })).toBeInTheDocument();
+});
+
+it("renders no tooltip trigger when no tooltip is provided", () => {
+  render(
+    <FormFieldFrame label="Qty" name="qty">
+      <input aria-label="qty" />
+    </FormFieldFrame>,
+  );
+  expect(screen.queryByRole("button", { name: "More information" })).not.toBeInTheDocument();
+});

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -1,4 +1,5 @@
 import InputError from "@lattice-php/lattice/form/components/base/input-error";
+import { InfoTooltip } from "@lattice-php/lattice/core/components/info-tooltip";
 import { TextLink } from "@lattice-php/lattice/core/components/link";
 import { Label } from "@lattice-php/lattice/form/components/base/label";
 import { useInTableCell } from "../row-layout-context";
@@ -12,6 +13,7 @@ export function FormFieldFrame({
   labelAction,
   name,
   required,
+  tooltip,
 }: {
   children: React.ReactNode;
   error?: string;
@@ -20,6 +22,7 @@ export function FormFieldFrame({
   labelAction?: FormLabelAction;
   name: string;
   required?: boolean;
+  tooltip?: string;
 }) {
   const bare = useInTableCell();
 
@@ -44,6 +47,7 @@ export function FormFieldFrame({
             *
           </span>
         )}
+        <InfoTooltip content={tooltip} />
         {labelAction && (
           <TextLink
             href={labelAction.href}

--- a/resources/js/form/components/field-props.ts
+++ b/resources/js/form/components/field-props.ts
@@ -21,6 +21,7 @@ export type FieldProps = {
   prefillResetOn?: string[] | null;
   readOnly?: boolean | null;
   required?: boolean | null;
+  tooltip?: string | null;
   value?: unknown;
 };
 

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -69,6 +69,7 @@ export const BuilderComponent: RendererComponent<"form.builder"> = ({ node }) =>
     <FormFieldFrame
       error={errors[name]}
       helperText={props.helperText ?? undefined}
+      tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
       name={name}
       required={required}

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -27,6 +27,7 @@ export const ChoiceComponent: RendererComponent<"form.choice"> = ({ node }) => {
     <FormFieldFrame
       error={error}
       helperText={node.props.helperText ?? undefined}
+      tooltip={node.props.tooltip ?? undefined}
       label={node.props.label ?? ""}
       name={name}
       required={required}

--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -231,6 +231,7 @@ export const FileUploadComponent: RendererComponent<"form.file-upload"> = ({ nod
     <FormFieldFrame
       error={errors[errorKey]}
       helperText={props.helperText ?? undefined}
+      tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
       name={name}
       required={required}

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -30,6 +30,7 @@ export const PasswordInputComponent: RendererComponent<"form.password-input"> = 
       <FormFieldFrame
         error={field.error}
         helperText={props.helperText ?? undefined}
+        tooltip={props.tooltip ?? undefined}
         label={props.label ?? ""}
         labelAction={props.labelAction ?? undefined}
         name={field.name}

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -43,6 +43,7 @@ export const RepeaterComponent: RendererComponent<"form.repeater"> = ({ node }) 
     <FormFieldFrame
       error={errors[name]}
       helperText={props.helperText ?? undefined}
+      tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
       name={name}
       required={required}

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -366,6 +366,7 @@ export const RichEditorComponent: RendererComponent<"form.rich-editor"> = ({ nod
     <FormFieldFrame
       error={errors[name]}
       helperText={node.props.helperText ?? undefined}
+      tooltip={node.props.tooltip ?? undefined}
       label={node.props.label ?? ""}
       name={name}
       required={required}

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -131,6 +131,7 @@ export const SelectComponent: RendererComponent<"form.select"> = ({ node }) => {
     <FormFieldFrame
       error={errors[errorKey]}
       helperText={props.helperText ?? undefined}
+      tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
       name={name}
       required={required}

--- a/resources/js/form/components/fields/simple-field.tsx
+++ b/resources/js/form/components/fields/simple-field.tsx
@@ -24,6 +24,7 @@ export function SimpleField({
     <FormFieldFrame
       error={field.error}
       helperText={fieldProps(node).helperText ?? undefined}
+      tooltip={fieldProps(node).tooltip ?? undefined}
       label={label}
       name={field.name}
       required={field.required}

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -77,6 +77,7 @@ export type Builder = {
   resizableColumns: boolean;
   resizeIndicator: boolean;
   rowActions: RowAction[] | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type BulkAction = {
@@ -168,6 +169,7 @@ export type Checkbox = {
   readOnly: boolean;
   required: boolean;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type Choice = {
@@ -193,6 +195,7 @@ export type Choice = {
   readOnly: boolean;
   required: boolean;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type CloseModalEffect = {
@@ -357,6 +360,7 @@ export type DateInput = {
   readOnly: boolean;
   required: boolean;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type DownloadEffect = {
@@ -443,6 +447,7 @@ export type FileUpload = {
   readOnly: boolean;
   required: boolean;
   signed: boolean;
+  tooltip: string | null;
   value: unknown;
 };
 export type FilterClause = {
@@ -596,6 +601,7 @@ export type HiddenInput = {
   prefillResetOn: string[] | null;
   readOnly: boolean;
   required: boolean;
+  tooltip: string | null;
   value: unknown;
 };
 export type HttpMethod = import("@inertiajs/core").Method;
@@ -720,6 +726,7 @@ export type NumberInput = {
   slider: boolean;
   step: number | null;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type Op =
@@ -785,6 +792,7 @@ export type PasswordInput = {
   readOnly: boolean;
   required: boolean;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type Placement = "top" | "bottom" | "right";
@@ -828,6 +836,7 @@ export type Repeater = {
   resizableColumns: boolean;
   resizeIndicator: boolean;
   rowActions: RowAction[] | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type ResetFormEffect = {
@@ -854,6 +863,7 @@ export type RichEditor = {
   prefillResetOn: string[] | null;
   readOnly: boolean;
   required: boolean;
+  tooltip: string | null;
   value: unknown;
 };
 export type RowAction = {
@@ -908,6 +918,7 @@ export type Select = {
   searchPlaceholder: string;
   searchable: boolean;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type Sidebar = {
@@ -1021,6 +1032,7 @@ export type TextInput = {
   readOnly: boolean;
   required: boolean;
   tabIndex: number | null;
+  tooltip: string | null;
   type: string | null;
   value: unknown;
 };
@@ -1051,6 +1063,7 @@ export type Textarea = {
   required: boolean;
   rows: number | null;
   tabIndex: number | null;
+  tooltip: string | null;
   value: unknown;
 };
 export type ToastEffect = {

--- a/src/Core/Concerns/HasTooltip.php
+++ b/src/Core/Concerns/HasTooltip.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Concerns;
+
+trait HasTooltip
+{
+    public ?string $tooltip = null;
+
+    public function tooltip(string $tooltip): static
+    {
+        $this->tooltip = $tooltip;
+
+        return $this;
+    }
+}

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -7,6 +7,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Core\Components\Component;
+use Lattice\Lattice\Core\Concerns\HasTooltip;
 use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Facades\Evaluate;
@@ -17,6 +18,8 @@ use Lattice\Lattice\Support\Evaluation\EvaluationContext;
 
 abstract class Field extends Component
 {
+    use HasTooltip;
+
     public string $name = '';
 
     public ?string $label = null;

--- a/tests/Browser/Forms/ShowcaseTest.php
+++ b/tests/Browser/Forms/ShowcaseTest.php
@@ -83,3 +83,14 @@ it('runs conditional and computed behavior on the showcase', function (): void {
         ->wait(1)
         ->assertValue('total', '20');
 });
+
+it('opens a field tooltip revealing a link', function (): void {
+    $this->actingAs(workbenchTestUser());
+    visit('/showcase')
+        ->assertNoSmoke()
+        ->assertDontSee('the form guide')
+        ->click('[aria-label="More information"]')
+        ->assertSee('the form guide')
+        ->assertPresent('a[href="/showcase"]')
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Unit/Forms/FieldTest.php
+++ b/tests/Unit/Forms/FieldTest.php
@@ -62,3 +62,13 @@ it('aliases hint to helper text', function (): void {
 
     expect(wire($field)['props']['helperText'])->toBe('Quick tip.');
 });
+
+it('serializes a tooltip', function (): void {
+    $field = makeField()->tooltip('See <a href="/docs">the docs</a>.');
+
+    expect(wire($field)['props']['tooltip'])->toBe('See <a href="/docs">the docs</a>.');
+});
+
+it('serializes tooltip as null when not set', function (): void {
+    expect(wire(makeField())['props']['tooltip'])->toBeNull();
+});

--- a/tests/Unit/Forms/FormSerializationTest.php
+++ b/tests/Unit/Forms/FormSerializationTest.php
@@ -41,6 +41,7 @@ test('password inputs can request automatic confirmation fields', function () {
                 ],
                 'label' => 'Password',
                 'helperText' => null,
+                'tooltip' => null,
                 'name' => 'password',
                 'passwordRules' => 'minlength:8',
                 'required' => true,

--- a/workbench/app/Forms/ShowcaseForm.php
+++ b/workbench/app/Forms/ShowcaseForm.php
@@ -37,6 +37,7 @@ class ShowcaseForm extends FormDefinition
                     Grid::make()->columns(2)->schema([
                         TextInput::make('name', __('workbench.forms.showcase.full-name'))
                             ->placeholder(__('workbench.forms.showcase.placeholders.name'))
+                            ->tooltip('Your legal name. See <a href="/showcase">the form guide</a>.')
                             ->rules(['required', 'string', 'max:255']),
                         TextInput::make('email', __('workbench.common.email'))
                             ->email()


### PR DESCRIPTION
## Summary
Adds `->tooltip(string)` to every form field. A field with a tooltip renders a clickable info icon next to its label that opens a popover with the tooltip content.

- Content may be plain text **or HTML with links**. It's developer-authored and trusted, rendered as-is (no sanitization) — same trust boundary as the existing `raw-block.tsx`. There is no path for end-user data to reach it.
- **Click/focus popover** (not a hover tooltip) so links inside are reachable for pointer, keyboard, and touch users.
- Backend: a `HasTooltip` trait on the `Field` base class (mirrors `HasPlaceholder`); the property auto-serializes.
- Frontend: a reusable `InfoTooltip` component (Radix popover + `info` icon) wired into `FormFieldFrame` and threaded through all 8 frame consumers. Omitted in the bare/table-cell branch, like `helperText`.
- a11y: real `<button>` trigger with a translatable `aria-label` (`a11y.moreInfo`, en + de).

```php
TextInput::make('name', 'Full name')
    ->tooltip('Your legal name. See <a href="/docs">the form guide</a>.')
```

## Test plan
- [x] `composer check` — 709 Pest tests, PHPStan, Pint
- [x] `npm run check` — tsc, type-coverage, 523 Vitest, library build
- [x] Showcase browser suite (6 incl. new tooltip test): opens the popover and asserts the in-popover link is present/reachable
- [x] `composer types` idempotent; docs fixtures refreshed