### PR TITLE
chore: seed more workbench products

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ueberdosis/tiptap-php": "^2.1"
     },
     "require-dev": {
-        "bambamboole/extended-faker": "^0.7.0",
+        "bambamboole/extended-faker": "^0.8.0",
         "bambamboole/laravel-i18next": "^0.6.0",
         "barryvdh/laravel-ide-helper": "^3.7",
         "larastan/larastan": "^3.0",

--- a/workbench/app/Seeders/DatabaseSeeder.php
+++ b/workbench/app/Seeders/DatabaseSeeder.php
@@ -32,7 +32,7 @@ class DatabaseSeeder extends Seeder
             ->create(['name' => 'VIP']);
 
         $products = Product::factory()
-            ->count(100)
+            ->count(250)
             ->withImages()
             ->withSalesPricesFor($wholesaleGroup, $vipGroup)
             ->create();


### PR DESCRIPTION
## Summary
- update `bambamboole/extended-faker` to `^0.8.0`
- seed 250 workbench products instead of 100 now that product generation is fast

## Verification
- `composer validate --strict`
- `composer check`
- `npm run check`
- temp DB seeder benchmark with fake S3: `2.1097s`
