### PR TITLE
fix: tighten TypeScript API boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,25 @@
       "types": "./dist/action/index.d.ts",
       "import": "./dist/action/index.js"
     },
+    "./action/*": {
+      "types": "./dist/action/*.d.ts",
+      "import": "./dist/action/*.js"
+    },
     "./appearance": {
       "types": "./dist/appearance/index.d.ts",
       "import": "./dist/appearance/index.js"
+    },
+    "./appearance/*": {
+      "types": "./dist/appearance/*.d.ts",
+      "import": "./dist/appearance/*.js"
+    },
+    "./chat": {
+      "types": "./dist/chat/index.d.ts",
+      "import": "./dist/chat/index.js"
+    },
+    "./chat/*": {
+      "types": "./dist/chat/*.d.ts",
+      "import": "./dist/chat/*.js"
     },
     "./clipboard": {
       "types": "./dist/clipboard/index.d.ts",
@@ -47,6 +63,18 @@
       "types": "./dist/core/components/index.d.ts",
       "import": "./dist/core/components/index.js"
     },
+    "./core/*": {
+      "types": "./dist/core/*.d.ts",
+      "import": "./dist/core/*.js"
+    },
+    "./effects/*": {
+      "types": "./dist/effects/*.d.ts",
+      "import": "./dist/effects/*.js"
+    },
+    "./events/*": {
+      "types": "./dist/events/*.d.ts",
+      "import": "./dist/events/*.js"
+    },
     "./form": {
       "types": "./dist/form/index.d.ts",
       "import": "./dist/form/index.js"
@@ -55,39 +83,91 @@
       "types": "./dist/form/components/index.d.ts",
       "import": "./dist/form/components/index.js"
     },
+    "./form/*": {
+      "types": "./dist/form/*.d.ts",
+      "import": "./dist/form/*.js"
+    },
     "./i18n": {
       "types": "./dist/i18n/index.d.ts",
       "import": "./dist/i18n/index.js"
+    },
+    "./i18n/*": {
+      "types": "./dist/i18n/*.d.ts",
+      "import": "./dist/i18n/*.js"
     },
     "./icons": {
       "types": "./dist/icons/index.d.ts",
       "import": "./dist/icons/index.js"
     },
+    "./icons/*": {
+      "types": "./dist/icons/*.d.ts",
+      "import": "./dist/icons/*.js"
+    },
+    "./inertia": {
+      "types": "./dist/inertia.d.ts",
+      "import": "./dist/inertia.js"
+    },
     "./layout": {
       "types": "./dist/layout/index.d.ts",
       "import": "./dist/layout/index.js"
+    },
+    "./layout/*": {
+      "types": "./dist/layout/*.d.ts",
+      "import": "./dist/layout/*.js"
+    },
+    "./lib/*": {
+      "types": "./dist/lib/*.d.ts",
+      "import": "./dist/lib/*.js"
+    },
+    "./page": {
+      "types": "./dist/page.d.ts",
+      "import": "./dist/page.js"
+    },
+    "./provider": {
+      "types": "./dist/provider.d.ts",
+      "import": "./dist/provider.js"
+    },
+    "./registry": {
+      "types": "./dist/registry.d.ts",
+      "import": "./dist/registry.js"
     },
     "./table": {
       "types": "./dist/table/index.d.ts",
       "import": "./dist/table/index.js"
     },
+    "./table/*": {
+      "types": "./dist/table/*.d.ts",
+      "import": "./dist/table/*.js"
+    },
+    "./toast": {
+      "types": "./dist/toast/index.d.ts",
+      "import": "./dist/toast/index.js"
+    },
+    "./toast/*": {
+      "types": "./dist/toast/*.d.ts",
+      "import": "./dist/toast/*.js"
+    },
     "./types": {
       "types": "./dist/types/index.d.ts",
       "import": "./dist/types/index.js"
+    },
+    "./types/*": {
+      "types": "./dist/types/*.d.ts",
+      "import": "./dist/types/*.js"
     },
     "./svg-sprite-client": {
       "types": "./dist/svg-sprite-client.d.ts",
       "import": "./dist/svg-sprite-client/index.js"
     },
+    "./svg-sprite-client/*": {
+      "types": "./dist/svg-sprite-client/*.d.ts",
+      "import": "./dist/svg-sprite-client/*.js"
+    },
     "./vite": {
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
     },
-    "./package.json": "./package.json",
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js"
-    }
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -47,7 +47,7 @@ function rejectAction(precognitive = false): Node {
   } as unknown as Node;
 }
 
-function lazyAction(): Node {
+function lazyAction(method = "post"): Node {
   return {
     id: "test.edit",
     type: "action",
@@ -57,7 +57,7 @@ function lazyAction(): Node {
       form: null,
       label: "Edit",
       lazyForm: true,
-      method: "post",
+      method,
       ref: "sealed-ref",
     },
   } as unknown as Node;
@@ -159,11 +159,36 @@ describe("action form modal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 
     expect(await screen.findByRole("textbox", { name: "Title" })).toBeVisible();
-    expect(
-      fetchMock.mock.calls.some(
-        ([, init]) => (JSON.parse(String((init as RequestInit).body)) as { _form?: boolean })._form,
-      ),
-    ).toBe(true);
+    const [, init] = fetchMock.mock.calls.find(
+      ([, requestInit]) =>
+        (JSON.parse(String((requestInit as RequestInit).body)) as { _form?: boolean })._form,
+    ) as [string, RequestInit];
+
+    expect(init.method).toBe("POST");
+  });
+
+  it("posts lazy schema requests even when the action submits with another method", async () => {
+    const formNode = {
+      id: "test.edit-form",
+      props: {},
+      schema: [{ key: "title", props: { label: "Title", name: "title" }, type: "form.text-input" }],
+      type: "form",
+    };
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => formNode,
+      ok: true,
+      status: 200,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(lazyAction("patch"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    await screen.findByRole("textbox", { name: "Title" });
+
+    const [, init] = fetchMock.mock.calls.at(0) as [string, RequestInit];
+    expect(init.method).toBe("POST");
   });
 
   it("validates precognitively as the user types", async () => {

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -41,7 +41,6 @@ type ActionFormProps = {
  */
 export function useLazyActionForm(
   endpoint: string,
-  method: string,
   componentRef: string,
   enabled: boolean,
 ): Node | null {
@@ -59,7 +58,7 @@ export function useLazyActionForm(
     void apiFetch(endpoint, {
       body: JSON.stringify({ _form: true }),
       ref: componentRef,
-      method,
+      method: "POST",
       signal: controller.signal,
       throwOnError: false,
     })
@@ -68,7 +67,7 @@ export function useLazyActionForm(
       .catch(() => {});
 
     return () => controller.abort();
-  }, [enabled, endpoint, method, componentRef]);
+  }, [enabled, endpoint, componentRef]);
 
   return node;
 }

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -30,7 +30,7 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const inlineForm = node.props.form;
   const lazyForm = node.props.lazyForm === true;
   const hasForm = Boolean(inlineForm) || lazyForm;
-  const lazyNode = useLazyActionForm(endpoint, method, componentRef, isFilling && lazyForm);
+  const lazyNode = useLazyActionForm(endpoint, componentRef, isFilling && lazyForm);
   const formNode = lazyForm ? lazyNode : inlineForm;
 
   const submit = async (): Promise<void> => {

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -268,6 +268,53 @@ describe("Lattice form schema components", () => {
     );
   });
 
+  it("refreshes field values when form state props change", () => {
+    const formNode = fakeNode({
+      id: "product-form",
+      props: {
+        action: "/lattice/forms/workbench.products.form",
+        state: {
+          name: "Desk Lamp",
+        },
+      },
+      type: "form",
+    });
+
+    const nameNode = fakeNode({
+      props: {
+        label: "Name",
+        name: "name",
+      },
+      type: "form.text-input",
+    });
+
+    const { rerender } = render(
+      <FormComponent node={formNode}>
+        <TextInputComponent node={nameNode}>{null}</TextInputComponent>
+      </FormComponent>,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Desk Lamp");
+
+    rerender(
+      <FormComponent
+        node={{
+          ...formNode,
+          props: {
+            ...formNode.props,
+            state: {
+              name: "Floor Lamp",
+            },
+          },
+        }}
+      >
+        <TextInputComponent node={nameNode}>{null}</TextInputComponent>
+      </FormComponent>,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Floor Lamp");
+  });
+
   it("passes precognitive validation delay to the inertia form", () => {
     const formNode = fakeNode({
       id: "product-form",

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -108,7 +108,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
     () => collectFields(node.schema),
     [node.schema],
   );
-  const initialValues = { ...fieldValues, ...state };
+  const initialValues = useMemo(() => ({ ...fieldValues, ...state }), [fieldValues, state]);
   const shouldRenderSubmitButton = props.submitButton;
   const submitLabel = props.submitLabel ?? "Submit";
   const summaryLabel = props.validationSummaryLabel;

--- a/resources/js/form/components/values.tsx
+++ b/resources/js/form/components/values.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 type FormValuesContextValue = {
   values: Record<string, unknown>;
@@ -10,6 +18,33 @@ const FormValuesContext = createContext<FormValuesContextValue>({
   setValue: () => {},
 });
 
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (!a || !b || typeof a !== "object" || typeof b !== "object") {
+    return false;
+  }
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((value, index) => valuesEqual(value, b[index]))
+    );
+  }
+
+  const aEntries = Object.entries(a);
+  const bObject = b as Record<string, unknown>;
+
+  return (
+    aEntries.length === Object.keys(bObject).length &&
+    aEntries.every(([key, value]) => valuesEqual(value, bObject[key]))
+  );
+}
+
 export function FormValuesProvider({
   initial,
   children,
@@ -18,9 +53,17 @@ export function FormValuesProvider({
   children: React.ReactNode;
 }) {
   const [values, setValues] = useState<Record<string, unknown>>(initial);
+  const initialRef = useRef(initial);
 
-  // A function `value` is applied as an updater against the field's previous
-  // value, letting callers mutate without capturing the current value in a closure.
+  useEffect(() => {
+    if (valuesEqual(initialRef.current, initial)) {
+      return;
+    }
+
+    initialRef.current = initial;
+    setValues(initial);
+  }, [initial]);
+
   const setValue = useCallback((name: string, value: unknown) => {
     setValues((current) => {
       const next =

--- a/resources/js/inertia.test.tsx
+++ b/resources/js/inertia.test.tsx
@@ -47,11 +47,11 @@ describe("createPageResolver", () => {
     expect(resolver("lattice/page")).toEqual({ default: Page });
   });
 
-  it("resolves app pages from the provided modules", async () => {
+  it("resolves app pages from the documented Pages directory", async () => {
     const component = (() => null) satisfies ResolvedComponent;
     const page = vi.fn<() => Promise<ResolvedComponent>>(() => Promise.resolve(component));
     const resolver = createPageResolver({
-      "./pages/dashboard.tsx": page,
+      "./Pages/dashboard.tsx": page,
     });
 
     await expect(resolver("dashboard")).resolves.toBe(component);

--- a/resources/js/inertia.ts
+++ b/resources/js/inertia.ts
@@ -23,7 +23,7 @@ export function createPageResolver(pages: PageModules) {
       return { default: Page };
     }
 
-    const resolvedPage = pages[`./pages/${name}.tsx`];
+    const resolvedPage = pages[`./Pages/${name}.tsx`] ?? pages[`./pages/${name}.tsx`];
 
     if (resolvedPage) {
       return resolvedPage();

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -99,6 +99,10 @@ describe("table bulk actions", () => {
         state: {
           filters: [{ field: "status", operator: "eq", value: "active" }],
           sorts: [],
+          tableFilters: {
+            featured: "true",
+            updated_at: { from: "2026-01-01", until: "" },
+          },
           page: 1,
           perPage: 25,
         },
@@ -129,6 +133,10 @@ describe("table bulk actions", () => {
     expect(http.transformer({})).toEqual({
       allMatching: true,
       filter: "status:eq:active",
+      tf: {
+        featured: "true",
+        updated_at: { from: "2026-01-01" },
+      },
     });
   });
 });

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -134,6 +134,50 @@ describe("Lattice table component", () => {
     expect(screen.getByRole("button", { name: "Copied Email" })).toBeVisible();
   });
 
+  it("refreshes rows when table data props change", () => {
+    const node = {
+      id: "workbench.users",
+      props: {
+        columns: [
+          col({
+            key: "name",
+            label: "Name",
+          }),
+        ],
+        data: [{ name: "Taylor" }],
+        endpoint: "/lattice/tables/workbench.users",
+        state: {
+          filters: [],
+          page: 1,
+          perPage: 25,
+          sorts: [],
+        },
+      },
+      type: "table",
+    } satisfies TableNode;
+
+    const { rerender } = render(<TableComponent node={node}>{null}</TableComponent>);
+
+    expect(screen.getByRole("cell", { name: "Taylor" })).toBeVisible();
+
+    rerender(
+      <TableComponent
+        node={{
+          ...node,
+          props: {
+            ...node.props,
+            data: [{ name: "Nuno" }],
+          },
+        }}
+      >
+        {null}
+      </TableComponent>,
+    );
+
+    expect(screen.getByRole("cell", { name: "Nuno" })).toBeVisible();
+    expect(screen.queryByRole("cell", { name: "Taylor" })).not.toBeInTheDocument();
+  });
+
   it("uses column width hints when building the table grid", () => {
     const node = {
       id: "workbench.products",

--- a/resources/js/table/query.ts
+++ b/resources/js/table/query.ts
@@ -47,11 +47,9 @@ export function buildEndpoint(endpoint: string, state: TableState): string {
  * dropped so an unset filter never reaches the server.
  */
 function appendTableFilters(url: URL, tableFilters: Record<string, unknown>): void {
-  for (const [key, value] of Object.entries(tableFilters)) {
+  for (const [key, value] of Object.entries(getTableFilterParams(tableFilters))) {
     if (typeof value === "string") {
-      if (value !== "") {
-        url.searchParams.set(`tf[${key}]`, value);
-      }
+      url.searchParams.set(`tf[${key}]`, value);
 
       continue;
     }
@@ -66,14 +64,52 @@ function appendTableFilters(url: URL, tableFilters: Record<string, unknown>): vo
       continue;
     }
 
-    if (value != null && typeof value === "object") {
+    if (typeof value === "object" && value !== null) {
       for (const [subKey, subValue] of Object.entries(value as Record<string, unknown>)) {
-        if (typeof subValue === "string" && subValue !== "") {
-          url.searchParams.set(`tf[${key}][${subKey}]`, subValue);
-        }
+        url.searchParams.set(`tf[${key}][${subKey}]`, String(subValue));
       }
     }
   }
+}
+
+function getTableFilterParams(tableFilters: Record<string, unknown>): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(tableFilters)) {
+    const normalized = normalizeTableFilterValue(value);
+
+    if (normalized !== undefined) {
+      params[key] = normalized;
+    }
+  }
+
+  return params;
+}
+
+function normalizeTableFilterValue(value: unknown): unknown | undefined {
+  if (value == null || value === "") {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const items = value.filter((item) => item != null && item !== "").map(String);
+
+    return items.length > 0 ? items : undefined;
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value)
+      .filter(([, subValue]) => subValue != null && subValue !== "")
+      .map(([subKey, subValue]) => [subKey, String(subValue)]);
+
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+
+  return String(value);
 }
 
 export function getQueryParams(state: TableState): Record<string, unknown> {
@@ -85,6 +121,12 @@ export function getQueryParams(state: TableState): Record<string, unknown> {
 
   if (state.sorts.length > 0) {
     params.sort = serializeSorts(state);
+  }
+
+  const tableFilters = getTableFilterParams(state.tableFilters);
+
+  if (Object.keys(tableFilters).length > 0) {
+    params.tf = tableFilters;
   }
 
   return params;

--- a/resources/js/table/use-table.ts
+++ b/resources/js/table/use-table.ts
@@ -20,8 +20,13 @@ export function useTable(node: TableNode) {
   const componentRef = typeof node.props?.ref === "string" ? node.props.ref : "";
   const isLazy = node.props?.lazy === true;
   const initialState = useMemo(() => getState(node.props?.state), [node.props?.state]);
-  const [rows, setRows] = useState(() => getRows(node.props?.data));
-  const [pagination, setPagination] = useState(() => getPagination(node.props?.pagination));
+  const initialRows = useMemo(() => getRows(node.props?.data), [node.props?.data]);
+  const initialPagination = useMemo(
+    () => getPagination(node.props?.pagination),
+    [node.props?.pagination],
+  );
+  const [rows, setRows] = useState(initialRows);
+  const [pagination, setPagination] = useState(initialPagination);
   const [state, setState] = useState(initialState);
   const [processing, setProcessing] = useState(isLazy);
   const [hasLoaded, setHasLoaded] = useState(!isLazy);
@@ -158,6 +163,14 @@ export function useTable(node: TableNode) {
       true,
     );
   }, [currentPage, load, pagination.hasMore, pagination.nextPage, processing, state]);
+
+  useEffect(() => {
+    setRows(initialRows);
+    setPagination(initialPagination);
+    setState(initialState);
+    setProcessing(isLazy);
+    setHasLoaded(!isLazy);
+  }, [initialRows, initialPagination, initialState, isLazy]);
 
   useEffect(() => {
     if (!isLazy || hasLoaded) {

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -1,7 +1,12 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { searchForWorkspaceRoot } from "vite";
 import { describe, expect, it } from "vitest";
 import { latticeConfig } from "./vite";
+
+type PackageJson = {
+  exports: Record<string, unknown>;
+};
 
 describe("lattice Vite helper", () => {
   it("configures package-link mode without reading an environment variable", () => {
@@ -49,5 +54,14 @@ describe("lattice Vite helper", () => {
         },
       },
     });
+  });
+
+  it("keeps package exports explicit and internal test helpers private", () => {
+    const packageJson = JSON.parse(
+      readFileSync(path.resolve(process.cwd(), "package.json"), "utf8"),
+    ) as PackageJson;
+
+    expect(packageJson.exports).not.toHaveProperty("./*");
+    expect(packageJson.exports).not.toHaveProperty("./test-support");
   });
 });

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -61,7 +61,13 @@ final class BulkActionController
 
         if ($request->boolean('allMatching')) {
             return $source->resolveMatching(
-                TableQuery::fromRequest($request, $table->columns(), $tableKey, $table->perPage()),
+                TableQuery::fromRequest(
+                    $request,
+                    $table->columns(),
+                    $tableKey,
+                    $table->perPage(),
+                    $table->filters(),
+                ),
             );
         }
 

--- a/tests/Feature/Actions/ProductActionsTest.php
+++ b/tests/Feature/Actions/ProductActionsTest.php
@@ -95,6 +95,34 @@ test('bulk actions ignore selected ids that are not in the table result', functi
     expect($a->fresh()->status)->toBe('archived');
 });
 
+test('bulk actions resolve all matching rows with dedicated table filters', function () {
+    Lattice::tables([ProductsTable::class]);
+    Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
+
+    $featured = Product::factory()->create(['featured' => true, 'status' => 'active']);
+    $notFeatured = Product::factory()->create(['featured' => false, 'status' => 'active']);
+    $draft = Product::factory()->create(['featured' => true, 'status' => 'draft']);
+
+    $ref = app(ComponentReferenceSigner::class)->seal(
+        'bulkAction',
+        'workbench.products.archive-selected',
+        ['table' => 'workbench.products'],
+    );
+
+    patch('/lattice/bulk-actions/workbench.products.archive-selected', [
+        'allMatching' => true,
+        'tf' => [
+            'featured' => 'true',
+        ],
+    ], ['X-Lattice-Ref' => $ref])
+        ->assertOk()
+        ->assertJsonPath('data.archived', 2);
+
+    expect($featured->fresh()->status)->toBe('archived')
+        ->and($notFeatured->fresh()->status)->toBe('active')
+        ->and($draft->fresh()->status)->toBe('archived');
+});
+
 test('bulk action endpoints require a valid component reference', function () {
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,7 @@ function libraryEntries(): string[] {
     // Exclude declaration files and type-level test files — *.test.ts, *.test-d.ts, *.d.ts — from the published bundle.
     .filter((file) => !/\.(test(-d)?|d)\.(ts|tsx)$/.test(file))
     .filter((file) => !file.startsWith("test/"))
+    .filter((file) => file !== "test-support.ts")
     .map((file) => path.join(sourceRoot, file));
 }
 
@@ -115,7 +116,12 @@ export default defineConfig(({ mode }) => {
               include: ["resources/js"],
               copyDtsFiles: true,
               // Exclude test files and declaration sources from .d.ts generation.
-              exclude: ["resources/js/**/*.test.*", "resources/js/**/*.test-d.*", "resources/js/test/**"],
+              exclude: [
+                "resources/js/**/*.test.*",
+                "resources/js/**/*.test-d.*",
+                "resources/js/test/**",
+                "resources/js/test-support.ts",
+              ],
               compilerOptions: { rootDir: sourceRoot },
               outDir: "dist",
             }),


### PR DESCRIPTION
## Summary
- support the documented Inertia Pages resolver path while preserving the lowercase fallback
- carry dedicated table filters through all-matching bulk actions and validate them on the server
- fetch lazy action forms with POST, refresh form/table state from new props, and keep test-only helpers out of package exports/build entries

## Verification
- npm run check
- composer check