### PR TITLE
Normalize component tokens and selectors

### DIFF
--- a/resources/js/chat/components/chat-box.test.tsx
+++ b/resources/js/chat/components/chat-box.test.tsx
@@ -70,7 +70,10 @@ describe("ChatBox component", () => {
 
     renderChatBox();
 
-    expect(await screen.findByTestId("chat-box")).toBeVisible();
+    const chatBox = await screen.findByTestId("chat-box");
+    expect(chatBox).toBeVisible();
+    expect(chatBox).toHaveClass("rounded-lt");
+    expect(chatBox).not.toHaveClass("rounded-lt-md");
     expect(screen.getByText("Assistant")).toBeVisible();
     expect(screen.queryByTestId("chat-launcher")).toBeNull();
     expect(screen.queryByTestId("chat-close")).toBeNull();

--- a/resources/js/chat/components/chat-box.test.tsx
+++ b/resources/js/chat/components/chat-box.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
+import type { ChatBox as ChatBoxProps } from "@lattice-php/lattice/types/generated";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 import { RegistryContext } from "@lattice-php/lattice/core/registry-context";
 import { createRegistry } from "@lattice-php/lattice/core/registry";
@@ -38,7 +39,7 @@ function streamResponse(lines: string[]): Response {
   return { ok: true, status: 200, body } as unknown as Response;
 }
 
-function renderChatBox(): void {
+function renderChatBox(props: Partial<ChatBoxProps> = {}): void {
   render(
     withRegistry(
       <ChatBox
@@ -49,6 +50,7 @@ function renderChatBox(): void {
             historyEndpoint: "/h",
             title: "Assistant",
             placeholder: "Ask…",
+            ...props,
           },
         })}
       >
@@ -77,6 +79,22 @@ describe("ChatBox component", () => {
     expect(screen.getByText("Assistant")).toBeVisible();
     expect(screen.queryByTestId("chat-launcher")).toBeNull();
     expect(screen.queryByTestId("chat-close")).toBeNull();
+  });
+
+  it("renders fill mode without fetching history when no history endpoint is configured", async () => {
+    const fetchMock = vi.fn<() => Promise<Response>>(async () => historyResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatBox({ fill: true, historyEndpoint: null, title: null, placeholder: null });
+
+    const chatBox = await screen.findByTestId("chat-box");
+    expect(chatBox).toBeVisible();
+    expect(chatBox).toHaveClass("sticky", "top-0", "h-svh", "w-full");
+    expect(chatBox).not.toHaveClass("h-[28rem]");
+    expect(chatBox).not.toHaveClass("rounded-lt");
+    expect(chatBox).not.toHaveClass("shadow-lg");
+    expect(screen.getByText("Chat")).toBeVisible();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("fetches history once on mount and seeds the conversation", async () => {

--- a/resources/js/chat/components/chat-box.tsx
+++ b/resources/js/chat/components/chat-box.tsx
@@ -47,7 +47,7 @@ export const ChatBox: RendererComponent<"chat.box"> = ({ node }) => {
     <div
       className={cn(
         "flex flex-col overflow-hidden border border-lt-border bg-lt-bg",
-        fill ? "sticky top-0 h-svh w-full" : "h-[28rem] w-80 rounded-lt-md shadow-lg",
+        fill ? "sticky top-0 h-svh w-full" : "h-[28rem] w-80 rounded-lt shadow-lg",
       )}
       data-test={testIdentity("chat-box")}
     >

--- a/resources/js/chat/components/message.test.tsx
+++ b/resources/js/chat/components/message.test.tsx
@@ -32,7 +32,10 @@ describe("Message", () => {
     render(withRegistry(<Message message={message} />));
 
     expect(screen.getByText("Hello there")).toBeVisible();
-    expect(screen.getByTestId("chat-message-user")).toBeInTheDocument();
+    const messageWrapper = screen.getByTestId("chat-message-user");
+    expect(messageWrapper).toBeInTheDocument();
+    expect(messageWrapper.firstElementChild).toHaveClass("rounded-lt");
+    expect(messageWrapper.firstElementChild).not.toHaveClass("rounded-lt-md");
   });
 
   it("renders an assistant message with its text part", () => {

--- a/resources/js/chat/components/message.tsx
+++ b/resources/js/chat/components/message.tsx
@@ -14,7 +14,7 @@ export function Message({ message }: { message: ChatMessage }): ReactNode {
     >
       <div
         className={cn(
-          "max-w-[80%] rounded-lt-md px-3 py-2 text-sm",
+          "max-w-[80%] rounded-lt px-3 py-2 text-sm",
           isUser ? "bg-lt-primary text-lt-primary-fg" : "bg-lt-muted text-lt-fg",
         )}
       >

--- a/resources/js/core/components/dialog.test.tsx
+++ b/resources/js/core/components/dialog.test.tsx
@@ -18,7 +18,7 @@ describe("Dialog", () => {
     expect(content).toHaveClass("bg-lt-bg", "max-w-md");
     expect(screen.getByText("Settings")).toBeVisible();
     expect(document.querySelector('[data-slot="dialog-overlay"]')).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    expect(screen.getByTestId("dialog-close")).toBe(screen.getByRole("button", { name: "Close" }));
   });
 
   it("renders the optional description in the header", () => {

--- a/resources/js/core/components/dialog.tsx
+++ b/resources/js/core/components/dialog.tsx
@@ -81,7 +81,7 @@ function DialogHeader({
         {description ? <DialogDescription>{description}</DialogDescription> : null}
       </div>
       <DialogClose asChild>
-        <Button aria-label={closeLabel} size="icon" variant="ghost">
+        <Button aria-label={closeLabel} data-test="dialog-close" size="icon" variant="ghost">
           <Icon name="x" aria-hidden="true" className="size-lt-icon-md" />
         </Button>
       </DialogClose>

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -66,7 +66,7 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
                 aria-expanded={!isCollapsed}
                 aria-label={isCollapsed ? "Expand section" : "Collapse section"}
                 data-test={prefixedTestId("section-toggle", identity) ?? "section-toggle-default"}
-                className="mt-0.5 inline-flex shrink-0 items-center rounded-md p-0.5 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
+                className="mt-0.5 inline-flex shrink-0 items-center rounded-lt-sm p-0.5 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
                 onClick={toggle}
                 type="button"
               >

--- a/resources/js/form/components/fields/file-upload.test.tsx
+++ b/resources/js/form/components/fields/file-upload.test.tsx
@@ -245,6 +245,7 @@ describe("FileUploadComponent image previews", () => {
     expect(createObjectURL).toHaveBeenCalledWith(file);
     expect(screen.getByRole("img", { name: "lamp.jpg" })).toHaveAttribute("src", "blob:lamp.jpg");
 
+    expect(screen.getByTestId("images-remove")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Remove lamp.jpg" }));
 
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:lamp.jpg");

--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -291,7 +291,9 @@ export const FileUploadComponent: RendererComponent<"field.file-upload"> = ({ no
                 <button
                   aria-label={t("file-upload.remove", "Remove {{name}}", { name: item.name })}
                   className="inline-flex size-7 shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg disabled:pointer-events-none disabled:opacity-50"
-                  data-test={item.existing ? testIdentity(`${name}-remove-existing`) : undefined}
+                  data-test={testIdentity(
+                    item.existing ? `${name}-remove-existing` : `${name}-remove`,
+                  )}
                   disabled={locked}
                   onClick={() => removeItem(item.id)}
                   type="button"

--- a/resources/js/layout/callouts.tsx
+++ b/resources/js/layout/callouts.tsx
@@ -61,7 +61,7 @@ const Callouts: RendererComponent<"callouts"> = () => {
               type="button"
               aria-label={t("a11y.dismiss", "Dismiss")}
               data-test="callout-dismiss"
-              className="shrink-0 rounded-md p-1 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
+              className="shrink-0 rounded-lt-sm p-1 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
               onClick={() => dismiss(callout.id)}
             >
               <Icon name="x" className="size-lt-icon-md" />

--- a/resources/js/layout/dropdown.tsx
+++ b/resources/js/layout/dropdown.tsx
@@ -10,7 +10,7 @@ const DropdownComponent: RendererComponent<"dropdown"> = ({ children, node }) =>
       placement={node.props.placement}
       testId={testId}
       trigger={
-        <span className="flex min-w-0 items-center rounded-md px-2 py-1.5 text-sm hover:bg-lt-muted">
+        <span className="flex min-w-0 items-center rounded-lt-sm px-2 py-1.5 text-sm hover:bg-lt-muted">
           {node.props.trigger.map((triggerNode, index) => (
             <RenderNode
               key={triggerNode.key ?? `${triggerNode.type}-${index}`}

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -9,7 +9,7 @@ import { useSidebarCollapsed } from "./context";
 import { Popover } from "./popover";
 
 const rowClass =
-  "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-lt-fg transition-colors hover:bg-lt-muted";
+  "flex items-center gap-2 rounded-lt-sm px-3 py-2 text-sm text-lt-fg transition-colors hover:bg-lt-muted";
 
 function schemaContainsPath(schema: Schema | undefined, path: string): boolean {
   return (schema ?? []).some(
@@ -30,7 +30,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
       {icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} /> : null}
       {collapsed ? (
         <span
-          className="pointer-events-none absolute top-1/2 left-full z-50 ml-2 hidden -translate-y-1/2 rounded-md border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lg group-hover:block"
+          className="pointer-events-none absolute top-1/2 left-full z-50 ml-2 hidden -translate-y-1/2 rounded-lt-sm border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lg group-hover:block"
           role="tooltip"
         >
           {label}

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -50,7 +50,7 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
             aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
             data-test="sidebar-toggle"
             className={cn(
-              "inline-flex items-center rounded-md p-2 text-lt-fg transition-colors hover:bg-lt-muted",
+              "inline-flex items-center rounded-lt-sm p-2 text-lt-fg transition-colors hover:bg-lt-muted",
               isCollapsed ? "self-center" : "self-end",
             )}
             onClick={toggle}

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -46,7 +46,7 @@ export const TextCell: ColumnCellComponent<"column.text"> = ({ column, props, ro
       <button
         type="button"
         data-test={`copy-${column.key}`}
-        className="inline-flex items-center gap-1 rounded border border-lt-border px-2 py-1 text-xs"
+        className="inline-flex items-center gap-1 rounded-lt-sm border border-lt-border px-2 py-1 text-xs"
         aria-label={`${copied ? "Copied" : "Copy"} ${column.label}`}
         onClick={handleCopy}
       >

--- a/resources/js/table/components/filter-bar.tsx
+++ b/resources/js/table/components/filter-bar.tsx
@@ -46,7 +46,7 @@ export function FilterBar({
             <button
               type="button"
               data-test={`table-filter-chip-${filter.key}-remove`}
-              className="inline-flex size-5 items-center justify-center rounded text-lt-muted-fg hover:bg-lt-border disabled:opacity-50"
+              className="inline-flex size-5 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-border disabled:opacity-50"
               disabled={processing}
               aria-label={t("filter.remove", "Remove {{label}} filter", {
                 label: filter.label,

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -156,7 +156,7 @@ function MultiSelectControl({
           {filterOptions(filter).map((option) => (
             <label
               key={option.value}
-              className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-lt-muted"
+              className="flex cursor-pointer items-center gap-2 rounded-lt-sm px-2 py-1.5 text-sm hover:bg-lt-muted"
             >
               <Checkbox
                 aria-label={option.label}

--- a/resources/js/table/components/filter-stack-bar.tsx
+++ b/resources/js/table/components/filter-stack-bar.tsx
@@ -36,7 +36,7 @@ export function FilterStackBar({
             <button
               type="button"
               data-test={`filter-chip-${clause.field}-remove`}
-              className="inline-flex size-5 items-center justify-center rounded text-lt-muted-fg hover:bg-lt-muted disabled:opacity-50"
+              className="inline-flex size-5 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted disabled:opacity-50"
               disabled={processing}
               aria-label={t("filter.remove", "Remove {{label}} filter", { label })}
               onClick={() => onRemove(index)}

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -105,7 +105,7 @@ export function FilterValueInput({
           type="button"
           aria-label={t("filter.clear", "Clear {{label}} filter", { label })}
           data-test={testId ? `${testId}-clear` : undefined}
-          className="absolute right-1 inline-flex size-6 items-center justify-center rounded hover:bg-lt-muted disabled:opacity-50"
+          className="absolute right-1 inline-flex size-6 items-center justify-center rounded-lt-sm hover:bg-lt-muted disabled:opacity-50"
           disabled={processing}
           onClick={onClear}
         >

--- a/resources/js/table/components/sort-bar.tsx
+++ b/resources/js/table/components/sort-bar.tsx
@@ -32,7 +32,7 @@ export function SortBar({
             />
             <button
               type="button"
-              className="inline-flex size-5 items-center justify-center rounded text-lt-muted-fg hover:bg-lt-muted disabled:opacity-50"
+              className="inline-flex size-5 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted disabled:opacity-50"
               disabled={processing}
               aria-label={`Clear ${label} sort`}
               data-test={`clear-${sort.key}-sort`}

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -59,7 +59,7 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
           {toast.dismissible ? (
             <Toast.Close
               aria-label={t("a11y.dismiss", "Dismiss")}
-              className="shrink-0 rounded-md p-1 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
+              className="shrink-0 rounded-lt-sm p-1 text-lt-muted-fg transition-colors hover:bg-lt-muted hover:text-lt-fg"
               data-test="toast-dismiss"
             >
               <Icon name="x" className="size-lt-icon-md" />


### PR DESCRIPTION
## What changed

- Replaced invalid `rounded-lt-md` and remaining raw `rounded` / `rounded-md` utilities with Lattice radius tokens.
- Added stable `data-test` hooks for the shared dialog close button and newly added file-upload remove buttons.
- Covered the selector gaps and chat radius token regression in component tests.

## Before / after

- Before: chat surfaces used `rounded-lt-md`, which has no theme token. After: they use `rounded-lt`.
- Before: small component controls mixed raw `rounded` / `rounded-md`. After: they use `rounded-lt-sm`.
- Before: new file-upload remove buttons and dialog close buttons had no stable test selector. After: they expose `images-remove` and `dialog-close`.

## Checks

- `npm run check`
- `composer check`