### PR TITLE
feat: support recursive form schemas

### DIFF
--- a/resources/js/form/components/field-scope.test.tsx
+++ b/resources/js/form/components/field-scope.test.tsx
@@ -36,6 +36,48 @@ it("derives scoped DOM name, error key, and row value", () => {
   expect(screen.getByTestId("row-sku").textContent).toBe("A-1");
 });
 
+it("derives nested scoped DOM names and error keys from dot collection paths", () => {
+  render(
+    <FieldScopeProvider
+      base="items.0.children"
+      index={1}
+      row={{ __rowId: "child-2", name: "nested", sku: "C-2" }}
+      onChange={() => {}}
+    >
+      <Probe />
+    </FieldScopeProvider>,
+  );
+
+  expect(screen.getByTestId("dom").textContent).toBe("items[0][children][1][name]");
+  expect(screen.getByTestId("err").textContent).toBe("items.0.children.1.name");
+  expect(screen.getByTestId("val").textContent).toBe("nested");
+  expect(screen.getByTestId("override").textContent).toBe("items.0.children.child-2.price");
+});
+
+it("derives nested override keys from parent row ids", () => {
+  render(
+    <FieldScopeProvider
+      base="sections"
+      index={0}
+      row={{ __rowId: "section-a", name: "section" }}
+      onChange={() => {}}
+    >
+      <FieldScopeProvider
+        base="sections.0.lines"
+        index={0}
+        row={{ __rowId: "line-a", name: "line" }}
+        onChange={() => {}}
+      >
+        <Probe />
+      </FieldScopeProvider>
+    </FieldScopeProvider>,
+  );
+
+  expect(screen.getByTestId("dom").textContent).toBe("sections[0][lines][0][name]");
+  expect(screen.getByTestId("err").textContent).toBe("sections.0.lines.0.name");
+  expect(screen.getByTestId("override").textContent).toBe("sections.section-a.lines.line-a.price");
+});
+
 it("returns null scope outside a provider", () => {
   render(<Probe />);
   expect(screen.getByTestId("dom").textContent).toBe("");

--- a/resources/js/form/components/field-scope.tsx
+++ b/resources/js/form/components/field-scope.tsx
@@ -1,9 +1,13 @@
 import { createContext, useContext, useMemo } from "react";
+import { appendPath, getPath, toHtmlName } from "./form-path";
 import { buildOverrideKey, rowIdFrom } from "./override-keys";
 
 export type FieldScopeValue = {
   row: Record<string, unknown>;
   rowId: string | null;
+  path: string;
+  values: Record<string, unknown>;
+  identityPath: string;
   getValue: (name: string) => unknown;
   setValue: (name: string, value: unknown) => void;
   scopedName: (name: string) => string;
@@ -12,6 +16,16 @@ export type FieldScopeValue = {
 };
 
 const FieldScopeContext = createContext<FieldScopeValue | null>(null);
+
+function childCollectionIdentity(base: string, parent: FieldScopeValue | null): string {
+  if (!parent) {
+    return base;
+  }
+
+  const local = base.startsWith(`${parent.path}.`) ? base.slice(parent.path.length + 1) : base;
+
+  return appendPath(parent.identityPath, local);
+}
 
 export function FieldScopeProvider({
   base,
@@ -26,19 +40,28 @@ export function FieldScopeProvider({
   onChange: (name: string, value: unknown) => void;
   children: React.ReactNode;
 }) {
+  const parent = useContext(FieldScopeContext);
+
   const value = useMemo<FieldScopeValue>(() => {
-    const rowId = rowIdFrom(row);
+    const scopedRow = row ?? {};
+    const rowId = rowIdFrom(scopedRow);
+    const path = appendPath(base, index);
+    const identityCollection = childCollectionIdentity(base, parent);
+    const identityPath = appendPath(identityCollection, rowId ?? index);
 
     return {
-      row,
+      row: scopedRow,
       rowId,
-      getValue: (name) => row[name],
+      path,
+      values: parent ? { ...parent.values, ...scopedRow } : scopedRow,
+      identityPath,
+      getValue: (name) => getPath(scopedRow, name),
       setValue: onChange,
-      scopedName: (name) => `${base}[${index}][${name}]`,
-      errorKey: (name) => `${base}.${index}.${name}`,
-      overrideKey: (name) => buildOverrideKey(base, rowId, index, name),
+      scopedName: (name) => toHtmlName(appendPath(path, name)),
+      errorKey: (name) => appendPath(path, name),
+      overrideKey: (name) => buildOverrideKey(identityCollection, rowId, index, name),
     };
-  }, [base, index, row, onChange]);
+  }, [base, index, row, onChange, parent]);
 
   return <FieldScopeContext.Provider value={value}>{children}</FieldScopeContext.Provider>;
 }

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -2,6 +2,7 @@ import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
 import { useT } from "@lattice-php/lattice/i18n";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
+import { appendPath, toHtmlName } from "../form-path";
 import { useDependentField } from "../use-dependent-field";
 import { BlockAddMenu, type BlockOption } from "./block-add-menu";
 import { ROW_ID_KEY } from "./repeater-rows";
@@ -22,7 +23,7 @@ export const BuilderComponent: RendererComponent<"field.builder"> = ({ node }) =
   const blocks = ((node as unknown as { blocks?: Block[] }).blocks ?? []) as Block[];
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
-  const { rows, onField, onRemove, onMove, onDuplicate, append } = useRowCollection(
+  const { path, rows, onField, onRemove, onMove, onDuplicate, append } = useRowCollection(
     name,
     props.defaultItems ?? 0,
   );
@@ -47,7 +48,7 @@ export const BuilderComponent: RendererComponent<"field.builder"> = ({ node }) =
     <input
       key={String(row[ROW_ID_KEY] ?? index)}
       type="hidden"
-      name={`${name}[${index}][type]`}
+      name={toHtmlName(appendPath(path, index, "type"))}
       value={String(row.type ?? "")}
     />
   ));
@@ -67,11 +68,11 @@ export const BuilderComponent: RendererComponent<"field.builder"> = ({ node }) =
 
   return (
     <FormFieldFrame
-      error={errors[name]}
+      error={errors[path]}
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={name}
+      name={path}
       required={required}
     >
       <div className="flex flex-col gap-3">
@@ -79,7 +80,7 @@ export const BuilderComponent: RendererComponent<"field.builder"> = ({ node }) =
           <>
             {hiddenTypeInputs}
             <TableRows
-              base={name}
+              base={path}
               columns={columnsFromSchema(primary?.schema ?? [])}
               rows={tableRows}
               reorderable={props.reorderable ?? false}
@@ -103,12 +104,12 @@ export const BuilderComponent: RendererComponent<"field.builder"> = ({ node }) =
               <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
                 <input
                   type="hidden"
-                  name={`${name}[${index}][type]`}
+                  name={toHtmlName(appendPath(path, index, "type"))}
                   value={String(row.type ?? "")}
                 />
                 {block ? (
                   <RowItem
-                    base={name}
+                    base={path}
                     index={index}
                     row={row}
                     template={block.schema ?? EMPTY_TEMPLATE}

--- a/resources/js/form/components/fields/hidden-input.test.tsx
+++ b/resources/js/form/components/fields/hidden-input.test.tsx
@@ -1,0 +1,31 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import { FieldScopeProvider } from "../field-scope";
+import { HiddenInputComponent } from "./hidden-input";
+
+describe("HiddenInputComponent", () => {
+  it("uses scoped names inside row fields", () => {
+    const node = fakeNode({
+      type: "field.hidden-input",
+      props: { name: "token", value: "abc" },
+    });
+
+    const { container } = render(
+      <FieldScopeProvider
+        base="items.0.children"
+        index={1}
+        row={{ __rowId: "r1", token: "abc" }}
+        onChange={() => {}}
+      >
+        <HiddenInputComponent node={node}>{null}</HiddenInputComponent>
+      </FieldScopeProvider>,
+    );
+
+    const input = container.querySelector<HTMLInputElement>(
+      'input[name="items[0][children][1][token]"]',
+    );
+
+    expect(input?.value).toBe("abc");
+  });
+});

--- a/resources/js/form/components/fields/hidden-input.tsx
+++ b/resources/js/form/components/fields/hidden-input.tsx
@@ -1,9 +1,16 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { useFieldScope } from "../field-scope";
 
-export const HiddenInputComponent: RendererComponent<"field.hidden-input"> = ({ node }) => (
-  <input
-    defaultValue={typeof node.props.value === "string" ? node.props.value : ""}
-    name={node.props.name}
-    type="hidden"
-  />
-);
+export const HiddenInputComponent: RendererComponent<"field.hidden-input"> = ({ node }) => {
+  const scope = useFieldScope();
+  const name = node.props.name;
+  const value = scope ? scope.getValue(name) : node.props.value;
+
+  return (
+    <input
+      defaultValue={typeof value === "string" ? value : ""}
+      name={scope ? scope.scopedName(name) : name}
+      type="hidden"
+    />
+  );
+};

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -16,7 +16,7 @@ export const RepeaterComponent: RendererComponent<"field.repeater"> = ({ node })
   const name = props.name;
   const { errors } = useFormContext();
   const { hidden, required } = useDependentField(node);
-  const { rows, onField, onRemove, onMove, onDuplicate, append } = useRowCollection(
+  const { path, rows, onField, onRemove, onMove, onDuplicate, append } = useRowCollection(
     name,
     props.defaultItems ?? 1,
   );
@@ -41,17 +41,17 @@ export const RepeaterComponent: RendererComponent<"field.repeater"> = ({ node })
 
   return (
     <FormFieldFrame
-      error={errors[name]}
+      error={errors[path]}
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={name}
+      name={path}
       required={required}
     >
       <div className="flex flex-col gap-3">
         {isTable ? (
           <TableRows
-            base={name}
+            base={path}
             columns={columnsFromSchema(template)}
             rows={tableRows}
             reorderable={props.reorderable ?? false}
@@ -71,7 +71,7 @@ export const RepeaterComponent: RendererComponent<"field.repeater"> = ({ node })
             return (
               <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
                 <RowItem
-                  base={name}
+                  base={path}
                   index={index}
                   row={row}
                   template={template}

--- a/resources/js/form/components/fields/rich-editor.test.tsx
+++ b/resources/js/form/components/fields/rich-editor.test.tsx
@@ -2,13 +2,32 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fakeNode } from "@lattice-php/lattice/test-support";
+import { FieldScopeProvider } from "../field-scope";
 import { FormValuesProvider } from "../values";
 import { RichEditorComponent } from "./rich-editor";
 
-function renderField(node: Node<"field.rich-editor">, initial: Record<string, unknown> = {}) {
+function renderField(
+  node: Node<"field.rich-editor">,
+  initial: Record<string, unknown> = {},
+  scoped = false,
+) {
+  const field = <RichEditorComponent node={node}>{null}</RichEditorComponent>;
+  const nested = initial as { items?: Array<{ children?: Array<{ body?: unknown }> }> };
+
   return render(
     <FormValuesProvider initial={initial}>
-      <RichEditorComponent node={node}>{null}</RichEditorComponent>
+      {scoped ? (
+        <FieldScopeProvider
+          base="items.0.children"
+          index={1}
+          row={{ __rowId: "r1", body: nested.items?.[0]?.children?.[1]?.body }}
+          onChange={() => {}}
+        >
+          {field}
+        </FieldScopeProvider>
+      ) : (
+        field
+      )}
     </FormValuesProvider>,
   );
 }
@@ -35,5 +54,18 @@ describe("RichEditorComponent", () => {
 
     expect(await screen.findByLabelText("Bold")).toBeInTheDocument();
     expect(document.querySelector('input[type="hidden"][name="body"]')).toBeInTheDocument();
+  });
+
+  it("uses scoped names inside row fields", async () => {
+    renderField(
+      fakeNode({ type: "field.rich-editor", props: { name: "body", label: "Body" } }),
+      { items: [{ children: [{}, { body: { type: "doc", content: [] } }] }] },
+      true,
+    );
+
+    expect(await screen.findByLabelText("Bold")).toBeInTheDocument();
+    expect(
+      document.querySelector('input[type="hidden"][name="items[0][children][1][body]"]'),
+    ).toBeInTheDocument();
   });
 });

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -12,6 +12,7 @@ import { useT } from "@lattice-php/lattice/i18n";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { FormFieldFrame } from "../base/field";
 import { useFormContext } from "../context";
+import { useFieldScope } from "../field-scope";
 import { useDependentField } from "../use-dependent-field";
 import { useFieldCommit } from "../use-field-commit";
 import { useFormValue } from "../values";
@@ -318,7 +319,11 @@ export const RichEditorComponent: RendererComponent<"field.rich-editor"> = ({ no
   const { hidden, required, readOnly, disabled } = useDependentField(node);
   const { change, blur } = useFieldCommit();
   const name = node.props.name;
-  const storedValue = useFormValue(name);
+  const scope = useFieldScope();
+  const globalValue = useFormValue(name);
+  const storedValue = scope ? scope.getValue(name) : globalValue;
+  const domName = scope ? scope.scopedName(name) : name;
+  const errorKey = scope ? scope.errorKey(name) : name;
   const locked = readOnly || disabled;
   const initialContent =
     typeof storedValue === "object" && storedValue !== null
@@ -364,11 +369,11 @@ export const RichEditorComponent: RendererComponent<"field.rich-editor"> = ({ no
 
   return (
     <FormFieldFrame
-      error={errors[name]}
+      error={errors[errorKey]}
       helperText={node.props.helperText ?? undefined}
       tooltip={node.props.tooltip ?? undefined}
       label={node.props.label ?? ""}
-      name={name}
+      name={domName}
       required={required}
     >
       <div
@@ -380,7 +385,7 @@ export const RichEditorComponent: RendererComponent<"field.rich-editor"> = ({ no
         {editor && !locked && <Toolbar editor={editor} />}
         <EditorContent editor={editor} />
       </div>
-      <input name={name} type="hidden" value={submittedValue} />
+      <input name={domName} type="hidden" value={submittedValue} />
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/use-row-collection.test.tsx
+++ b/resources/js/form/components/fields/use-row-collection.test.tsx
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import { act, render } from "@testing-library/react";
-import { FormValuesProvider } from "../values";
+import { FieldScopeProvider } from "../field-scope";
+import { FormValuesProvider, useFormValue, useFormValues, useSetFormValue } from "../values";
 import { ROW_ID_KEY } from "./repeater-rows";
 import { useRowCollection } from "./use-row-collection";
 
@@ -53,4 +54,46 @@ it("duplicates a row in place with a fresh id", () => {
   expect(c.rows[1].a).toBe("1");
   expect(c.rows[1][ROW_ID_KEY]).not.toBe(id0);
   expect(c.rows[2].a).toBe("2");
+});
+
+it("reads and writes collections inside the current field scope", () => {
+  let c!: ReturnType<typeof useRowCollection>;
+  let latestValues!: Record<string, unknown>;
+
+  function Probe() {
+    c = useRowCollection("children", 0);
+    latestValues = useFormValues();
+
+    return null;
+  }
+
+  function ScopedProbe() {
+    const setValue = useSetFormValue();
+    const row = useFormValue("items.0") as Record<string, unknown>;
+
+    return (
+      <FieldScopeProvider
+        base="items"
+        index={0}
+        row={row}
+        onChange={(field, value) => setValue(`items.0.${field}`, value)}
+      >
+        <Probe />
+      </FieldScopeProvider>
+    );
+  }
+
+  render(
+    <FormValuesProvider initial={{ items: [{ children: [{ name: "A" }] }] }}>
+      <ScopedProbe />
+    </FormValuesProvider>,
+  );
+
+  expect(c.rows[0].name).toBe("A");
+
+  act(() => c.onField(0, "name", "B"));
+
+  expect(latestValues).toEqual({
+    items: [{ children: [{ name: "B", [ROW_ID_KEY]: c.rows[0][ROW_ID_KEY] }] }],
+  });
 });

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect } from "react";
+import { useFieldScope } from "../field-scope";
 import { useFormValue, useSetFormValue } from "../values";
 import {
   duplicateRow,
@@ -11,6 +12,7 @@ import {
 } from "./repeater-rows";
 
 export type RowCollection = {
+  path: string;
   rows: RepeaterRow[];
   onField: (index: number, field: string, value: unknown) => void;
   onRemove: (index: number) => void;
@@ -20,26 +22,28 @@ export type RowCollection = {
 };
 
 export function useRowCollection(name: string, defaultItems: number): RowCollection {
+  const scope = useFieldScope();
+  const path = scope ? scope.errorKey(name) : name;
   const setValue = useSetFormValue();
-  const stored = useFormValue(name);
+  const stored = useFormValue(path);
   const raw: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
   const rows = ensureRowIds(raw);
 
   useLayoutEffect(() => {
     if (rows !== raw) {
-      setValue(name, rows);
+      setValue(path, rows);
     }
-  }, [raw, rows, setValue, name]);
+  }, [raw, rows, setValue, path]);
 
   // Functional store updates preserve the identity of untouched rows, which lets
   // the memoised RowItem skip re-rendering siblings on a single-row edit.
   const mutate = useCallback(
     (fn: (rows: RepeaterRow[]) => RepeaterRow[]): void => {
-      setValue(name, (prev: unknown) =>
+      setValue(path, (prev: unknown) =>
         fn(Array.isArray(prev) ? (prev as RepeaterRow[]) : seedRows(prev, defaultItems)),
       );
     },
-    [setValue, name, defaultItems],
+    [setValue, path, defaultItems],
   );
 
   const onField = useCallback(
@@ -65,5 +69,5 @@ export function useRowCollection(name: string, defaultItems: number): RowCollect
     [mutate],
   );
 
-  return { rows, onField, onRemove, onMove, onDuplicate, append };
+  return { path, rows, onField, onRemove, onMove, onDuplicate, append };
 }

--- a/resources/js/form/components/form-path.test.ts
+++ b/resources/js/form/components/form-path.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { appendPath, getPath, setPath, toHtmlName } from "./form-path";
+
+describe("form paths", () => {
+  it("converts dot paths to bracketed HTML names", () => {
+    expect(toHtmlName("items.0.children.1.name")).toBe("items[0][children][1][name]");
+  });
+
+  it("appends local names to parent paths", () => {
+    expect(appendPath(null, "items")).toBe("items");
+    expect(appendPath("items.0", "children")).toBe("items.0.children");
+  });
+
+  it("reads and writes nested values immutably", () => {
+    const values = { items: [{ children: [{ name: "A" }] }] };
+    const next = setPath(values, "items.0.children.0.name", "B");
+
+    expect(getPath(next, "items.0.children.0.name")).toBe("B");
+    expect(getPath(values, "items.0.children.0.name")).toBe("A");
+  });
+});

--- a/resources/js/form/components/form-path.ts
+++ b/resources/js/form/components/form-path.ts
@@ -1,0 +1,64 @@
+export function pathParts(path: string): string[] {
+  return path.split(".").filter((part) => part !== "");
+}
+
+export function appendPath(
+  base: string | null | undefined,
+  ...parts: Array<string | number>
+): string {
+  const suffix = parts.map(String).filter((part) => part !== "");
+
+  return [base ?? "", ...suffix].filter((part) => part !== "").join(".");
+}
+
+export function toHtmlName(path: string): string {
+  const [head, ...tail] = pathParts(path);
+
+  return tail.reduce((name, part) => `${name}[${part}]`, head ?? "");
+}
+
+export function getPath(values: Record<string, unknown>, path: string): unknown {
+  let current: unknown = values;
+
+  for (const part of pathParts(path)) {
+    if (current == null) {
+      return undefined;
+    }
+
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+}
+
+function emptyContainer(nextPart: string | undefined): Record<string, unknown> | unknown[] {
+  return nextPart !== undefined && /^\d+$/.test(nextPart) ? [] : {};
+}
+
+export function setPath(
+  values: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): Record<string, unknown> {
+  const parts = pathParts(path);
+
+  if (parts.length === 0) {
+    return values;
+  }
+
+  const write = (current: unknown, index: number): unknown => {
+    const part = parts[index];
+    const last = index === parts.length - 1;
+    const source =
+      current && typeof current === "object" ? current : emptyContainer(parts[index + 1]);
+    const next = Array.isArray(source) ? [...source] : { ...(source as Record<string, unknown>) };
+
+    (next as Record<string, unknown>)[part] = last
+      ? value
+      : write((source as Record<string, unknown>)[part], index + 1);
+
+    return next;
+  };
+
+  return write(values, 0) as Record<string, unknown>;
+}

--- a/resources/js/form/components/prefill-targets.test.ts
+++ b/resources/js/form/components/prefill-targets.test.ts
@@ -31,6 +31,22 @@ function builderNode(): Node {
   } as unknown as Node;
 }
 
+function nestedRepeaterNode(): Node {
+  return {
+    id: "r1",
+    type: "field.repeater",
+    props: { name: "sections" },
+    schema: [
+      {
+        id: "r2",
+        type: "field.repeater",
+        props: { name: "lines" },
+        schema: [priceField()],
+      },
+    ],
+  } as unknown as Node;
+}
+
 it("collects a concrete target per row, mapping bare and @ deps", () => {
   const values = {
     items: [
@@ -73,6 +89,27 @@ it("ignores rows whose block type is unknown", () => {
   expect(collectPrefillTargets([builderNode()], values)).toEqual([]);
 });
 
+it("collects targets recursively through nested row collections", () => {
+  const values = {
+    customer: "vip",
+    sections: [
+      {
+        __rowId: "section-a",
+        lines: [{ __rowId: "line-a", product: "sku-1" }],
+      },
+    ],
+  };
+
+  expect(collectPrefillTargets([nestedRepeaterNode()], values)).toEqual([
+    {
+      path: "sections.0.lines.0.price",
+      overrideKey: "sections.section-a.lines.line-a.price",
+      resetOn: ["sections.0.lines.0.product"],
+      refreshOn: ["customer"],
+    },
+  ]);
+});
+
 it("reads and applies nested row paths", () => {
   const values: Record<string, unknown> = { items: [{ type: "product", price: 1 }] };
   expect(getPath(values, "items.0.price")).toBe(1);
@@ -85,8 +122,7 @@ it("reads and applies nested row paths", () => {
   };
   applyPrefillValue(setValue, "items.0.price", 9.5);
 
-  expect(writes[0][0]).toBe("items");
-  expect((writes[0][1] as Array<Record<string, unknown>>)[0].price).toBe(9.5);
+  expect(writes).toEqual([["items.0.price", 9.5]]);
 });
 
 it("clears targets whose resetOn dependency changed", () => {

--- a/resources/js/form/components/prefill-targets.ts
+++ b/resources/js/form/components/prefill-targets.ts
@@ -1,5 +1,6 @@
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fieldProps } from "./field-props";
+import { appendPath, getPath } from "./form-path";
 import { buildOverrideKey, rowIdFrom } from "./override-keys";
 
 export type PrefillTarget = {
@@ -18,17 +19,20 @@ type Block = { type: string; label: string; schema: Node[] };
 
 const ROW_COLLECTION_TYPES = new Set(["field.builder", "field.repeater"]);
 
-function mapDep(dep: string, base: string | null, index: number): string {
+export { getPath } from "./form-path";
+
+function mapDep(dep: string, rowPath: string | null): string {
   if (dep.startsWith("@")) {
     return dep.slice(1);
   }
 
-  return base === null ? dep : `${base}.${index}.${dep}`;
+  return rowPath === null ? dep : appendPath(rowPath, dep);
 }
 
 function targetFor(
   node: Node,
-  base: string | null,
+  rowPath: string | null,
+  identityCollectionPath: string | null,
   index = 0,
   row: Record<string, unknown> = {},
 ): PrefillTarget | null {
@@ -41,10 +45,13 @@ function targetFor(
   const rowId = rowIdFrom(row);
 
   return {
-    path: base === null ? props.name : `${base}.${index}.${props.name}`,
-    overrideKey: base === null ? props.name : buildOverrideKey(base, rowId, index, props.name),
-    resetOn: (props.prefillResetOn ?? []).map((dep) => mapDep(dep, base, index)),
-    refreshOn: (props.prefillRefreshOn ?? []).map((dep) => mapDep(dep, base, index)),
+    path: rowPath === null ? props.name : appendPath(rowPath, props.name),
+    overrideKey:
+      identityCollectionPath === null
+        ? props.name
+        : buildOverrideKey(identityCollectionPath, rowId, index, props.name),
+    resetOn: (props.prefillResetOn ?? []).map((dep) => mapDep(dep, rowPath)),
+    refreshOn: (props.prefillRefreshOn ?? []).map((dep) => mapDep(dep, rowPath)),
   };
 }
 
@@ -54,39 +61,51 @@ export function collectPrefillTargets(
 ): PrefillTarget[] {
   const targets: PrefillTarget[] = [];
 
-  const walk = (list: Node[] | undefined): void => {
+  const walk = (
+    list: Node[] | undefined,
+    rowPath: string | null = null,
+    identityRowPath: string | null = null,
+    identityCollectionPath: string | null = null,
+    index = 0,
+    row: Record<string, unknown> = {},
+  ): void => {
     for (const node of list ?? []) {
       if (ROW_COLLECTION_TYPES.has(node.type)) {
         const name = fieldProps(node).name;
         if (name) {
-          const rows = Array.isArray(values[name])
-            ? (values[name] as Array<Record<string, unknown>>)
+          const childCollectionPath = appendPath(rowPath, name);
+          const childIdentityCollectionPath = appendPath(identityRowPath, name);
+          const storedRows = getPath(values, childCollectionPath);
+          const rows = Array.isArray(storedRows)
+            ? (storedRows as Array<Record<string, unknown>>)
             : [];
           const blocks = (node as unknown as { blocks?: Block[] }).blocks;
 
-          rows.forEach((row, index) => {
+          rows.forEach((childRow, childIndex) => {
             const template = blocks
-              ? (blocks.find((block) => block.type === row.type)?.schema ?? [])
+              ? (blocks.find((block) => block.type === childRow.type)?.schema ?? [])
               : (node.schema ?? []);
 
-            for (const child of template) {
-              const target = targetFor(child, name, index, row);
-              if (target) {
-                targets.push(target);
-              }
-            }
+            walk(
+              template,
+              appendPath(childCollectionPath, childIndex),
+              appendPath(childIdentityCollectionPath, rowIdFrom(childRow) ?? childIndex),
+              childIdentityCollectionPath,
+              childIndex,
+              childRow,
+            );
           });
         }
 
         continue;
       }
 
-      const target = targetFor(node, null);
+      const target = targetFor(node, rowPath, identityCollectionPath, index, row);
       if (target) {
         targets.push(target);
       }
 
-      walk(node.schema);
+      walk(node.schema, rowPath, identityRowPath, identityCollectionPath, index, row);
     }
   };
 
@@ -95,45 +114,12 @@ export function collectPrefillTargets(
   return targets;
 }
 
-export function getPath(values: Record<string, unknown>, path: string): unknown {
-  let current: unknown = values;
-
-  for (const part of path.split(".")) {
-    if (current == null) {
-      return undefined;
-    }
-    current = (current as Record<string, unknown>)[part];
-  }
-
-  return current;
-}
-
 export function applyPrefillValue(
   setValue: (name: string, value: unknown) => void,
   path: string,
   value: unknown,
 ): void {
-  const [head, ...rest] = path.split(".");
-
-  if (rest.length === 0) {
-    setValue(head, value);
-
-    return;
-  }
-
-  const index = Number(rest[0]);
-  const field = rest.slice(1).join(".");
-
-  setValue(head, (prev: unknown) => {
-    if (!Array.isArray(prev) || prev[index] == null) {
-      return prev;
-    }
-
-    const rows = [...(prev as Array<Record<string, unknown>>)];
-    rows[index] = { ...rows[index], [field]: value };
-
-    return rows;
-  });
+  setValue(path, value);
 }
 
 export function pathsToClear(previous: PrefillSnapshot, next: PrefillSnapshot): string[] {

--- a/resources/js/form/components/resolved-nodes.test.tsx
+++ b/resources/js/form/components/resolved-nodes.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
+import { FieldScopeProvider } from "./field-scope";
 import { ResolvedNodesProvider, useResolvedNode } from "./resolved-nodes";
 
 function Probe({ node }: { node: Node }) {
@@ -31,5 +32,31 @@ describe("ResolvedNodes", () => {
       </ResolvedNodesProvider>,
     );
     expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("overrides a scoped node by full path", () => {
+    const original = { type: "field.text-input", props: { name: "price", value: "0" } } as Node;
+
+    render(
+      <ResolvedNodesProvider
+        nodes={{
+          "items.0.price": {
+            type: "field.text-input",
+            props: { name: "price", value: "12" },
+          } as Node,
+        }}
+      >
+        <FieldScopeProvider
+          base="items"
+          index={0}
+          row={{ __rowId: "r1", price: "0" }}
+          onChange={() => {}}
+        >
+          <Probe node={original} />
+        </FieldScopeProvider>
+      </ResolvedNodesProvider>,
+    );
+
+    expect(screen.getByText("12")).toBeInTheDocument();
   });
 });

--- a/resources/js/form/components/resolved-nodes.tsx
+++ b/resources/js/form/components/resolved-nodes.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fieldProps } from "./field-props";
+import { useFieldScope } from "./field-scope";
 
 const ResolvedNodesContext = createContext<Record<string, Node>>({});
 
@@ -17,6 +18,8 @@ export function ResolvedNodesProvider({
 export function useResolvedNode(node: Node): Node {
   const nodes = useContext(ResolvedNodesContext);
   const name = fieldProps(node).name ?? "";
+  const scope = useFieldScope();
+  const path = name && scope ? scope.errorKey(name) : name;
 
-  return name && nodes[name] ? nodes[name] : node;
+  return (path && nodes[path]) || (name && nodes[name]) || node;
 }

--- a/resources/js/form/components/use-dependent-field.test.tsx
+++ b/resources/js/form/components/use-dependent-field.test.tsx
@@ -69,4 +69,42 @@ describe("useDependentField", () => {
 
     expect(result.current.hidden).toBe(false);
   });
+
+  it("falls back to ancestor row values from inside nested rows", () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FormValuesProvider
+        initial={{
+          sections: [
+            {
+              __rowId: "section-1",
+              section: "office",
+              items: [{ __rowId: "item-1", product: "sku-1" }],
+            },
+          ],
+        }}
+      >
+        <FieldScopeProvider
+          base="sections"
+          index={0}
+          row={{ __rowId: "section-1", section: "office" }}
+          onChange={() => {}}
+        >
+          <FieldScopeProvider
+            base="sections.0.items"
+            index={0}
+            row={{ __rowId: "item-1", product: "sku-1" }}
+            onChange={() => {}}
+          >
+            {children}
+          </FieldScopeProvider>
+        </FieldScopeProvider>
+      </FormValuesProvider>
+    );
+
+    const { result } = renderHook(() => useDependentField(conditionNode("section", "office")), {
+      wrapper,
+    });
+
+    expect(result.current.hidden).toBe(false);
+  });
 });

--- a/resources/js/form/components/use-dependent-field.ts
+++ b/resources/js/form/components/use-dependent-field.ts
@@ -9,7 +9,7 @@ export function useDependentField(node: Node): FieldState {
   const scope = useFieldScope();
   const props = fieldProps(node);
   // Bare condition names resolve to row siblings first; form values remain the fallback.
-  const conditionValues = scope ? { ...values, ...scope.row } : values;
+  const conditionValues = scope ? { ...values, ...scope.values } : values;
 
   return evaluateConditions(props.conditions ?? undefined, conditionValues, {
     hidden: props.hidden ?? false,

--- a/resources/js/form/components/values.test.tsx
+++ b/resources/js/form/components/values.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { FormValuesProvider, useFormValue, useSetFormValue } from "./values";
+import { FormValuesProvider, useFormValue, useFormValues, useSetFormValue } from "./values";
 
 function wrapper(initial: Record<string, unknown>) {
   return ({ children }: { children: ReactNode }) => (
@@ -21,5 +21,23 @@ describe("FormValues", () => {
     act(() => result.current.setValue("type", "business"));
 
     expect(result.current.value).toBe("business");
+  });
+
+  it("reads and writes nested dot paths", () => {
+    const { result } = renderHook(
+      () => ({
+        value: useFormValue("items.0.children.0.name"),
+        values: useFormValues(),
+        setValue: useSetFormValue(),
+      }),
+      { wrapper: wrapper({ items: [{ children: [{ name: "A" }] }] }) },
+    );
+
+    expect(result.current.value).toBe("A");
+
+    act(() => result.current.setValue("items.0.children.0.name", "B"));
+
+    expect(result.current.value).toBe("B");
+    expect(result.current.values).toEqual({ items: [{ children: [{ name: "B" }] }] });
   });
 });

--- a/resources/js/form/components/values.tsx
+++ b/resources/js/form/components/values.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { getPath, setPath } from "./form-path";
 
 type FormValuesContextValue = {
   values: Record<string, unknown>;
@@ -68,10 +69,10 @@ export function FormValuesProvider({
     setValues((current) => {
       const next =
         typeof value === "function"
-          ? (value as (previous: unknown) => unknown)(current[name])
+          ? (value as (previous: unknown) => unknown)(getPath(current, name))
           : value;
 
-      return Object.is(current[name], next) ? current : { ...current, [name]: next };
+      return Object.is(getPath(current, name), next) ? current : setPath(current, name, next);
     });
   }, []);
 
@@ -85,7 +86,7 @@ export function useFormValues(): Record<string, unknown> {
 }
 
 export function useFormValue(name: string): unknown {
-  return useContext(FormValuesContext).values[name];
+  return getPath(useContext(FormValuesContext).values, name);
 }
 
 export function useSetFormValue(): (name: string, value: unknown) => void {

--- a/src/Forms/Components/Builder.php
+++ b/src/Forms/Components/Builder.php
@@ -100,7 +100,7 @@ class Builder extends Field implements ProvidesRowFields, ProvidesRowPrefills
      * @param  array<string, mixed>  $row
      * @return array<int, Field>
      */
-    protected function rowFields(array $row): array
+    public function rowFields(array $row): array
     {
         $type = is_string($row['type'] ?? null) ? $row['type'] : null;
 

--- a/src/Forms/Components/Concerns/HandlesRowSchemas.php
+++ b/src/Forms/Components/Concerns/HandlesRowSchemas.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Forms\Components\Concerns;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\FormData;
 
 /**
@@ -20,7 +21,7 @@ trait HandlesRowSchemas
      * @param  array<string, mixed>  $row
      * @return array<int, Field>
      */
-    abstract protected function rowFields(array $row): array;
+    abstract public function rowFields(array $row): array;
 
     /**
      * @param  array<int, mixed>  $rows
@@ -88,6 +89,12 @@ trait HandlesRowSchemas
                 $name = $field->name();
 
                 if (! array_key_exists($name, $row)) {
+                    continue;
+                }
+
+                if ($field instanceof ProvidesRowFields) {
+                    $field->prefillRowFields($row[$name]);
+
                     continue;
                 }
 

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -118,7 +118,7 @@ class Repeater extends Field implements ProvidesRowFields, ProvidesRowPrefills
      * @param  array<string, mixed>  $row
      * @return array<int, Field>
      */
-    protected function rowFields(array $row): array
+    public function rowFields(array $row): array
     {
         return $this->childFields();
     }

--- a/src/Forms/Concerns/ResolvesFormFields.php
+++ b/src/Forms/Concerns/ResolvesFormFields.php
@@ -9,9 +9,8 @@ use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Field;
 use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Components\Select;
-use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
-use Lattice\Lattice\Forms\Contracts\ProvidesRowPrefills;
 use Lattice\Lattice\Forms\FormData;
+use Lattice\Lattice\Forms\FormSchemaWalker;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -41,58 +40,13 @@ trait ResolvesFormFields
         $data = FormData::fromRequest($request);
         $fields = $this->formFields($request);
 
-        $field = $fields
-            ->first(fn (Field $field): bool => $field->name() === $name);
-        $scope = $data;
-
-        if ($field === null) {
-            [$field, $scope] = $this->rowFieldTarget($fields, $name, $data);
-        }
+        $instance = app(FormSchemaWalker::class)->find($fields, $name, $data);
+        $field = $instance?->field;
 
         abort_if($field === null, Response::HTTP_NOT_FOUND);
         abort_unless($field instanceof Select && $field->isSearchable(), Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        return ['options' => $field->resolveSearch($query, $scope, $request)];
-    }
-
-    /**
-     * @param  Collection<int, Field>  $fields
-     * @return array{0: Field|null, 1: FormData}
-     */
-    private function rowFieldTarget(Collection $fields, string $path, FormData $data): array
-    {
-        $segments = explode('.', $path);
-
-        if (count($segments) < 3 || ! ctype_digit($segments[1])) {
-            return [null, $data];
-        }
-
-        $base = $segments[0];
-        $rowIndex = (int) $segments[1];
-        $name = implode('.', array_slice($segments, 2));
-
-        $container = $fields->first(
-            fn (Field $field): bool => $field->name() === $base && $field instanceof ProvidesRowFields,
-        );
-
-        if (! $container instanceof ProvidesRowFields) {
-            return [null, $data];
-        }
-
-        $rows = $data->get($base);
-
-        if (! is_array($rows) || ! array_key_exists($rowIndex, $rows) || ! is_array($rows[$rowIndex])) {
-            return [null, $data];
-        }
-
-        $row = $rows[$rowIndex];
-        $field = $container->rowField($row, $name);
-
-        if ($field === null) {
-            return [null, $data];
-        }
-
-        return [$field, $container->rowScope($data, $row)];
+        return ['options' => $field->resolveSearch($query, $instance->scope, $request)];
     }
 
     /**
@@ -104,12 +58,7 @@ trait ResolvesFormFields
         $data = FormData::fromRequest($request);
         $fields = $this->formFields($request);
 
-        $field = $fields
-            ->first(fn (Field $field): bool => $field->name() === $name);
-
-        if ($field === null) {
-            [$field] = $this->rowFieldTarget($fields, $name, $data);
-        }
+        $field = app(FormSchemaWalker::class)->find($fields, $name, $data)?->field;
 
         abort_if($field === null, Response::HTTP_NOT_FOUND);
         abort_unless($field instanceof FileUpload && $field->usesSignedUpload(), Response::HTTP_UNPROCESSABLE_ENTITY);
@@ -127,22 +76,22 @@ trait ResolvesFormFields
         $values = [];
         $prefill = [];
 
-        foreach ($this->formFields($request) as $field) {
-            if ($field instanceof ProvidesRowPrefills) {
-                $prefill = [...$prefill, ...$field->rowPrefillValues($data, $request)];
-            } elseif ($field->hasPrefill()) {
-                $prefill[$field->name()] = $field->resolvePrefillValue($data, $data, $request);
+        foreach (app(FormSchemaWalker::class)->instances($this->formFields($request), $data) as $instance) {
+            $field = $instance->field;
+
+            if ($field->hasPrefill()) {
+                $prefill[$instance->path] = $field->resolvePrefillValue($instance->scope, $data, $request);
             }
 
             if (! $field->isComputed()) {
                 continue;
             }
 
-            $field->applyResolution($data, $request);
-            $fields[$field->name()] = $field;
+            $field->applyResolution($instance->scope, $request);
+            $fields[$instance->path] = $field;
 
             if ($field->hasResolvedValue()) {
-                $values[$field->name()] = $field->resolvedValue();
+                $values[$instance->path] = $field->resolvedValue();
             }
         }
 

--- a/src/Forms/Contracts/ProvidesRowFields.php
+++ b/src/Forms/Contracts/ProvidesRowFields.php
@@ -10,6 +10,12 @@ interface ProvidesRowFields
 {
     /**
      * @param  array<string, mixed>  $row
+     * @return array<int, Field>
+     */
+    public function rowFields(array $row): array;
+
+    /**
+     * @param  array<string, mixed>  $row
      */
     public function rowField(array $row, string $name): ?Field;
 

--- a/src/Forms/FieldValidator.php
+++ b/src/Forms/FieldValidator.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Forms;
 
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Validator;
 use Lattice\Lattice\Forms\Components\Field;
@@ -26,85 +27,100 @@ final class FieldValidator
     {
         $data = FormData::fromRequest($request);
 
-        /** @var Collection<int, Field> $fields */
-        $fields = collect($fields)->each(fn (Field $field) => $field->applyResolution($data, $request));
+        /** @var Collection<int, FormFieldInstance> $instances */
+        $instances = collect(app(FormSchemaWalker::class)->instances($fields, $data))
+            ->each(fn (FormFieldInstance $instance) => $instance->field->applyResolution($instance->scope, $request));
 
         $input = $request->all();
         $rules = [];
         $messages = [];
         $attributes = [];
 
-        /** @var array<int, array{field: Field, name: string, visible: bool, serverValue: bool, locked: bool}> $plan */
+        /** @var array<int, array{field: Field, path: string, visible: bool, serverValue: bool, locked: bool}> $plan */
         $plan = [];
 
-        foreach ($fields as $field) {
-            $name = $field->name();
-            $visible = $field->isVisible($data);
-            $locked = $field->isReadOnly($data) || $field->isDisabled($data);
+        foreach ($instances as $instance) {
+            $field = $instance->field;
+            $path = $instance->path;
+            $visible = $field->isVisible($instance->scope);
+            $locked = $field->isReadOnly($instance->scope) || $field->isDisabled($instance->scope);
             $serverValue = $field->hasResolvedValue() || ($locked && $field->hasValue());
 
             $plan[] = [
                 'field' => $field,
-                'name' => $name,
+                'path' => $path,
                 'visible' => $visible,
                 'serverValue' => $serverValue,
                 'locked' => $locked,
             ];
 
             if ($serverValue) {
-                $input[$name] = $field->resolvedValue();
+                Arr::set($input, $path, $field->resolvedValue());
             }
 
             if (! $visible) {
                 continue;
             }
 
-            $fieldRules = $field->resolvedRulesWithRequired($data, $request);
+            $fieldRules = $field->resolvedRulesWithRequired($instance->scope, $request);
 
             if ($fieldRules !== []) {
-                $rules[$name] = $fieldRules;
+                $rules[$path] = $fieldRules;
             }
 
-            foreach ($field->nestedRules($data, $request) as $ruleKey => $ruleSet) {
-                $rules[$ruleKey] = $ruleSet;
+            foreach ($field->nestedRules($instance->scope, $request) as $ruleKey => $ruleSet) {
+                $rules[$this->nestedRulePath($ruleKey, $field->name(), $path)] = $ruleSet;
             }
 
             foreach ($field->messages() as $rule => $message) {
-                $messages["{$name}.{$rule}"] = $message;
+                $messages["{$path}.{$rule}"] = $message;
             }
 
             if (($label = $field->getLabel()) !== null) {
-                $attributes[$name] = $label;
+                $attributes[$path] = $label;
             }
         }
 
         $validated = $this->validator($input, $rules, $messages, $attributes, $request)->validate();
 
-        foreach ($plan as ['field' => $field, 'name' => $name, 'visible' => $visible, 'serverValue' => $serverValue, 'locked' => $locked]) {
+        foreach ($plan as ['field' => $field, 'path' => $path, 'visible' => $visible, 'serverValue' => $serverValue, 'locked' => $locked]) {
             if (! $visible) {
-                unset($validated[$name]);
+                Arr::forget($validated, $path);
 
                 continue;
             }
 
             if ($serverValue) {
-                $validated[$name] = $field->resolvedValue();
+                Arr::set($validated, $path, $field->resolvedValue());
 
                 continue;
             }
 
             if ($locked) {
-                unset($validated[$name]);
+                Arr::forget($validated, $path);
 
                 continue;
             }
 
-            if (array_key_exists($name, $validated)) {
-                $validated[$name] = $field->castValue($validated[$name]);
+            if (Arr::has($validated, $path)) {
+                Arr::set($validated, $path, $field->castValue(Arr::get($validated, $path)));
             }
         }
 
         return $validated;
+    }
+
+    private function nestedRulePath(string $ruleKey, string $name, string $path): string
+    {
+        if ($ruleKey === $name) {
+            return $path;
+        }
+
+        if (str_starts_with($ruleKey, "{$name}.")) {
+            return $path.substr($ruleKey, strlen($name));
+        }
+
+        return $ruleKey;
     }
 
     /**

--- a/src/Forms/FormFieldInstance.php
+++ b/src/Forms/FormFieldInstance.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms;
+
+use Lattice\Lattice\Forms\Components\Field;
+
+final readonly class FormFieldInstance
+{
+    public function __construct(
+        public Field $field,
+        public string $path,
+        public FormData $scope,
+        public FormData $form,
+    ) {}
+}

--- a/src/Forms/FormSchemaWalker.php
+++ b/src/Forms/FormSchemaWalker.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms;
+
+use Illuminate\Support\Arr;
+use Lattice\Lattice\Forms\Components\Field;
+use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
+
+final class FormSchemaWalker
+{
+    /**
+     * @param  iterable<int, Field>  $fields
+     * @return array<int, FormFieldInstance>
+     */
+    public function instances(iterable $fields, FormData $form): array
+    {
+        $instances = [];
+
+        foreach ($fields as $field) {
+            $this->walkField($instances, $field, $field->name(), $form, $form);
+        }
+
+        return $instances;
+    }
+
+    /**
+     * @param  iterable<int, Field>  $fields
+     */
+    public function find(iterable $fields, string $path, FormData $form): ?FormFieldInstance
+    {
+        foreach ($this->instances($fields, $form) as $instance) {
+            if ($instance->path === $path) {
+                return $instance;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int, FormFieldInstance>  $instances
+     */
+    private function walkField(array &$instances, Field $template, string $path, FormData $scope, FormData $form): void
+    {
+        $field = clone $template;
+
+        $instances[] = new FormFieldInstance($field, $path, $scope, $form);
+
+        if (! $field instanceof ProvidesRowFields) {
+            return;
+        }
+
+        $rows = Arr::get($form->all(), $path);
+
+        if (! is_array($rows)) {
+            return;
+        }
+
+        foreach ($rows as $index => $row) {
+            $row = is_array($row) ? $row : [];
+            $rowScope = FormData::make([...$scope->all(), ...$row]);
+
+            foreach ($field->rowFields($row) as $child) {
+                $this->walkField(
+                    $instances,
+                    $child,
+                    "{$path}.{$index}.{$child->name()}",
+                    $rowScope,
+                    $form,
+                );
+            }
+        }
+    }
+}

--- a/tests/Browser/Forms/BuilderTest.php
+++ b/tests/Browser/Forms/BuilderTest.php
@@ -27,7 +27,7 @@ it('surfaces a per-row required error for the active block', function (): void {
         ->click('@builder-add')
         ->click('@builder-add-product')
         ->click('Save')
-        ->assertSee('The items.0.product field is required.')
+        ->assertSee('The Product field is required.')
         ->assertNoSmoke()
         ->assertNoJavaScriptErrors();
 });

--- a/tests/Browser/Forms/RepeaterTest.php
+++ b/tests/Browser/Forms/RepeaterTest.php
@@ -50,6 +50,6 @@ it('surfaces the per-row required validation error on submit', function (): void
     visit('/repeater')
         ->assertSee('Repeater Demo')
         ->click('Save')
-        ->assertSee('The items.0.name field is required.')
+        ->assertSee('The Name field is required.')
         ->assertNoSmoke();
 });

--- a/tests/Feature/Forms/FileUploadFieldTest.php
+++ b/tests/Feature/Forms/FileUploadFieldTest.php
@@ -1,11 +1,16 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Forms\UploadForm;
 
 use function Pest\Laravel\post;
@@ -54,6 +59,44 @@ it('signs an upload for a file field inside a repeater row', function (): void {
     ], uploadHeaders($form))
         ->assertOk()
         ->assertJsonStructure(['key', 'url', 'headers', 'method']);
+});
+
+it('signs an upload for a file field inside nested repeater rows', function (): void {
+    Storage::fake('s3');
+    Storage::disk('s3')->buildTemporaryUploadUrlsUsing(
+        fn (string $path, $expiration, array $options = []) => ['url' => "https://s3.test/{$path}", 'headers' => []],
+    );
+
+    $definition = new class extends FormDefinition
+    {
+        public function definition(Form $form, Request $request): Form
+        {
+            return $form->schema([
+                Repeater::make('sections')->schema([
+                    Repeater::make('documents')->schema([
+                        FileUpload::make('file')->disk('s3')->signedUpload(),
+                    ]),
+                ]),
+            ]);
+        }
+
+        public function handle(Request $request): Response
+        {
+            return new Response('ok');
+        }
+    };
+
+    $result = $definition->signUpload(Request::create('/', 'POST', [
+        '_upload' => 'sections.0.documents.0.file',
+        'filename' => 'invoice.pdf',
+        'sections' => [[
+            'documents' => [
+                ['file' => null],
+            ],
+        ]],
+    ]));
+
+    expect($result)->toHaveKeys(['key', 'url', 'headers', 'method']);
 });
 
 it('returns 422 when the field does not use signed uploads', function (): void {

--- a/tests/Feature/Forms/FormResolveTest.php
+++ b/tests/Feature/Forms/FormResolveTest.php
@@ -124,3 +124,48 @@ it('resolves repeater row prefill values from the fixed schema', function (): vo
         'lines.1.doubled' => 16.0,
     ]);
 });
+
+it('resolves nested repeater prefill values keyed by recursive full path', function (): void {
+    $definition = new class extends FormDefinition
+    {
+        public function definition(Form $form, Request $request): Form
+        {
+            return $form->schema([
+                TextInput::make('customer', 'Customer'),
+                Repeater::make('sections', 'Sections')->schema([
+                    TextInput::make('section', 'Section'),
+                    Repeater::make('lines', 'Lines')->schema([
+                        TextInput::make('base', 'Base'),
+                        TextInput::make('price', 'Price')->value(
+                            fn (FormData $row, FormData $form) => $row->float('base') + ($form->string('customer') === 'vip' ? 10 : 0),
+                            editable: true,
+                            resetOn: ['base'],
+                            refreshOn: ['@customer'],
+                        ),
+                    ]),
+                ]),
+            ]);
+        }
+
+        public function handle(Request $request): Response
+        {
+            return new Response('ok');
+        }
+    };
+
+    $result = $definition->resolveFields(Request::create('/', 'POST', [
+        'customer' => 'vip',
+        'sections' => [[
+            'section' => 'Hardware',
+            'lines' => [
+                ['base' => '5'],
+                ['base' => '8'],
+            ],
+        ]],
+    ]));
+
+    expect($result['prefill'])->toBe([
+        'sections.0.lines.0.price' => 15.0,
+        'sections.0.lines.1.price' => 18.0,
+    ]);
+});

--- a/tests/Feature/Forms/SelectPrefillTest.php
+++ b/tests/Feature/Forms/SelectPrefillTest.php
@@ -26,6 +26,14 @@ function repeaterPrefilledOptions(Form $form): array
 /**
  * @return array<int, array{label: string, value: string}>
  */
+function nestedRepeaterPrefilledOptions(Form $form): array
+{
+    return wire($form)['schema'][0]['schema'][0]['schema'][0]['props']['options'] ?? [];
+}
+
+/**
+ * @return array<int, array{label: string, value: string}>
+ */
 function builderPrefilledOptions(Form $form): array
 {
     return wire($form)['schema'][0]['blocks'][0]['schema'][0]['props']['options'] ?? [];
@@ -165,6 +173,37 @@ it('resolves labels for filled ids inside builder rows', function (): void {
         ]);
 
     expect(builderPrefilledOptions($form))->toBe([
+        ['label' => 'Product 5', 'value' => '5'],
+        ['label' => 'Product 8', 'value' => '8'],
+    ])->and($received)->toBe(['5', '8']);
+});
+
+it('resolves labels for filled ids inside nested repeater rows', function (): void {
+    $received = null;
+
+    $form = Form::make('f')
+        ->fill(['sections' => [[
+            'items' => [
+                ['product' => '5'],
+                ['product' => '8'],
+            ],
+        ]]])
+        ->schema([
+            Repeater::make('sections')->schema([
+                Repeater::make('items')->schema([
+                    Select::make('product', 'Product')
+                        ->resolveSelectedUsing(function (array $values) use (&$received) {
+                            $received = $values;
+
+                            return collect($values)
+                                ->map(fn (string $id) => Select::option("Product {$id}", $id))
+                                ->all();
+                        }),
+                ]),
+            ]),
+        ]);
+
+    expect(nestedRepeaterPrefilledOptions($form))->toBe([
         ['label' => 'Product 5', 'value' => '5'],
         ['label' => 'Product 8', 'value' => '8'],
     ])->and($received)->toBe(['5', '8']);

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -80,6 +80,38 @@ function rowSearchDefinition(): FormDefinition
     };
 }
 
+function nestedRowSearchDefinition(): FormDefinition
+{
+    return new class extends FormDefinition
+    {
+        public function definition(Form $form, Request $request): Form
+        {
+            $resolver = fn (string $search, FormData $data) => [
+                Select::option(
+                    "{$data->get('customer')}:{$data->get('section')}:{$data->get('category')}:{$search}",
+                    '1',
+                ),
+            ];
+
+            return $form->schema([
+                TextInput::make('customer'),
+                Repeater::make('sections')->schema([
+                    TextInput::make('section'),
+                    Repeater::make('items')->schema([
+                        TextInput::make('category'),
+                        Select::make('product')->searchable($resolver),
+                    ]),
+                ]),
+            ]);
+        }
+
+        public function handle(Request $request): Response
+        {
+            return new Response('ok');
+        }
+    };
+}
+
 it('resolves options for a searchable field', function (): void {
     $result = searchableDefinition()->searchOptions(
         Request::create('/', 'POST', ['_search' => 'author_id', 'q' => 'jane']),
@@ -139,6 +171,28 @@ it('resolves options for a searchable select inside a builder row', function ():
     expect($result)->toEqual([
         'options' => [
             new Option('initech:lighting:lamp', '1'),
+        ],
+    ]);
+});
+
+it('resolves options for a searchable select inside nested repeater rows', function (): void {
+    $result = nestedRowSearchDefinition()->searchOptions(
+        Request::create('/', 'POST', [
+            '_search' => 'sections.0.items.0.product',
+            'q' => 'desk',
+            'customer' => 'acme',
+            'sections' => [[
+                'section' => 'office',
+                'items' => [
+                    ['category' => 'chairs'],
+                ],
+            ]],
+        ]),
+    );
+
+    expect($result)->toEqual([
+        'options' => [
+            new Option('acme:office:chairs:desk', '1'),
         ],
     ]);
 });

--- a/tests/Feature/Forms/Validation/BuilderValidationTest.php
+++ b/tests/Feature/Forms/Validation/BuilderValidationTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Lattice\Lattice\Forms\Components\Block;
 use Lattice\Lattice\Forms\Components\Builder;
+use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FieldValidator;
@@ -126,4 +127,116 @@ it('skips validation for block children hidden by same-row conditions', function
     $validated = (new FieldValidator)->validate([$field], $request);
 
     expect($validated['items'][0]['type'])->toBe('product');
+});
+
+it('validates builder children recursively inside repeater rows', function (): void {
+    $field = Repeater::make('sections')
+        ->schema([
+            TextInput::make('title')->required(),
+            Builder::make('blocks')->blocks([
+                Block::make('text')->schema([
+                    Textarea::make('content')->required(),
+                ]),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'title' => 'Intro',
+        'blocks' => [
+            ['type' => 'text', 'content' => ''],
+        ],
+    ]]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect(array_keys($errors ?? []))->toBe(['sections.0.blocks.0.content']);
+});
+
+it('uses nested builder child labels in validation messages', function (): void {
+    $field = Repeater::make('sections')
+        ->schema([
+            Builder::make('blocks')->blocks([
+                Block::make('text')->schema([
+                    Textarea::make('content', 'Block Content')->required(),
+                ]),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'blocks' => [
+            ['type' => 'text', 'content' => ''],
+        ],
+    ]]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect($errors['sections.0.blocks.0.content'][0] ?? null)->toBe('The Block Content field is required.');
+});
+
+it('validates repeater children recursively inside builder rows', function (): void {
+    $field = Builder::make('sections')
+        ->blocks([
+            Block::make('section')->schema([
+                Repeater::make('items')->schema([
+                    TextInput::make('name')->required(),
+                ]),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'type' => 'section',
+        'items' => [
+            ['name' => ''],
+        ],
+    ]]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect(array_keys($errors ?? []))->toBe(['sections.0.items.0.name']);
+});
+
+it('uses nested repeater child labels inside builder rows in validation messages', function (): void {
+    $field = Builder::make('sections')
+        ->blocks([
+            Block::make('section')->schema([
+                Repeater::make('items')->schema([
+                    TextInput::make('name', 'Item Name')->required(),
+                ]),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'type' => 'section',
+        'items' => [
+            ['name' => ''],
+        ],
+    ]]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect($errors['sections.0.items.0.name'][0] ?? null)->toBe('The Item Name field is required.');
 });

--- a/tests/Feature/Forms/Validation/RepeaterValidationTest.php
+++ b/tests/Feature/Forms/Validation/RepeaterValidationTest.php
@@ -110,3 +110,82 @@ it('skips validation for row children hidden by same-row conditions', function (
 
     expect($validated['items'][0]['kind'])->toBe('free');
 });
+
+it('validates repeater children recursively with full error paths', function (): void {
+    $field = Repeater::make('sections')
+        ->schema([
+            TextInput::make('title')->required(),
+            Repeater::make('items')->schema([
+                TextInput::make('name')->required(),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'title' => 'Hardware',
+        'items' => [
+            ['name' => 'Desk'],
+            ['name' => ''],
+        ],
+    ]]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect(array_keys($errors ?? []))->toBe(['sections.0.items.1.name']);
+});
+
+it('uses nested repeater child labels in validation messages', function (): void {
+    $field = Repeater::make('sections')
+        ->schema([
+            Repeater::make('items')->schema([
+                TextInput::make('name', 'Item Name')->required(),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'items' => [
+            ['name' => ''],
+        ],
+    ]]]);
+
+    $errors = null;
+
+    try {
+        (new FieldValidator)->validate([$field], $request);
+    } catch (ValidationException $exception) {
+        $errors = $exception->errors();
+    }
+
+    expect($errors['sections.0.items.0.name'][0] ?? null)->toBe('The Item Name field is required.');
+});
+
+it('returns recursively cast repeater values', function (): void {
+    $field = Repeater::make('sections')
+        ->schema([
+            TextInput::make('title')->required(),
+            Repeater::make('items')->schema([
+                TextInput::make('name')->required(),
+            ]),
+        ]);
+
+    $request = Request::create('/', 'POST', ['sections' => [[
+        'title' => 'Hardware',
+        'items' => [
+            ['name' => 'Desk'],
+        ],
+    ]]]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['sections'])->toBe([[
+        'title' => 'Hardware',
+        'items' => [
+            ['name' => 'Desk'],
+        ],
+    ]]);
+});


### PR DESCRIPTION
## Summary
- add a recursive form schema walker for nested repeater and builder fields
- update backend validation, resolution, select search, signed uploads, and prefill handling to use full dot paths
- update frontend value, scope, error, hidden input, rich editor, and prefill override handling for nested row paths
- cover nested validation labels, recursive field resolution, select prefill/search, file upload lookup, and row path behavior

## Verification
- npm run check
- composer check