### PR TITLE
chore(ci): bump GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Vitest coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: coverage_vitest/lcov.info
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Vitest test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: coverage_vitest/junit.xml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload Pest coverage to Codecov
         if: ${{ !cancelled() && matrix.php-version == '8.4' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: coverage_phpunit/clover.xml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Upload Pest test results to Codecov
         if: ${{ !cancelled() && matrix.php-version == '8.4' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: coverage_phpunit/pest.junit.xml
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload Pest browser coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: coverage_phpunit/browser-clover.xml
@@ -237,7 +237,7 @@ jobs:
 
       - name: Upload Pest browser test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           use_oidc: true
           files: coverage_phpunit/pest-browser.junit.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -61,7 +61,7 @@ jobs:
       - name: Build the docs site
         run: npm run docs:build
       - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist-docs/
 


### PR DESCRIPTION
Audited every `uses:` across all workflows against each action's latest stable release.

## Bumped
| Action | From | To |
|---|---|---|
| `codecov/codecov-action` | v5 | **v7** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/setup-node` (docs.yml) | v4 | **v6** |

## Already current
`actions/checkout@v6`, `actions/cache@v5`, `actions/configure-pages@v6`, `actions/deploy-pages@v5`, `actions/upload-artifact@v7`, `googleapis/release-please-action@v5`, `shivammathur/setup-php@v2`.

## Breaking-change review
- **codecov v5→v7**: v6 only added Node 24 support (runner already has it); v7 is a GPG-key/internal change. None of our inputs (`use_oidc`, `files`, `flags`, `name`, `disable_search`, `report_type`) changed.
- **upload-pages-artifact v3→v5**: v4 stopped including dotfiles in the artifact — Astro's `dist-docs/` has none that matter (Pagefind uses `_pagefind/`; no `.nojekyll` needed for Actions-based Pages). Pairs with the existing `deploy-pages@v5`.

Note: the `setup-node` docs.yml bump overlaps PR #157 (same line, identical change) — harmless whichever merges first.