### PR TITLE
Regenerate Boost guidelines + skills on composer install

### DIFF
--- a/.ai/skills/worktrees/SKILL.md
+++ b/.ai/skills/worktrees/SKILL.md
@@ -92,6 +92,16 @@ That is the whole setup. Testbench provisions the `workbench/` skeleton and its 
 demand (via `composer post-autoload-dump` and the test bootstrap); there is no app `.env`, key
 generation, or manual `migrate` step to run.
 
+`composer install` also refreshes the Laravel Boost guidelines — its `post-install-cmd` runs
+`composer boost:refresh`, which regenerates the gitignored `CLAUDE.md` / `AGENTS.md` so each fresh
+worktree has the agent context. It uses `--ignore-skills`, so it only writes those generated files
+and never touches tracked sources (`boost.json`, `.ai/`) — running it leaves `git status` clean. If
+the guidelines ever look stale or missing, regenerate them on demand:
+
+```bash
+composer boost:refresh   # = php artisan boost:update --ignore-skills --no-interaction
+```
+
 ## Verify
 
 Always run both gates in a new worktree before reporting work — they mirror CI:

--- a/.ai/skills/worktrees/SKILL.md
+++ b/.ai/skills/worktrees/SKILL.md
@@ -92,14 +92,15 @@ That is the whole setup. Testbench provisions the `workbench/` skeleton and its 
 demand (via `composer post-autoload-dump` and the test bootstrap); there is no app `.env`, key
 generation, or manual `migrate` step to run.
 
-`composer install` also refreshes the Laravel Boost guidelines — its `post-install-cmd` runs
-`composer boost:refresh`, which regenerates the gitignored `CLAUDE.md` / `AGENTS.md` so each fresh
-worktree has the agent context. It uses `--ignore-skills`, so it only writes those generated files
-and never touches tracked sources (`boost.json`, `.ai/`) — running it leaves `git status` clean. If
-the guidelines ever look stale or missing, regenerate them on demand:
+`composer install` also refreshes the Laravel Boost guidelines and skills — its `post-install-cmd`
+runs `composer boost:refresh` (`boost:update`), which regenerates the gitignored `CLAUDE.md` /
+`AGENTS.md` so each fresh worktree has the agent context. `boost.json` is kept in sync with the
+skills the pinned Boost version ships, so the update is idempotent and leaves `git status` clean
+(the only outputs are the gitignored guideline files). If the guidelines ever look stale or missing,
+regenerate them on demand:
 
 ```bash
-composer boost:refresh   # = php artisan boost:update --ignore-skills --no-interaction
+composer boost:refresh   # = php artisan boost:update --no-interaction
 ```
 
 ## Verify

--- a/boost.json
+++ b/boost.json
@@ -11,7 +11,6 @@
     "skills": [
         "laravel-best-practices",
         "pest-testing",
-        "inertia-react-development",
         "tailwindcss-development",
         "documentation",
         "pr-review",

--- a/composer.json
+++ b/composer.json
@@ -92,8 +92,11 @@
             "@clear",
             "@prepare"
         ],
+        "post-install-cmd": "@boost:refresh",
+        "post-update-cmd": "@boost:refresh",
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
+        "boost:refresh": "@php vendor/bin/testbench boost:update --ignore-skills --no-interaction",
         "build": "@php vendor/bin/testbench workbench:build --ansi",
         "serve": [
             "Composer\\Config::disableProcessTimeout",

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "post-update-cmd": "@boost:refresh",
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
-        "boost:refresh": "@php vendor/bin/testbench boost:update --ignore-skills --no-interaction",
+        "boost:refresh": "@php vendor/bin/testbench boost:update --no-interaction",
         "build": "@php vendor/bin/testbench workbench:build --ansi",
         "serve": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
## Problem

Fresh checkouts and worktrees only contain the committed guideline **sources** (`.ai/guidelines/*`, `.ai/skills/*`). The aggregated **`CLAUDE.md` / `AGENTS.md`** that coding agents read at startup are gitignored (generated by Laravel Boost) and were **never regenerated** by the worktree setup (`composer install` + `npm install`). Result: a new worktree starts with **no agent context**.

## Fix

- Add a `boost:refresh` composer script: `php artisan boost:update --no-interaction` (the **full** update — guidelines **and** skills).
- Wire it into `post-install-cmd` and `post-update-cmd`, so every `composer install` (which worktree setup already runs) regenerates the gitignored `CLAUDE.md` / `AGENTS.md`.
- Document it in `.ai/skills/worktrees/SKILL.md` (Set up).

## Keeping it clean in CI (no gate)

The full `boost:update` reconciles `boost.json` against the skills the installed Boost ships. `boost.json` referenced `"inertia-react-development"`, which **Boost v2.4.10 does not provide** (it ships 6 skills: laravel-best-practices, pest-testing, tailwindcss-development, documentation, pr-review, worktrees) — so `boost:update` pruned that dead entry on every run, dirtying the tree.

This PR **removes the dead `inertia-react-development` entry** from `boost.json`. Because `composer.lock` pins the Boost version, CI installs the same version whose available skills now match `boost.json` exactly → `boost:update` is **idempotent** and leaves `git status` clean. No CI gate, no `--no-scripts` needed (~2s).

## Verified

- Fresh `composer install` (old config) → `CLAUDE.md` absent (the bug).
- After the change, the `post-install-cmd` hook runs the full `boost:update`, generates `CLAUDE.md` + `AGENTS.md`, and — with the reconciled `boost.json` committed — leaves **`git status` completely clean** across repeated runs.

## Note

`inertia-react-development` was a dead reference (Boost has no Inertia/React skill in 2.4.x). If first-class Inertia/React guidance is wanted, it would need a custom/remote skill via `boost:add-skill` — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)