### PR TITLE
feat(design): align design tokens & components with the Xentral app shell

### DIFF
--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -1,6 +1,6 @@
 :root,
 [data-theme="light"] {
-  --lt-bg: var(--background, oklch(1 0 0));
+  --lt-bg: var(--background, oklch(0.97 0 0));
   --lt-fg: var(--foreground, oklch(0.145 0 0));
   --lt-surface: var(--card, oklch(1 0 0));
   --lt-surface-fg: var(--card-foreground, oklch(0.145 0 0));
@@ -25,15 +25,75 @@
   --lt-success-fg: var(--success-foreground, oklch(0.985 0 0));
   --lt-info: var(--info, oklch(0.62 0.14 240));
   --lt-info-fg: var(--info-foreground, oklch(0.985 0 0));
-  --lt-radius: var(--radius, 0.625rem);
-  --lt-radius-sm: calc(var(--lt-radius) - 2px);
-  --lt-radius-xs: calc(var(--lt-radius) - 4px);
+  /* Interaction-state colours, derived from the existing primary/muted tokens
+     (no new brand hues introduced). Override via the bare --primary-hover etc. */
+  --lt-primary-hover: var(--primary-hover, oklch(0.43 0.092 182));
+  --lt-primary-active: var(--primary-active, oklch(0.39 0.092 182));
+  --lt-danger-hover: var(--destructive-hover, oklch(0.53 0.21 27.3));
+  --lt-danger-active: var(--destructive-active, oklch(0.48 0.21 27.3));
+  --lt-success-hover: var(--success-hover, oklch(0.57 0.125 160));
+  --lt-success-active: var(--success-active, oklch(0.52 0.125 160));
+  --lt-info-hover: var(--info-hover, oklch(0.57 0.14 240));
+  --lt-info-active: var(--info-active, oklch(0.52 0.14 240));
+  --lt-secondary-hover: var(--secondary-hover, oklch(0.93 0 0));
+  --lt-secondary-active: var(--secondary-active, oklch(0.9 0 0));
+  --lt-disabled: var(--disabled, oklch(0.95 0 0));
+  --lt-disabled-fg: var(--disabled-foreground, oklch(0.7 0 0));
+
+  /* Radius. Base drives cards; -sm controls (buttons/inputs); -xs chips.
+     Derived steps stay in rem so the whole token layer is unit-consistent. */
+  --lt-radius: var(--radius, 0.5rem);
+  --lt-radius-sm: calc(var(--lt-radius) - 0.125rem);
+  --lt-radius-xs: calc(var(--lt-radius) - 0.25rem);
 
   --lt-icon-xs: 0.75rem;
   --lt-icon-sm: 0.875rem;
   --lt-icon-md: 1rem;
   --lt-icon-lg: 1.25rem;
   --lt-icon-xl: 1.5rem;
+  --lt-icon-stroke: 1.5;
+
+  /* Density — control heights are the primary lever for compactness.
+     -md (2.25rem / 36px) matches the host app's control height. */
+  --lt-control-h-sm: 2rem;
+  --lt-control-h-md: 2.25rem;
+  --lt-control-h-lg: 2.5rem;
+
+  --lt-font-weight-normal: 400;
+  --lt-font-weight-medium: 500;
+  --lt-font-weight-semibold: 600;
+  --lt-font-weight-bold: 700;
+
+  /* Focus ring — colour lives in --lt-ring; these size it. */
+  --lt-ring-width: 0.125rem;
+  --lt-ring-offset: 0.125rem;
+
+  /* Elevation */
+  --lt-shadow-xs: 0 1px 1px 0 oklch(0 0 0 / 0.04);
+  --lt-shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.05);
+  --lt-shadow-md:
+    0 2px 4px -1px oklch(0 0 0 / 0.08), 0 1px 2px -1px oklch(0 0 0 / 0.06);
+  --lt-shadow-lg:
+    0 8px 16px -4px oklch(0 0 0 / 0.12), 0 2px 4px -2px oklch(0 0 0 / 0.08);
+
+  /* Layering — keep overlay surfaces stacked in a documented order. */
+  --lt-z-dropdown: 1000;
+  --lt-z-sticky: 1100;
+  --lt-z-overlay: 1200;
+  --lt-z-modal: 1300;
+  --lt-z-popover: 1400;
+  --lt-z-toast: 1500;
+
+  /* Motion */
+  --lt-duration-fast: 120ms;
+  --lt-duration-base: 160ms;
+  --lt-duration-slow: 240ms;
+  --lt-ease: cubic-bezier(0.2, 0, 0, 1);
+
+  /* Layout dimensions (topbar height intentionally omitted — owned elsewhere) */
+  --lt-sidebar-w: 16rem;
+  --lt-sidebar-w-collapsed: 4rem;
+  --lt-container-max: 80rem;
 
   color-scheme: light;
 }
@@ -66,6 +126,20 @@
   --lt-info: var(--info, oklch(0.7 0.14 240));
   --lt-info-fg: var(--info-foreground, oklch(0.205 0 0));
 
+  /* Interaction states (dark): fills lighten on hover/active. */
+  --lt-primary-hover: var(--primary-hover, oklch(0.79 0.105 182));
+  --lt-primary-active: var(--primary-active, oklch(0.84 0.105 182));
+  --lt-danger-hover: var(--destructive-hover, oklch(0.47 0.13 26));
+  --lt-danger-active: var(--destructive-active, oklch(0.52 0.13 26));
+  --lt-success-hover: var(--success-hover, oklch(0.75 0.15 162));
+  --lt-success-active: var(--success-active, oklch(0.8 0.15 162));
+  --lt-info-hover: var(--info-hover, oklch(0.75 0.14 240));
+  --lt-info-active: var(--info-active, oklch(0.8 0.14 240));
+  --lt-secondary-hover: var(--secondary-hover, oklch(0.32 0 0));
+  --lt-secondary-active: var(--secondary-active, oklch(0.36 0 0));
+  --lt-disabled: var(--disabled, oklch(0.32 0 0));
+  --lt-disabled-fg: var(--disabled-foreground, oklch(0.55 0 0));
+
   color-scheme: dark;
 }
 
@@ -95,16 +169,32 @@
   --color-lt-success-fg: var(--lt-success-fg);
   --color-lt-info: var(--lt-info);
   --color-lt-info-fg: var(--lt-info-fg);
+  --color-lt-primary-hover: var(--lt-primary-hover);
+  --color-lt-primary-active: var(--lt-primary-active);
+  --color-lt-danger-hover: var(--lt-danger-hover);
+  --color-lt-danger-active: var(--lt-danger-active);
+  --color-lt-success-hover: var(--lt-success-hover);
+  --color-lt-success-active: var(--lt-success-active);
+  --color-lt-info-hover: var(--lt-info-hover);
+  --color-lt-info-active: var(--lt-info-active);
+  --color-lt-secondary-hover: var(--lt-secondary-hover);
+  --color-lt-secondary-active: var(--lt-secondary-active);
+  --color-lt-disabled: var(--lt-disabled);
+  --color-lt-disabled-fg: var(--lt-disabled-fg);
   --radius-lt: var(--lt-radius);
   --radius-lt-sm: var(--lt-radius-sm);
   --radius-lt-xs: var(--lt-radius-xs);
+  --shadow-lt-xs: var(--lt-shadow-xs);
+  --shadow-lt-sm: var(--lt-shadow-sm);
+  --shadow-lt-md: var(--lt-shadow-md);
+  --shadow-lt-lg: var(--lt-shadow-lg);
   --spacing-lt-icon-xs: var(--lt-icon-xs);
   --spacing-lt-icon-sm: var(--lt-icon-sm);
   --spacing-lt-icon-md: var(--lt-icon-md);
   --spacing-lt-icon-lg: var(--lt-icon-lg);
   --spacing-lt-icon-xl: var(--lt-icon-xl);
-  --animate-lt-toast-in: lt-toast-in 160ms ease-out;
-  --animate-lt-toast-out: lt-toast-out 120ms ease-in;
+  --animate-lt-toast-in: lt-toast-in var(--lt-duration-base) ease-out;
+  --animate-lt-toast-out: lt-toast-out var(--lt-duration-fast) ease-in;
 }
 
 @theme {
@@ -112,6 +202,9 @@
     "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";
+
+  /* Base spacing unit — scales every gap/padding utility at once. */
+  --spacing: 0.25rem;
 
   --text-xs: 0.625rem;
   --text-xs--line-height: 1.6;

--- a/resources/js/chat/components/chat-box.tsx
+++ b/resources/js/chat/components/chat-box.tsx
@@ -47,7 +47,7 @@ export const ChatBox: RendererComponent<"chat.box"> = ({ node }) => {
     <div
       className={cn(
         "flex flex-col overflow-hidden border border-lt-border bg-lt-bg",
-        fill ? "sticky top-0 h-full min-h-[28rem] w-full" : "h-[28rem] w-80 rounded-lt shadow-lg",
+        fill ? "sticky top-0 h-full min-h-[28rem] w-full" : "h-[28rem] w-80 rounded-lt shadow-lt-lg",
       )}
       data-test={testIdentity("chat-box")}
     >

--- a/resources/js/core/components/badge.tsx
+++ b/resources/js/core/components/badge.tsx
@@ -9,11 +9,12 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "border-transparent bg-lt-primary text-lt-primary-fg [a&]:hover:bg-lt-primary/90",
+        default:
+          "border-transparent bg-lt-primary text-lt-primary-fg [a&]:hover:bg-lt-primary-hover",
         secondary:
-          "border-transparent bg-lt-secondary text-lt-secondary-fg [a&]:hover:bg-lt-secondary/90",
+          "border-transparent bg-lt-secondary text-lt-secondary-fg [a&]:hover:bg-lt-secondary-hover",
         destructive:
-          "border-transparent bg-lt-danger text-lt-danger-fg [a&]:hover:bg-lt-danger/90 focus-visible:ring-lt-danger/20 dark:focus-visible:ring-lt-danger/40 dark:bg-lt-danger/60",
+          "border-transparent bg-lt-danger text-lt-danger-fg [a&]:hover:bg-lt-danger-hover focus-visible:ring-lt-danger/20 dark:focus-visible:ring-lt-danger/40 dark:bg-lt-danger/60",
         outline: "border-lt-border text-lt-fg [a&]:hover:bg-lt-accent [a&]:hover:text-lt-accent-fg",
       },
     },

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -10,26 +10,29 @@ import type { ButtonVariant } from "@lattice-php/lattice/types/generated";
 export type { ButtonVariant };
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lt-sm text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-lt-icon-md [&_svg]:shrink-0 outline-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lt-sm text-base font-medium transition-[color,box-shadow] disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-lt-icon-md [&_svg]:shrink-0 outline-none focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px] aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
   {
     variants: {
       variant: {
-        default: "bg-lt-primary text-lt-primary-fg shadow-xs hover:bg-lt-primary/90",
+        default:
+          "bg-lt-primary text-lt-primary-fg shadow-lt-xs hover:bg-lt-primary-hover active:bg-lt-primary-active disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:shadow-none",
         destructive:
-          "bg-lt-danger text-lt-danger-fg shadow-xs hover:bg-lt-danger/90 focus-visible:ring-lt-danger/20 dark:focus-visible:ring-lt-danger/40",
-        success: "bg-lt-success text-lt-success-fg shadow-xs hover:bg-lt-success/90",
-        info: "bg-lt-info text-lt-info-fg shadow-xs hover:bg-lt-info/90",
+          "bg-lt-danger text-lt-danger-fg shadow-lt-xs hover:bg-lt-danger-hover active:bg-lt-danger-active focus-visible:ring-lt-danger/20 dark:focus-visible:ring-lt-danger/40 disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:shadow-none",
+        success:
+          "bg-lt-success text-lt-success-fg shadow-lt-xs hover:bg-lt-success-hover active:bg-lt-success-active disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:shadow-none",
+        info: "bg-lt-info text-lt-info-fg shadow-lt-xs hover:bg-lt-info-hover active:bg-lt-info-active disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:shadow-none",
         outline:
-          "border border-lt-input bg-lt-bg shadow-xs hover:bg-lt-accent hover:text-lt-accent-fg",
-        secondary: "bg-lt-secondary text-lt-secondary-fg shadow-xs hover:bg-lt-secondary/80",
-        ghost: "hover:bg-lt-accent hover:text-lt-accent-fg",
-        link: "text-lt-primary underline-offset-4 hover:underline",
+          "border border-lt-input bg-lt-bg shadow-lt-xs hover:bg-lt-accent hover:text-lt-accent-fg disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:border-transparent disabled:shadow-none",
+        secondary:
+          "bg-lt-secondary text-lt-secondary-fg shadow-lt-xs hover:bg-lt-secondary-hover active:bg-lt-secondary-active disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:shadow-none",
+        ghost: "hover:bg-lt-accent hover:text-lt-accent-fg disabled:text-lt-disabled-fg",
+        link: "text-lt-primary underline-offset-4 hover:underline disabled:text-lt-disabled-fg disabled:no-underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-lt-sm px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-lt-sm px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: "h-[var(--lt-control-h-md)] px-4 py-2 has-[>svg]:px-3",
+        sm: "h-[var(--lt-control-h-sm)] rounded-lt-sm px-3 has-[>svg]:px-2.5",
+        lg: "h-[var(--lt-control-h-lg)] rounded-lt-sm px-6 has-[>svg]:px-4",
+        icon: "size-[var(--lt-control-h-md)]",
       },
     },
     defaultVariants: {
@@ -67,14 +70,14 @@ const ButtonComponent: RendererComponent<"button"> = ({ node }) => {
 
   if (href) {
     return (
-      <Button asChild data-test={testId} variant={variant} size="lg">
+      <Button asChild data-test={testId} variant={variant} size="default">
         <Link href={href}>{label}</Link>
       </Button>
     );
   }
 
   return (
-    <Button data-test={testId} type={node.props.buttonType} variant={variant} size="lg">
+    <Button data-test={testId} type={node.props.buttonType} variant={variant} size="default">
       {label}
     </Button>
   );

--- a/resources/js/core/components/card.tsx
+++ b/resources/js/core/components/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"article">) {
     <article
       data-slot="card"
       className={cn(
-        "flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-xs",
+        "flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-lt-sm",
         className,
       )}
       {...props}

--- a/resources/js/core/components/chart.tsx
+++ b/resources/js/core/components/chart.tsx
@@ -102,7 +102,7 @@ function ChartFrame({
 
   return (
     <div
-      className="flex flex-col gap-3 rounded-lt border border-lt-border bg-lt-surface p-4 text-lt-surface-fg shadow-xs"
+      className="flex flex-col gap-3 rounded-lt border border-lt-border bg-lt-surface p-4 text-lt-surface-fg shadow-lt-sm"
       data-lattice-component={id}
     >
       {hasHeader && (

--- a/resources/js/core/components/checkbox.tsx
+++ b/resources/js/core/components/checkbox.tsx
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-lt-input data-[state=checked]:bg-lt-primary data-[state=checked]:text-lt-primary-fg data-[state=checked]:border-lt-primary focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger size-4 shrink-0 rounded-lt-xs border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-lt-input data-[state=checked]:bg-lt-primary data-[state=checked]:text-lt-primary-fg data-[state=checked]:border-lt-primary focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger size-4 shrink-0 rounded-lt-xs border shadow-lt-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/resources/js/core/components/control.ts
+++ b/resources/js/core/components/control.ts
@@ -12,17 +12,17 @@ export const FOCUS_RING =
  */
 export const controlSurface = cva(
   [
-    "w-full min-w-0 rounded-lt-sm border border-lt-input shadow-xs outline-none transition-[color,box-shadow]",
+    "w-full min-w-0 rounded-lt-sm border border-lt-input shadow-lt-xs outline-none transition-[color,box-shadow]",
     "placeholder:text-lt-muted-fg",
     FOCUS_RING,
     "aria-invalid:border-lt-danger aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40",
-    "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+    "disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg",
   ],
   {
     variants: {
       density: {
-        comfortable: "h-9 bg-transparent px-3 py-1 text-base md:text-sm",
-        compact: "h-9 bg-lt-bg px-2 text-sm font-normal",
+        comfortable: "h-[var(--lt-control-h-md)] bg-transparent px-3 py-1 text-base",
+        compact: "h-[var(--lt-control-h-md)] bg-lt-bg px-2 text-sm font-normal",
       },
     },
     defaultVariants: { density: "comfortable" },

--- a/resources/js/core/components/dialog.tsx
+++ b/resources/js/core/components/dialog.tsx
@@ -5,7 +5,7 @@ import { Button } from "@lattice-php/lattice/core/components/button";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
 export const DIALOG_SURFACE =
-  "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lg";
+  "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lt-lg";
 
 function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;

--- a/resources/js/core/components/floating-panel.tsx
+++ b/resources/js/core/components/floating-panel.tsx
@@ -31,7 +31,7 @@ const FloatingPanelComponent: RendererComponent<"floating-panel"> = ({ children,
     return (
       <div
         aria-label={label}
-        className="fixed z-50 max-w-[calc(100vw-2rem)] rounded-lt border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-md"
+        className="fixed z-50 max-w-[calc(100vw-2rem)] rounded-lt border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-lt-md"
         data-lattice-component={node.id}
         role={label ? "group" : undefined}
         style={placementStyle(placement, offset)}
@@ -56,7 +56,7 @@ const FloatingPanelComponent: RendererComponent<"floating-panel"> = ({ children,
         <button
           aria-expanded={open}
           className={cn(
-            "inline-flex items-center gap-2 rounded-lt border border-lt-border bg-lt-popover px-3 py-1.5 text-sm font-medium text-lt-popover-fg shadow-md hover:bg-lt-muted",
+            "inline-flex items-center gap-2 rounded-lt border border-lt-border bg-lt-popover px-3 py-1.5 text-sm font-medium text-lt-popover-fg shadow-lt-md hover:bg-lt-muted",
             anchorsToStart ? "self-start" : "self-end",
           )}
           data-test={node.key ? `${node.key}-trigger` : undefined}

--- a/resources/js/core/components/heading.tsx
+++ b/resources/js/core/components/heading.tsx
@@ -6,9 +6,9 @@ const HeadingComponent: RendererComponent<"heading"> = ({ node }) => {
   const level = Math.min(Math.max(node.props.level, 1), 6);
   const className = cn(
     "max-w-3xl font-semibold tracking-normal text-balance text-lt-fg",
-    level === 1 && "text-4xl leading-tight sm:text-5xl",
-    level === 2 && "text-2xl",
-    level > 2 && "text-lg",
+    level === 1 && "text-2xl font-bold leading-tight",
+    level === 2 && "text-xl",
+    level > 2 && "text-base",
   );
 
   switch (level) {

--- a/resources/js/core/components/popover.tsx
+++ b/resources/js/core/components/popover.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
 export const POPOVER_SURFACE =
-  "z-50 rounded-lt-sm border border-lt-border bg-lt-popover text-lt-popover-fg shadow-md";
+  "z-50 rounded-lt-sm border border-lt-border bg-lt-popover text-lt-popover-fg shadow-lt-md";
 
 function Popover(props: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -55,7 +55,7 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
 
   return (
     <section
-      className="flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-xs"
+      className="flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-lt-sm"
       data-lattice-component={node.id}
     >
       {hasHeader && (

--- a/resources/js/core/components/segmented-pills.tsx
+++ b/resources/js/core/components/segmented-pills.tsx
@@ -57,7 +57,7 @@ export function SegmentedPills({
             className={cn(
               "whitespace-nowrap rounded-lt-sm px-3 py-1.5 text-sm font-medium transition-colors",
               isSelected
-                ? "bg-lt-bg text-lt-fg shadow-xs"
+                ? "bg-lt-bg text-lt-fg shadow-lt-xs"
                 : "text-lt-muted-fg hover:bg-lt-bg/60 hover:text-lt-fg",
               disabled && "cursor-not-allowed opacity-60",
             )}

--- a/resources/js/core/components/tabs.tsx
+++ b/resources/js/core/components/tabs.tsx
@@ -184,7 +184,7 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
                 className={cn(
                   "whitespace-nowrap rounded-lt-sm px-3 py-1.5 text-sm font-medium transition-colors",
                   isActive
-                    ? "bg-lt-bg text-lt-fg shadow-xs"
+                    ? "bg-lt-bg text-lt-fg shadow-lt-xs"
                     : "text-lt-muted-fg hover:bg-lt-bg/60 hover:text-lt-fg",
                   isVertical && "text-left",
                 )}

--- a/resources/js/form/components/base/label.tsx
+++ b/resources/js/form/components/base/label.tsx
@@ -8,7 +8,7 @@ function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimiti
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "text-base leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       {...props}

--- a/resources/js/form/components/base/submit-button.tsx
+++ b/resources/js/form/components/base/submit-button.tsx
@@ -34,7 +34,7 @@ export function FormSubmitButton({
 
       {hasErrors && (
         <div
-          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 w-max max-w-xs -translate-x-1/2 rounded-lt border border-lt-border bg-lt-surface p-3 text-left text-sm opacity-0 shadow-md transition-opacity group-hover:opacity-100"
+          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 w-max max-w-xs -translate-x-1/2 rounded-lt border border-lt-border bg-lt-surface p-3 text-left text-sm opacity-0 shadow-lt-md transition-opacity group-hover:opacity-100"
           role="tooltip"
         >
           <p className="mb-1 font-medium text-lt-fg">{summaryLabel}</p>

--- a/resources/js/form/components/base/textarea.tsx
+++ b/resources/js/form/components/base/textarea.tsx
@@ -8,7 +8,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-lt-input placeholder:text-lt-muted-fg flex field-sizing-content min-h-16 w-full rounded-lt-sm border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-lt-input placeholder:text-lt-muted-fg flex field-sizing-content min-h-16 w-full rounded-lt-sm border bg-transparent px-3 py-2 text-base shadow-lt-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg",
         FOCUS_RING,
         "aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
         className,

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -252,7 +252,7 @@ function EmojiPicker({ editor }: { editor: Editor }) {
         <Icon name="smile" />
       </button>
       {open && (
-        <div className="absolute z-10 mt-1 grid grid-cols-8 gap-0.5 rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-md">
+        <div className="absolute z-10 mt-1 grid grid-cols-8 gap-0.5 rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-lt-md">
           {emojis.map((emoji) => (
             <button
               className="inline-flex size-7 items-center justify-center rounded-lt-sm text-base hover:bg-lt-accent"
@@ -378,7 +378,7 @@ export const RichEditorComponent: RendererComponent<"field.rich-editor"> = ({ no
     >
       <div
         className={cn(
-          "overflow-hidden rounded-lt-sm border border-lt-input bg-transparent shadow-xs focus-within:border-lt-ring focus-within:ring-[3px] focus-within:ring-lt-ring/50",
+          "overflow-hidden rounded-lt-sm border border-lt-input bg-transparent shadow-lt-xs focus-within:border-lt-ring focus-within:ring-[3px] focus-within:ring-lt-ring/50",
           locked && "opacity-60",
         )}
       >

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -84,7 +84,7 @@ function FormBody({
           {children}
 
           {shouldRenderSubmitButton && (
-            <div className="flex justify-end rounded-lt border border-lt-border bg-lt-surface px-6 py-4 shadow-xs">
+            <div className="flex justify-end rounded-lt border border-lt-border bg-lt-surface px-6 py-4 shadow-lt-sm">
               <FormSubmitButton label={submitLabel} summaryLabel={summaryLabel} />
             </div>
           )}

--- a/resources/js/form/skeleton.tsx
+++ b/resources/js/form/skeleton.tsx
@@ -15,7 +15,7 @@ export const FormSkeletonComponent: RendererComponent<"form"> = ({ node }) => {
   return (
     <div
       aria-hidden="true"
-      className="mx-auto flex w-full max-w-md flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface p-6 shadow-xs"
+      className="mx-auto flex w-full max-w-md flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface p-6 shadow-lt-sm"
       data-lattice-skeleton={node.id ?? node.type}
     >
       <div className="grid gap-6">

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -9,7 +9,7 @@ import { useSidebarCollapsed } from "./context";
 import { Popover } from "./popover";
 
 const rowClass =
-  "flex items-center gap-2 rounded-lt-sm px-3 py-2 text-sm text-lt-fg transition-colors hover:bg-lt-muted";
+  "flex items-center gap-2 rounded-lt-sm px-3 py-2 text-base font-medium text-lt-fg transition-colors hover:bg-lt-muted";
 
 function schemaContainsPath(schema: Schema | undefined, path: string): boolean {
   return (schema ?? []).some(
@@ -30,7 +30,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
       {icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} /> : null}
       {collapsed ? (
         <span
-          className="pointer-events-none absolute top-1/2 left-full z-50 ml-2 hidden -translate-y-1/2 rounded-lt-sm border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lg group-hover:block"
+          className="pointer-events-none absolute top-1/2 left-full z-50 ml-2 hidden -translate-y-1/2 rounded-lt-sm border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lt-md group-hover:block"
           role="tooltip"
         >
           {label}

--- a/resources/js/remote/components/chat-box.tsx
+++ b/resources/js/remote/components/chat-box.tsx
@@ -58,7 +58,7 @@ export const RemoteChatBox: RendererComponent<"remote.chat-box"> = ({ node }) =>
         "flex flex-col overflow-hidden border border-lt-border bg-lt-bg",
         props.fill
           ? "sticky top-0 h-full min-h-[28rem] w-full"
-          : "h-[28rem] w-80 rounded-lt shadow-lg",
+          : "h-[28rem] w-80 rounded-lt shadow-lt-lg",
       )}
       data-test={testIdentity("chat-box")}
     >

--- a/resources/js/table/components/column-header.tsx
+++ b/resources/js/table/components/column-header.tsx
@@ -43,7 +43,7 @@ export function ColumnHeader({
     <div
       aria-sort={getColumnAriaSort(columnSort)}
       className={cn(
-        "relative min-w-0 px-4 py-3 pr-5 align-middle font-medium text-lt-muted-fg",
+        "relative min-w-0 px-4 py-3 pr-5 align-middle font-semibold text-lt-fg",
         alignText(align),
       )}
       role="columnheader"
@@ -52,7 +52,7 @@ export function ColumnHeader({
         <button
           type="button"
           aria-label={`Sort ${column.label}`}
-          className={cn("flex w-full items-center gap-1.5 font-medium", alignJustify(align))}
+          className={cn("flex w-full items-center gap-1.5 font-semibold", alignJustify(align))}
           data-test={`sort-${column.key}`}
           disabled={processing}
           onClick={() => sort(column)}

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -152,7 +152,7 @@ function MultiSelectControl({
         <Icon name="chevron-down" aria-hidden="true" className="size-lt-icon-sm shrink-0" />
       </button>
       {open && (
-        <div className="absolute z-10 mt-1 min-w-full rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-md">
+        <div className="absolute z-10 mt-1 min-w-full rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-lt-md">
           {filterOptions(filter).map((option) => (
             <label
               key={option.value}

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -162,7 +162,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
             onClear={clearSort}
           />
         )}
-        <div className="min-w-full text-sm" role="table">
+        <div className="min-w-full text-base" role="table">
           <div className="border-b border-lt-border bg-lt-muted/50" role="rowgroup">
             <div
               className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
@@ -193,7 +193,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
               ))}
               {hasTrailingUtility && (
                 <div
-                  className="flex items-center justify-end gap-2 px-4 py-2 align-middle font-medium text-lt-muted-fg"
+                  className="flex items-center justify-end gap-2 px-4 py-2 align-middle font-semibold text-lt-fg"
                   role="columnheader"
                 >
                   {hasDedicatedFilters && (

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -34,7 +34,7 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
         <Toast.Root
           key={toast.id}
           className={cn(
-            "flex items-start gap-3 rounded-lt border border-l-4 border-lt-border bg-lt-popover p-4 text-lt-popover-fg shadow-lg",
+            "flex items-start gap-3 rounded-lt border border-l-4 border-lt-border bg-lt-popover p-4 text-lt-popover-fg shadow-lt-lg",
             variantStyles[toast.variant].accent,
             "data-[state=open]:animate-lt-toast-in data-[state=closed]:animate-lt-toast-out",
             "data-[swipe=move]:translate-y-[var(--radix-toast-swipe-move-y)] data-[swipe=cancel]:translate-y-0 data-[swipe=cancel]:transition-transform",

--- a/workbench/resources/css/app.css
+++ b/workbench/resources/css/app.css
@@ -14,8 +14,8 @@
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
   --radius-lg: var(--radius);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 0.125rem);
+  --radius-sm: calc(var(--radius) - 0.25rem);
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -39,7 +39,7 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
+  --background: oklch(0.97 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -58,7 +58,7 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.72 0.075 182);
-  --radius: 0.625rem;
+  --radius: 0.5rem;
 }
 
 .dark {


### PR DESCRIPTION
## What & why

Tunes Lattice's design-token layer and component styling so the workbench reads like the **Xentral app shell** — matching spacing, type scale, density, and elevation. This was a brainstorming/design exploration; **no corporate colours are introduced** (the only colour change is a neutral, chroma-0 grey page canvas), and **all length tokens are rem-based**.

> The top bar + global ⌘K search is owned by a separate effort and is intentionally **not** included here.

## Design tokens (`resources/css/lattice.css`)
- Radius base `0.625rem → 0.5rem`; all `calc()` steps converted `px → rem`
- Neutral grey canvas so white cards lift off the page surface
- New scales: **control heights**, spacing base, font-weights, focus-ring width/offset, icon stroke, z-index, motion, layout dimensions
- New **elevation scale**: `--lt-shadow-xs/sm/md/lg`
- New **interaction-state colours** (primary / danger / success / info / secondary `hover`+`active`, plus `disabled` bg/fg) for light **and** dark, derived from the existing palette and exposed via `@theme inline`

## Components (`resources/js`)
- Page titles **30 → 18px**; nav, labels and controls **11 → 12px** (weight 500)
- Buttons/inputs wired to `--lt-control-h-*`; primary buttons **40 → 36px**
- Tables: **12px** text with **bold, dark** column headers
- Every elevated surface wired to `--lt-shadow-*` (controls → `xs`, popovers/tooltips → `md`, modals/toasts/chat → `lg`)
- Disabled **filled buttons + form inputs** use the `--lt-disabled` tokens (icon/table/minimal controls keep `opacity-50`)
- All button/badge variant `hover`/`active` states use the new state tokens

## Consumer theme (`workbench/resources/css/app.css`)
- Grey canvas + `0.5rem` radius (this is the demo app acting as the token consumer); radius `calc()` `px → rem`

## Verification
- Full JS suite green: **591/591** (`npx vitest run`)
- Live-checked computed values: page title `18px/700`, control text `12px`, primary/destructive hover resolve to the `*-hover` tokens, disabled button = grey bg + muted text, input shadow = `--lt-shadow-xs`

## Notes
- Tokens are additive/back-compatible; consumers can override every value via the bare CSS variables (`--background`, `--radius`, `--primary-hover`, …).
- 28 files; no changes to `package-lock.json`, `solo.yml`, or `workbench/app/Layouts/AppLayout.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
