### PR TITLE
feat: column alignment & numeric/money formatting

### DIFF
--- a/docs/content/docs/tables/columns.mdx
+++ b/docs/content/docs/tables/columns.mdx
@@ -52,6 +52,9 @@ and filter type:
   default to `End`.
 
 ```php
+use Lattice\Lattice\Tables\Enums\ColumnAlign;
+use Lattice\Lattice\Tables\Enums\NumberFormatUnit;
+
 NumberColumn::make('progress')->unit(NumberFormatUnit::Percent);
 MoneyColumn::make('total')->currencyField('currency');
 ```

--- a/docs/content/docs/tables/columns.mdx
+++ b/docs/content/docs/tables/columns.mdx
@@ -38,11 +38,23 @@ TextColumn::make('email')
 
 ## Boolean & Number columns
 
-`BooleanColumn` and `NumberColumn` are dedicated text-style columns with their own rendering and
-filter type:
+`BooleanColumn`, `NumberColumn`, and `MoneyColumn` are dedicated columns with their own rendering
+and filter type:
 
 - `BooleanColumn` renders a check or cross instead of the raw value, and filters as a boolean.
-- `NumberColumn` right-aligns the column and formats the value as a number, and filters as a number.
+- `NumberColumn` right-aligns and formats the value as a number; `->decimals(2)` fixes the fraction
+  digits (`->decimals(0, 2)` for a min–max range); `->unit(NumberFormatUnit::Percent)` adds a
+  locale-correct unit suffix (percent, kilogram, byte, …). Filters as a number.
+- `MoneyColumn` formats the value as a currency amount — `->currency('EUR')` for a fixed currency or
+  `->currencyField('currency')` to read each row's currency from another field; symbol placement and
+  decimal digits follow the viewer's locale.
+- Every column also accepts `->align(ColumnAlign::Start|Center|End)`; numeric and money columns
+  default to `End`.
+
+```php
+NumberColumn::make('progress')->unit(NumberFormatUnit::Percent);
+MoneyColumn::make('total')->currencyField('currency');
+```
 
 ```php
 BooleanColumn::make('featured')->sortable()->filterable();

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -6,6 +6,7 @@
             "bulkActions": [],
             "columns": [
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "avatar",
@@ -19,6 +20,7 @@
                     "width": "md"
                 },
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "name",
@@ -33,6 +35,7 @@
                     "width": "md"
                 },
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "status",
@@ -49,6 +52,7 @@
                     "width": "md"
                 },
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "verified",

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -6,6 +6,7 @@
             "bulkActions": [],
             "columns": [
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": {
                         "control": null,
@@ -37,6 +38,7 @@
                     "width": "md"
                 },
                 {
+                    "align": "end",
                     "columns": null,
                     "filter": {
                         "control": null,
@@ -59,12 +61,17 @@
                     },
                     "key": "price",
                     "label": "Price",
-                    "props": null,
+                    "props": {
+                        "maximumFractionDigits": null,
+                        "minimumFractionDigits": null,
+                        "unit": null
+                    },
                     "sortable": true,
                     "type": "number",
                     "width": "md"
                 },
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "featured",
@@ -75,6 +82,7 @@
                     "width": "md"
                 },
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "updated_at",

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -6,8 +6,10 @@
             "bulkActions": [],
             "columns": [
                 {
+                    "align": "start",
                     "columns": [
                         {
+                            "align": "start",
                             "columns": null,
                             "filter": null,
                             "key": "name",
@@ -22,6 +24,7 @@
                             "width": "md"
                         },
                         {
+                            "align": "start",
                             "columns": null,
                             "filter": null,
                             "key": "email",
@@ -45,6 +48,7 @@
                     "width": "xl"
                 },
                 {
+                    "align": "start",
                     "columns": null,
                     "filter": null,
                     "key": "role",

--- a/resources/boost/skills/lattice-tables/SKILL.md
+++ b/resources/boost/skills/lattice-tables/SKILL.md
@@ -48,7 +48,8 @@ class ProductsTable extends EloquentTableDefinition
 Columns live in `Lattice\Lattice\Tables\Columns`. `Column::make('key')` reads `$row['key']`; the label defaults to the humanized key (override with `->label()`).
 
 - **`TextColumn`** — `->date('Y-m-d H:i')`, `->copyable()`, `->link('/products/{value}')` (`{value}` is substituted; pass `external: true` for outbound).
-- **`NumberColumn`** — right-aligns and formats the value as a number; filters as a number.
+- **`NumberColumn`** — right-aligns and formats the value as a number; `->decimals(2)` fixes fraction digits (`->decimals(0, 2)` for a range); `->unit(NumberFormatUnit::Percent)` adds a locale-correct unit (percent, kilogram, byte, …). Filters as a number.
+- **`MoneyColumn`** — formats as a currency amount; `->currency('EUR')` for a fixed currency or `->currencyField('currency')` to read the currency from another row field; symbol placement and decimals follow the viewer's locale.
 - **`BooleanColumn`** — renders a check or cross; filters as a boolean.
 - **`BadgeColumn`** — `->colors(['active' => 'green', 'invited' => 'yellow', 'archived' => 'gray'])`. Colors: `gray`, `red`, `green`, `yellow`, `blue`, `purple`, `orange` (unmapped → gray).
 - **`IconColumn`** — `->icon(Icon::Star)` for one icon, or `->icons(['1' => Icon::Check, '0' => Icon::Minus])`; add `->colors([...])` to tint.

--- a/resources/js/table/align.test.ts
+++ b/resources/js/table/align.test.ts
@@ -8,5 +8,9 @@ describe("column align classes", () => {
     expect(alignText("end")).toBe("text-end");
     expect(alignJustify("end")).toBe("justify-end");
     expect(alignJustifyItems("end")).toBe("justify-items-end");
+    expect(alignJustify("start")).toBe("justify-start");
+    expect(alignJustify("center")).toBe("justify-center");
+    expect(alignJustifyItems("start")).toBe("justify-items-start");
+    expect(alignJustifyItems("center")).toBe("justify-items-center");
   });
 });

--- a/resources/js/table/align.test.ts
+++ b/resources/js/table/align.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { alignJustify, alignJustifyItems, alignText } from "./align";
+
+describe("column align classes", () => {
+  it("maps logical alignment to static Tailwind classes", () => {
+    expect(alignText("start")).toBe("text-start");
+    expect(alignText("center")).toBe("text-center");
+    expect(alignText("end")).toBe("text-end");
+    expect(alignJustify("end")).toBe("justify-end");
+    expect(alignJustifyItems("end")).toBe("justify-items-end");
+  });
+});

--- a/resources/js/table/align.ts
+++ b/resources/js/table/align.ts
@@ -1,0 +1,23 @@
+import type { ColumnAlign } from "@lattice-php/lattice/types/generated";
+
+const TEXT: Record<ColumnAlign, string> = {
+  start: "text-start",
+  center: "text-center",
+  end: "text-end",
+};
+
+const JUSTIFY: Record<ColumnAlign, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+};
+
+const JUSTIFY_ITEMS: Record<ColumnAlign, string> = {
+  start: "justify-items-start",
+  center: "justify-items-center",
+  end: "justify-items-end",
+};
+
+export const alignText = (align: ColumnAlign): string => TEXT[align];
+export const alignJustify = (align: ColumnAlign): string => JUSTIFY[align];
+export const alignJustifyItems = (align: ColumnAlign): string => JUSTIFY_ITEMS[align];

--- a/resources/js/table/components/cells/money-cell.test.tsx
+++ b/resources/js/table/components/cells/money-cell.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { TableColumn, TableRow } from "../../types";
+import { MoneyCell } from "./money-cell";
+
+function column(props: Record<string, unknown>): TableColumn {
+  return { key: "total", label: "Total", type: "money", align: "end", props } as TableColumn;
+}
+
+function renderCell(value: unknown, props: Record<string, unknown>, row: TableRow = {}) {
+  const col = column(props);
+  return render(<MoneyCell column={col} props={col.props as never} row={row} value={value} />);
+}
+
+describe("MoneyCell", () => {
+  it("formats with a static currency", () => {
+    const { container } = renderCell(1234.5, { currency: "EUR" });
+    expect(container.textContent).toBe(
+      new Intl.NumberFormat("en", { style: "currency", currency: "EUR" }).format(1234.5),
+    );
+  });
+
+  it("reads the currency from the row when currencyField is set", () => {
+    const { container } = renderCell(1000, { currencyField: "currency" }, { currency: "JPY" });
+    expect(container.textContent).toBe(
+      new Intl.NumberFormat("en", { style: "currency", currency: "JPY" }).format(1000),
+    );
+  });
+
+  it("falls back to a plain number when no currency resolves", () => {
+    const { container } = renderCell(42, { currencyField: "currency" }, {});
+    expect(container.textContent).toBe(new Intl.NumberFormat("en").format(42));
+  });
+});

--- a/resources/js/table/components/cells/money-cell.tsx
+++ b/resources/js/table/components/cells/money-cell.tsx
@@ -1,0 +1,26 @@
+import { useLocale } from "@lattice-php/lattice/i18n";
+import { formatCell } from "../../format";
+import type { ColumnCellComponent } from "../../registry";
+
+export const MoneyCell: ColumnCellComponent<"money"> = ({ column, props, row, value }) => {
+  const { locale } = useLocale();
+  const number = typeof value === "number" ? value : Number(value);
+  const isNumeric =
+    value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
+
+  if (!isNumeric) {
+    return <span>{formatCell(value, column)}</span>;
+  }
+
+  const code = props.currency ?? (props.currencyField ? String(row[props.currencyField] ?? "") : "");
+  const fractionDigits = {
+    minimumFractionDigits: props.minimumFractionDigits ?? undefined,
+    maximumFractionDigits: props.maximumFractionDigits ?? undefined,
+  };
+
+  const text = code
+    ? new Intl.NumberFormat(locale, { style: "currency", currency: code, ...fractionDigits }).format(number)
+    : new Intl.NumberFormat(locale, fractionDigits).format(number);
+
+  return <span className="tabular-nums">{text}</span>;
+};

--- a/resources/js/table/components/cells/money-cell.tsx
+++ b/resources/js/table/components/cells/money-cell.tsx
@@ -5,21 +5,25 @@ import type { ColumnCellComponent } from "../../registry";
 export const MoneyCell: ColumnCellComponent<"money"> = ({ column, props, row, value }) => {
   const { locale } = useLocale();
   const number = typeof value === "number" ? value : Number(value);
-  const isNumeric =
-    value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
+  const isNumeric = value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
 
   if (!isNumeric) {
     return <span>{formatCell(value, column)}</span>;
   }
 
-  const code = props.currency ?? (props.currencyField ? String(row[props.currencyField] ?? "") : "");
+  const code =
+    props.currency ?? (props.currencyField ? String(row[props.currencyField] ?? "") : "");
   const fractionDigits = {
     minimumFractionDigits: props.minimumFractionDigits ?? undefined,
     maximumFractionDigits: props.maximumFractionDigits ?? undefined,
   };
 
   const text = code
-    ? new Intl.NumberFormat(locale, { style: "currency", currency: code, ...fractionDigits }).format(number)
+    ? new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency: code,
+        ...fractionDigits,
+      }).format(number)
     : new Intl.NumberFormat(locale, fractionDigits).format(number);
 
   return <span className="tabular-nums">{text}</span>;

--- a/resources/js/table/components/cells/money-cell.tsx
+++ b/resources/js/table/components/cells/money-cell.tsx
@@ -1,18 +1,18 @@
 import { useLocale } from "@lattice-php/lattice/i18n";
 import { formatCell } from "../../format";
 import type { ColumnCellComponent } from "../../registry";
+import { numericValue } from "./numeric";
 
 export const MoneyCell: ColumnCellComponent<"money"> = ({ column, props, row, value }) => {
   const { locale } = useLocale();
-  const number = typeof value === "number" ? value : Number(value);
-  const isNumeric = value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
+  const number = numericValue(value);
 
-  if (!isNumeric) {
+  if (number === null) {
     return <span>{formatCell(value, column)}</span>;
   }
 
-  const code =
-    props.currency ?? (props.currencyField ? String(row[props.currencyField] ?? "") : "");
+  const rawCode = props.currencyField ? row[props.currencyField] : undefined;
+  const code = props.currency ?? (typeof rawCode === "string" ? rawCode : "");
   const fractionDigits = {
     minimumFractionDigits: props.minimumFractionDigits ?? undefined,
     maximumFractionDigits: props.maximumFractionDigits ?? undefined,

--- a/resources/js/table/components/cells/number-cell.test.tsx
+++ b/resources/js/table/components/cells/number-cell.test.tsx
@@ -5,16 +5,17 @@ import { NumberCell } from "./number-cell";
 
 const column = { key: "price", label: "Price", type: "number" } as TableColumn;
 
+const numberProps = { maximumFractionDigits: null, minimumFractionDigits: null, unit: null };
+
 function renderCell(value: unknown) {
-  return render(<NumberCell column={column} props={{}} row={{}} value={value} />);
+  return render(<NumberCell column={column} props={numberProps} row={{}} value={value} />);
 }
 
 describe("NumberCell", () => {
-  it("formats a numeric value and right-aligns it", () => {
+  it("formats a numeric value", () => {
     const { container } = renderCell(1234.5);
     const span = container.querySelector("span");
 
-    expect(span?.className).toContain("text-right");
     expect(span?.textContent).toBe(new Intl.NumberFormat().format(1234.5));
   });
 

--- a/resources/js/table/components/cells/number-cell.test.tsx
+++ b/resources/js/table/components/cells/number-cell.test.tsx
@@ -36,7 +36,8 @@ describe("NumberCell", () => {
     expect(renderCell("n/a").container.textContent).toBe("n/a");
   });
 
-  it("renders empty for null", () => {
+  it("renders empty for null and undefined", () => {
     expect(renderCell(null).container.textContent).toBe("");
+    expect(renderCell(undefined).container.textContent).toBe("");
   });
 });

--- a/resources/js/table/components/cells/number-cell.test.tsx
+++ b/resources/js/table/components/cells/number-cell.test.tsx
@@ -14,9 +14,14 @@ function renderCell(value: unknown, props: Record<string, unknown> = {}) {
 
 describe("NumberCell", () => {
   it("formats with the configured fraction digits", () => {
-    const { container } = renderCell(1234.5, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const { container } = renderCell(1234.5, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
     expect(container.textContent).toBe(
-      new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(1234.5),
+      new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(
+        1234.5,
+      ),
     );
   });
 

--- a/resources/js/table/components/cells/number-cell.test.tsx
+++ b/resources/js/table/components/cells/number-cell.test.tsx
@@ -3,36 +3,35 @@ import { describe, expect, it } from "vitest";
 import type { TableColumn } from "../../types";
 import { NumberCell } from "./number-cell";
 
-const column = { key: "price", label: "Price", type: "number" } as TableColumn;
+function column(props: Record<string, unknown> = {}): TableColumn {
+  return { key: "price", label: "Price", type: "number", align: "end", props } as TableColumn;
+}
 
-const numberProps = { maximumFractionDigits: null, minimumFractionDigits: null, unit: null };
-
-function renderCell(value: unknown) {
-  return render(<NumberCell column={column} props={numberProps} row={{}} value={value} />);
+function renderCell(value: unknown, props: Record<string, unknown> = {}) {
+  const col = column(props);
+  return render(<NumberCell column={col} props={col.props as never} row={{}} value={value} />);
 }
 
 describe("NumberCell", () => {
-  it("formats a numeric value", () => {
-    const { container } = renderCell(1234.5);
-    const span = container.querySelector("span");
-
-    expect(span?.textContent).toBe(new Intl.NumberFormat().format(1234.5));
+  it("formats with the configured fraction digits", () => {
+    const { container } = renderCell(1234.5, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    expect(container.textContent).toBe(
+      new Intl.NumberFormat("en", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(1234.5),
+    );
   });
 
-  it("formats a numeric string", () => {
-    const { container } = renderCell("42");
-
-    expect(container.textContent).toBe(new Intl.NumberFormat().format(42));
+  it("renders percent without multiplying", () => {
+    const { container } = renderCell(50, { unit: "percent" });
+    expect(container.textContent).toBe(
+      new Intl.NumberFormat("en", { style: "unit", unit: "percent" }).format(50),
+    );
   });
 
-  it("falls back to the raw text for non-numeric values", () => {
-    const { container } = renderCell("n/a");
-
-    expect(container.textContent).toBe("n/a");
+  it("falls back to raw text for non-numeric values", () => {
+    expect(renderCell("n/a").container.textContent).toBe("n/a");
   });
 
-  it("renders empty for null and undefined", () => {
+  it("renders empty for null", () => {
     expect(renderCell(null).container.textContent).toBe("");
-    expect(renderCell(undefined).container.textContent).toBe("");
   });
 });

--- a/resources/js/table/components/cells/number-cell.tsx
+++ b/resources/js/table/components/cells/number-cell.tsx
@@ -5,8 +5,7 @@ import type { ColumnCellComponent } from "../../registry";
 export const NumberCell: ColumnCellComponent<"number"> = ({ column, props, value }) => {
   const { locale } = useLocale();
   const number = typeof value === "number" ? value : Number(value);
-  const isNumeric =
-    value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
+  const isNumeric = value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
 
   if (!isNumeric) {
     return <span>{formatCell(value, column)}</span>;

--- a/resources/js/table/components/cells/number-cell.tsx
+++ b/resources/js/table/components/cells/number-cell.tsx
@@ -1,13 +1,13 @@
 import { useLocale } from "@lattice-php/lattice/i18n";
 import { formatCell } from "../../format";
 import type { ColumnCellComponent } from "../../registry";
+import { numericValue } from "./numeric";
 
 export const NumberCell: ColumnCellComponent<"number"> = ({ column, props, value }) => {
   const { locale } = useLocale();
-  const number = typeof value === "number" ? value : Number(value);
-  const isNumeric = value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
+  const number = numericValue(value);
 
-  if (!isNumeric) {
+  if (number === null) {
     return <span>{formatCell(value, column)}</span>;
   }
 

--- a/resources/js/table/components/cells/number-cell.tsx
+++ b/resources/js/table/components/cells/number-cell.tsx
@@ -1,12 +1,22 @@
+import { useLocale } from "@lattice-php/lattice/i18n";
 import { formatCell } from "../../format";
 import type { ColumnCellComponent } from "../../registry";
 
-export const NumberCell: ColumnCellComponent<"number"> = ({ column, value }) => {
+export const NumberCell: ColumnCellComponent<"number"> = ({ column, props, value }) => {
+  const { locale } = useLocale();
   const number = typeof value === "number" ? value : Number(value);
-  const text =
-    value !== null && value !== undefined && value !== "" && !Number.isNaN(number)
-      ? new Intl.NumberFormat().format(number)
-      : formatCell(value, column);
+  const isNumeric =
+    value !== null && value !== undefined && value !== "" && !Number.isNaN(number);
+
+  if (!isNumeric) {
+    return <span>{formatCell(value, column)}</span>;
+  }
+
+  const text = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: props.minimumFractionDigits ?? undefined,
+    maximumFractionDigits: props.maximumFractionDigits ?? undefined,
+    ...(props.unit ? { style: "unit" as const, unit: props.unit } : {}),
+  }).format(number);
 
   return <span className="tabular-nums">{text}</span>;
 };

--- a/resources/js/table/components/cells/number-cell.tsx
+++ b/resources/js/table/components/cells/number-cell.tsx
@@ -1,7 +1,6 @@
 import { formatCell } from "../../format";
 import type { ColumnCellComponent } from "../../registry";
 
-/** Renders a numeric column right-aligned, formatting numbers for the locale. */
 export const NumberCell: ColumnCellComponent<"number"> = ({ column, value }) => {
   const number = typeof value === "number" ? value : Number(value);
   const text =
@@ -9,5 +8,5 @@ export const NumberCell: ColumnCellComponent<"number"> = ({ column, value }) => 
       ? new Intl.NumberFormat().format(number)
       : formatCell(value, column);
 
-  return <span className="block text-right tabular-nums">{text}</span>;
+  return <span className="tabular-nums">{text}</span>;
 };

--- a/resources/js/table/components/cells/numeric.test.ts
+++ b/resources/js/table/components/cells/numeric.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { numericValue } from "./numeric";
+
+describe("numericValue", () => {
+  it("parses numbers and numeric strings", () => {
+    expect(numericValue(42)).toBe(42);
+    expect(numericValue("3.5")).toBe(3.5);
+  });
+
+  it("returns null for non-numeric values", () => {
+    expect(numericValue(null)).toBeNull();
+    expect(numericValue(undefined)).toBeNull();
+    expect(numericValue("")).toBeNull();
+    expect(numericValue("n/a")).toBeNull();
+  });
+});

--- a/resources/js/table/components/cells/numeric.ts
+++ b/resources/js/table/components/cells/numeric.ts
@@ -1,0 +1,8 @@
+/** Parses a cell value to a finite number, or null when it isn't numeric. */
+export function numericValue(value: unknown): number | null {
+  const number = typeof value === "number" ? value : Number(value);
+
+  return value !== null && value !== undefined && value !== "" && !Number.isNaN(number)
+    ? number
+    : null;
+}

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@lattice-php/lattice/icons";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import type { HTMLAttributes } from "react";
+import { alignJustify, alignText } from "../align";
 import { getColumnAriaSort, getColumnSort } from "../query";
 import type { TableColumn, TableSort, TableState } from "../types";
 
@@ -36,14 +37,14 @@ export function ColumnHeader({
   state: TableState;
 }) {
   const columnSort = getColumnSort(state, column);
-  const alignEnd = column.type === "number";
+  const align = column.align;
 
   return (
     <div
       aria-sort={getColumnAriaSort(columnSort)}
       className={cn(
         "relative min-w-0 px-4 py-3 pr-5 align-middle font-medium text-lt-muted-fg",
-        alignEnd ? "text-right" : "text-left",
+        alignText(align),
       )}
       role="columnheader"
     >
@@ -51,18 +52,18 @@ export function ColumnHeader({
         <button
           type="button"
           aria-label={`Sort ${column.label}`}
-          className={cn("flex w-full items-center gap-1.5 font-medium", alignEnd && "justify-end")}
+          className={cn("flex w-full items-center gap-1.5 font-medium", alignJustify(align))}
           data-test={`sort-${column.key}`}
           disabled={processing}
           onClick={() => sort(column)}
         >
-          <span className={cn("min-w-0 flex-1 truncate", alignEnd ? "text-right" : "text-left")}>
+          <span className={cn("min-w-0 flex-1 truncate", alignText(align))}>
             {column.label}
           </span>
           <SortIndicator sort={columnSort} />
         </button>
       ) : (
-        <span className={cn("block truncate", alignEnd && "text-right")}>{column.label}</span>
+        <span className={cn("block truncate", alignText(align))}>{column.label}</span>
       )}
       {resizeHandleProps && <div {...resizeHandleProps} />}
     </div>

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -57,9 +57,7 @@ export function ColumnHeader({
           disabled={processing}
           onClick={() => sort(column)}
         >
-          <span className={cn("min-w-0 flex-1 truncate", alignText(align))}>
-            {column.label}
-          </span>
+          <span className={cn("min-w-0 flex-1 truncate", alignText(align))}>{column.label}</span>
           <SortIndicator sort={columnSort} />
         </button>
       ) : (

--- a/resources/js/table/components/column-select-filter.test.tsx
+++ b/resources/js/table/components/column-select-filter.test.tsx
@@ -30,6 +30,7 @@ function col(filter: ColumnFilter): ColumnData {
     filter,
     columns: null,
     props: null,
+    align: "start",
   };
 }
 

--- a/resources/js/table/components/searchable-filter.test.tsx
+++ b/resources/js/table/components/searchable-filter.test.tsx
@@ -26,6 +26,7 @@ function col(): ColumnData {
     filter: null,
     columns: null,
     props: null,
+    align: "start",
   };
 }
 

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -12,6 +12,7 @@ function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): 
     filter: null,
     columns: null,
     props: null,
+    align: "start",
     ...partial,
   };
 }

--- a/resources/js/table/components/table-cell.tsx
+++ b/resources/js/table/components/table-cell.tsx
@@ -5,6 +5,7 @@ import { BadgeCell } from "./cells/badge-cell";
 import { BooleanCell } from "./cells/boolean-cell";
 import { IconCell } from "./cells/icon-cell";
 import { ImageCell } from "./cells/image-cell";
+import { MoneyCell } from "./cells/money-cell";
 import { NumberCell } from "./cells/number-cell";
 import { StackCell } from "./cells/stack-cell";
 import { TextCell } from "./cells/text-cell";
@@ -17,6 +18,7 @@ const builtinColumnCells: ColumnRegistry = {
   boolean: columnCell(BooleanCell),
   icon: columnCell(IconCell),
   image: columnCell(ImageCell),
+  money: columnCell(MoneyCell),
   number: columnCell(NumberCell),
   stack: columnCell(StackCell),
   text: columnCell(TextCell),

--- a/resources/js/table/components/table-filters.test.tsx
+++ b/resources/js/table/components/table-filters.test.tsx
@@ -14,6 +14,7 @@ function col(key: string, label: string): ColumnData {
     filter: null,
     columns: null,
     props: null,
+    align: "start",
   };
 }
 

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -14,6 +14,7 @@ function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): 
     filter: null,
     columns: null,
     props: null,
+    align: "start",
     ...partial,
   };
 }

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -1,9 +1,11 @@
 import { type ReactNode, useMemo } from "react";
 import { useT } from "@lattice-php/lattice/i18n";
+import { cn } from "@lattice-php/lattice/lib/utils";
 import { useColumnResizing } from "@lattice-php/lattice/core/use-column-resizing";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import { Checkbox } from "@lattice-php/lattice/core/components/checkbox";
 import { Icon } from "@lattice-php/lattice/icons";
+import { alignJustifyItems, alignText } from "../align";
 import type { TableNode } from "../types";
 import { getBulkActions } from "../bulk";
 import { flattenColumns, getRowActions, getRowKey } from "../payload";
@@ -255,7 +257,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                     {columns.map((column) => (
                       <div
                         key={column.key}
-                        className="grid min-w-0 gap-1 p-4 align-middle"
+                        className={cn("grid min-w-0 gap-1 p-4 align-middle", alignText(column.align), alignJustifyItems(column.align))}
                         role="cell"
                       >
                         <span

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -257,7 +257,11 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                     {columns.map((column) => (
                       <div
                         key={column.key}
-                        className={cn("grid min-w-0 gap-1 p-4 align-middle", alignText(column.align), alignJustifyItems(column.align))}
+                        className={cn(
+                          "grid min-w-0 gap-1 p-4 align-middle",
+                          alignText(column.align),
+                          alignJustifyItems(column.align),
+                        )}
                         role="cell"
                       >
                         <span

--- a/resources/js/table/registry.test.tsx
+++ b/resources/js/table/registry.test.tsx
@@ -19,6 +19,7 @@ function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): 
     filter: null,
     columns: null,
     props: null,
+    align: "start",
     ...partial,
   };
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -203,11 +203,13 @@ export type CloseModalEffect = {
   readonly modal: string | null;
 };
 export type Color = "default" | "muted" | "primary" | "success" | "info" | "warning" | "danger";
+export type ColumnAlign = "start" | "center" | "end";
 export type ColumnData = {
   readonly key: string;
   readonly label: string;
   readonly type: ColumnType | string;
   readonly width: ColumnWidth;
+  readonly align: ColumnAlign;
   readonly sortable: boolean | null;
   readonly filter: ColumnFilter | null;
   readonly columns: ColumnData[] | null;
@@ -228,10 +230,19 @@ export type ColumnPropsMap = {
   boolean: BooleanColumn;
   icon: IconColumn;
   image: ImageColumn;
+  money: MoneyColumn;
   number: NumberColumn;
   text: TextColumn;
 };
-export type ColumnType = "text" | "boolean" | "number" | "stack" | "badge" | "icon" | "image";
+export type ColumnType =
+  | "text"
+  | "boolean"
+  | "number"
+  | "money"
+  | "stack"
+  | "badge"
+  | "icon"
+  | "image";
 export type ColumnWidth = "xs" | "sm" | "md" | "lg" | "xl";
 export type Condition = {
   readonly field: string;
@@ -693,6 +704,12 @@ export type Modal = {
   ref: string | null;
   title: string | null;
 };
+export type MoneyColumn = {
+  currency: string | null;
+  currencyField: string | null;
+  maximumFractionDigits: number | null;
+  minimumFractionDigits: number | null;
+};
 export type Node =
   | FormNode
   | CoreNode
@@ -702,7 +719,27 @@ export type Node =
   | LayoutNode
   | ChatNode;
 export type NodeType = Node["type"];
-export type NumberColumn = Record<string, never>;
+export type NumberColumn = {
+  maximumFractionDigits: number | null;
+  minimumFractionDigits: number | null;
+  unit: NumberFormatUnit | null;
+};
+export type NumberFormatUnit =
+  | "percent"
+  | "kilogram"
+  | "gram"
+  | "kilometer"
+  | "meter"
+  | "byte"
+  | "kilobyte"
+  | "megabyte"
+  | "gigabyte"
+  | "millisecond"
+  | "second"
+  | "minute"
+  | "hour"
+  | "celsius"
+  | "fahrenheit";
 export type NumberInput = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;

--- a/src/Tables/Columns/Column.php
+++ b/src/Tables/Columns/Column.php
@@ -8,6 +8,7 @@ use JsonSerializable;
 use Lattice\Lattice\Attributes\Component as ComponentAttribute;
 use Lattice\Lattice\Core\Components\Concerns\ReflectsWireProps;
 use Lattice\Lattice\Core\Enums\ColumnWidth;
+use Lattice\Lattice\Tables\Enums\ColumnAlign;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 /**
@@ -20,6 +21,8 @@ abstract class Column implements JsonSerializable
     protected string $label;
 
     protected ?ColumnWidth $width = null;
+
+    protected ?ColumnAlign $align = null;
 
     public function __construct(protected readonly string $key)
     {
@@ -59,6 +62,13 @@ abstract class Column implements JsonSerializable
         return $this;
     }
 
+    public function align(ColumnAlign $align): static
+    {
+        $this->align = $align;
+
+        return $this;
+    }
+
     /**
      * Reflects the column's public properties into the wire shape, mirroring how
      * components serialize their props. The common fields (key, label, type,
@@ -74,6 +84,7 @@ abstract class Column implements JsonSerializable
             label: $this->label,
             type: $this->resolvedType(),
             width: $this->resolvedWidth(),
+            align: $this->resolvedAlign(),
             sortable: $this->sortableValue(),
             filter: $this->filterValue(),
             props: $props === [] ? null : $props,
@@ -100,6 +111,16 @@ abstract class Column implements JsonSerializable
     protected function defaultWidth(): ColumnWidth
     {
         return ColumnWidth::Md;
+    }
+
+    protected function resolvedAlign(): ColumnAlign
+    {
+        return $this->align ?? $this->defaultAlign();
+    }
+
+    protected function defaultAlign(): ColumnAlign
+    {
+        return ColumnAlign::Start;
     }
 
     protected function sortableValue(): ?bool

--- a/src/Tables/Columns/ColumnData.php
+++ b/src/Tables/Columns/ColumnData.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Tables\Columns;
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\ColumnWidth;
+use Lattice\Lattice\Tables\Enums\ColumnAlign;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 /**
@@ -25,6 +26,7 @@ final readonly class ColumnData implements JsonSerializable
         public string $label,
         public ColumnType|string $type,
         public ColumnWidth $width = ColumnWidth::Md,
+        public ColumnAlign $align = ColumnAlign::Start,
         public ?bool $sortable = null,
         public ?ColumnFilter $filter = null,
         public ?array $columns = null,
@@ -41,6 +43,7 @@ final readonly class ColumnData implements JsonSerializable
             'label' => $this->label,
             'type' => $this->type instanceof ColumnType ? $this->type->value : $this->type,
             'width' => $this->width->value,
+            'align' => $this->align->value,
             'sortable' => $this->sortable,
             'filter' => $this->filter,
             'columns' => $this->columns,

--- a/src/Tables/Columns/MoneyColumn.php
+++ b/src/Tables/Columns/MoneyColumn.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Columns;
+
+use Lattice\Lattice\Tables\Attributes\AsColumn;
+use Lattice\Lattice\Tables\Enums\ColumnType;
+
+/**
+ * A numeric column rendered as currency on the client. The currency code is
+ * either fixed for the whole column ({@see currency()}) or read per row from
+ * another field ({@see currencyField()}); the cell formats with Intl, so symbol
+ * placement and per-currency decimals follow the active locale.
+ */
+#[AsColumn(ColumnType::Money)]
+class MoneyColumn extends NumericColumn
+{
+    public ?string $currency = null;
+
+    public ?string $currencyField = null;
+
+    public function currency(string $currency): static
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function currencyField(string $field): static
+    {
+        $this->currencyField = $field;
+
+        return $this;
+    }
+}

--- a/src/Tables/Columns/NumberColumn.php
+++ b/src/Tables/Columns/NumberColumn.php
@@ -5,6 +5,17 @@ namespace Lattice\Lattice\Tables\Columns;
 
 use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Enums\ColumnType;
+use Lattice\Lattice\Tables\Enums\NumberFormatUnit;
 
 #[AsColumn(ColumnType::Number)]
-class NumberColumn extends NumericColumn {}
+class NumberColumn extends NumericColumn
+{
+    public ?NumberFormatUnit $unit = null;
+
+    public function unit(NumberFormatUnit $unit): static
+    {
+        $this->unit = $unit;
+
+        return $this;
+    }
+}

--- a/src/Tables/Columns/NumberColumn.php
+++ b/src/Tables/Columns/NumberColumn.php
@@ -4,19 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables\Columns;
 
 use Lattice\Lattice\Tables\Attributes\AsColumn;
-use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
-use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
 use Lattice\Lattice\Tables\Enums\ColumnType;
-use Lattice\Lattice\Tables\Enums\FilterType;
 
 #[AsColumn(ColumnType::Number)]
-class NumberColumn extends Column implements Filterable, Sortable
-{
-    use IsFilterable;
-    use IsSortable;
-
-    public function filterType(): FilterType
-    {
-        return FilterType::Number;
-    }
-}
+class NumberColumn extends NumericColumn {}

--- a/src/Tables/Columns/NumericColumn.php
+++ b/src/Tables/Columns/NumericColumn.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Columns;
+
+use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
+use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
+use Lattice\Lattice\Tables\Enums\ColumnAlign;
+use Lattice\Lattice\Tables\Enums\FilterType;
+
+abstract class NumericColumn extends Column implements Filterable, Sortable
+{
+    use IsFilterable;
+    use IsSortable;
+
+    public ?int $minimumFractionDigits = null;
+
+    public ?int $maximumFractionDigits = null;
+
+    public function decimals(int $min, ?int $max = null): static
+    {
+        $this->minimumFractionDigits = $min;
+        $this->maximumFractionDigits = $max ?? $min;
+
+        return $this;
+    }
+
+    #[\Override]
+    public function filterType(): FilterType
+    {
+        return FilterType::Number;
+    }
+
+    #[\Override]
+    protected function defaultAlign(): ColumnAlign
+    {
+        return ColumnAlign::End;
+    }
+}

--- a/src/Tables/Columns/StackColumn.php
+++ b/src/Tables/Columns/StackColumn.php
@@ -31,6 +31,7 @@ class StackColumn extends Column
             label: $this->label,
             type: ColumnType::Stack,
             width: $this->resolvedWidth(),
+            align: $this->resolvedAlign(),
             sortable: $this->sortableValue(),
             filter: $this->filterValue(),
             columns: array_map(

--- a/src/Tables/Enums/ColumnAlign.php
+++ b/src/Tables/Enums/ColumnAlign.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum ColumnAlign: string
+{
+    case Start = 'start';
+    case Center = 'center';
+    case End = 'end';
+}

--- a/src/Tables/Enums/ColumnType.php
+++ b/src/Tables/Enums/ColumnType.php
@@ -11,6 +11,7 @@ enum ColumnType: string
     case Text = 'text';
     case Boolean = 'boolean';
     case Number = 'number';
+    case Money = 'money';
     case Stack = 'stack';
     case Badge = 'badge';
     case Icon = 'icon';

--- a/src/Tables/Enums/NumberFormatUnit.php
+++ b/src/Tables/Enums/NumberFormatUnit.php
@@ -6,8 +6,7 @@ namespace Lattice\Lattice\Tables\Enums;
 use Lattice\Lattice\Attributes\TypeScript;
 
 /**
- * The subset of Intl.NumberFormat sanctioned units Lattice exposes. Backed
- * values are the exact Intl unit identifiers the client passes through.
+ * The subset of Intl.NumberFormat sanctioned units Lattice exposes.
  */
 #[TypeScript]
 enum NumberFormatUnit: string

--- a/src/Tables/Enums/NumberFormatUnit.php
+++ b/src/Tables/Enums/NumberFormatUnit.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+/**
+ * The subset of Intl.NumberFormat sanctioned units Lattice exposes. Backed
+ * values are the exact Intl unit identifiers the client passes through.
+ */
+#[TypeScript]
+enum NumberFormatUnit: string
+{
+    case Percent = 'percent';
+    case Kilogram = 'kilogram';
+    case Gram = 'gram';
+    case Kilometer = 'kilometer';
+    case Meter = 'meter';
+    case Byte = 'byte';
+    case Kilobyte = 'kilobyte';
+    case Megabyte = 'megabyte';
+    case Gigabyte = 'gigabyte';
+    case Millisecond = 'millisecond';
+    case Second = 'second';
+    case Minute = 'minute';
+    case Hour = 'hour';
+    case Celsius = 'celsius';
+    case Fahrenheit = 'fahrenheit';
+}

--- a/tests/Browser/Tables/ProductsTableTest.php
+++ b/tests/Browser/Tables/ProductsTableTest.php
@@ -110,3 +110,13 @@ it('searches products inside the reject modal form', function (): void {
         ->assertPresent("[data-test=\"select-replacement-option-{$replacement->getKey()}\"]")
         ->assertNoSmoke();
 });
+
+it('renders the default price as euro currency in the money column', function (): void {
+    $this->actingAs(workbenchTestUser());
+    Product::factory()->create(['name' => 'Euro Product', 'sku' => 'EURO-1', 'status' => 'active']);
+
+    visit('/products')
+        ->assertSee('Euro Product')
+        ->assertSee('€')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -66,6 +66,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
                         'width' => 'md',
+                        'align' => 'start',
                     ],
                     [
                         'key' => 'status',
@@ -85,6 +86,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
                         'width' => 'md',
+                        'align' => 'start',
                     ],
                     [
                         'key' => 'email',
@@ -95,6 +97,7 @@ test('registered tables serialize their configured endpoint columns state and in
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
                         'width' => 'md',
+                        'align' => 'start',
                     ],
                 ],
                 'data' => [
@@ -147,6 +150,7 @@ test('registered tables can serialize lazily without running their query', funct
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
                         'width' => 'md',
+                        'align' => 'start',
                     ],
                 ],
                 'data' => [],
@@ -201,6 +205,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
                         'width' => 'md',
+                        'align' => 'start',
                     ],
                     [
                         'key' => 'email',
@@ -211,10 +216,12 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                         'columns' => null,
                         'props' => ['date' => null, 'copyable' => false, 'link' => null],
                         'width' => 'md',
+                        'align' => 'start',
                     ],
                 ],
                 'props' => null,
                 'width' => 'xl',
+                'align' => 'start',
             ],
             [
                 'key' => 'status',
@@ -225,6 +232,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
                 'columns' => null,
                 'props' => ['date' => null, 'copyable' => false, 'link' => null],
                 'width' => 'md',
+                'align' => 'start',
             ],
         ])
         ->and($table['props']['data'][0]['actions'][0])->toMatchArray([

--- a/tests/Unit/Tables/Columns/ColumnAlignmentTest.php
+++ b/tests/Unit/Tables/Columns/ColumnAlignmentTest.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Enums\ColumnAlign;
+
+it('defaults a column to start alignment', function () {
+    expect(wire(TextColumn::make('name'))['align'])->toBe('start');
+});
+
+it('lets a column override its alignment', function () {
+    expect(wire(TextColumn::make('name')->align(ColumnAlign::Center))['align'])->toBe('center');
+});

--- a/tests/Unit/Tables/Columns/ColumnDataTest.php
+++ b/tests/Unit/Tables/Columns/ColumnDataTest.php
@@ -19,6 +19,7 @@ it('serializes common fields plus a reflected props object', function () {
         'label' => 'Status',
         'type' => 'badge',
         'width' => 'sm',
+        'align' => 'start',
         'sortable' => null,
         'filter' => null,
         'columns' => null,

--- a/tests/Unit/Tables/Columns/ColumnPropsTest.php
+++ b/tests/Unit/Tables/Columns/ColumnPropsTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
-use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 
 it('reflects a column\'s public properties into the full props shape', function () {
@@ -24,8 +23,7 @@ it('reflects a column\'s public properties into the full props shape', function 
 });
 
 it('omits props for columns that expose no public properties', function () {
-    expect(wire(BooleanColumn::make('active'))['props'])->toBeNull()
-        ->and(wire(NumberColumn::make('total'))['props'])->toBeNull();
+    expect(wire(BooleanColumn::make('active'))['props'])->toBeNull();
 });
 
 it('keeps protected filter and sort state off the wire props', function () {

--- a/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
+++ b/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
@@ -36,7 +36,7 @@ it('exposes only the intended wire props on each built-in column', function (str
 })->with([
     'text' => [TextColumn::class, ['date', 'copyable', 'link']],
     'boolean' => [BooleanColumn::class, []],
-    'number' => [NumberColumn::class, ['minimumFractionDigits', 'maximumFractionDigits']],
+    'number' => [NumberColumn::class, ['minimumFractionDigits', 'maximumFractionDigits', 'unit']],
     'badge' => [BadgeColumn::class, ['colors']],
     'icon' => [IconColumn::class, ['icon', 'icons', 'colors']],
     'image' => [ImageColumn::class, ['circular', 'size']],

--- a/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
+++ b/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
@@ -36,7 +36,7 @@ it('exposes only the intended wire props on each built-in column', function (str
 })->with([
     'text' => [TextColumn::class, ['date', 'copyable', 'link']],
     'boolean' => [BooleanColumn::class, []],
-    'number' => [NumberColumn::class, []],
+    'number' => [NumberColumn::class, ['minimumFractionDigits', 'maximumFractionDigits']],
     'badge' => [BadgeColumn::class, ['colors']],
     'icon' => [IconColumn::class, ['icon', 'icons', 'colors']],
     'image' => [ImageColumn::class, ['circular', 'size']],

--- a/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
+++ b/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
@@ -6,6 +6,7 @@ use Lattice\Lattice\Tables\Columns\BooleanColumn;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\IconColumn;
 use Lattice\Lattice\Tables\Columns\ImageColumn;
+use Lattice\Lattice\Tables\Columns\MoneyColumn;
 use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Columns\StackColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
@@ -37,6 +38,7 @@ it('exposes only the intended wire props on each built-in column', function (str
     'text' => [TextColumn::class, ['date', 'copyable', 'link']],
     'boolean' => [BooleanColumn::class, []],
     'number' => [NumberColumn::class, ['minimumFractionDigits', 'maximumFractionDigits', 'unit']],
+    'money' => [MoneyColumn::class, ['minimumFractionDigits', 'maximumFractionDigits', 'currency', 'currencyField']],
     'badge' => [BadgeColumn::class, ['colors']],
     'icon' => [IconColumn::class, ['icon', 'icons', 'colors']],
     'image' => [ImageColumn::class, ['circular', 'size']],

--- a/tests/Unit/Tables/Columns/ColumnTypesTest.php
+++ b/tests/Unit/Tables/Columns/ColumnTypesTest.php
@@ -55,11 +55,11 @@ it('serializes a boolean column with a boolean filter and no props', function ()
         ->and($data['filter']['type'])->toBe(FilterType::Boolean->value);
 });
 
-it('serializes a number column with a number filter and no props', function (): void {
+it('serializes a number column with a number filter and end alignment', function (): void {
     $data = wire(NumberColumn::make('price')->label('Price')->sortable()->filterable());
 
     expect($data['type'])->toBe('number')
-        ->and($data['props'])->toBeNull()
+        ->and($data['align'])->toBe('end')
         ->and($data['sortable'])->toBeTrue()
         ->and($data['filter']['type'])->toBe(FilterType::Number->value);
 });

--- a/tests/Unit/Tables/Columns/MoneyColumnTest.php
+++ b/tests/Unit/Tables/Columns/MoneyColumnTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Tables\Columns\MoneyColumn;
+use Lattice\Lattice\Tables\Enums\FilterType;
+
+it('serializes a static-currency money column', function () {
+    $data = wire(MoneyColumn::make('total')->currency('EUR'));
+
+    expect($data['type'])->toBe('money')
+        ->and($data['align'])->toBe('end')
+        ->and($data['props']['currency'])->toBe('EUR')
+        ->and($data['props']['currencyField'])->toBeNull()
+        ->and($data['filter'] ?? null)->toBeNull();
+});
+
+it('serializes a per-row currency reference', function () {
+    $props = wire(MoneyColumn::make('total')->currencyField('currency')->decimals(0))['props'];
+
+    expect($props['currencyField'])->toBe('currency')
+        ->and($props['currency'])->toBeNull()
+        ->and($props['minimumFractionDigits'])->toBe(0);
+});
+
+it('filters money as a number', function () {
+    $data = wire(MoneyColumn::make('total')->filterable());
+
+    expect($data['filter']['type'])->toBe(FilterType::Number->value);
+});

--- a/tests/Unit/Tables/Columns/NumericColumnTest.php
+++ b/tests/Unit/Tables/Columns/NumericColumnTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Enums\FilterType;
+use Lattice\Lattice\Tables\Enums\NumberFormatUnit;
 
 it('defaults a numeric column to end alignment', function () {
     expect(wire(NumberColumn::make('price'))['align'])->toBe('end');
@@ -26,4 +27,13 @@ it('filters a numeric column as a number', function () {
     $data = wire(NumberColumn::make('price')->filterable());
 
     expect($data['filter']['type'])->toBe(FilterType::Number->value);
+});
+
+it('emits the Intl unit as its backed value', function () {
+    $props = wire(
+        NumberColumn::make('progress')
+            ->unit(NumberFormatUnit::Percent),
+    )['props'];
+
+    expect($props['unit'])->toBe('percent');
 });

--- a/tests/Unit/Tables/Columns/NumericColumnTest.php
+++ b/tests/Unit/Tables/Columns/NumericColumnTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Tables\Columns\NumberColumn;
+use Lattice\Lattice\Tables\Enums\FilterType;
+
+it('defaults a numeric column to end alignment', function () {
+    expect(wire(NumberColumn::make('price'))['align'])->toBe('end');
+});
+
+it('emits fixed fraction digits', function () {
+    $props = wire(NumberColumn::make('price')->decimals(2))['props'];
+
+    expect($props['minimumFractionDigits'])->toBe(2)
+        ->and($props['maximumFractionDigits'])->toBe(2);
+});
+
+it('emits a fraction-digit range', function () {
+    $props = wire(NumberColumn::make('price')->decimals(0, 2))['props'];
+
+    expect($props['minimumFractionDigits'])->toBe(0)
+        ->and($props['maximumFractionDigits'])->toBe(2);
+});
+
+it('filters a numeric column as a number', function () {
+    $data = wire(NumberColumn::make('price')->filterable());
+
+    expect($data['filter']['type'])->toBe(FilterType::Number->value);
+});

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -13,7 +13,7 @@ use Lattice\Lattice\Core\Components\Link;
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\ImageColumn;
-use Lattice\Lattice\Tables\Columns\NumberColumn;
+use Lattice\Lattice\Tables\Columns\MoneyColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 use Lattice\Lattice\Tables\EloquentTableDefinition;
 use Lattice\Lattice\Tables\Filters\BaseFilter;
@@ -45,7 +45,7 @@ class ProductsTable extends EloquentTableDefinition
             ImageColumn::make('image')->label(__('workbench.tables.columns.image'))->size(44),
             TextColumn::make('name')->label(__('workbench.tables.columns.name'))->sortable()->filterable(),
             TextColumn::make('sku')->label(__('workbench.tables.columns.sku'))->sortable()->filterable(),
-            NumberColumn::make('default_price')->label(__('workbench.tables.columns.default-price'))->sortable(),
+            MoneyColumn::make('default_price')->label(__('workbench.tables.columns.default-price'))->sortable()->currency('EUR'),
             StatusBadgeColumn::make('status')->label(__('workbench.tables.columns.status'))->filterOptions([
                 'draft' => 'Draft',
                 'active' => 'Active',


### PR DESCRIPTION
Adds declarative per-column alignment and richer numeric formatting (fraction digits, units, currency) to tables. All formatting happens in the React frontend via `Intl.NumberFormat` using the app locale, so external/non-PHP table sources only need to return raw values (plus a currency field per row when using `currencyField`).

> Stacked on `codex/ts-cleanups-and-api-boundaries` (which carries the column reflect-public-props refactor it builds on). Retarget to `main` once that lands.

## What's new

- **Alignment on every column** — `->align(ColumnAlign::Start|Center|End)` (logical, RTL-safe). A common `ColumnData` field like `width`, with per-type defaults (numeric/money default to `End`); applied generically in the header and cell wrapper, replacing the old `type === "number"` special-case.
- **`NumberColumn`** — `->decimals(2)` (or `->decimals(0, 2)` for a range) and `->unit(NumberFormatUnit::Percent)` for locale-correct units (percent uses Intl `style:"unit"`, so `50 → "50%"`, no multiply).
- **`MoneyColumn`** — `->currency('EUR')` (static) or `->currencyField('currency')` (per-row, read from another field). Symbol placement and per-currency decimals follow the viewer's locale.
- Shared abstract `NumericColumn` base (decimals, end-align, number filter) keeps `NumberColumn`/`MoneyColumn` DRY; cells share a `numericValue` guard.

Wire-shape change is additive: a new `align` field (defaults `start`) and new optional props; no breaking changes.

## Design docs (local)

`docs/superpowers/specs/2026-06-15-column-formatting-design.md` and `docs/superpowers/plans/2026-06-15-column-formatting.md`.

## Test plan

- [x] `composer check` — Pint, PHPStan, 733 Pest (PHP column serialization, reflection guard for each column's prop set)
- [x] `npm run check` — tsc, type-coverage, 546 vitest (alignment helper, `NumberCell`/`MoneyCell` formatting incl. percent-no-multiply, static + per-row currency), lib build
- [x] `composer types` — no `generated.ts` drift
- [x] Browser — workbench `ProductsTable` renders the money column (`€`)
