### PR TITLE
fix(build): export ./realtime/* and bump docs workflow to setup-node v6

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm

--- a/package.json
+++ b/package.json
@@ -127,6 +127,10 @@
       "types": "./dist/provider.d.ts",
       "import": "./dist/provider.js"
     },
+    "./realtime/*": {
+      "types": "./dist/realtime/*.d.ts",
+      "import": "./dist/realtime/*.js"
+    },
     "./registry": {
       "types": "./dist/registry.d.ts",
       "import": "./dist/registry.js"


### PR DESCRIPTION
## What
Fixes the docs deploy pipeline failure and the deprecated-Node-20 warning.

## The bug
The reverb realtime feature merged in `@lattice-php/lattice/realtime/listeners` self-imports (e.g. in `resources/js/page.tsx`), but `package.json`'s `exports` field was never given a `./realtime` subpath. Every sibling subpath (`core/*`, `effects/*`, `chat/*`, …) has an entry, so they validate fine; `realtime` threw:

```
"./realtime/listeners" is not exported under the conditions
[…"astro","import"] from package …/lattice (see exports field …)
```

## Fix
- Add `./realtime/*` to `exports`, mirroring the existing `./effects/*` / `./events/*` entries (`dist/realtime/*` is already emitted by the `libraryEntries()` glob in `vite.config.ts`).
- Bump `actions/setup-node@v4` → `@v6` in `docs.yml`. The job already requested `node-version: 24`; the v4 action itself runs on the deprecated Node 20 runtime, which is the warning source. Other workflows already use `@v6`.

## Verification
Reproduced the exact failure on `main` (clean `npm ci`, `astro build`) — fails on `./realtime/listeners`. After adding the export, `astro build` completes: **53 pages built, exit 0**.