### PR TITLE
chore(testing): type assertion callbacks + configure and apply Rector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
       - name: PHPStan
         run: composer analyse
 
+      - name: Rector (dry-run)
+        run: composer rector:test
+
       - name: Pest (parallel)
         if: ${{ matrix.php-version != '8.4' }}
         run: composer test:parallel

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
         "check": [
             "@test:lint",
             "@analyse",
+            "@rector:test",
             "@test:parallel"
         ],
         "lint": "./vendor/bin/pint",

--- a/rector.php
+++ b/rector.php
@@ -1,7 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -10,4 +12,16 @@ return RectorConfig::configure()
         __DIR__.'/workbench/app',
         __DIR__.'/workbench/routes',
     ])
-    ->withPhpSets(php83: true);
+    ->withPhpSets()
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+    )
+    ->withSkip([
+        // Misinfers the array_map row callback as `int $original`, contradicting the
+        // `is_array($original)` guard in Builder::castValue().
+        AddClosureParamTypeForArrayMapRector::class => [
+            __DIR__.'/src/Forms/Components/Builder.php',
+        ],
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -12,7 +12,7 @@ return RectorConfig::configure()
         __DIR__.'/workbench/app',
         __DIR__.'/workbench/routes',
     ])
-    ->withPhpSets()
+    ->withPhpSets(php84: true)
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/src/Attributes/AsComponent.php
+++ b/src/Attributes/AsComponent.php
@@ -37,7 +37,7 @@ class AsComponent
      */
     private static function resolveType(string $class): string
     {
-        $attributes = (new ReflectionClass($class))->getAttributes(self::class, ReflectionAttribute::IS_INSTANCEOF);
+        $attributes = new ReflectionClass($class)->getAttributes(self::class, ReflectionAttribute::IS_INSTANCEOF);
 
         if ($attributes === []) {
             throw new LogicException(sprintf(

--- a/src/Core/Components/Component.php
+++ b/src/Core/Components/Component.php
@@ -145,8 +145,8 @@ abstract class Component implements JsonSerializable
     private function serializationHooks(): array
     {
         return self::$serializationHookCache[static::class] ??= collect(Attributes::find($this, SerializationHook::class))
-            ->filter(fn (AttributeTarget $target) => $target->attribute instanceof SerializationHook && $target->target instanceof ReflectionMethod)
-            ->filter(fn (AttributeTarget $target) => ! $target->target->isPrivate())
+            ->filter(fn (AttributeTarget $target): bool => $target->attribute instanceof SerializationHook && $target->target instanceof ReflectionMethod)
+            ->filter(fn (AttributeTarget $target): bool => ! $target->target->isPrivate())
             ->sortBy(fn (AttributeTarget $target): array => [$target->attribute->priority, $target->name])
             ->map(fn (AttributeTarget $target): string => $target->name)
             ->values()

--- a/src/Core/Components/Concerns/ReflectsWireProps.php
+++ b/src/Core/Components/Concerns/ReflectsWireProps.php
@@ -51,7 +51,7 @@ trait ReflectsWireProps
     private static function wireProperties(string $class): array
     {
         return self::$wirePropertyCache[$class] ??= array_values(array_filter(
-            (new ReflectionClass($class))->getProperties(ReflectionProperty::IS_PUBLIC),
+            new ReflectionClass($class)->getProperties(ReflectionProperty::IS_PUBLIC),
             static fn (ReflectionProperty $property): bool => ! $property->isStatic(),
         ));
     }

--- a/src/Core/Discovery/DiscoveryManifest.php
+++ b/src/Core/Discovery/DiscoveryManifest.php
@@ -105,7 +105,7 @@ final class DiscoveryManifest
 
         foreach (self::configuredPaths() as $path) {
             foreach (ClassWalker::classes($path) as $class) {
-                if ((new ReflectionClass($class))->isAbstract()) {
+                if (new ReflectionClass($class)->isAbstract()) {
                     continue;
                 }
 

--- a/src/Core/EloquentOptions.php
+++ b/src/Core/EloquentOptions.php
@@ -129,7 +129,7 @@ final class EloquentOptions implements OptionSource
     {
         $builder = $this->model::query();
 
-        if ($this->scope !== null) {
+        if ($this->scope instanceof Closure) {
             $scoped = ($this->scope)($builder);
 
             if ($scoped instanceof Builder) {

--- a/src/Core/PageMetadata.php
+++ b/src/Core/PageMetadata.php
@@ -54,9 +54,9 @@ final readonly class PageMetadata
             class: $class,
             route: $own?->route,
             name: self::resolveName($class, $own),
-            layout: self::inherited($class, fn (AsPage $a) => $a->layout) ?? PageLayout::None,
-            container: self::inherited($class, fn (AsPage $a) => $a->container) ?? PageContainer::Centered,
-            middleware: (array) (self::inherited($class, fn (AsPage $a) => $a->middleware) ?? []),
+            layout: self::inherited($class, fn (AsPage $a): PageLayout|string|null => $a->layout) ?? PageLayout::None,
+            container: self::inherited($class, fn (AsPage $a): PageContainer|string|null => $a->container) ?? PageContainer::Centered,
+            middleware: (array) (self::inherited($class, fn (AsPage $a): string|array|null => $a->middleware) ?? []),
         );
     }
 
@@ -70,8 +70,8 @@ final readonly class PageMetadata
             'route' => $this->route,
             'name' => $this->name,
             'middleware' => $this->middleware,
-            'layout' => self::serialize($this->layout),
-            'container' => self::serialize($this->container),
+            'layout' => $this->serialize($this->layout),
+            'container' => $this->serialize($this->container),
         ];
     }
 
@@ -90,14 +90,14 @@ final readonly class PageMetadata
         );
     }
 
-    private static function serialize(PageLayout|PageContainer|string $value): string
+    private function serialize(PageLayout|PageContainer|string $value): string
     {
         return $value instanceof BackedEnum ? (string) $value->value : $value;
     }
 
     private static function attributeOn(string $class): ?AsPage
     {
-        $attributes = (new ReflectionClass($class))->getAttributes(AsPage::class);
+        $attributes = new ReflectionClass($class)->getAttributes(AsPage::class);
 
         return $attributes === [] ? null : $attributes[0]->newInstance();
     }
@@ -110,7 +110,7 @@ final readonly class PageMetadata
         for ($current = $class; $current !== false; $current = get_parent_class($current)) {
             $attribute = self::attributeOn($current);
 
-            if ($attribute !== null && ($resolved = $value($attribute)) !== null) {
+            if ($attribute instanceof AsPage && ($resolved = $value($attribute)) !== null) {
                 return $resolved;
             }
         }
@@ -124,7 +124,7 @@ final readonly class PageMetadata
             return $own->name;
         }
 
-        $route = $own !== null ? ($own->route ?? '') : '';
+        $route = $own instanceof AsPage ? ($own->route ?? '') : '';
 
         $segments = array_filter(
             explode('/', $route),

--- a/src/Forms/Components/Block.php
+++ b/src/Forms/Components/Block.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Forms\Components;
 
 use Illuminate\Support\Str;
 use JsonSerializable;
+use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
 
 final class Block implements JsonSerializable
@@ -34,7 +35,7 @@ final class Block implements JsonSerializable
     {
         return array_values(array_filter(
             $this->children,
-            static fn ($child): bool => $child instanceof Field,
+            static fn (Component $child): bool => $child instanceof Field,
         ));
     }
 

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -269,7 +269,7 @@ abstract class Field extends Component
             return $this;
         }
 
-        return $this->addCondition('visible', (string) $attributes, $operatorOrValue, $value);
+        return $this->addCondition('visible', $attributes, $operatorOrValue, $value);
     }
 
     public function visibleWhen(string $field, mixed $operatorOrValue = null, mixed $value = null): static
@@ -376,7 +376,7 @@ abstract class Field extends Component
      */
     public function isComputed(): bool
     {
-        return $this->dependencies !== [] || $this->valueResolver !== null;
+        return $this->dependencies !== [] || $this->valueResolver instanceof Closure;
     }
 
     /**
@@ -384,7 +384,7 @@ abstract class Field extends Component
      */
     public function hasPrefill(): bool
     {
-        return $this->prefillResolver !== null;
+        return $this->prefillResolver instanceof Closure;
     }
 
     /**
@@ -392,7 +392,7 @@ abstract class Field extends Component
      */
     public function resolvePrefillValue(FormData $row, FormData $form, Request $request): mixed
     {
-        assert($this->prefillResolver !== null);
+        assert($this->prefillResolver instanceof Closure);
 
         $context = $this->evaluationContext($row, $request)
             ->named('row', $row)
@@ -414,7 +414,7 @@ abstract class Field extends Component
             Evaluate::resolve($dependency['callback'], $context);
         }
 
-        if ($this->valueResolver !== null) {
+        if ($this->valueResolver instanceof Closure) {
             $this->value(Evaluate::resolve($this->valueResolver, $context));
         }
 
@@ -457,7 +457,7 @@ abstract class Field extends Component
      */
     public function isVisible(FormData $data): bool
     {
-        return $this->hidden !== true && $this->allConditionsMatch('visible', $data);
+        return ! $this->hidden && $this->allConditionsMatch('visible', $data);
     }
 
     /**
@@ -465,7 +465,7 @@ abstract class Field extends Component
      */
     public function isRequired(FormData $data): bool
     {
-        return $this->required === true || $this->anyConditionMatches('required', $data);
+        return $this->required || $this->anyConditionMatches('required', $data);
     }
 
     /**
@@ -473,7 +473,7 @@ abstract class Field extends Component
      */
     public function isReadOnly(FormData $data): bool
     {
-        return $this->readOnly === true || $this->anyConditionMatches('readOnly', $data);
+        return $this->readOnly || $this->anyConditionMatches('readOnly', $data);
     }
 
     /**
@@ -481,7 +481,7 @@ abstract class Field extends Component
      */
     public function isDisabled(FormData $data): bool
     {
-        return $this->disabled === true || $this->anyConditionMatches('disabled', $data);
+        return $this->disabled || $this->anyConditionMatches('disabled', $data);
     }
 
     /**
@@ -574,7 +574,7 @@ abstract class Field extends Component
         }
 
         $this->dependsOnKeys = $keys === [] ? null : array_keys($keys);
-        $this->dependsOnAny = $this->valueResolver !== null;
+        $this->dependsOnAny = $this->valueResolver instanceof Closure;
 
         return $data;
     }

--- a/src/Forms/Components/FileUpload.php
+++ b/src/Forms/Components/FileUpload.php
@@ -161,7 +161,7 @@ class FileUpload extends Field
         foreach ($keys as $key) {
             $this->ensureFinalizableKey($disk, $key);
 
-            $mimeType = self::fileMimeType($disk, $key);
+            $mimeType = $this->fileMimeType($disk, $key);
             $size = self::fileSize($disk, $key);
             $extension = pathinfo($key, PATHINFO_EXTENSION);
             $path = $destinationUsing($key, [
@@ -195,7 +195,7 @@ class FileUpload extends Field
     {
         $userRules = parent::resolveRules($data, $request);
 
-        if ($this->multiple === true) {
+        if ($this->multiple) {
             $rules = ['array'];
 
             if ($this->maxFiles !== null) {
@@ -211,7 +211,7 @@ class FileUpload extends Field
     #[\Override]
     public function nestedRules(FormData $data, Request $request): array
     {
-        if ($this->multiple !== true) {
+        if (! $this->multiple) {
             return [];
         }
 
@@ -313,7 +313,7 @@ class FileUpload extends Field
         }
     }
 
-    private static function fileMimeType(FilesystemAdapter $disk, string $path): ?string
+    private function fileMimeType(FilesystemAdapter $disk, string $path): ?string
     {
         try {
             $mimeType = $disk->mimeType($path);

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Forms\Components;
 
 use Closure;
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Components\Concerns\HasChildSchema;
 use Lattice\Lattice\Facades\Evaluate;
 use Lattice\Lattice\Forms\Attributes\AsField;
@@ -101,7 +102,7 @@ class Repeater extends Field implements ProvidesRowFields, ProvidesRowPrefills
     {
         return array_values(array_filter(
             $this->children,
-            static fn ($child): bool => $child instanceof Field,
+            static fn (Component $child): bool => $child instanceof Field,
         ));
     }
 
@@ -154,7 +155,7 @@ class Repeater extends Field implements ProvidesRowFields, ProvidesRowPrefills
     #[\Override]
     public function hydrateState(mixed $value, ?FormData $form = null, ?Request $request = null): void
     {
-        if ($this->itemLabelResolver === null || ! is_array($value)) {
+        if (! $this->itemLabelResolver instanceof Closure || ! is_array($value)) {
             $this->itemLabels = null;
 
             return;

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -91,7 +91,7 @@ class Select extends Field
      */
     public function isSearchable(): bool
     {
-        return $this->optionSource !== null || $this->searchResolver !== null;
+        return $this->optionSource instanceof OptionSource || $this->searchResolver instanceof Closure;
     }
 
     /**
@@ -115,11 +115,11 @@ class Select extends Field
      */
     public function resolveSearch(string $query, FormData $data, Request $request): array
     {
-        if ($this->optionSource !== null) {
+        if ($this->optionSource instanceof OptionSource) {
             return $this->normalizeOptions($this->optionSource->search($query));
         }
 
-        if ($this->searchResolver === null) {
+        if (! $this->searchResolver instanceof Closure) {
             return [];
         }
 
@@ -131,7 +131,7 @@ class Select extends Field
     #[\Override]
     public function hydrateState(mixed $value, ?FormData $form = null, ?Request $request = null): void
     {
-        if ($this->optionSource === null && $this->selectedResolver === null) {
+        if (! $this->optionSource instanceof OptionSource && ! $this->selectedResolver instanceof Closure) {
             return;
         }
 
@@ -144,7 +144,7 @@ class Select extends Field
             return;
         }
 
-        $resolved = $this->optionSource !== null
+        $resolved = $this->optionSource instanceof OptionSource
             ? $this->normalizeOptions($this->optionSource->selected($values))
             : $this->normalizeOptions(Evaluate::resolve(
                 $this->selectedResolver,

--- a/src/Forms/Conditions/ConditionSet.php
+++ b/src/Forms/Conditions/ConditionSet.php
@@ -28,24 +28,12 @@ final class ConditionSet implements JsonSerializable
 
     public function anyMatches(FormData $data): bool
     {
-        foreach ($this->conditions as $condition) {
-            if ($condition->matches($data)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->conditions, fn ($condition) => $condition->matches($data));
     }
 
     public function allMatch(FormData $data): bool
     {
-        foreach ($this->conditions as $condition) {
-            if (! $condition->matches($data)) {
-                return false;
-            }
-        }
-
-        return true;
+        return array_all($this->conditions, fn ($condition) => $condition->matches($data));
     }
 
     /**

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -74,7 +74,7 @@ final class RichContent
 
     private function editor(): Editor
     {
-        return $this->editor ??= (new Editor(['extensions' => [
+        return $this->editor ??= new Editor(['extensions' => [
             new StarterKit,
             new Underline,
             new Highlight,
@@ -87,12 +87,12 @@ final class RichContent
             new Details,
             new DetailsSummary,
             new DetailsContent,
-        ]]))->setContent($this->document);
+        ]])->setContent($this->document);
     }
 
     private function isEmpty(): bool
     {
-        return $this->document === null || $this->document === '' || $this->document === [];
+        return in_array($this->document, [null, '', []], true);
     }
 
     private function sanitize(string $html): string
@@ -111,6 +111,6 @@ final class RichContent
             ->allowElement('summary')
             ->allowAttribute('style', ['p', 'h1', 'h2', 'h3']);
 
-        return (new HtmlSanitizer($config))->sanitize($html);
+        return new HtmlSanitizer($config)->sanitize($html);
     }
 }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -28,7 +28,7 @@ final readonly class ActionController
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->actions, 'action', $action);
 
-        if (($response = $this->formSubRequest($request, $definition)) !== null) {
+        if (($response = $this->formSubRequest($request, $definition)) instanceof Response) {
             return $response;
         }
 

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -34,7 +34,7 @@ final readonly class BulkActionController
 
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->bulkActions, 'bulkAction', $bulkAction);
 
-        if (($response = $this->formSubRequest($request, $definition)) !== null) {
+        if (($response = $this->formSubRequest($request, $definition)) instanceof Response) {
             return $response;
         }
 

--- a/src/Http/PageRegistry.php
+++ b/src/Http/PageRegistry.php
@@ -42,7 +42,7 @@ final class PageRegistry
                 continue;
             }
 
-            if (! is_a($page, PageContract::class, true) || (new ReflectionClass($page))->isAbstract()) {
+            if (! is_a($page, PageContract::class, true) || new ReflectionClass($page)->isAbstract()) {
                 continue;
             }
 

--- a/src/Remote/Components/RemoteComponent.php
+++ b/src/Remote/Components/RemoteComponent.php
@@ -73,6 +73,7 @@ abstract class RemoteComponent extends Component
      * @param  array<string, mixed>  $props
      * @return array<string, mixed>
      */
+    #[\Override]
     protected function decorateProps(array $props): array
     {
         if ($this->source !== null || $this->audience !== null || $this->scopes !== []) {

--- a/src/Remote/Components/RemoteNode.php
+++ b/src/Remote/Components/RemoteNode.php
@@ -24,6 +24,7 @@ final class RemoteNode extends Component
         parent::__construct($key);
     }
 
+    #[\Override]
     protected function type(): string
     {
         return $this->nodeType;
@@ -34,6 +35,7 @@ final class RemoteNode extends Component
      * @return array<string, mixed>
      */
     #[SerializationHook(priority: 200)]
+    #[\Override]
     protected function serialiseProps(array $data): array
     {
         return [

--- a/src/Remote/RemoteSchemaNormalizer.php
+++ b/src/Remote/RemoteSchemaNormalizer.php
@@ -27,7 +27,7 @@ final class RemoteSchemaNormalizer
      * @param  array<string, mixed>  $node
      * @param  array<string, mixed>  $context
      */
-    private function node(array $node, string $path, array $context): Component
+    private function node(array $node, string $path, array $context): RemoteNode
     {
         $type = $node['type'] ?? null;
 

--- a/src/Remote/RemoteSchemaResolver.php
+++ b/src/Remote/RemoteSchemaResolver.php
@@ -88,7 +88,7 @@ final readonly class RemoteSchemaResolver
         try {
             return json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $exception) {
-            throw new InvalidRemoteSchema("Remote schema source [{$source}] did not return valid JSON.", previous: $exception);
+            throw new InvalidRemoteSchema("Remote schema source [{$source}] did not return valid JSON.", $exception->getCode(), previous: $exception);
         }
     }
 

--- a/src/Remote/RemoteSourceDefinition.php
+++ b/src/Remote/RemoteSourceDefinition.php
@@ -41,7 +41,7 @@ abstract class RemoteSourceDefinition extends Definition
     {
         $endpoint = $this->schemaEndpoint($request);
 
-        if ($endpoint === null) {
+        if (! $endpoint instanceof RemoteSchemaEndpoint) {
             return [];
         }
 

--- a/src/Remote/RemoteSourceRegistry.php
+++ b/src/Remote/RemoteSourceRegistry.php
@@ -53,6 +53,7 @@ final class RemoteSourceRegistry extends DefinitionRegistry
         return 'remote-sources';
     }
 
+    #[\Override]
     public function resolve(string $key): RemoteSourceDefinition
     {
         $definitions = $this->definitions();

--- a/src/Support/Discovery/ClassWalker.php
+++ b/src/Support/Discovery/ClassWalker.php
@@ -27,7 +27,7 @@ final class ClassWalker
         }
 
         /** @var list<class-string> $classes */
-        $classes = (new Discover(directories: [$path]))->classes()->get();
+        $classes = new Discover(directories: [$path])->classes()->get();
 
         return $classes;
     }
@@ -44,7 +44,7 @@ final class ClassWalker
         }
 
         /** @var list<class-string> $classes */
-        $classes = (new Discover(directories: [$path]))->get();
+        $classes = new Discover(directories: [$path])->get();
 
         return $classes;
     }

--- a/src/Support/Evaluation/Evaluator.php
+++ b/src/Support/Evaluation/Evaluator.php
@@ -36,7 +36,7 @@ final readonly class Evaluator
 
         $arguments = array_map(
             fn (ReflectionParameter $parameter): mixed => $this->resolveParameter($parameter, $context),
-            (new ReflectionFunction($value))->getParameters(),
+            new ReflectionFunction($value)->getParameters(),
         );
 
         return $value(...$arguments);
@@ -87,13 +87,7 @@ final readonly class Evaluator
      */
     private function isNonAutowirable(string $class): bool
     {
-        foreach ($this->nonAutowirableTypes as $base) {
-            if ($class === $base || is_subclass_of($class, $base)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($this->nonAutowirableTypes, fn ($base): bool => $class === $base || is_subclass_of($class, $base));
     }
 
     /**

--- a/src/Support/Testing/Assertions/ComponentAssertions.php
+++ b/src/Support/Testing/Assertions/ComponentAssertions.php
@@ -14,6 +14,9 @@ final readonly class ComponentAssertions
 {
     public function __construct(private ComponentNode $node) {}
 
+    /**
+     * @param  (Closure(FormAssertions): mixed)|null  $tap
+     */
     public function form(?string $id = null, ?Closure $tap = null): FormAssertions|self
     {
         $node = $this->node->firstOfTypeIncludingSelf('form', $id);
@@ -35,6 +38,9 @@ final readonly class ComponentAssertions
         return $assertions;
     }
 
+    /**
+     * @param  (Closure(TableAssertions): mixed)|null  $tap
+     */
     public function table(?string $id = null, ?Closure $tap = null): TableAssertions|self
     {
         $node = $this->node->firstOfTypeIncludingSelf('table', $id);
@@ -56,6 +62,9 @@ final readonly class ComponentAssertions
         return $assertions;
     }
 
+    /**
+     * @param  (Closure(ActionAssertions): mixed)|null  $tap
+     */
     public function action(string $id, ?Closure $tap = null): ActionAssertions|self
     {
         $node = $this->node->firstOfTypeIncludingSelf('action', $id);
@@ -80,6 +89,7 @@ final readonly class ComponentAssertions
     /**
      * @param  class-string<Component>|string  $type  A wire type (`'menu-item'`) or
      *                                                the component class (`MenuItem::class`).
+     * @param  (Closure(self): mixed)|null  $tap
      */
     public function component(string $type, ?string $id = null, ?Closure $tap = null): self
     {

--- a/src/Support/Testing/Assertions/ComponentAssertions.php
+++ b/src/Support/Testing/Assertions/ComponentAssertions.php
@@ -29,7 +29,7 @@ final readonly class ComponentAssertions
 
         $assertions = new FormAssertions($node, $this);
 
-        if ($tap !== null) {
+        if ($tap instanceof Closure) {
             $tap($assertions);
 
             return $this;
@@ -53,7 +53,7 @@ final readonly class ComponentAssertions
 
         $assertions = new TableAssertions($node, $this);
 
-        if ($tap !== null) {
+        if ($tap instanceof Closure) {
             $tap($assertions);
 
             return $this;
@@ -77,7 +77,7 @@ final readonly class ComponentAssertions
 
         $assertions = new ActionAssertions($node, $this);
 
-        if ($tap !== null) {
+        if ($tap instanceof Closure) {
             $tap($assertions);
 
             return $this;
@@ -93,7 +93,7 @@ final readonly class ComponentAssertions
      */
     public function component(string $type, ?string $id = null, ?Closure $tap = null): self
     {
-        $type = self::resolveType($type);
+        $type = $this->resolveType($type);
         $node = $this->node->firstOfTypeIncludingSelf($type, $id);
 
         Assert::assertNotNull($node, sprintf(
@@ -104,7 +104,7 @@ final readonly class ComponentAssertions
 
         $scoped = new self($node);
 
-        if ($tap !== null) {
+        if ($tap instanceof Closure) {
             $tap($scoped);
 
             return $this;
@@ -185,7 +185,7 @@ final readonly class ComponentAssertions
     private function select(string $selector): array
     {
         [$type, $id] = array_pad(explode(':', $selector, 2), 2, null);
-        $type = self::resolveType($type);
+        $type = $this->resolveType($type);
 
         return $this->node->findAllIncludingSelf(
             static fn (ComponentNode $node): bool => $node->matches($type, $id),
@@ -196,7 +196,7 @@ final readonly class ComponentAssertions
      * Accept either a wire type (`'menu-item'`) or a component class
      * (`MenuItem::class`), resolving the class to its declared wire type.
      */
-    private static function resolveType(string $type): string
+    private function resolveType(string $type): string
     {
         if (is_subclass_of($type, Component::class)) {
             return AsComponent::typeForClass($type);

--- a/src/Support/Testing/Assertions/FieldAssertions.php
+++ b/src/Support/Testing/Assertions/FieldAssertions.php
@@ -175,7 +175,7 @@ final readonly class FieldAssertions
     {
         $name = $this->node->prop('name');
 
-        if ($this->formNode !== null && is_string($name)) {
+        if ($this->formNode instanceof ComponentNode && is_string($name)) {
             $state = $this->formNode->prop('state');
 
             if (is_array($state) && array_key_exists($name, $state)) {

--- a/src/Support/Testing/Assertions/FormAssertions.php
+++ b/src/Support/Testing/Assertions/FormAssertions.php
@@ -15,6 +15,9 @@ final readonly class FormAssertions
         private ComponentAssertions $root,
     ) {}
 
+    /**
+     * @param  (Closure(FieldAssertions): mixed)|null  $tap
+     */
     public function field(string $name, ?Closure $tap = null): FieldAssertions|self
     {
         $node = $this->node->field($name);

--- a/src/Support/Testing/Assertions/FormAssertions.php
+++ b/src/Support/Testing/Assertions/FormAssertions.php
@@ -31,7 +31,7 @@ final readonly class FormAssertions
 
         $assertions = new FieldAssertions($node, $this, $this->node);
 
-        if ($tap !== null) {
+        if ($tap instanceof Closure) {
             $tap($assertions);
 
             return $this;

--- a/src/Support/Testing/Assertions/TableAssertions.php
+++ b/src/Support/Testing/Assertions/TableAssertions.php
@@ -28,7 +28,7 @@ final readonly class TableAssertions
 
         $assertions = new FilterAssertions($key, $filter, $this);
 
-        if ($tap !== null) {
+        if ($tap instanceof Closure) {
             $tap($assertions);
 
             return $this;

--- a/src/Tables/CallbackTableSource.php
+++ b/src/Tables/CallbackTableSource.php
@@ -35,7 +35,7 @@ final readonly class CallbackTableSource implements TableSource
      */
     public function resolveMatching(TableQuery $query): Collection
     {
-        return $this->matching !== null ? ($this->matching)($query) : new Collection;
+        return $this->matching instanceof Closure ? ($this->matching)($query) : new Collection;
     }
 
     /**
@@ -44,6 +44,6 @@ final readonly class CallbackTableSource implements TableSource
      */
     public function resolveSelection(array $keys): Collection
     {
-        return $this->selection !== null ? ($this->selection)($keys) : new Collection;
+        return $this->selection instanceof Closure ? ($this->selection)($keys) : new Collection;
     }
 }

--- a/src/Tables/Columns/IconColumn.php
+++ b/src/Tables/Columns/IconColumn.php
@@ -27,7 +27,7 @@ class IconColumn extends Column
      */
     public function icon(BackedEnum|string $icon): static
     {
-        $this->icon = self::iconValue($icon);
+        $this->icon = $this->iconValue($icon);
 
         return $this;
     }
@@ -39,12 +39,12 @@ class IconColumn extends Column
      */
     public function icons(array $icons): static
     {
-        $this->icons = $icons === [] ? null : array_map(self::iconValue(...), $icons);
+        $this->icons = $icons === [] ? null : array_map($this->iconValue(...), $icons);
 
         return $this;
     }
 
-    private static function iconValue(BackedEnum|string $icon): string
+    private function iconValue(BackedEnum|string $icon): string
     {
         return $icon instanceof BackedEnum ? (string) $icon->value : $icon;
     }

--- a/src/Tables/Enums/FilterType.php
+++ b/src/Tables/Enums/FilterType.php
@@ -68,7 +68,7 @@ enum FilterType: string
     public function acceptsValue(string $value): bool
     {
         return match ($this) {
-            self::Date => self::dateFrom($value) !== null,
+            self::Date => self::dateFrom($value) instanceof DateTimeImmutable,
             self::Boolean => self::booleanFrom($value) !== null,
             default => true,
         };

--- a/src/Tables/Filters/Filter.php
+++ b/src/Tables/Filters/Filter.php
@@ -49,11 +49,11 @@ class Filter extends BaseFilter
 
     public function apply(Builder $builder, mixed $value): void
     {
-        if (filter_var($value, FILTER_VALIDATE_BOOLEAN) !== true) {
+        if (! filter_var($value, FILTER_VALIDATE_BOOLEAN)) {
             return;
         }
 
-        if ($this->query !== null) {
+        if ($this->query instanceof Closure) {
             Evaluate::resolve(
                 $this->query,
                 Evaluate::context()->typed($builder::class, $builder)->named('value', $value),

--- a/src/Tables/Filters/TernaryFilter.php
+++ b/src/Tables/Filters/TernaryFilter.php
@@ -89,7 +89,7 @@ class TernaryFilter extends BaseFilter
 
         $query = $state ? $this->trueQuery : $this->falseQuery;
 
-        if ($query !== null) {
+        if ($query instanceof Closure) {
             Evaluate::resolve($query, Evaluate::context()->typed($builder::class, $builder));
 
             return;

--- a/src/Tables/TableResult.php
+++ b/src/Tables/TableResult.php
@@ -87,7 +87,6 @@ final readonly class TableResult implements JsonSerializable
                 from: $total > 0 ? 1 : 0,
                 to: $total,
                 hasMore: false,
-                nextPage: null,
             ),
         );
     }

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -181,7 +181,7 @@ arch('domain registries extend the base definition registry')
  * an intermediate base (FormActionDefinition, EloquentTableDefinition); a
  * transitive is_subclass_of check covers those, where ->toExtend would not.
  */
-it('derives every definition from the base definition', function (string $definition) {
+it('derives every definition from the base definition', function (string $definition): void {
     expect(is_subclass_of($definition, Definition::class))->toBeTrue();
 })->with([
     ActionDefinition::class,

--- a/tests/Browser/RealtimeTest.php
+++ b/tests/Browser/RealtimeTest.php
@@ -24,7 +24,7 @@ function retryUntil(Closure $assert, int $attempts, int $sleepMicroseconds, ?Clo
                 throw $exception;
             }
 
-            if ($between !== null) {
+            if ($between instanceof Closure) {
                 $between();
             }
 

--- a/tests/Browser/Support/ReverbServer.php
+++ b/tests/Browser/Support/ReverbServer.php
@@ -14,7 +14,7 @@ use Symfony\Component\Process\Process;
  * via symfony/process, wait for the ready marker on stdout, and tear down on
  * process shutdown.
  */
-final class ReverbServer
+final readonly class ReverbServer
 {
     private const string HOST = '127.0.0.1';
 
@@ -27,8 +27,8 @@ final class ReverbServer
     private const string READY_MARKER = 'Starting server on';
 
     private function __construct(
-        private readonly int $port,
-        private readonly Process $process,
+        private int $port,
+        private Process $process,
     ) {}
 
     public static function boot(): self

--- a/tests/Feature/Actions/ActionEndpointTest.php
+++ b/tests/Feature/Actions/ActionEndpointTest.php
@@ -11,7 +11,7 @@ use Workbench\App\Actions\SetLocaleAction;
 
 use function Pest\Laravel\postJson;
 
-test('registered actions serialize their configured endpoint method label and effects', function () {
+test('registered actions serialize their configured endpoint method label and effects', function (): void {
     config(['lattice.actions.endpoint' => 'custom/actions/{action}']);
 
     Lattice::actions([WorkbenchPingAction::class]);
@@ -53,7 +53,7 @@ test('registered actions serialize their configured endpoint method label and ef
         ]);
 });
 
-test('registered actions can be handled through the package endpoint', function () {
+test('registered actions can be handled through the package endpoint', function (): void {
     Lattice::actions([WorkbenchPingAction::class]);
 
     $ref = componentRef(wire(ActionComponent::use(WorkbenchPingAction::class)
@@ -76,7 +76,7 @@ test('registered actions can be handled through the package endpoint', function 
         ->assertJsonPath('effects.1.component', 'workbench.users');
 });
 
-test('registered actions can return a locale change effect', function () {
+test('registered actions can return a locale change effect', function (): void {
     $ref = componentRef(wire(ActionComponent::use(SetLocaleAction::class)
         ->context(['locale' => 'de'])));
 
@@ -87,7 +87,7 @@ test('registered actions can return a locale change effect', function () {
         ->assertJsonPath('effects.0.locale', 'de');
 });
 
-test('toast effects serialize correctly for action results', function () {
+test('toast effects serialize correctly for action results', function (): void {
     expect(wire(Effect::toast(Variant::Warning, 'Review the settings.')))
         ->toBe([
             'type' => 'toast',
@@ -134,7 +134,7 @@ test('toast effects serialize correctly for action results', function () {
         ]);
 });
 
-test('registered action endpoints require a valid component reference', function () {
+test('registered action endpoints require a valid component reference', function (): void {
     Lattice::actions([WorkbenchPingAction::class]);
 
     postJson('/lattice/actions/workbench.ping', ['name' => 'Taylor'])

--- a/tests/Feature/Actions/EffectFlasherTest.php
+++ b/tests/Feature/Actions/EffectFlasherTest.php
@@ -9,7 +9,7 @@ use Lattice\Lattice\Effects\Effect;
 use Lattice\Lattice\Effects\EffectFlasher;
 use Lattice\Lattice\Facades\Effects;
 
-test('effects accumulate across multiple flash calls', function () {
+test('effects accumulate across multiple flash calls', function (): void {
     Effects::flash(Effect::toast(ToastMessage::make(Variant::Success, 'Saved.')));
     Effects::flash(Effect::callout(Callout::make(Variant::Warning, 'Heads up.')));
 
@@ -20,13 +20,13 @@ test('effects accumulate across multiple flash calls', function () {
         ->and($effects[1]->jsonSerialize()['type'])->toBe('callout');
 });
 
-test('flashing no effects is a no-op', function () {
+test('flashing no effects is a no-op', function (): void {
     Effects::flash();
 
     expect(app(EffectFlasher::class)->all())->toBeEmpty();
 });
 
-test('the scoped buffer resets between request cycles', function () {
+test('the scoped buffer resets between request cycles', function (): void {
     Effects::flash(Effect::toast(ToastMessage::make(Variant::Info, 'One.')));
     expect(app(EffectFlasher::class)->all())->toHaveCount(1);
 
@@ -35,7 +35,7 @@ test('the scoped buffer resets between request cycles', function () {
     expect(app(EffectFlasher::class)->all())->toBeEmpty();
 });
 
-test('flash sends the accumulated effects to the latticeEffects bag', function () {
+test('flash sends the accumulated effects to the latticeEffects bag', function (): void {
     $flashed = [];
 
     Inertia::shouldReceive('flash')

--- a/tests/Feature/Actions/ProductActionsTest.php
+++ b/tests/Feature/Actions/ProductActionsTest.php
@@ -13,7 +13,7 @@ use Workbench\App\Tables\ProductsTable;
 
 use function Pest\Laravel\patch;
 
-test('the product archive row action is pinned to its sealed product', function () {
+test('the product archive row action is pinned to its sealed product', function (): void {
     Lattice::actions([ArchiveProductAction::class]);
 
     $target = Product::factory()->create(['status' => 'active']);
@@ -35,7 +35,7 @@ test('the product archive row action is pinned to its sealed product', function 
         ->and($other->fresh()->status)->toBe('active');
 });
 
-test('the product archive row action authorizes per row', function () {
+test('the product archive row action authorizes per row', function (): void {
     Lattice::actions([ArchiveProductAction::class]);
 
     $archived = Product::factory()->create(['status' => 'archived']);
@@ -49,7 +49,7 @@ test('the product archive row action authorizes per row', function () {
         ->assertForbidden();
 });
 
-test('bulk actions resolve the selection through the table and archive only those rows', function () {
+test('bulk actions resolve the selection through the table and archive only those rows', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
@@ -74,7 +74,7 @@ test('bulk actions resolve the selection through the table and archive only thos
         ->and($c->fresh()->status)->toBe('active');
 });
 
-test('bulk actions ignore selected ids that are not in the table result', function () {
+test('bulk actions ignore selected ids that are not in the table result', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
@@ -95,7 +95,7 @@ test('bulk actions ignore selected ids that are not in the table result', functi
     expect($a->fresh()->status)->toBe('archived');
 });
 
-test('bulk actions resolve all matching rows with dedicated table filters', function () {
+test('bulk actions resolve all matching rows with dedicated table filters', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
@@ -123,7 +123,7 @@ test('bulk actions resolve all matching rows with dedicated table filters', func
         ->and($draft->fresh()->status)->toBe('archived');
 });
 
-test('bulk action endpoints require a valid component reference', function () {
+test('bulk action endpoints require a valid component reference', function (): void {
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
     patch('/lattice/bulk-actions/workbench.products.archive-selected', [
@@ -131,7 +131,7 @@ test('bulk action endpoints require a valid component reference', function () {
     ])->assertForbidden();
 });
 
-test('bulk actions execute through their serialized component reference', function () {
+test('bulk actions execute through their serialized component reference', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
@@ -152,7 +152,7 @@ test('bulk actions execute through their serialized component reference', functi
     expect($product->fresh()->status)->toBe('archived');
 });
 
-test('bulk form actions validate the submitted reason before archiving', function () {
+test('bulk form actions validate the submitted reason before archiving', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([RejectSelectedProductsAction::class]);
 
@@ -185,7 +185,7 @@ test('bulk form actions validate the submitted reason before archiving', functio
     expect($product->fresh()->status)->toBe('archived');
 });
 
-test('bulk form actions validate precognitively without archiving', function () {
+test('bulk form actions validate precognitively without archiving', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([RejectSelectedProductsAction::class]);
 

--- a/tests/Feature/Commerce/GroupFormTest.php
+++ b/tests/Feature/Commerce/GroupFormTest.php
@@ -11,14 +11,14 @@ use function Pest\Laravel\patch;
 use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
 
-test('the group create page renders', function () {
+test('the group create page renders', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser());
 
     get('/groups/create')->assertOk();
 });
 
-test('the group form creates a group and redirects', function () {
+test('the group form creates a group and redirects', function (): void {
     Lattice::forms([GroupForm::class]);
 
     $form = wire(Form::use(GroupForm::class));
@@ -31,7 +31,7 @@ test('the group form creates a group and redirects', function () {
     expect(Group::query()->where('name', 'Premium Customers')->exists())->toBeTrue();
 });
 
-test('the group edit page renders with prefilled form state', function () {
+test('the group edit page renders with prefilled form state', function (): void {
     $group = Group::factory()->create(['name' => 'VIP Partners']);
 
     withoutVite();
@@ -42,7 +42,7 @@ test('the group edit page renders with prefilled form state', function () {
             ->field('name', fn ($name) => $name->assertInitialValue('VIP Partners')));
 });
 
-test('the group form updates an existing group', function () {
+test('the group form updates an existing group', function (): void {
     Lattice::forms([GroupForm::class]);
 
     $group = Group::factory()->create(['name' => 'Old Name']);

--- a/tests/Feature/Console/DiscoverCacheCommandTest.php
+++ b/tests/Feature/Console/DiscoverCacheCommandTest.php
@@ -6,11 +6,11 @@ use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
 
 use function Pest\Laravel\artisan;
 
-afterEach(function () {
+afterEach(function (): void {
     app(DiscoveryManifest::class)->clear();
 });
 
-it('caches and clears the discovery manifest', function () {
+it('caches and clears the discovery manifest', function (): void {
     $manifest = app(DiscoveryManifest::class);
 
     expect($manifest->isCached())->toBeFalse();
@@ -22,7 +22,7 @@ it('caches and clears the discovery manifest', function () {
     expect($manifest->isCached())->toBeFalse();
 });
 
-it('walks fresh when the cache is cold', function () {
+it('walks fresh when the cache is cold', function (): void {
     discoverFixtures();
 
     $manifest = app(DiscoveryManifest::class);

--- a/tests/Feature/Console/MakeColumnCommandTest.php
+++ b/tests/Feature/Console/MakeColumnCommandTest.php
@@ -15,8 +15,8 @@ function withColumnScaffold(Closure $callback): mixed
     });
 }
 
-it('scaffolds a column class, a cell tsx and registers it in columns.ts', function () {
-    withColumnScaffold(function () {
+it('scaffolds a column class, a cell tsx and registers it in columns.ts', function (): void {
+    withColumnScaffold(function (): void {
         artisan('lattice:column', ['name' => 'StatusBadge'])->assertSuccessful();
 
         $columnFile = app_path('Tables/Columns/StatusBadge.php');
@@ -40,8 +40,8 @@ it('scaffolds a column class, a cell tsx and registers it in columns.ts', functi
     });
 });
 
-it('is idempotent and honors --type', function () {
-    withColumnScaffold(function () {
+it('is idempotent and honors --type', function (): void {
+    withColumnScaffold(function (): void {
         artisan('lattice:column', ['name' => 'StatusBadge'])->assertSuccessful();
         artisan('lattice:column', ['name' => 'StatusBadge'])->assertSuccessful();
         expect(substr_count(File::get(resource_path('js/lattice/columns.ts')), '"column.status-badge": StatusBadgeCell'))->toBe(1);

--- a/tests/Feature/Console/MakeComponentCommandTest.php
+++ b/tests/Feature/Console/MakeComponentCommandTest.php
@@ -15,8 +15,8 @@ function withComponentScaffold(Closure $callback): mixed
     });
 }
 
-it('scaffolds a component class with the AsComponent attribute and registers it', function () {
-    withComponentScaffold(function () {
+it('scaffolds a component class with the AsComponent attribute and registers it', function (): void {
+    withComponentScaffold(function (): void {
         artisan('lattice:component', ['name' => 'Rating'])->assertSuccessful();
 
         $php = File::get(app_path('Components/Rating.php'));
@@ -35,8 +35,8 @@ it('scaffolds a component class with the AsComponent attribute and registers it'
     });
 });
 
-it('honors a --type override', function () {
-    withComponentScaffold(function () {
+it('honors a --type override', function (): void {
+    withComponentScaffold(function (): void {
         artisan('lattice:component', ['name' => 'Stars', '--type' => 'rating.stars'])->assertSuccessful();
 
         expect(File::get(app_path('Components/Stars.php')))->toContain("#[AsComponent('rating.stars')]");

--- a/tests/Feature/Console/MakeFieldCommandTest.php
+++ b/tests/Feature/Console/MakeFieldCommandTest.php
@@ -15,8 +15,8 @@ function withFieldScaffold(Closure $callback): mixed
     });
 }
 
-it('scaffolds a field PHP class, a tsx renderer, registers it and derives the type', function () {
-    withFieldScaffold(function () {
+it('scaffolds a field PHP class, a tsx renderer, registers it and derives the type', function (): void {
+    withFieldScaffold(function (): void {
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
 
         $php = File::get(app_path('Forms/Fields/ColorPicker.php'));
@@ -37,8 +37,8 @@ it('scaffolds a field PHP class, a tsx renderer, registers it and derives the ty
     });
 });
 
-it('is idempotent — re-running does not duplicate the registration', function () {
-    withFieldScaffold(function () {
+it('is idempotent — re-running does not duplicate the registration', function (): void {
+    withFieldScaffold(function (): void {
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
 
@@ -48,8 +48,8 @@ it('is idempotent — re-running does not duplicate the registration', function 
     });
 });
 
-it('honors a --type override', function () {
-    withFieldScaffold(function () {
+it('honors a --type override', function (): void {
+    withFieldScaffold(function (): void {
         artisan('lattice:field', ['name' => 'Swatch', '--type' => 'color'])->assertSuccessful();
 
         expect(File::get(app_path('Forms/Fields/Swatch.php')))
@@ -63,8 +63,8 @@ it('honors a --type override', function () {
     });
 });
 
-it('registers multiple distinct fields without clobbering earlier ones', function () {
-    withFieldScaffold(function () {
+it('registers multiple distinct fields without clobbering earlier ones', function (): void {
+    withFieldScaffold(function (): void {
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
         artisan('lattice:field', ['name' => 'StarRating'])->assertSuccessful();
 

--- a/tests/Feature/Console/PublishJsScaffoldTest.php
+++ b/tests/Feature/Console/PublishJsScaffoldTest.php
@@ -30,8 +30,8 @@ function withPublishedJsScaffold(Closure $callback): mixed
     });
 }
 
-it('publishes the JS scaffold under resources/js/lattice', function () {
-    withPublishedJsScaffold(function () {
+it('publishes the JS scaffold under resources/js/lattice', function (): void {
+    withPublishedJsScaffold(function (): void {
         File::delete(resource_path('js/lattice/plugin.ts'));
         File::delete(resource_path('js/lattice/columns.ts'));
 

--- a/tests/Feature/Console/TypeScriptCommandTest.php
+++ b/tests/Feature/Console/TypeScriptCommandTest.php
@@ -7,12 +7,12 @@ use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use function Pest\Laravel\artisan;
 
 // Restore the default profile; the workbench binds BaseProfile.
-beforeEach(function () {
+beforeEach(function (): void {
     app()->bind(TypeScriptProfile::class, AugmentProfile::class);
 });
 
-it('writes an augmentation file for app components, not built-ins', function () {
-    withScaffoldWorkspace(function () {
+it('writes an augmentation file for app components, not built-ins', function (): void {
+    withScaffoldWorkspace(function (): void {
         $output = base_path('resources/js/lattice/generated.d.ts');
 
         config()->set('lattice.typescript.output', $output);
@@ -39,8 +39,8 @@ it('writes an augmentation file for app components, not built-ins', function () 
     });
 });
 
-it('produces a valid augmentation file even when discover config is empty', function () {
-    withScaffoldWorkspace(function () {
+it('produces a valid augmentation file even when discover config is empty', function (): void {
+    withScaffoldWorkspace(function (): void {
         $output = base_path('resources/js/lattice/generated-empty.d.ts');
 
         config()->set('lattice.typescript.output', $output);

--- a/tests/Feature/Core/RawBlockTest.php
+++ b/tests/Feature/Core/RawBlockTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Core\Components\RawBlock;
 
-it('serializes trusted raw html', function () {
+it('serializes trusted raw html', function (): void {
     $node = wire(RawBlock::make('avatar')->html('<span class="avatar">AL</span>'));
 
     expect($node['type'])->toBe('raw-block')
@@ -11,7 +11,7 @@ it('serializes trusted raw html', function () {
         ->and($node['props']['html'])->toBe('<span class="avatar">AL</span>');
 });
 
-it('renders a blade view into raw html', function () {
+it('renders a blade view into raw html', function (): void {
     view()->addNamespace('raw-block-test', __DIR__);
 
     $node = wire(RawBlock::make()->blade('raw-block-test::Fixtures.raw-block', ['name' => 'Ada Lovelace']));

--- a/tests/Feature/Core/RegistryTest.php
+++ b/tests/Feature/Core/RegistryTest.php
@@ -18,7 +18,7 @@ use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredUsersTable;
 use function Pest\Laravel\patch;
 use function Pest\Laravel\postJson;
 
-test('lattice can discover attributed definitions from a path and namespace', function () {
+test('lattice can discover attributed definitions from a path and namespace', function (): void {
     discoverFixtures();
 
     $form = wire(Form::use(DiscoveredProfileForm::class));
@@ -83,14 +83,14 @@ test('lattice can discover attributed definitions from a path and namespace', fu
         ]);
 });
 
-test('lattice discovers attributed bulk action definitions', function () {
+test('lattice discovers attributed bulk action definitions', function (): void {
     discoverFixtures();
 
     expect(app(BulkActionRegistry::class)->resolve('fixtures.archive'))
         ->toBeInstanceOf(DiscoveredArchiveBulkAction::class);
 });
 
-test('interaction endpoints return 404 for unknown component ids', function () {
+test('interaction endpoints return 404 for unknown component ids', function (): void {
     $signer = app(ComponentReferenceSigner::class);
     $refs = [
         'action' => $signer->seal('action', 'workbench.missing', []),
@@ -109,7 +109,7 @@ test('interaction endpoints return 404 for unknown component ids', function () {
         ->assertNotFound();
 });
 
-test('interaction endpoints re-run authorization for every interaction', function () {
+test('interaction endpoints re-run authorization for every interaction', function (): void {
     Lattice::actions([WorkbenchDeniedAction::class]);
     Lattice::forms([WorkbenchDeniedForm::class]);
     Lattice::tables([WorkbenchDeniedTable::class]);

--- a/tests/Feature/Discovery/ClassWalkerTest.php
+++ b/tests/Feature/Discovery/ClassWalkerTest.php
@@ -5,14 +5,14 @@ use Lattice\Lattice\Support\Discovery\ClassWalker;
 use Lattice\Lattice\Tables\Columns\BadgeColumn;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
-it('walks classes under a path and returns an empty list for a missing path', function () {
+it('walks classes under a path and returns an empty list for a missing path', function (): void {
     $classes = ClassWalker::classes(dirname(__DIR__, 3).'/src/Tables/Columns');
 
     expect($classes)->toContain(BadgeColumn::class)
         ->and(ClassWalker::classes('/no/such/path'))->toBe([]);
 });
 
-it('includes enums via all()', function () {
+it('includes enums via all()', function (): void {
     $all = ClassWalker::all(dirname(__DIR__, 3).'/src/Tables/Enums');
 
     expect($all)->toContain(ColumnType::class);

--- a/tests/Feature/Discovery/DiscoveryManifestTest.php
+++ b/tests/Feature/Discovery/DiscoveryManifestTest.php
@@ -15,7 +15,7 @@ use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredDemoPage;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredUsersTable;
 
-test('discovery kinds map every component group to its attribute', function () {
+test('discovery kinds map every component group to its attribute', function (): void {
     expect(DiscoveryKinds::COMPONENTS)->toMatchArray([
         'forms' => AsForm::class,
         'tables' => AsTable::class,
@@ -26,12 +26,12 @@ test('discovery kinds map every component group to its attribute', function () {
     ]);
 });
 
-test('discovery kinds extracts a component key from its attribute', function () {
+test('discovery kinds extracts a component key from its attribute', function (): void {
     expect(DiscoveryKinds::keyOf(DiscoveredProfileForm::class, AsForm::class))
         ->toBe('fixtures.profile');
 });
 
-test('the manifest builds resolved entries for every kind', function () {
+test('the manifest builds resolved entries for every kind', function (): void {
     discoverFixtures();
 
     $manifest = app(DiscoveryManifest::class);
@@ -42,7 +42,7 @@ test('the manifest builds resolved entries for every kind', function () {
         ->toMatchArray(['route' => '/discovered-demo', 'name' => 'discovered.demo', 'middleware' => ['web']]);
 });
 
-test('the manifest indexes page descriptors by class', function () {
+test('the manifest indexes page descriptors by class', function (): void {
     discoverFixtures();
 
     $manifest = app(DiscoveryManifest::class);
@@ -55,7 +55,7 @@ test('the manifest indexes page descriptors by class', function () {
         ->toMatchArray(['route' => '/discovered-demo', 'name' => 'discovered.demo', 'middleware' => ['web']]);
 });
 
-test('the manifest round-trips through the cached file', function () {
+test('the manifest round-trips through the cached file', function (): void {
     discoverFixtures();
 
     $manifest = app(DiscoveryManifest::class);
@@ -76,7 +76,7 @@ test('the manifest round-trips through the cached file', function () {
 
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
 
-test('registries resolve discovered definitions from the manifest', function () {
+test('registries resolve discovered definitions from the manifest', function (): void {
     discoverFixtures();
 
     // No explicit Lattice::forms([...]) — resolution comes from the manifest.
@@ -85,7 +85,7 @@ test('registries resolve discovered definitions from the manifest', function () 
     expect($form)->toMatchArray(['type' => 'form', 'id' => 'fixtures.profile']);
 });
 
-test('discovered pages are available through the page registry', function () {
+test('discovered pages are available through the page registry', function (): void {
     discoverFixtures();
 
     $classes = collect(Lattice::pageRegistry()->all())->pluck('class');

--- a/tests/Feature/Effects/BuiltinRegistrationTest.php
+++ b/tests/Feature/Effects/BuiltinRegistrationTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Effects\EffectRegistry;
 
-it('auto-registers all built-in effects in the container', function () {
+it('auto-registers all built-in effects in the container', function (): void {
     $registry = app(EffectRegistry::class);
 
     expect(array_keys($registry->all()))

--- a/tests/Feature/Effects/CustomEffectTest.php
+++ b/tests/Feature/Effects/CustomEffectTest.php
@@ -12,19 +12,19 @@ final readonly class ConfettiEffect extends Effect
     public function __construct(public string $color) {}
 }
 
-it('serializes a custom effect with its wire type and payload', function () {
-    expect((new ConfettiEffect('gold'))->jsonSerialize())
+it('serializes a custom effect with its wire type and payload', function (): void {
+    expect(new ConfettiEffect('gold')->jsonSerialize())
         ->toBe(['type' => 'confetti', 'color' => 'gold']);
 });
 
-it('carries a custom effect through an ActionResult', function () {
+it('carries a custom effect through an ActionResult', function (): void {
     $result = ActionResult::success()->effect(new ConfettiEffect('gold'));
 
     expect($result->jsonSerialize()['effects'][0]->jsonSerialize())
         ->toBe(['type' => 'confetti', 'color' => 'gold']);
 });
 
-it('registers a custom effect alongside the built-ins', function () {
+it('registers a custom effect alongside the built-ins', function (): void {
     $registry = app(EffectRegistry::class);
     $registry->register(ConfettiEffect::class);
 

--- a/tests/Feature/Forms/FieldClosureInjectionTest.php
+++ b/tests/Feature/Forms/FieldClosureInjectionTest.php
@@ -8,34 +8,34 @@ use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Support\Evaluation\UnresolvableEvaluationParameter;
 
-it('injects named utilities into rule closures', function () {
-    $field = TextInput::make('email')->rules(fn ($get) => $get('strict') ? ['email'] : []);
+it('injects named utilities into rule closures', function (): void {
+    $field = TextInput::make('email')->rules(fn ($get): array => $get('strict') ? ['email'] : []);
 
     expect($field->resolveRules(FormData::make(['strict' => true]), Request::create('/')))->toBe(['email']);
 });
 
-it('injects the field component and its own value into rule closures', function () {
-    $field = TextInput::make('email')->rules(fn ($component, $value) => [$component->name().':'.$value]);
+it('injects the field component and its own value into rule closures', function (): void {
+    $field = TextInput::make('email')->rules(fn ($component, $value): array => [$component->name().':'.$value]);
 
     expect($field->resolveRules(FormData::make(['email' => 'a@b.c']), Request::create('/')))->toBe(['email:a@b.c']);
 });
 
-it('keeps supporting typed FormData and Request rule closures', function () {
-    $field = TextInput::make('age')->rules(fn (FormData $state, Request $request) => [$state->string('extra')]);
+it('keeps supporting typed FormData and Request rule closures', function (): void {
+    $field = TextInput::make('age')->rules(fn (FormData $state, Request $request): array => [$state->string('extra')]);
 
     expect($field->resolveRules(FormData::make(['extra' => 'min:3']), Request::create('/')))->toBe(['min:3']);
 });
 
-it('injects named utilities into computed value resolvers', function () {
+it('injects named utilities into computed value resolvers', function (): void {
     $field = TextInput::make('total')
-        ->value(fn ($get) => $get('qty') * 2);
+        ->value(fn ($get): int|float => $get('qty') * 2);
 
     $field->applyResolution(FormData::make(['qty' => 5]), Request::create('/'));
 
     expect($field->resolvedValue())->toBe(10);
 });
 
-it('injects named utilities into dependsOn callbacks', function () {
+it('injects named utilities into dependsOn callbacks', function (): void {
     $field = TextInput::make('city')
         ->dependsOn('country', fn ($component, $get) => $component->value($get('country').'-city'));
 
@@ -44,9 +44,9 @@ it('injects named utilities into dependsOn callbacks', function () {
     expect($field->resolvedValue())->toBe('de-city');
 });
 
-it('injects row and form scopes into prefill resolvers by name', function () {
+it('injects row and form scopes into prefill resolvers by name', function (): void {
     $field = TextInput::make('label')
-        ->value(fn ($form, $row) => $row->string('first').'@'.$form->string('domain'), editable: true);
+        ->value(fn ($form, $row): string => $row->string('first').'@'.$form->string('domain'), editable: true);
 
     $row = FormData::make(['first' => 'ada']);
     $form = FormData::make(['domain' => 'lattice.dev']);
@@ -54,9 +54,9 @@ it('injects row and form scopes into prefill resolvers by name', function () {
     expect($field->resolvePrefillValue($row, $form, Request::create('/')))->toBe('ada@lattice.dev');
 });
 
-it('resolves a typed FormData prefill parameter to the row scope', function () {
+it('resolves a typed FormData prefill parameter to the row scope', function (): void {
     $field = TextInput::make('label')
-        ->value(fn (FormData $data) => $data->string('first'), editable: true);
+        ->value(fn (FormData $data): string => $data->string('first'), editable: true);
 
     $row = FormData::make(['first' => 'ada']);
     $form = FormData::make(['first' => 'grace']);
@@ -64,24 +64,24 @@ it('resolves a typed FormData prefill parameter to the row scope', function () {
     expect($field->resolvePrefillValue($row, $form, Request::create('/')))->toBe('ada');
 });
 
-it('resolves a concrete field-typed parameter to the live component', function () {
-    $field = TextInput::make('total')->value(fn (TextInput $self) => $self->name());
+it('resolves a concrete field-typed parameter to the live component', function (): void {
+    $field = TextInput::make('total')->value(fn (TextInput $self): string => $self->name());
 
     $field->applyResolution(FormData::make([]), Request::create('/'));
 
     expect($field->resolvedValue())->toBe('total');
 });
 
-it('resolves an abstract Field-typed parameter to the live component', function () {
-    $field = TextInput::make('total')->value(fn (Field $self) => $self->name());
+it('resolves an abstract Field-typed parameter to the live component', function (): void {
+    $field = TextInput::make('total')->value(fn (Field $self): string => $self->name());
 
     $field->applyResolution(FormData::make([]), Request::create('/'));
 
     expect($field->resolvedValue())->toBe('total');
 });
 
-it('throws instead of autowiring a mismatched component type', function () {
-    $field = TextInput::make('total')->value(fn (Select $other) => $other);
+it('throws instead of autowiring a mismatched component type', function (): void {
+    $field = TextInput::make('total')->value(fn (Select $other): Select => $other);
 
     expect(fn () => $field->applyResolution(FormData::make([]), Request::create('/')))
         ->toThrow(UnresolvableEvaluationParameter::class);

--- a/tests/Feature/Forms/FileUploadFieldTest.php
+++ b/tests/Feature/Forms/FileUploadFieldTest.php
@@ -28,7 +28,7 @@ function uploadHeaders(array $component, array $extra = []): array
 it('signs an upload through the form endpoint', function (): void {
     Storage::fake('s3');
     Storage::disk('s3')->buildTemporaryUploadUrlsUsing(
-        fn (string $path, $expiration, array $options = []) => ['url' => "https://s3.test/{$path}", 'headers' => []],
+        fn (string $path, $expiration, array $options = []): array => ['url' => "https://s3.test/{$path}", 'headers' => []],
     );
 
     Lattice::forms([UploadForm::class]);
@@ -43,7 +43,7 @@ it('signs an upload through the form endpoint', function (): void {
 it('signs an upload for a file field inside a repeater row', function (): void {
     Storage::fake('s3');
     Storage::disk('s3')->buildTemporaryUploadUrlsUsing(
-        fn (string $path, $expiration, array $options = []) => ['url' => "https://s3.test/{$path}", 'headers' => []],
+        fn (string $path, $expiration, array $options = []): array => ['url' => "https://s3.test/{$path}", 'headers' => []],
     );
 
     Lattice::forms([UploadForm::class]);
@@ -64,7 +64,7 @@ it('signs an upload for a file field inside a repeater row', function (): void {
 it('signs an upload for a file field inside nested repeater rows', function (): void {
     Storage::fake('s3');
     Storage::disk('s3')->buildTemporaryUploadUrlsUsing(
-        fn (string $path, $expiration, array $options = []) => ['url' => "https://s3.test/{$path}", 'headers' => []],
+        fn (string $path, $expiration, array $options = []): array => ['url' => "https://s3.test/{$path}", 'headers' => []],
     );
 
     $definition = new class extends FormDefinition

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -16,7 +16,7 @@ use function Pest\Laravel\getJson;
 use function Pest\Laravel\patch;
 use function Pest\Laravel\patchJson;
 
-test('registered forms serialize their configured endpoint and isolated error bag', function () {
+test('registered forms serialize their configured endpoint and isolated error bag', function (): void {
     config(['lattice.forms.endpoint' => 'custom/forms/{form}']);
 
     Lattice::forms([WorkbenchProfileForm::class]);
@@ -56,7 +56,7 @@ test('registered forms serialize their configured endpoint and isolated error ba
         ]);
 });
 
-test('registered forms can be submitted through the package endpoint', function () {
+test('registered forms can be submitted through the package endpoint', function (): void {
     Lattice::forms([WorkbenchProfileForm::class]);
 
     $ref = componentRef(wire(Form::use(WorkbenchProfileForm::class)
@@ -74,7 +74,7 @@ test('registered forms can be submitted through the package endpoint', function 
     expect(session('handled-form-team'))->toBe('lattice-core');
 });
 
-test('registered form endpoints require a valid component reference', function () {
+test('registered form endpoints require a valid component reference', function (): void {
     Lattice::forms([WorkbenchProfileForm::class]);
 
     patch('/lattice/forms/settings.profile', ['name' => 'Taylor'])
@@ -86,7 +86,7 @@ test('registered form endpoints require a valid component reference', function (
         ->assertForbidden();
 });
 
-test('registered form submissions validate before handle is called', function () {
+test('registered form submissions validate before handle is called', function (): void {
     Lattice::forms([WorkbenchRequiredProfileForm::class]);
 
     $ref = componentRef(wire(Form::use(WorkbenchRequiredProfileForm::class)));
@@ -98,7 +98,7 @@ test('registered form submissions validate before handle is called', function ()
     expect(session('handled-required-profile'))->toBeNull();
 });
 
-test('registered forms receive the current request while serializing definitions', function () {
+test('registered forms receive the current request while serializing definitions', function (): void {
     Lattice::forms([WorkbenchRequestAwareForm::class]);
 
     Route::get('request-aware-form', fn () => response()->json(wire(Form::use(WorkbenchRequestAwareForm::class))))

--- a/tests/Feature/Forms/FormResolveTest.php
+++ b/tests/Feature/Forms/FormResolveTest.php
@@ -21,7 +21,7 @@ function computedDefinition(): FormDefinition
                 TextInput::make('qty', 'Qty'),
                 TextInput::make('price', 'Price'),
                 TextInput::make('total', 'Total')
-                    ->value(fn (FormData $d) => $d->float('qty') * $d->float('price')),
+                    ->value(fn (FormData $d): float => $d->float('qty') * $d->float('price')),
             ]);
         }
 
@@ -51,7 +51,7 @@ function pricingDefinition(): FormDefinition
                     Block::make('product')->label('Product')->schema([
                         TextInput::make('product', 'Product'),
                         TextInput::make('price', 'Price')->value(
-                            fn (FormData $row, FormData $form) => $row->float('product') * ($form->string('customer') === 'vip' ? 0.5 : 1.0),
+                            fn (FormData $row, FormData $form): float => $row->float('product') * ($form->string('customer') === 'vip' ? 0.5 : 1.0),
                             editable: true,
                             resetOn: ['product'],
                             refreshOn: ['@customer'],
@@ -101,7 +101,7 @@ it('resolves repeater row prefill values from the fixed schema', function (): vo
                 Repeater::make('lines', 'Lines')->schema([
                     TextInput::make('base', 'Base'),
                     TextInput::make('doubled', 'Doubled')->value(
-                        fn (FormData $row, FormData $form) => $row->float('base') * 2,
+                        fn (FormData $row, FormData $form): float => $row->float('base') * 2,
                         editable: true,
                         resetOn: ['base'],
                     ),
@@ -137,7 +137,7 @@ it('resolves nested repeater prefill values keyed by recursive full path', funct
                     Repeater::make('lines', 'Lines')->schema([
                         TextInput::make('base', 'Base'),
                         TextInput::make('price', 'Price')->value(
-                            fn (FormData $row, FormData $form) => $row->float('base') + ($form->string('customer') === 'vip' ? 10 : 0),
+                            fn (FormData $row, FormData $form): float => $row->float('base') + ($form->string('customer') === 'vip' ? 10 : 0),
                             editable: true,
                             resetOn: ['base'],
                             refreshOn: ['@customer'],

--- a/tests/Feature/Forms/ProductFormTest.php
+++ b/tests/Feature/Forms/ProductFormTest.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
 use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Actions\EditProductAction;
@@ -32,7 +33,7 @@ function productHeaders(array $component, array $extra = []): array
     return ['X-Lattice-Ref' => componentRef($component), ...$extra];
 }
 
-test('forms serialize initial state for bound edit values', function () {
+test('forms serialize initial state for bound edit values', function (): void {
     $form = Form::make('product-form')
         ->fill([
             'name' => 'Desk Lamp',
@@ -44,7 +45,7 @@ test('forms serialize initial state for bound edit values', function () {
 
     $this->assertLatticeComponent($form)
         ->assertHasForm('product-form')
-        ->form('product-form', fn (FormAssertions $f) => $f
+        ->form('product-form', fn (FormAssertions $f): FieldAssertions => $f
             ->field('name')->assertInitialValue('Desk Lamp'));
 
     expect(wire($form)['props']['state'])->toBe([
@@ -53,7 +54,7 @@ test('forms serialize initial state for bound edit values', function () {
     ]);
 });
 
-test('forms can enable precognitive validation with a delay', function () {
+test('forms can enable precognitive validation with a delay', function (): void {
     $form = wire(Form::make('product-form')
         ->precognitive(650));
 
@@ -61,7 +62,7 @@ test('forms can enable precognitive validation with a delay', function () {
         ->and($form['props']['validationTimeout'])->toBe(650);
 });
 
-test('the product index page lists products and links to creation', function () {
+test('the product index page lists products and links to creation', function (): void {
     Product::factory()->create([
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
@@ -73,7 +74,7 @@ test('the product index page lists products and links to creation', function () 
 
     $response = get('/products')->assertOk();
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
         ->component('lattice/page', false)
         ->where('lattice.title', 'Products'));
 
@@ -82,7 +83,7 @@ test('the product index page lists products and links to creation', function () 
         ->component('table', 'workbench.products', fn ($table) => $table->assertProp('data.0.name', 'Desk Lamp'));
 });
 
-test('the product form creates products', function () {
+test('the product form creates products', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $form = wire(Form::use(ProductForm::class));
@@ -105,7 +106,7 @@ test('the product form creates products', function () {
         ->and($product?->status)->toBe('active');
 });
 
-test('the product form creates product images from signed uploads', function () {
+test('the product form creates product images from signed uploads', function (): void {
     Storage::fake('s3');
     Storage::disk('s3')->put('tmp/lamp.jpg', 'image-data');
     Lattice::forms([ProductForm::class]);
@@ -139,7 +140,7 @@ test('the product form creates product images from signed uploads', function () 
     Storage::disk('s3')->assertExists($image->path);
 });
 
-test('the product edit page binds existing product state', function () {
+test('the product edit page binds existing product state', function (): void {
     Storage::fake('s3');
     $product = Product::factory()->withoutDefaultPrice()->create([
         'name' => 'Desk Lamp',
@@ -162,7 +163,7 @@ test('the product edit page binds existing product state', function () {
 
     $response = get("/products/{$product->getKey()}/edit")->assertOk();
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
         ->component('lattice/page', false)
         ->where('lattice.title', 'Edit Product'));
 
@@ -179,7 +180,7 @@ test('the product edit page binds existing product state', function () {
         ]));
 });
 
-test('the product form updates the trusted product from sealed context', function () {
+test('the product form updates the trusted product from sealed context', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $trustedProduct = Product::factory()->withoutDefaultPrice()->create([
@@ -218,7 +219,7 @@ test('the product form updates the trusted product from sealed context', functio
         ->and($tamperedProduct->sku)->toBe('SHELF-001');
 });
 
-test('the product form updates product images from signed uploads and removals', function () {
+test('the product form updates product images from signed uploads and removals', function (): void {
     Storage::fake('s3');
     Lattice::forms([ProductForm::class]);
 
@@ -286,7 +287,7 @@ test('the product form updates product images from signed uploads and removals',
     Storage::disk('s3')->assertExists($newImage->path);
 });
 
-test('the product form validates required fields', function () {
+test('the product form validates required fields', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $form = wire(Form::use(ProductForm::class));
@@ -308,7 +309,7 @@ test('the product form validates required fields', function () {
         ->assertStatus(Response::HTTP_FOUND);
 });
 
-test('the product form returns precognitive validation errors without creating products', function () {
+test('the product form returns precognitive validation errors without creating products', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $form = wire(Form::use(ProductForm::class));
@@ -332,7 +333,7 @@ test('the product form returns precognitive validation errors without creating p
     expect(Product::query()->count())->toBe(0);
 });
 
-test('the product form accepts valid precognitive validation without creating products', function () {
+test('the product form accepts valid precognitive validation without creating products', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $form = wire(Form::use(ProductForm::class));
@@ -355,7 +356,7 @@ test('the product form accepts valid precognitive validation without creating pr
     expect(Product::query()->count())->toBe(0);
 });
 
-test('the product form validates edit uniqueness from sealed context during precognition', function () {
+test('the product form validates edit uniqueness from sealed context during precognition', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $trustedProduct = Product::factory()->create([
@@ -404,7 +405,7 @@ test('the product form validates edit uniqueness from sealed context during prec
         ->and($trustedProduct->status)->toBe('draft');
 });
 
-test('the product form create rejects two default sales prices', function () {
+test('the product form create rejects two default sales prices', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $form = wire(Form::use(ProductForm::class));
@@ -423,7 +424,7 @@ test('the product form create rejects two default sales prices', function () {
     expect(Product::query()->count())->toBe(0);
 });
 
-test('the product form update rejects two default sales prices', function () {
+test('the product form update rejects two default sales prices', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $product = Product::factory()->withoutDefaultPrice()->create([
@@ -450,7 +451,7 @@ test('the product form update rejects two default sales prices', function () {
     expect($product->salesPrices()->whereNull('group_id')->count())->toBeLessThanOrEqual(1);
 });
 
-test('the edit product action syncs sales prices', function () {
+test('the edit product action syncs sales prices', function (): void {
     Lattice::actions([EditProductAction::class]);
 
     $product = Product::factory()->withoutDefaultPrice()->create([
@@ -479,7 +480,7 @@ test('the edit product action syncs sales prices', function () {
         ->and($product->salesPrices()->whereNull('group_id')->first()->amount)->toBe('79.99');
 });
 
-test('the edit product action syncs images', function () {
+test('the edit product action syncs images', function (): void {
     Storage::fake('s3');
     Storage::disk('s3')->put('tmp/modal.jpg', 'image-data');
     Lattice::actions([EditProductAction::class]);
@@ -517,7 +518,7 @@ test('the edit product action syncs images', function () {
     Storage::disk('s3')->assertExists($image->path);
 });
 
-test('the edit product action removes existing images without new uploads', function () {
+test('the edit product action removes existing images without new uploads', function (): void {
     Storage::fake('s3');
     Lattice::actions([EditProductAction::class]);
 
@@ -562,7 +563,7 @@ test('the edit product action removes existing images without new uploads', func
     Storage::disk('s3')->assertMissing('workbench/products/lamp.jpg');
 });
 
-test('the edit product action rejects two default sales prices with a 422', function () {
+test('the edit product action rejects two default sales prices with a 422', function (): void {
     Lattice::actions([EditProductAction::class]);
 
     $product = Product::factory()->withoutDefaultPrice()->create([

--- a/tests/Feature/Forms/ProductRelatedProductsTest.php
+++ b/tests/Feature/Forms/ProductRelatedProductsTest.php
@@ -11,7 +11,7 @@ use function Pest\Laravel\patch;
 use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
 
-test('the product form syncs related products on create', function () {
+test('the product form syncs related products on create', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $alpha = Product::factory()->create(['name' => 'Alpha']);
@@ -33,7 +33,7 @@ test('the product form syncs related products on create', function () {
         ->toEqualCanonicalizing([$alpha->getKey(), $beta->getKey()]);
 });
 
-test('the product form replaces related products on update', function () {
+test('the product form replaces related products on update', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $product = Product::factory()->create([
@@ -62,7 +62,7 @@ test('the product form replaces related products on update', function () {
         ->toBe([$gamma->getKey()]);
 });
 
-test('the product form ignores related ids that do not exist', function () {
+test('the product form ignores related ids that do not exist', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $alpha = Product::factory()->create(['name' => 'Alpha']);
@@ -82,7 +82,7 @@ test('the product form ignores related ids that do not exist', function () {
     expect($product->relatedProducts->pluck('id')->all())->toBe([$alpha->getKey()]);
 });
 
-test('the product edit page binds related product ids into form state', function () {
+test('the product edit page binds related product ids into form state', function (): void {
     $product = Product::factory()->create([
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
@@ -100,7 +100,7 @@ test('the product edit page binds related product ids into form state', function
                 ->assertInitialValue([$related->getKey()])));
 });
 
-test('the product form resolves related product labels for prefilled ids', function () {
+test('the product form resolves related product labels for prefilled ids', function (): void {
     Lattice::forms([ProductForm::class]);
 
     $related = Product::factory()->create(['name' => 'Walnut Desk']);

--- a/tests/Feature/Forms/SelectClosureInjectionTest.php
+++ b/tests/Feature/Forms/SelectClosureInjectionTest.php
@@ -6,9 +6,9 @@ use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
 
-it('injects the search string and form utilities into search resolvers', function () {
+it('injects the search string and form utilities into search resolvers', function (): void {
     $field = Select::make('user')->searchable(
-        fn ($search, $get) => [new Option($search.'/'.$get('scope'), '1')],
+        fn ($search, $get): array => [new Option($search.'/'.$get('scope'), '1')],
     );
 
     $options = $field->resolveSearch('ada', FormData::make(['scope' => 'admins']), Request::create('/'));
@@ -17,9 +17,9 @@ it('injects the search string and form utilities into search resolvers', functio
         ->and($options[0]->label)->toBe('ada/admins');
 });
 
-it('injects selected values into the selected resolver', function () {
+it('injects selected values into the selected resolver', function (): void {
     $field = Select::make('user')->resolveSelectedUsing(
-        fn ($values) => array_map(fn (string $value) => new Option('User '.$value, $value), $values),
+        fn ($values): array => array_map(fn (string $value): Option => new Option('User '.$value, $value), $values),
     );
 
     $field->hydrateState(['7']);

--- a/tests/Feature/Forms/SelectPrefillTest.php
+++ b/tests/Feature/Forms/SelectPrefillTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Block;
 use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\Form;
@@ -44,9 +45,9 @@ it('resolves the label for a single filled id', function (): void {
         ->fill(['author_id' => '5'])
         ->schema([
             Select::make('author_id', 'Author')
-                ->searchable(fn (string $search) => [])
+                ->searchable(fn (string $search): array => [])
                 ->resolveSelectedUsing(fn (array $values) => collect($values)
-                    ->map(fn (string $id) => Select::option("User {$id}", $id))
+                    ->map(fn (string $id): Option => Select::option("User {$id}", $id))
                     ->all()),
         ]);
 
@@ -61,9 +62,9 @@ it('resolves labels for multiple filled ids', function (): void {
         ->schema([
             Select::make('tags', 'Tags')
                 ->multiple()
-                ->searchable(fn (string $search) => [])
+                ->searchable(fn (string $search): array => [])
                 ->resolveSelectedUsing(fn (array $values) => collect($values)
-                    ->map(fn (string $id) => Select::option("Tag {$id}", $id))
+                    ->map(fn (string $id): Option => Select::option("Tag {$id}", $id))
                     ->all()),
         ]);
 
@@ -80,7 +81,7 @@ it('passes a single value to the resolver as a one-element array', function (): 
         ->fill(['author_id' => '7'])
         ->schema([
             Select::make('author_id', 'Author')
-                ->resolveSelectedUsing(function (array $values) use (&$received) {
+                ->resolveSelectedUsing(function (array $values) use (&$received): array {
                     $received = $values;
 
                     return [];
@@ -110,7 +111,7 @@ it('does not resolve when there is no filled value', function (): void {
     $form = Form::make('f')
         ->schema([
             Select::make('author_id', 'Author')
-                ->resolveSelectedUsing(function (array $values) use (&$resolved) {
+                ->resolveSelectedUsing(function (array $values) use (&$resolved): array {
                     $resolved = true;
 
                     return [];
@@ -137,7 +138,7 @@ it('resolves labels for filled ids inside repeater rows', function (): void {
                         $received = $values;
 
                         return collect($values)
-                            ->map(fn (string $id) => Select::option("Product {$id}", $id))
+                            ->map(fn (string $id): Option => Select::option("Product {$id}", $id))
                             ->all();
                     }),
             ]),
@@ -165,7 +166,7 @@ it('resolves labels for filled ids inside builder rows', function (): void {
                             $received = $values;
 
                             return collect($values)
-                                ->map(fn (string $id) => Select::option("Product {$id}", $id))
+                                ->map(fn (string $id): Option => Select::option("Product {$id}", $id))
                                 ->all();
                         }),
                 ]),
@@ -196,7 +197,7 @@ it('resolves labels for filled ids inside nested repeater rows', function (): vo
                             $received = $values;
 
                             return collect($values)
-                                ->map(fn (string $id) => Select::option("Product {$id}", $id))
+                                ->map(fn (string $id): Option => Select::option("Product {$id}", $id))
                                 ->all();
                         }),
                 ]),

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -30,7 +30,7 @@ function searchableDefinition(): FormDefinition
                 TextInput::make('name', 'Name'),
                 Select::make('plan', 'Plan')->options([Select::option('Free', 'free')]),
                 Select::make('author_id', 'Author')
-                    ->searchable(fn (string $search) => [
+                    ->searchable(fn (string $search): array => [
                         ['label' => "Match: {$search}", 'value' => '1'],
                         ['label' => 'Other', 'value' => '2'],
                     ]),
@@ -50,7 +50,7 @@ function rowSearchDefinition(): FormDefinition
     {
         public function definition(Form $form, Request $request): Form
         {
-            $resolver = fn (string $search, FormData $data) => [
+            $resolver = fn (string $search, FormData $data): array => [
                 Select::option(
                     "{$data->get('customer')}:{$data->get('category')}:{$search}",
                     '1',
@@ -86,7 +86,7 @@ function nestedRowSearchDefinition(): FormDefinition
     {
         public function definition(Form $form, Request $request): Form
         {
-            $resolver = fn (string $search, FormData $data) => [
+            $resolver = fn (string $search, FormData $data): array => [
                 Select::option(
                     "{$data->get('customer')}:{$data->get('section')}:{$data->get('category')}:{$search}",
                     '1',

--- a/tests/Feature/Forms/Validation/FieldRulesValidationTest.php
+++ b/tests/Feature/Forms/Validation/FieldRulesValidationTest.php
@@ -74,7 +74,7 @@ function conditionalDefinition(): FormDefinition
 it('derives validation rules from fields and fails an empty payload', function (): void {
     $definition = stubDefinition();
 
-    expect(fn () => $definition->validate(Request::create('/', 'POST', [])))
+    expect(fn (): array => $definition->validate(Request::create('/', 'POST', [])))
         ->toThrow(ValidationException::class);
 });
 
@@ -90,7 +90,7 @@ it('passes validation with a valid payload', function (): void {
 });
 
 it('rejects a non-fully-qualified email when email() is used', function (): void {
-    expect(fn () => emailDefinition()->validate(Request::create('/', 'POST', ['email' => 'a@a'])))
+    expect(fn (): array => emailDefinition()->validate(Request::create('/', 'POST', ['email' => 'a@a'])))
         ->toThrow(ValidationException::class);
 });
 
@@ -107,6 +107,6 @@ it('skips hidden field rules', function (): void {
 });
 
 it('requires the field when its condition matches', function (): void {
-    expect(fn () => conditionalDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
+    expect(fn (): array => conditionalDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
         ->toThrow(ValidationException::class);
 });

--- a/tests/Feature/Forms/Validation/ImperativeRulesTest.php
+++ b/tests/Feature/Forms/Validation/ImperativeRulesTest.php
@@ -18,7 +18,7 @@ function imperativeRulesDefinition(): FormDefinition
             return $form->schema([
                 TextInput::make('type', 'Type'),
                 TextInput::make('vat_id', 'VAT ID')
-                    ->rules(fn (FormData $data) => $data->get('type') === 'business'
+                    ->rules(fn (FormData $data): array => $data->get('type') === 'business'
                         ? ['required', 'string']
                         : ['nullable']),
             ]);
@@ -38,7 +38,7 @@ it('skips the rule when the closure returns it optional', function (): void {
 });
 
 it('enforces the rule when the closure makes it required', function (): void {
-    expect(fn () => imperativeRulesDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
+    expect(fn (): array => imperativeRulesDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
         ->toThrow(ValidationException::class);
 });
 

--- a/tests/Feature/Forms/Validation/ResolvedValidationTest.php
+++ b/tests/Feature/Forms/Validation/ResolvedValidationTest.php
@@ -24,7 +24,7 @@ function resolvedDefinition(): FormDefinition
                 TextInput::make('qty', 'Qty'),
                 TextInput::make('price', 'Price'),
                 TextInput::make('total', 'Total')
-                    ->value(fn (FormData $d) => $d->float('qty') * $d->float('price')),
+                    ->value(fn (FormData $d): float => $d->float('qty') * $d->float('price')),
             ]);
         }
 
@@ -42,7 +42,7 @@ it('skips validation for a field hidden by a closure', function (): void {
 });
 
 it('applies rules set inside a dependsOn closure', function (): void {
-    expect(fn () => resolvedDefinition()->validate(Request::create('/', 'POST', ['mode' => 'reveal'])))
+    expect(fn (): array => resolvedDefinition()->validate(Request::create('/', 'POST', ['mode' => 'reveal'])))
         ->toThrow(ValidationException::class);
 });
 

--- a/tests/Feature/Fragments/FragmentEndpointTest.php
+++ b/tests/Feature/Fragments/FragmentEndpointTest.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Fragments\FragmentDefinition;
 
 use function Pest\Laravel\getJson;
 
-test('registered fragments serialize lazy endpoints and return component schemas', function () {
+test('registered fragments serialize lazy endpoints and return component schemas', function (): void {
     Lattice::fragments([WorkbenchTwoFactorSetupFragment::class]);
 
     $fragment = wire(FragmentComponent::lazy(WorkbenchTwoFactorSetupFragment::class));

--- a/tests/Feature/Http/ChatLayoutToggleTest.php
+++ b/tests/Feature/Http/ChatLayoutToggleTest.php
@@ -7,13 +7,13 @@ use function Pest\Laravel\get;
 use function Pest\Laravel\withoutVite;
 use function Pest\Laravel\withSession;
 
-test('workbench pages render the floating chat layout by default', function () {
+test('workbench pages render the floating chat layout by default', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser());
 
     $response = get('/')->assertOk();
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page->where('lattice.layout.key', 'app'));
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page->where('lattice.layout.key', 'app'));
 
     $this->assertLatticeLayout($response)
         ->component('floating-panel', 'assistant-chat', fn ($panel) => $panel
@@ -21,7 +21,7 @@ test('workbench pages render the floating chat layout by default', function () {
             ->assertRendered('chat.box'));
 });
 
-test('workbench pages dock the chat in a side rail when the chat-inline flag is set', function () {
+test('workbench pages dock the chat in a side rail when the chat-inline flag is set', function (): void {
     withoutVite();
     config(['session.driver' => 'array']);
     $this->actingAs(workbenchTestUser());
@@ -30,7 +30,7 @@ test('workbench pages dock the chat in a side rail when the chat-inline flag is 
 
     $response = get('/')->assertOk();
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page->where('lattice.layout.key', 'app-chat'));
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page->where('lattice.layout.key', 'app-chat'));
 
     $this->assertLatticeLayout($response)
         ->assertRendered('stack:chat-rail')

--- a/tests/Feature/Http/LatticeLayoutTest.php
+++ b/tests/Feature/Http/LatticeLayoutTest.php
@@ -46,7 +46,7 @@ final class WorkbenchStandalonePage extends Page
     }
 }
 
-test('the layout registry resolves a registered layout to its wire schema', function () {
+test('the layout registry resolves a registered layout to its wire schema', function (): void {
     Lattice::layouts([WorkbenchAppLayout::class]);
 
     $rendered = app(LayoutRegistry::class)->render('app', new Request);
@@ -59,12 +59,12 @@ test('the layout registry resolves a registered layout to its wire schema', func
         ->and($schema[0]['schema'][1]['type'])->toBe('outlet');
 });
 
-test('the layout registry rejects an unregistered layout key', function () {
+test('the layout registry rejects an unregistered layout key', function (): void {
     expect(fn () => app(LayoutRegistry::class)->render('missing', new Request))
         ->toThrow(UnknownComponent::class);
 });
 
-test('a page serializes its layout as key and schema with an outlet', function () {
+test('a page serializes its layout as key and schema with an outlet', function (): void {
     Lattice::layouts([WorkbenchAppLayout::class]);
 
     $page = new WorkbenchLayoutPage;
@@ -80,7 +80,7 @@ test('a page serializes its layout as key and schema with an outlet', function (
         ]);
 });
 
-test('a page without a layout serializes a null layout', function () {
+test('a page without a layout serializes a null layout', function (): void {
     $page = new WorkbenchStandalonePage;
 
     $payload = $page->toArray($page->render(PageSchema::make()), new Request);
@@ -88,7 +88,7 @@ test('a page without a layout serializes a null layout', function () {
     expect($payload['layout'])->toBeNull();
 });
 
-test('the none layout sentinel serializes a null layout', function () {
+test('the none layout sentinel serializes a null layout', function (): void {
     $page = new class extends Page
     {
         public function render(PageSchema $schema): PageSchema

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -25,7 +25,7 @@ final class RegWidgetsPage extends RegBasePage
     }
 }
 
-test('Lattice::pageRegistry()->all() resolves route metadata for registered pages', function () {
+test('Lattice::pageRegistry()->all() resolves route metadata for registered pages', function (): void {
     Lattice::pages([RegWidgetsPage::class]);
 
     $widgets = collect(Lattice::pageRegistry()->all())
@@ -37,7 +37,7 @@ test('Lattice::pageRegistry()->all() resolves route metadata for registered page
         ->and($widgets->middleware)->toContain('web');
 });
 
-test('Lattice::pageRegistry()->all() excludes abstract base pages', function () {
+test('Lattice::pageRegistry()->all() excludes abstract base pages', function (): void {
     Lattice::pages([RegBasePage::class]);
 
     $classes = collect(Lattice::pageRegistry()->all())->pluck('class');
@@ -45,10 +45,10 @@ test('Lattice::pageRegistry()->all() excludes abstract base pages', function () 
     expect($classes)->not->toContain(RegBasePage::class);
 });
 
-test('the service provider builds a named GET route for each page', function () {
+test('the service provider builds a named GET route for each page', function (): void {
     Lattice::pages([RegWidgetsPage::class]);
 
-    (new LatticeServiceProvider(app()))->bootPages();
+    new LatticeServiceProvider(app())->bootPages();
 
     $route = Route::getRoutes()->getByName('widgets.index');
 
@@ -58,7 +58,7 @@ test('the service provider builds a named GET route for each page', function () 
         ->and($route->gatherMiddleware())->toContain('web');
 });
 
-test('the service provider skips building routes when the route cache is active', function () {
+test('the service provider skips building routes when the route cache is active', function (): void {
     Lattice::pages([RegWidgetsPage::class]);
 
     $cachedApp = new class extends Application
@@ -71,7 +71,7 @@ test('the service provider skips building routes when the route cache is active'
         }
     };
 
-    (new LatticeServiceProvider($cachedApp))->bootPages();
+    new LatticeServiceProvider($cachedApp)->bootPages();
 
     expect(Route::getRoutes()->getByName('widgets.index'))->toBeNull();
 });

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -20,21 +20,21 @@ use function Pest\Laravel\get;
 use function Pest\Laravel\withoutVite;
 use function Pest\Laravel\withSession;
 
-test('tabs hydrate their active value from the request query string', function () {
+test('tabs hydrate their active value from the request query string', function (): void {
     Route::get('query-tabs', [WorkbenchTabsPage::class, 'render'])->middleware('web')->name('query-tabs.show');
 
     withoutVite();
 
     get('/query-tabs?tabs=security')
         ->assertOk()
-        ->assertInertia(fn (AssertableInertia $page) => $page
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
             ->component('lattice/page')
             ->where('lattice.schema.0.props.defaultValue', 'profile')
             ->where('lattice.schema.0.props.activeValue', 'security')
         );
 });
 
-test('confirmed active tabs redirect to password confirmation when the password is not confirmed', function () {
+test('confirmed active tabs redirect to password confirmation when the password is not confirmed', function (): void {
     Route::get('confirmed-tabs', [WorkbenchConfirmedTabsPage::class, 'render'])->middleware('web')->name('confirmed-tabs.show');
     config(['session.driver' => 'array']);
 
@@ -44,7 +44,7 @@ test('confirmed active tabs redirect to password confirmation when the password 
     expect(session('url.intended'))->toContain('/confirmed-tabs?tabs=security');
 });
 
-test('confirmed active tabs serialize their children after password confirmation', function () {
+test('confirmed active tabs serialize their children after password confirmation', function (): void {
     Route::get('confirmed-tabs', [WorkbenchConfirmedTabsPage::class, 'render'])->middleware('web')->name('confirmed-tabs.show');
 
     withoutVite();
@@ -54,22 +54,22 @@ test('confirmed active tabs serialize their children after password confirmation
 
     get('/confirmed-tabs?tabs=security')
         ->assertOk()
-        ->assertInertia(fn (AssertableInertia $page) => $page
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
             ->component('lattice/page')
             ->where('lattice.schema.0.props.activeValue', 'security')
             ->where('lattice.schema.0.schema.1.schema.0.props.text', 'Security form')
         );
 });
 
-test('the workbench home route uses a workbench-owned page directly', function () {
+test('the workbench home route uses a workbench-owned page directly', function (): void {
     expect(Route::getRoutes()->getByName('home')?->getActionName())->toBe(HomePage::class.'@render');
 });
 
-test('the workbench tables route uses lazy pagination tab tables', function () {
+test('the workbench tables route uses lazy pagination tab tables', function (): void {
     expect(Route::getRoutes()->getByName('tables')?->getActionName())->toBe(TablesPage::class.'@render');
 });
 
-test('pages use laravel controller resolution for constructor dependencies render dependencies and route arguments', function () {
+test('pages use laravel controller resolution for constructor dependencies render dependencies and route arguments', function (): void {
     $user = UserFactory::new()->create([
         'name' => 'Route Bound User',
     ]);
@@ -82,13 +82,13 @@ test('pages use laravel controller resolution for constructor dependencies rende
 
     get("/page-injection/{$user->getKey()}/details")
         ->assertOk()
-        ->assertInertia(fn (AssertableInertia $page) => $page
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
             ->component('lattice/page')
             ->where('lattice.schema.0.props.text', 'Injected Route Bound User details details')
         );
 });
 
-test('pages can authorize requests before rendering', function () {
+test('pages can authorize requests before rendering', function (): void {
     Route::get('authorized-page', [WorkbenchAuthorizedPage::class, 'render'])
         ->middleware('web')
         ->name('authorized-page.show');
@@ -100,13 +100,13 @@ test('pages can authorize requests before rendering', function () {
 
     get('/authorized-page?allow=yes')
         ->assertOk()
-        ->assertInertia(fn (AssertableInertia $page) => $page
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
             ->component('lattice/page')
             ->where('lattice.schema.0.props.text', 'Authorized page')
         );
 });
 
-test('workbench pages serialize package component trees for inertia', function () {
+test('workbench pages serialize package component trees for inertia', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser());
 
@@ -143,7 +143,7 @@ test('workbench pages serialize package component trees for inertia', function (
         ->component('table', 'workbench.users', fn ($table) => $table
             ->assertProps(['resizableColumns' => true, 'resizeIndicator' => true]));
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
         ->component('lattice/page')
         ->where('lattice.title', 'Lattice Workbench')
         ->where('lattice.layout.key', 'app')
@@ -153,13 +153,13 @@ test('workbench pages serialize package component trees for inertia', function (
         ->etc());
 });
 
-test('workbench tables page serializes lazy tables for each pagination type', function () {
+test('workbench tables page serializes lazy tables for each pagination type', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser());
 
     get('/tables')
         ->assertOk()
-        ->assertInertia(fn (AssertableInertia $page) => $page
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
             ->component('lattice/page')
             ->where('lattice.title', 'Lattice Tables')
             ->where('lattice.schema.0.type', 'stack')

--- a/tests/Feature/I18n/I18nextTranslationsTest.php
+++ b/tests/Feature/I18n/I18nextTranslationsTest.php
@@ -12,19 +12,19 @@ use function Pest\Laravel\getJson;
 use function Pest\Laravel\postJson;
 use function Pest\Laravel\withoutVite;
 
-afterEach(function () {
+afterEach(function (): void {
     File::deleteDirectory(package_path('lang/zz'));
     File::deleteDirectory(package_path('workbench/lang/zz'));
     File::delete(package_path('lang/zz.json'));
 });
 
-it('shares the i18n config to the frontend as a once prop', function () {
+it('shares the i18n config to the frontend as a once prop', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser());
 
     $response = get('/');
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
         ->where('lattice.i18n.enabled', true)
         ->where('lattice.i18n.saveMissing', true)
         ->where('lattice.i18n.locales', ['en', 'de'])
@@ -38,7 +38,7 @@ it('shares the i18n config to the frontend as a once prop', function () {
     expect($page['onceProps']['lattice.i18n']['prop'] ?? null)->toBe('lattice.i18n');
 });
 
-it('omits the i18n config when the client already has the once prop', function () {
+it('omits the i18n config when the client already has the once prop', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser());
 
@@ -59,7 +59,7 @@ it('omits the i18n config when the client already has the once prop', function (
         ->and($response->json('onceProps')['lattice.i18n']['prop'] ?? null)->toBe('lattice.i18n');
 });
 
-it('serves the bundled English lattice namespace from the package lang dir', function () {
+it('serves the bundled English lattice namespace from the package lang dir', function (): void {
     getJson('/locales/en/lattice.json')
         ->assertOk()
         ->assertJsonPath('editor.bold', 'Bold')
@@ -67,7 +67,7 @@ it('serves the bundled English lattice namespace from the package lang dir', fun
         ->assertJsonPath('operators.eq', 'equals');
 });
 
-it('serves the lattice namespace from the package lang dir as nested i18next JSON', function () {
+it('serves the lattice namespace from the package lang dir as nested i18next JSON', function (): void {
     getJson('/locales/de/lattice.json')
         ->assertOk()
         ->assertJsonPath('editor.bold', 'Fett')
@@ -78,7 +78,7 @@ it('serves the lattice namespace from the package lang dir as nested i18next JSO
         ->assertJsonPath('bulk.selected', '{{count}} ausgewählt');
 });
 
-it('serves workbench translations from the workbench lang dir', function () {
+it('serves workbench translations from the workbench lang dir', function (): void {
     getJson('/locales/en/workbench::workbench.json')
         ->assertOk()
         ->assertJsonPath('pages.products.title', 'Products')
@@ -90,13 +90,13 @@ it('serves workbench translations from the workbench lang dir', function () {
         ->assertJsonPath('forms.product.fields.name', 'Name');
 });
 
-it('localizes workbench page props and table column labels from the accept language header', function () {
+it('localizes workbench page props and table column labels from the accept language header', function (): void {
     withoutVite();
     $this->actingAs(workbenchTestUser(['locale' => 'de']));
 
     $response = get('/products', ['Accept-Language' => 'de'])->assertOk();
 
-    $response->assertInertia(fn (AssertableInertia $page) => $page
+    $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
         ->component('lattice/page', false)
         ->where('lattice.title', 'Produkte'));
 
@@ -111,7 +111,7 @@ it('localizes workbench page props and table column labels from the accept langu
         ]));
 });
 
-it('keeps workbench translation keys aligned between English and German', function () {
+it('keeps workbench translation keys aligned between English and German', function (): void {
     $english = require package_path('workbench/lang/en/workbench.php');
     $german = require package_path('workbench/lang/de/workbench.php');
 
@@ -124,7 +124,7 @@ it('keeps workbench translation keys aligned between English and German', functi
         ->toBe(array_keys(Arr::dot($english)));
 });
 
-it('dumps missing lattice keys into the package lang dir, never vendor', function () {
+it('dumps missing lattice keys into the package lang dir, never vendor', function (): void {
     postJson('/locales/add/zz/lattice', ['editor.demo' => 'editor.demo'])->assertOk();
 
     $file = package_path('lang/zz/lattice.php');
@@ -136,7 +136,7 @@ it('dumps missing lattice keys into the package lang dir, never vendor', functio
     expect(require $file)->toBe(['editor' => ['demo' => 'i18next-editor.demo']]);
 });
 
-it('dumps namespace-less keys to a JSON file in the package lang dir', function () {
+it('dumps namespace-less keys to a JSON file in the package lang dir', function (): void {
     postJson('/locales/add/zz/translation', ['Save changes' => 'Save changes'])->assertOk();
 
     $file = package_path('lang/zz.json');
@@ -147,7 +147,7 @@ it('dumps namespace-less keys to a JSON file in the package lang dir', function 
     expect(json_decode(File::get($file), true))->toBe(['Save changes' => 'i18next-Save changes']);
 });
 
-it('dumps missing workbench keys into the workbench lang dir', function () {
+it('dumps missing workbench keys into the workbench lang dir', function (): void {
     postJson('/locales/add/zz/workbench::workbench', ['language.demo' => 'language.demo'])->assertOk();
 
     $file = package_path('workbench/lang/zz/workbench.php');

--- a/tests/Feature/Layouts/LatticeMenuTest.php
+++ b/tests/Feature/Layouts/LatticeMenuTest.php
@@ -19,7 +19,7 @@ final class MenuProductsPage extends Page
     }
 }
 
-test('a menu serializes its items as a menu node tree', function () {
+test('a menu serializes its items as a menu node tree', function (): void {
     $menu = Menu::make('main')->items([
         MenuItem::make('Home')->href('/'),
         MenuItem::make('Account')->children([
@@ -40,7 +40,7 @@ test('a menu serializes its items as a menu node tree', function () {
         ]);
 });
 
-test('a menu item nests children that pipe to its schema', function () {
+test('a menu item nests children that pipe to its schema', function (): void {
     $wire = wire(
         MenuItem::make('Account')->children([
             MenuItem::make('Profile')->href('/profile'),
@@ -54,7 +54,7 @@ test('a menu item nests children that pipe to its schema', function () {
         ]);
 });
 
-test('a menu item serializes its icon and method', function () {
+test('a menu item serializes its icon and method', function (): void {
     $wire = wire(
         MenuItem::make('Log out')->href('/logout')->icon('log-out')->method(HttpMethod::Post),
     );
@@ -68,7 +68,7 @@ test('a menu item serializes its icon and method', function () {
         ]);
 });
 
-test('a menu item includes unset optional props as null on the wire', function () {
+test('a menu item includes unset optional props as null on the wire', function (): void {
     $wire = wire(MenuItem::make('Home')->href('/'));
 
     expect($wire['props']['method'])->toBeNull()
@@ -77,7 +77,7 @@ test('a menu item includes unset optional props as null on the wire', function (
         ->and($wire['props']['suffix'])->toBeNull();
 });
 
-test('a menu item serializes prefix and suffix affixes', function () {
+test('a menu item serializes prefix and suffix affixes', function (): void {
     $wire = wire(
         MenuItem::make('Tables')->href('/tables')->prefix(Icon::Table)->suffix('beta'),
     );
@@ -86,20 +86,20 @@ test('a menu item serializes prefix and suffix affixes', function () {
         ->and($wire['props']['suffix'])->toBe(['icon' => null, 'text' => 'beta']);
 });
 
-test('a menu item prefix takes an icon by name via the affix escape hatch', function () {
+test('a menu item prefix takes an icon by name via the affix escape hatch', function (): void {
     $wire = wire(MenuItem::make('Home')->href('/')->prefix(Affix::icon('house')));
 
     expect($wire['props']['prefix'])->toBe(['icon' => 'house', 'text' => null]);
 });
 
-test('icon sets a menu item as icon-only and replaces the iconOnly flag', function () {
+test('icon sets a menu item as icon-only and replaces the iconOnly flag', function (): void {
     $wire = wire(MenuItem::make('Settings')->href('/settings')->icon(Icon::Settings));
 
     expect($wire['props']['icon'])->toBe('settings')
         ->and($wire['props'])->not->toHaveKey('iconOnly');
 });
 
-test('fromPage resolves the href and a default label from the page route', function () {
+test('fromPage resolves the href and a default label from the page route', function (): void {
     Route::get('/menu-products', [MenuProductsPage::class, 'render']);
 
     $wire = wire(MenuItem::fromPage(MenuProductsPage::class));
@@ -110,7 +110,7 @@ test('fromPage resolves the href and a default label from the page route', funct
     ]);
 });
 
-test('fromPage substitutes route parameters into the href', function () {
+test('fromPage substitutes route parameters into the href', function (): void {
     Route::get('/menu-products/{product}', [MenuProductsPage::class, 'render']);
 
     $wire = wire(MenuItem::fromPage(MenuProductsPage::class, ['product' => 7]));
@@ -118,7 +118,7 @@ test('fromPage substitutes route parameters into the href', function () {
     expect($wire['props']['href'])->toBe('/menu-products/7');
 });
 
-test('fromPage label can be overridden fluently', function () {
+test('fromPage label can be overridden fluently', function (): void {
     Route::get('/menu-products', [MenuProductsPage::class, 'render']);
 
     $wire = wire(MenuItem::fromPage(MenuProductsPage::class)->label('Catalog'));
@@ -126,24 +126,24 @@ test('fromPage label can be overridden fluently', function () {
     expect($wire['props']['label'])->toBe('Catalog');
 });
 
-test('fromPage rejects a class that is not a lattice page', function () {
-    expect(fn () => MenuItem::fromPage(stdClass::class))
+test('fromPage rejects a class that is not a lattice page', function (): void {
+    expect(fn (): MenuItem => MenuItem::fromPage(stdClass::class))
         ->toThrow(InvalidArgumentException::class);
 });
 
-test('fromPage rejects a page without a registered route', function () {
-    expect(fn () => MenuItem::fromPage(MenuProductsPage::class))
+test('fromPage rejects a page without a registered route', function (): void {
+    expect(fn (): MenuItem => MenuItem::fromPage(MenuProductsPage::class))
         ->toThrow(InvalidArgumentException::class);
 });
 
-test('a link menu item cannot be given children', function () {
-    expect(fn () => MenuItem::make('Account')->href('/account')->children([
+test('a link menu item cannot be given children', function (): void {
+    expect(fn (): MenuItem => MenuItem::make('Account')->href('/account')->children([
         MenuItem::make('Profile')->href('/profile'),
     ]))->toThrow(InvalidArgumentException::class);
 });
 
-test('a menu item with children cannot become a link', function () {
-    expect(fn () => MenuItem::make('Account')->children([
+test('a menu item with children cannot become a link', function (): void {
+    expect(fn (): MenuItem => MenuItem::make('Account')->children([
         MenuItem::make('Profile')->href('/profile'),
     ])->href('/account'))->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Feature/Support/EvaluateFacadeTest.php
+++ b/tests/Feature/Support/EvaluateFacadeTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Facades\Evaluate;
 
-it('resolves a closure through the facade', function () {
+it('resolves a closure through the facade', function (): void {
     $context = Evaluate::context()->named('state', 7);
 
-    expect(Evaluate::resolve(fn ($state) => $state * 2, $context))->toBe(14);
+    expect(Evaluate::resolve(fn ($state): int|float => $state * 2, $context))->toBe(14);
 });
 
-it('passes a non-closure through the facade unchanged', function () {
+it('passes a non-closure through the facade unchanged', function (): void {
     expect(Evaluate::resolve('plain', Evaluate::context()))->toBe('plain');
 });

--- a/tests/Feature/Tables/ProductTableTest.php
+++ b/tests/Feature/Tables/ProductTableTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
@@ -17,7 +18,7 @@ use Workbench\App\Tables\ProductsTable;
 
 use function Pest\Laravel\patch;
 
-test('the products table exposes product images', function () {
+test('the products table exposes product images', function (): void {
     Storage::fake('s3');
     Lattice::tables([ProductsTable::class]);
 
@@ -61,13 +62,13 @@ test('the products table exposes product images', function () {
         ->and($product->images()->count())->toBe(2);
 });
 
-test('the products table is serialized as striped', function () {
+test('the products table is serialized as striped', function (): void {
     Lattice::tables([ProductsTable::class]);
 
     expect(data_get(wire(Table::use(ProductsTable::class)), 'props.striped'))->toBeTrue();
 });
 
-test('the products table serializes bulk actions bound to the table', function () {
+test('the products table serializes bulk actions bound to the table', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class, RejectSelectedProductsAction::class]);
 
@@ -82,7 +83,7 @@ test('the products table serializes bulk actions bound to the table', function (
         ->and($bulkActions[1]['props']['form']['schema'][0]['props']['name'])->toBe('reason');
 });
 
-test('bulk actions can target every row matching the current filter', function () {
+test('bulk actions can target every row matching the current filter', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
@@ -106,7 +107,7 @@ test('bulk actions can target every row matching the current filter', function (
         ->and($draft->fresh()->status)->toBe('draft');
 });
 
-test('bulk all-matching validates the filter against the table columns', function () {
+test('bulk all-matching validates the filter against the table columns', function (): void {
     Lattice::tables([ProductsTable::class]);
     Lattice::bulkActions([ArchiveSelectedProductsAction::class]);
 
@@ -124,14 +125,14 @@ test('bulk all-matching validates the filter against the table columns', functio
         ->assertJsonPath('errors.filter.0', 'Filter [id] is not allowed for table [workbench.products].');
 });
 
-test('the products table applies date and boolean clause filters', function () {
+test('the products table applies date and boolean clause filters', function (): void {
     $featured = Product::factory()->create(['featured' => true, 'updated_at' => '2026-06-01 10:00:00']);
     Product::factory()->create(['featured' => false, 'updated_at' => '2026-06-02 10:00:00']);
 
     $table = new ProductsTable;
     $columns = $table->columns();
 
-    $resolve = fn (string $filter) => $table->source()->resolveMatching(
+    $resolve = fn (string $filter): Collection => $table->source()->resolveMatching(
         TableQuery::fromRequest(Request::create('/', 'GET', ['filter' => $filter]), $columns, 'workbench.products'),
     );
 
@@ -139,14 +140,14 @@ test('the products table applies date and boolean clause filters', function () {
         ->and($resolve('updated_at:before:2026-06-02')->pluck('id')->all())->toBe([$featured->getKey()]);
 });
 
-test('the products table high value filter matches by default sales price', function () {
+test('the products table high value filter matches by default sales price', function (): void {
     $expensive = Product::factory()->withoutDefaultPrice()->create();
     $expensive->salesPrices()->create(['group_id' => null, 'amount' => '1500.00']);
     Product::factory()->withoutDefaultPrice()->create()
         ->salesPrices()->create(['group_id' => null, 'amount' => '50.00']);
 
     $table = new ProductsTable;
-    $highValue = collect($table->filters())->firstOrFail(fn ($filter) => $filter->key === 'high_value');
+    $highValue = collect($table->filters())->firstOrFail(fn ($filter): bool => $filter->key === 'high_value');
 
     $builder = $table->builder(TableQuery::fromRequest(Request::create('/'), $table->columns(), 'workbench.products'));
     $highValue->apply($builder, true);
@@ -154,7 +155,7 @@ test('the products table high value filter matches by default sales price', func
     expect($builder->pluck('products.id')->all())->toBe([$expensive->getKey()]);
 });
 
-test('the products table applies text, starts/ends-with, and presence filters', function () {
+test('the products table applies text, starts/ends-with, and presence filters', function (): void {
     $widget = Product::factory()->create(['name' => 'Widget']);
     $gizmo = Product::factory()->create(['name' => 'Gizmo']);
     $blank = Product::factory()->create(['name' => '']);
@@ -162,7 +163,7 @@ test('the products table applies text, starts/ends-with, and presence filters', 
     $table = new ProductsTable;
     $columns = $table->columns();
 
-    $resolve = fn (string $filter) => $table->source()->resolveMatching(
+    $resolve = fn (string $filter): Collection => $table->source()->resolveMatching(
         TableQuery::fromRequest(Request::create('/', 'GET', ['filter' => $filter]), $columns, 'workbench.products'),
     );
 
@@ -172,10 +173,10 @@ test('the products table applies text, starts/ends-with, and presence filters', 
         ->and($resolve('name:filled:')->pluck('id')->sort()->values()->all())->toBe([$widget->getKey(), $gizmo->getKey()]);
 });
 
-test('the products table rejects a filter operator not allowed for the column', function () {
+test('the products table rejects a filter operator not allowed for the column', function (): void {
     $columns = (new ProductsTable)->columns();
 
-    expect(fn () => TableQuery::fromRequest(
+    expect(fn (): TableQuery => TableQuery::fromRequest(
         Request::create('/', 'GET', ['filter' => 'featured:contains:x']),
         $columns,
         'workbench.products',
@@ -185,10 +186,10 @@ test('the products table rejects a filter operator not allowed for the column', 
     );
 });
 
-test('the products table rejects invalid boolean and date filter values', function (string $filter, string $message) {
+test('the products table rejects invalid boolean and date filter values', function (string $filter, string $message): void {
     $columns = (new ProductsTable)->columns();
 
-    expect(fn () => TableQuery::fromRequest(
+    expect(fn (): TableQuery => TableQuery::fromRequest(
         Request::create('/', 'GET', ['filter' => $filter]),
         $columns,
         'workbench.products',

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -24,7 +24,7 @@ use Workbench\App\Tables\UsersTable as WorkbenchAppUsersTable;
 
 use function Pest\Laravel\getJson;
 
-test('registered tables serialize their configured endpoint columns state and initial data', function () {
+test('registered tables serialize their configured endpoint columns state and initial data', function (): void {
     config(['lattice.tables.endpoint' => 'custom/tables/{table}']);
 
     Lattice::tables([WorkbenchUsersTable::class]);
@@ -119,7 +119,7 @@ test('registered tables serialize their configured endpoint columns state and in
         ]);
 });
 
-test('registered tables can serialize lazily without running their query', function () {
+test('registered tables can serialize lazily without running their query', function (): void {
     config(['lattice.tables.endpoint' => 'custom/tables/{table}']);
 
     Lattice::tables([WorkbenchLazyUsersTable::class]);
@@ -178,7 +178,7 @@ test('registered tables can serialize lazily without running their query', funct
         ]);
 });
 
-test('registered tables serialize grid layout stack columns and row actions', function () {
+test('registered tables serialize grid layout stack columns and row actions', function (): void {
     Lattice::actions([WorkbenchPingAction::class]);
     Lattice::tables([WorkbenchStackedUsersTable::class]);
 
@@ -248,7 +248,7 @@ test('registered tables serialize grid layout stack columns and row actions', fu
         ]);
 });
 
-test('registered tables parse clause filters sorts and pagination through the endpoint', function () {
+test('registered tables parse clause filters sorts and pagination through the endpoint', function (): void {
     Lattice::tables([WorkbenchUsersTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchUsersTable::class)));
@@ -275,7 +275,7 @@ test('registered tables parse clause filters sorts and pagination through the en
     ]);
 });
 
-test('registered tables reject filters and sorts that are not allowed by columns', function () {
+test('registered tables reject filters and sorts that are not allowed by columns', function (): void {
     Lattice::tables([WorkbenchUsersTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchUsersTable::class)));
@@ -291,7 +291,7 @@ test('registered tables reject filters and sorts that are not allowed by columns
         ->assertJsonPath('errors.sort.0', 'Sort [password] is not allowed for table [workbench.users].');
 });
 
-test('registered table endpoints require a valid component reference and use trusted context', function () {
+test('registered table endpoints require a valid component reference and use trusted context', function (): void {
     discoverFixtures();
 
     $ref = componentRef(wire(Table::use(DiscoveredUsersTable::class)
@@ -308,7 +308,7 @@ test('registered table endpoints require a valid component reference and use tru
         ->assertJsonPath('data.0.name', 'trusted-team');
 });
 
-test('registered table responses expose only declared columns row identity and generated actions', function () {
+test('registered table responses expose only declared columns row identity and generated actions', function (): void {
     Lattice::tables([WorkbenchProjectedProductsTable::class]);
 
     $product = Product::factory()->create([
@@ -341,7 +341,7 @@ test('registered table responses expose only declared columns row identity and g
         ->and($row['actions'][0]['props']['href'])->toBe("/products/{$product->getKey()}/edit");
 });
 
-test('text columns serialize display modifiers', function () {
+test('text columns serialize display modifiers', function (): void {
     expect(wire(TextColumn::make('published_at')
         ->label('Published')
         ->date('Y-m-d')
@@ -359,7 +359,7 @@ test('text columns serialize display modifiers', function () {
         ]);
 });
 
-test('workbench users table exposes timestamp columns for each row', function () {
+test('workbench users table exposes timestamp columns for each row', function (): void {
     Lattice::tables([WorkbenchAppUsersTable::class]);
 
     $columns = wire(Table::use(WorkbenchAppUsersTable::class))['props']['columns'];

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -19,7 +19,7 @@ function peopleOptionSource(): OptionSource
     return inMemoryOptionSource(['1' => 'Ada', '2' => 'Linus', '3' => 'Grace']);
 }
 
-test('a table serializes its declared filters and starts with no active values', function () {
+test('a table serializes its declared filters and starts with no active values', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
     $table = wire(Table::use(WorkbenchFilteredProductsTable::class));
@@ -43,7 +43,7 @@ test('a table serializes its declared filters and starts with no active values',
         ->and($table['props']['state']['tableFilters'])->toBe([]);
 });
 
-test('a table applies a dedicated select filter from the request', function () {
+test('a table applies a dedicated select filter from the request', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
     Product::factory()->create(['name' => 'Active One', 'status' => 'active']);
@@ -59,7 +59,7 @@ test('a table applies a dedicated select filter from the request', function () {
     expect($response->json('data'))->toHaveCount(1);
 });
 
-test('a table rejects a filter key that is not declared', function () {
+test('a table rejects a filter key that is not declared', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
@@ -69,7 +69,7 @@ test('a table rejects a filter key that is not declared', function () {
         ->assertJsonPath('message', 'Filter [unknown] is not allowed for table [workbench.filtered-products].');
 });
 
-test('a table searches a searchable filter\'s options through the endpoint', function () {
+test('a table searches a searchable filter\'s options through the endpoint', function (): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchSearchableFilterTable::class)));
@@ -79,7 +79,7 @@ test('a table searches a searchable filter\'s options through the endpoint', fun
         ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
 });
 
-test('a table searches a searchable column filter through the endpoint', function () {
+test('a table searches a searchable column filter through the endpoint', function (): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchSearchableFilterTable::class)));
@@ -89,7 +89,7 @@ test('a table searches a searchable column filter through the endpoint', functio
         ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
 });
 
-test('a table 404s searching an unknown filter key', function () {
+test('a table 404s searching an unknown filter key', function (): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchSearchableFilterTable::class)));
@@ -98,7 +98,7 @@ test('a table 404s searching an unknown filter key', function () {
         ->assertNotFound();
 });
 
-test('a table rejects searching a filter that is not searchable', function () {
+test('a table rejects searching a filter that is not searchable', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
     $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
@@ -107,7 +107,7 @@ test('a table rejects searching a filter that is not searchable', function () {
         ->assertStatus(422);
 });
 
-test('a table accepts column filter clause option operators', function () {
+test('a table accepts column filter clause option operators', function (): void {
     Lattice::tables([WorkbenchClauseOptionProductsTable::class]);
 
     Product::factory()->create(['name' => 'June One', 'updated_at' => '2026-06-12 12:00:00']);

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -12,7 +12,7 @@ use Lattice\Lattice\Tables\Enums\PaginationType;
 use Lattice\Lattice\Tables\TableQuery;
 use Orchestra\Testbench\Factories\UserFactory;
 
-test('eloquent tables can use infinite pagination metadata', function () {
+test('eloquent tables can use infinite pagination metadata', function (): void {
     User::query()->delete();
 
     foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {
@@ -57,7 +57,7 @@ test('eloquent tables can use infinite pagination metadata', function () {
         ->assertJsonPath('pagination.nextPage', null);
 });
 
-test('eloquent tables use table pagination with totals by default', function () {
+test('eloquent tables use table pagination with totals by default', function (): void {
     User::query()->delete();
 
     foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {
@@ -81,7 +81,7 @@ test('eloquent tables use table pagination with totals by default', function () 
         ->assertJsonPath('pagination.nextPage', 2);
 });
 
-test('eloquent tables can use simple pagination without totals', function () {
+test('eloquent tables can use simple pagination without totals', function (): void {
     User::query()->delete();
 
     foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {
@@ -104,7 +104,7 @@ test('eloquent tables can use simple pagination without totals', function () {
         ->assertJsonPath('pagination.nextPage', 2);
 });
 
-test('eloquent tables can disable pagination for small datasets', function () {
+test('eloquent tables can disable pagination for small datasets', function (): void {
     User::query()->delete();
 
     foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -59,18 +59,18 @@ it('asserts field visibility, conditions and initial value', function (): void {
         ]);
 
     $this->assertLatticeComponent($form)
-        ->form('create', fn (FormAssertions $form) => $form
+        ->form('create', fn (FormAssertions $form): FieldAssertions|\Lattice\Lattice\Support\Testing\Assertions\FormAssertions => $form
             ->assertSubmitsTo('/products')
             ->assertHasField('email')
             ->assertMissingField('nope')
-            ->field('email', fn (FieldAssertions $f) => $f
+            ->field('email', fn (FieldAssertions $f): FieldAssertions => $f
                 ->assertVisible()
                 ->assertInitialValue('a@b.c'))
-            ->field('company', fn (FieldAssertions $f) => $f
+            ->field('company', fn (FieldAssertions $f): FieldAssertions => $f
                 ->assertVisibleWhen(['type' => 'business'])
                 ->assertHiddenWhen(['type' => 'personal'])
                 ->assertHasCondition('visible', 'type', Op::Equals, 'business'))
-            ->field('secret', fn (FieldAssertions $f) => $f->assertHidden()));
+            ->field('secret', fn (FieldAssertions $f): FieldAssertions => $f->assertHidden()));
 });
 
 it('asserts table filters, columns and operators', function (): void {
@@ -83,11 +83,11 @@ it('asserts table filters, columns and operators', function (): void {
         ->result(TableResult::make([]), TableQuery::empty());
 
     $this->assertLatticeComponent($table)
-        ->table('products', fn (TableAssertions $table) => $table
+        ->table('products', fn (TableAssertions $table): FilterAssertions|\Lattice\Lattice\Support\Testing\Assertions\TableAssertions => $table
             ->assertHasColumn('name')
             ->assertHasFilter('name')
             ->assertMissingFilter('price')
-            ->filter('name', fn (FilterAssertions $f) => $f
+            ->filter('name', fn (FilterAssertions $f): FilterAssertions => $f
                 ->assertType(FilterType::Text)
                 ->assertDefaultOperator(Op::Contains)
                 ->assertOperators([
@@ -105,7 +105,7 @@ it('asserts action state', function (): void {
         ->form([Textarea::make('reason')->label('Reason')]);
 
     $this->assertLatticeComponent($action)
-        ->action('archive', fn (ActionAssertions $a) => $a
+        ->action('archive', fn (ActionAssertions $a): ActionAssertions => $a
             ->assertLabel('Archive')
             ->assertEndpoint('/lattice/actions/archive')
             ->assertVariant(ButtonVariant::Destructive)
@@ -123,11 +123,11 @@ it('asserts field required, optional, disabled, enabled and read-only flags', fu
     ]);
 
     $this->assertLatticeComponent($form)
-        ->form('flags', fn (FormAssertions $f) => $f
-            ->field('plain', fn (FieldAssertions $x) => $x->assertOptional()->assertEnabled())
-            ->field('req', fn (FieldAssertions $x) => $x->assertRequired())
-            ->field('ro', fn (FieldAssertions $x) => $x->assertReadOnly())
-            ->field('dis', fn (FieldAssertions $x) => $x->assertDisabled()));
+        ->form('flags', fn (FormAssertions $f): FieldAssertions|\Lattice\Lattice\Support\Testing\Assertions\FormAssertions => $f
+            ->field('plain', fn (FieldAssertions $x): FieldAssertions => $x->assertOptional()->assertEnabled())
+            ->field('req', fn (FieldAssertions $x): FieldAssertions => $x->assertRequired())
+            ->field('ro', fn (FieldAssertions $x): FieldAssertions => $x->assertReadOnly())
+            ->field('dis', fn (FieldAssertions $x): FieldAssertions => $x->assertDisabled()));
 });
 
 it('asserts table presence and bulk actions', function (): void {
@@ -138,7 +138,7 @@ it('asserts table presence and bulk actions', function (): void {
 
     $this->assertLatticeComponent($table)
         ->assertHasTable('orders')
-        ->table('orders', fn (TableAssertions $t) => $t->assertHasBulkAction('archive'));
+        ->table('orders', fn (TableAssertions $t): TableAssertions => $t->assertHasBulkAction('archive'));
 });
 
 it('asserts against a rendered Inertia page', function (): void {
@@ -160,8 +160,8 @@ it('asserts against a rendered Inertia page', function (): void {
     $this->assertLatticePage($this->get('lattice-demo-page'))
         ->assertRendered('form:create')
         ->assertRendered('table:products')
-        ->table('products', fn (TableAssertions $t) => $t->assertHasFilter('name'))
-        ->form('create', fn (FormAssertions $f) => $f
+        ->table('products', fn (TableAssertions $t): TableAssertions => $t->assertHasFilter('name'))
+        ->form('create', fn (FormAssertions $f): FieldAssertions => $f
             ->field('email')->assertInitialValue('a@b.c'));
 });
 

--- a/tests/Feature/TypeScript/ColumnPropsGenerationTest.php
+++ b/tests/Feature/TypeScript/ColumnPropsGenerationTest.php
@@ -8,11 +8,11 @@ use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use function Pest\Laravel\artisan;
 
 // Restore the default profile; the workbench binds BaseProfile.
-beforeEach(function () {
+beforeEach(function (): void {
     app()->bind(TypeScriptProfile::class, AugmentProfile::class);
 });
 
-it('writes a ColumnProps augmentation from the column class public props', function () {
+it('writes a ColumnProps augmentation from the column class public props', function (): void {
     $output = base_path('resources/js/lattice/generated-column.d.ts');
 
     config()->set('lattice.typescript.output', $output);

--- a/tests/Feature/TypeScript/ComponentDiscoveryTest.php
+++ b/tests/Feature/TypeScript/ComponentDiscoveryTest.php
@@ -6,7 +6,7 @@ use Lattice\Lattice\Support\TypeScript\DiscoveredComponent;
 use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleColumn;
 use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleUnattributed;
 
-it('discovers attributed components under a path with type, flags and category', function () {
+it('discovers attributed components under a path with type, flags and category', function (): void {
     $discovered = (new ComponentDiscovery)->discover(__DIR__.'/../../Fixtures/TypeScript');
 
     $byType = collect($discovered)->keyBy->type;
@@ -24,7 +24,7 @@ it('discovers attributed components under a path with type, flags and category',
         ->and($field->category)->toBe('field');
 });
 
-it('excludes classes without the AsComponent attribute from discovery', function () {
+it('excludes classes without the AsComponent attribute from discovery', function (): void {
     $discovered = (new ComponentDiscovery)->discover(__DIR__.'/../../Fixtures/TypeScript');
 
     $types = collect($discovered)->pluck('type')->all();
@@ -35,13 +35,13 @@ it('excludes classes without the AsComponent attribute from discovery', function
     expect($classes)->not->toContain(SampleUnattributed::class);
 });
 
-it('returns an empty array when the path does not exist', function () {
+it('returns an empty array when the path does not exist', function (): void {
     $discovered = (new ComponentDiscovery)->discover(__DIR__.'/../../Fixtures/TypeScript/does-not-exist');
 
     expect($discovered)->toBe([]);
 });
 
-it('derives the domain from the namespace segment before Components', function () {
+it('derives the domain from the namespace segment before Components', function (): void {
     $discovered = (new ComponentDiscovery)->discover(dirname(__DIR__, 3).'/src/Core/Components');
 
     $card = collect($discovered)->keyBy->type->get('card');
@@ -51,7 +51,7 @@ it('derives the domain from the namespace segment before Components', function (
     expect($card->domain)->toBe('Core');
 });
 
-it('discovers columns via attribute inheritance and captures the column class', function () {
+it('discovers columns via attribute inheritance and captures the column class', function (): void {
     $discovered = (new ComponentDiscovery)->discover(__DIR__.'/../../Fixtures/TypeScript');
 
     $column = collect($discovered)->keyBy->type->get('column.rating');

--- a/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
+++ b/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use function Pest\Laravel\artisan;
 
-it('keeps the committed generated.ts in sync with the transformer', function () {
+it('keeps the committed generated.ts in sync with the transformer', function (): void {
     $path = dirname(__DIR__, 3).'/resources/js/types/generated.ts';
     $manifest = dirname(__DIR__, 3).'/resources/js/types/typescript-transformer-manifest.json';
 

--- a/tests/Feature/TypeScript/MarkedTypeDiscoveryTest.php
+++ b/tests/Feature/TypeScript/MarkedTypeDiscoveryTest.php
@@ -8,7 +8,7 @@ use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Effects\Enums\EffectType;
 use Workbench\App\Support\TypeScript\MarkedTypeDiscovery;
 
-it('splits #[TypeScript]-marked classes into enums and value objects', function () {
+it('splits #[TypeScript]-marked classes into enums and value objects', function (): void {
     $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
 
     expect($result['enums'])->toContain(Align::class)->toContain(EffectType::class);
@@ -18,7 +18,7 @@ it('splits #[TypeScript]-marked classes into enums and value objects', function 
     expect($result['valueObjects'])->not->toContain(Align::class);
 });
 
-it('excludes classes without the #[TypeScript] attribute', function () {
+it('excludes classes without the #[TypeScript] attribute', function (): void {
     $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
 
     $all = [...$result['enums'], ...$result['valueObjects']];
@@ -26,7 +26,7 @@ it('excludes classes without the #[TypeScript] attribute', function () {
     expect($all)->not->toContain(Card::class);
 });
 
-it('sorts each list deterministically by class-string', function () {
+it('sorts each list deterministically by class-string', function (): void {
     $result = (new MarkedTypeDiscovery)->discover(dirname(__DIR__, 3).'/src');
 
     $sortedEnums = $result['enums'];
@@ -38,7 +38,7 @@ it('sorts each list deterministically by class-string', function () {
         ->and($result['valueObjects'])->toBe($sortedValueObjects);
 });
 
-it('returns empty lists when the path does not exist', function () {
+it('returns empty lists when the path does not exist', function (): void {
     expect((new MarkedTypeDiscovery)->discover('/no/such/path'))
         ->toBe(['enums' => [], 'valueObjects' => []]);
 });

--- a/tests/Fixtures/Discovery/DemoCrmSource.php
+++ b/tests/Fixtures/Discovery/DemoCrmSource.php
@@ -11,6 +11,7 @@ use Lattice\Lattice\Remote\RemoteSourceDefinition;
 #[AsRemoteSource('fixtures.crm')]
 final class DemoCrmSource extends RemoteSourceDefinition
 {
+    #[\Override]
     public function issueBrowserToken(Request $request): BrowserToken
     {
         return new BrowserToken(

--- a/tests/Fixtures/Discovery/RemoteSchemaSource.php
+++ b/tests/Fixtures/Discovery/RemoteSchemaSource.php
@@ -24,6 +24,7 @@ final class RemoteSchemaSource extends RemoteSourceDefinition
         return self::$endpoint;
     }
 
+    #[\Override]
     public function issueBrowserToken(Request $request): BrowserToken
     {
         return new BrowserToken(

--- a/tests/Fixtures/Remote/DynamicExternalAppRemoteSource.php
+++ b/tests/Fixtures/Remote/DynamicExternalAppRemoteSource.php
@@ -20,6 +20,7 @@ final class DynamicExternalAppRemoteSource extends RemoteSourceDefinition
         return $this->apps->schemaEndpoint($this->sourceKey);
     }
 
+    #[\Override]
     public function issueBrowserToken(Request $request): BrowserToken
     {
         return new BrowserToken(

--- a/tests/Unit/Actions/Components/ActionIconTest.php
+++ b/tests/Unit/Actions/Components/ActionIconTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Core\Enums\Icon;
 
-test('actions serialize lucide icon enum values', function () {
+test('actions serialize lucide icon enum values', function (): void {
     expect(wire(Action::make('send-message')
         ->label('Send')
         ->icon(Icon::Send)))
@@ -26,7 +26,7 @@ test('actions serialize lucide icon enum values', function () {
         ]);
 });
 
-test('actions serialize arbitrary backed enum icon values', function () {
+test('actions serialize arbitrary backed enum icon values', function (): void {
     expect(wire(Action::make('custom-action')
         ->label('Custom')
         ->icon(WorkbenchCustomActionIcon::Spark))['props']['icon'])

--- a/tests/Unit/Actions/EffectSerializationTest.php
+++ b/tests/Unit/Actions/EffectSerializationTest.php
@@ -11,7 +11,7 @@ use Lattice\Lattice\Core\Values\Callout;
 use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Effects\Effect;
 
-test('a toast serializes its lifetime, dismissibility and link', function () {
+test('a toast serializes its lifetime, dismissibility and link', function (): void {
     $wire = wire(Effect::toast(
         ToastMessage::make(Variant::Success, 'Saved.')
             ->duration(8000)
@@ -29,7 +29,7 @@ test('a toast serializes its lifetime, dismissibility and link', function () {
         ->and($wire['toast']['action']['props']['method'])->toBe('patch');
 });
 
-test('a toast can carry an action component', function () {
+test('a toast can carry an action component', function (): void {
     $wire = wire(Effect::toast(
         ToastMessage::make(Variant::Info, 'Done.')
             ->persistent()
@@ -42,7 +42,7 @@ test('a toast can carry an action component', function () {
         ->and($wire['toast']['action']['props']['endpoint'])->toBe('/x');
 });
 
-test('action results expose the full effect vocabulary', function () {
+test('action results expose the full effect vocabulary', function (): void {
     $result = ActionResult::success()
         ->reloadPage()
         ->redirect('/dashboard')
@@ -61,7 +61,7 @@ test('action results expose the full effect vocabulary', function () {
         ->and(wire(Effect::reloadPage()))->toBe(['type' => 'reloadPage']);
 });
 
-test('a callout effect serializes its callout payload', function () {
+test('a callout effect serializes its callout payload', function (): void {
     $wire = wire(Effect::callout(
         Callout::make(Variant::Warning, 'Your trial ends in 3 days.')
             ->title('Trial ending')
@@ -75,7 +75,7 @@ test('a callout effect serializes its callout payload', function () {
         ->and($wire['callout']['action']['props']['label'])->toBe('Upgrade');
 });
 
-test('action results expose the callout effect', function () {
+test('action results expose the callout effect', function (): void {
     $result = ActionResult::success()->callout(
         Callout::make(Variant::Info, 'Saved as draft.'),
     );
@@ -84,7 +84,7 @@ test('action results expose the callout effect', function () {
         ->and(wire($result)['effects'][0]['callout']['variant'])->toBe('info');
 });
 
-test('action groups serialize grouped child actions', function () {
+test('action groups serialize grouped child actions', function (): void {
     $group = wire(ActionGroup::make('workbench.user-actions')
         ->label('Manage user')
         ->actions([

--- a/tests/Unit/Attributes/AsComponentAttributeTest.php
+++ b/tests/Unit/Attributes/AsComponentAttributeTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Attributes\AsComponent;
 
-it('carries the type string', function () {
+it('carries the type string', function (): void {
     $attribute = new AsComponent('badge');
 
     expect($attribute->type)->toBe('badge');

--- a/tests/Unit/Attributes/ColumnAttributeTest.php
+++ b/tests/Unit/Attributes/ColumnAttributeTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
-it('carries a built-in type from the ColumnType enum', function () {
+it('carries a built-in type from the ColumnType enum', function (): void {
     $attribute = new AsColumn(ColumnType::Badge);
 
     expect($attribute->type)->toBe('column.badge');
 });
 
-it('accepts a raw string type for a custom column', function () {
+it('accepts a raw string type for a custom column', function (): void {
     $attribute = new AsColumn('column.rating');
 
     expect($attribute->type)->toBe('column.rating');
 });
 
-it('prefixes a custom column type when the column namespace is omitted', function () {
+it('prefixes a custom column type when the column namespace is omitted', function (): void {
     $attribute = new AsColumn('rating');
 
     expect($attribute->type)->toBe('column.rating');

--- a/tests/Unit/Attributes/FieldAttributeTest.php
+++ b/tests/Unit/Attributes/FieldAttributeTest.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 use Lattice\Lattice\Forms\Attributes\AsField;
 use Lattice\Lattice\Forms\Enums\FieldType;
 
-it('carries a built-in type from the FieldType enum', function () {
+it('carries a built-in type from the FieldType enum', function (): void {
     $attribute = new AsField(FieldType::TextInput);
 
     expect($attribute->type)->toBe('field.text-input');
 });
 
-it('accepts a prefixed raw string type for a custom field', function () {
+it('accepts a prefixed raw string type for a custom field', function (): void {
     $attribute = new AsField('field.color-picker');
 
     expect($attribute->type)->toBe('field.color-picker');
 });
 
-it('prefixes a custom field type when the field namespace is omitted', function () {
+it('prefixes a custom field type when the field namespace is omitted', function (): void {
     $attribute = new AsField('color-picker');
 
     expect($attribute->type)->toBe('field.color-picker');

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -32,19 +32,19 @@ use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\LatticeRegistry;
 use Lattice\Lattice\Tables\Components\Table;
 
-test('lattice component factories stay open for extension', function () {
+test('lattice component factories stay open for extension', function (): void {
     $badgeClass = (new class extends Badge {})::class;
     $badge = $badgeClass::make('Extended badge', 'extended-badge');
 
     expect($badge::class)->toBe($badgeClass)
-        ->and((new ReflectionClass(Badge::class))->isFinal())->toBeFalse();
+        ->and(new ReflectionClass(Badge::class)->isFinal())->toBeFalse();
 });
 
-test('lattice facade resolves the registry', function () {
+test('lattice facade resolves the registry', function (): void {
     expect(Lattice::getFacadeRoot())->toBe(app(LatticeRegistry::class));
 });
 
-test('interactive components keep their serialized ids', function () {
+test('interactive components keep their serialized ids', function (): void {
     expect(wire(Form::make('demo-form')))
         ->toMatchArray([
             'type' => 'form',
@@ -57,7 +57,7 @@ test('interactive components keep their serialized ids', function () {
         ]);
 });
 
-test('interactive components seal request context for endpoints', function () {
+test('interactive components seal request context for endpoints', function (): void {
     $form = wire(Form::make('demo-form')
         ->action('/lattice/forms/demo-form')
         ->context(['team' => 'lattice-core']));
@@ -86,7 +86,7 @@ function exposesSchemaApi(object $component): bool
     return method_exists($component, 'schema');
 }
 
-test('only container components expose a schema', function () {
+test('only container components expose a schema', function (): void {
     $containerComponents = [
         Card::make('Card', 'Description'),
         FloatingPanel::make('locale-switcher-panel'),
@@ -120,7 +120,7 @@ test('only container components expose a schema', function () {
     }
 });
 
-test('floating panels serialize their placement and children', function () {
+test('floating panels serialize their placement and children', function (): void {
     $payload = wire(FloatingPanel::make('locale-switcher-panel')
         ->label('Language')
         ->placement(FloatingPlacement::TopEnd)
@@ -144,7 +144,7 @@ test('floating panels serialize their placement and children', function () {
         ->and($payload['schema'][0]['key'])->toBe('locale-en');
 });
 
-test('chat boxes serialize their fluent endpoint and presentation configuration', function () {
+test('chat boxes serialize their fluent endpoint and presentation configuration', function (): void {
     expect(wire(ChatBox::make('default-assistant'))['props']['fill'])->toBeFalse();
 
     expect(wire(ChatBox::make('assistant')
@@ -168,7 +168,7 @@ test('chat boxes serialize their fluent endpoint and presentation configuration'
         ]);
 });
 
-test('components serialize through prioritized hook attributes without child-specific base hooks', function () {
+test('components serialize through prioritized hook attributes without child-specific base hooks', function (): void {
     $component = new class extends Component
     {
         protected function type(): string
@@ -199,11 +199,11 @@ test('components serialize through prioritized hook attributes without child-spe
         ])
         ->and(method_exists(Component::class, 'serializedChildren'))
         ->toBeFalse()
-        ->and((new ReflectionClass(Component::class))->hasProperty('serialisationHooks'))
+        ->and(new ReflectionClass(Component::class)->hasProperty('serialisationHooks'))
         ->toBeFalse();
 });
 
-test('private serialization hooks are ignored', function () {
+test('private serialization hooks are ignored', function (): void {
     $component = new class extends Component
     {
         protected function type(): string
@@ -242,7 +242,7 @@ test('private serialization hooks are ignored', function () {
     ]);
 });
 
-test('components can opt out of rendering with when', function () {
+test('components can opt out of rendering with when', function (): void {
     $page = new class extends Page
     {
         public function render(PageSchema $schema): PageSchema
@@ -267,7 +267,7 @@ test('components can opt out of rendering with when', function () {
         ->and($pageData['schema'][1]['schema'][0]['props']['text'])->toBe('Visible child');
 });
 
-test('actions can serialize confirmation modal configuration', function () {
+test('actions can serialize confirmation modal configuration', function (): void {
     expect(wire(ActionComponent::make('delete-account')
         ->label('Delete account')
         ->method(HttpMethod::Delete)
@@ -301,7 +301,7 @@ test('actions can serialize confirmation modal configuration', function () {
         ]);
 });
 
-test('modals serialize composable children for action driven dialogs', function () {
+test('modals serialize composable children for action driven dialogs', function (): void {
     expect(wire(Modal::make('settings.two-factor-setup')
         ->title('Set up two-factor authentication')
         ->description('Scan the QR code with your authenticator app.')
@@ -332,7 +332,7 @@ test('modals serialize composable children for action driven dialogs', function 
         ]);
 });
 
-test('links and horizontal stacks serialize as separate composable primitives', function () {
+test('links and horizontal stacks serialize as separate composable primitives', function (): void {
     expect(wire(Stack::make('prompt')->direction('row')->gap(Gap::ExtraSmall)->schema([
         Text::make('Need access?'),
         Link::make('Register')->href('/register'),
@@ -372,7 +372,7 @@ test('links and horizontal stacks serialize as separate composable primitives', 
         ]);
 });
 
-test('tabs ignore hidden tab children when resolving their active value', function () {
+test('tabs ignore hidden tab children when resolving their active value', function (): void {
     $tabs = wire(Tabs::make('settings-tabs')
         ->defaultValue('security')
         ->schema([

--- a/tests/Unit/Core/ComponentTypeResolutionTest.php
+++ b/tests/Unit/Core/ComponentTypeResolutionTest.php
@@ -14,11 +14,11 @@ class TypeResolutionWidget extends Component
     }
 }
 
-it('resolves the wire type from the AsComponent attribute', function () {
+it('resolves the wire type from the AsComponent attribute', function (): void {
     expect((new TypeResolutionWidget)->jsonSerialize()['type'])->toBe('test.widget');
 });
 
-it('throws a clear error when the attribute is missing', function () {
+it('throws a clear error when the attribute is missing', function (): void {
     $component = new class extends Component
     {
         protected function type(): string
@@ -27,6 +27,6 @@ it('throws a clear error when the attribute is missing', function () {
         }
     };
 
-    expect(fn () => $component->jsonSerialize())
+    expect(fn (): array => $component->jsonSerialize())
         ->toThrow(LogicException::class, 'missing the #[AsComponent] attribute');
 });

--- a/tests/Unit/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Unit/Core/Components/CoreTypedPropsTest.php
@@ -17,7 +17,7 @@ use Lattice\Lattice\Core\Enums\Orientation;
 use Lattice\Lattice\Core\Enums\Size;
 use Lattice\Lattice\Core\Enums\Width;
 
-test('stack serializes enums direction and key wire-identically', function () {
+test('stack serializes enums direction and key wire-identically', function (): void {
     expect(wire(Stack::make('layout')
         ->direction('row')
         ->gap(Gap::Large)
@@ -42,7 +42,7 @@ test('stack serializes enums direction and key wire-identically', function () {
         ]);
 });
 
-test('segmented control serializes name label value emits options', function () {
+test('segmented control serializes name label value emits options', function (): void {
     expect(wire(SegmentedControl::make('appearance', 'Appearance')
         ->value('system')
         ->emits('lattice:appearance-change')
@@ -65,7 +65,7 @@ test('segmented control serializes name label value emits options', function () 
         ]);
 });
 
-test('modal serializes id title description and children', function () {
+test('modal serializes id title description and children', function (): void {
     expect(wire(Modal::make('settings.modal')
         ->title('Title')
         ->description('Desc')
@@ -88,7 +88,7 @@ test('modal serializes id title description and children', function () {
         ]);
 });
 
-test('modal without optional props includes them as null', function () {
+test('modal without optional props includes them as null', function (): void {
     expect(wire(Modal::make('bare.modal')))
         ->toEqual([
             'type' => 'modal',
@@ -103,7 +103,7 @@ test('modal without optional props includes them as null', function () {
         ]);
 });
 
-test('tabs serialize defaultValue queryKey and computed activeValue', function () {
+test('tabs serialize defaultValue queryKey and computed activeValue', function (): void {
     expect(wire(Tabs::make('settings-tabs')
         ->defaultValue('security')
         ->schema([
@@ -134,7 +134,7 @@ test('tabs serialize defaultValue queryKey and computed activeValue', function (
         ]);
 });
 
-test('tabs with custom queryKey and no defaultValue keep empty activeValue', function () {
+test('tabs with custom queryKey and no defaultValue keep empty activeValue', function (): void {
     expect(wire(Tabs::make('settings-tabs')->queryKey('settings-tab')))
         ->toEqual([
             'type' => 'tabs',
@@ -148,12 +148,12 @@ test('tabs with custom queryKey and no defaultValue keep empty activeValue', fun
         ]);
 });
 
-test('tabs serialize a vertical orientation', function () {
+test('tabs serialize a vertical orientation', function (): void {
     expect(wire(Tabs::make('settings-tabs')->orientation(Orientation::Vertical))['props']['orientation'])
         ->toBe('vertical');
 });
 
-test('confirmed inactive tab serializes confirm metadata and drops its children', function () {
+test('confirmed inactive tab serializes confirm metadata and drops its children', function (): void {
     $tabs = wire(Tabs::make('settings-tabs')
         ->defaultValue('profile')
         ->schema([
@@ -174,7 +174,7 @@ test('confirmed inactive tab serializes confirm metadata and drops its children'
     ]);
 });
 
-test('tab confirm keeps a provided timeout and custom redirect', function () {
+test('tab confirm keeps a provided timeout and custom redirect', function (): void {
     expect(wire(Tab::make('security', 'Security')->confirm('/auth/confirm', 60)))
         ->toEqual([
             'type' => 'tab',

--- a/tests/Unit/Core/PageMetadataTest.php
+++ b/tests/Unit/Core/PageMetadataTest.php
@@ -25,7 +25,7 @@ final class FixtureHomePage extends FixtureBasePage {}
 #[AsPage(route: '/standalone', container: PageContainer::Centered)]
 final class FixtureStandalonePage extends FixtureBasePage {}
 
-test('metadata inherits layout and container from a base AsPage attribute', function () {
+test('metadata inherits layout and container from a base AsPage attribute', function (): void {
     $meta = PageMetadata::for(FixtureProductsPage::class);
 
     expect($meta->route)->toBe('/products')
@@ -35,20 +35,20 @@ test('metadata inherits layout and container from a base AsPage attribute', func
         ->and($meta->middleware)->toBe([]);
 });
 
-test('metadata derives the route name when none is given', function () {
+test('metadata derives the route name when none is given', function (): void {
     expect(PageMetadata::for(FixtureEditPage::class)->name)->toBe('products.edit');
 });
 
-test('metadata falls back to the class name for the root route', function () {
+test('metadata falls back to the class name for the root route', function (): void {
     expect(PageMetadata::for(FixtureHomePage::class)->name)->toBe('fixture-home')
         ->and(PageMetadata::for(FixtureHomePage::class)->middleware)->toBe(['web']);
 });
 
-test('a concrete page overrides an inherited container', function () {
+test('a concrete page overrides an inherited container', function (): void {
     expect(PageMetadata::for(FixtureStandalonePage::class)->container)->toBe(PageContainer::Centered);
 });
 
-test('a page without any attribute resolves to defaults', function () {
+test('a page without any attribute resolves to defaults', function (): void {
     $page = new class extends BasePage {};
 
     $meta = PageMetadata::for($page);
@@ -59,7 +59,7 @@ test('a page without any attribute resolves to defaults', function () {
         ->and($meta->middleware)->toBe([]);
 });
 
-test('page metadata round-trips through an array descriptor', function () {
+test('page metadata round-trips through an array descriptor', function (): void {
     $descriptor = PageMetadata::reflect(FixtureEditPage::class)->toArray();
 
     expect($descriptor)->toMatchArray([
@@ -78,7 +78,7 @@ test('page metadata round-trips through an array descriptor', function () {
         ->and($rebuilt->container)->toBe('default');
 });
 
-test('for() prefers a manifest descriptor and falls back to reflection', function () {
+test('for() prefers a manifest descriptor and falls back to reflection', function (): void {
     config(['lattice.discover' => [
         __DIR__.'/../Fixtures/Discovery',
     ]]);

--- a/tests/Unit/Core/ServiceProviderTest.php
+++ b/tests/Unit/Core/ServiceProviderTest.php
@@ -3,6 +3,6 @@ declare(strict_types=1);
 
 use Lattice\Lattice\LatticeServiceProvider;
 
-test('the lattice service provider is registered', function () {
+test('the lattice service provider is registered', function (): void {
     expect(app()->getLoadedProviders())->toHaveKey(LatticeServiceProvider::class);
 });

--- a/tests/Unit/Core/Values/CalloutTest.php
+++ b/tests/Unit/Core/Values/CalloutTest.php
@@ -5,7 +5,7 @@ use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\Enums\Variant;
 use Lattice\Lattice\Core\Values\Callout;
 
-test('a callout serializes its variant, title, body, dismissibility and action', function () {
+test('a callout serializes its variant, title, body, dismissibility and action', function (): void {
     $wire = wire(
         Callout::make(Variant::Warning, 'Your trial ends in 3 days.')
             ->title('Trial ending')
@@ -21,7 +21,7 @@ test('a callout serializes its variant, title, body, dismissibility and action',
         ->and($wire['action']['props']['label'])->toBe('Upgrade');
 });
 
-test('a callout defaults to dismissible with no title or action', function () {
+test('a callout defaults to dismissible with no title or action', function (): void {
     $wire = wire(Callout::make(Variant::Info, 'Heads up.'));
 
     expect($wire['title'])->toBeNull()

--- a/tests/Unit/Core/Values/ToastMessageTranslatableTest.php
+++ b/tests/Unit/Core/Values/ToastMessageTranslatableTest.php
@@ -5,7 +5,7 @@ use Lattice\Lattice\Core\Enums\Variant;
 use Lattice\Lattice\Core\Values\ToastMessage;
 use Lattice\Lattice\Effects\Effect;
 
-test('a toast message accepts a Translatable and serializes it', function () {
+test('a toast message accepts a Translatable and serializes it', function (): void {
     $toast = ToastMessage::make(Variant::Success, rt('orders.shipped-live')->with(['a' => 'b']));
 
     expect($toast->jsonSerialize()['message'])->toBe([
@@ -15,7 +15,7 @@ test('a toast message accepts a Translatable and serializes it', function () {
     ]);
 });
 
-test('Effect::toast accepts a Translatable message', function () {
+test('Effect::toast accepts a Translatable message', function (): void {
     $effect = Effect::toast(rt('orders.shipped-live'));
 
     expect($effect->jsonSerialize())
@@ -24,7 +24,7 @@ test('Effect::toast accepts a Translatable message', function () {
         ->toBe(['key' => 'orders.shipped-live', 'payload' => [], 'replacements' => []]);
 });
 
-test('Effect::toast accepts a Translatable message with an explicit variant', function () {
+test('Effect::toast accepts a Translatable message with an explicit variant', function (): void {
     $effect = Effect::toast(rt('orders.shipped-live'), Variant::Warning);
 
     $toast = $effect->jsonSerialize()['toast'];
@@ -37,7 +37,7 @@ test('Effect::toast accepts a Translatable message with an explicit variant', fu
         ]);
 });
 
-test('Effect::toast still accepts a plain string', function () {
+test('Effect::toast still accepts a plain string', function (): void {
     $effect = Effect::toast('Order shipped');
 
     expect($effect->jsonSerialize()['toast']->jsonSerialize()['message'])->toBe('Order shipped');

--- a/tests/Unit/Core/Values/TranslatableTest.php
+++ b/tests/Unit/Core/Values/TranslatableTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Core\Values\Translatable;
 
-test('it serializes key, payload paths, and static replacements', function () {
+test('it serializes key, payload paths, and static replacements', function (): void {
     $translatable = Translatable::make('orders.shipped-live')
         ->fromPayload(['id' => 'order.id'])
         ->with(['warehouse' => 'Berlin']);
@@ -15,7 +15,7 @@ test('it serializes key, payload paths, and static replacements', function () {
     ]);
 });
 
-test('payload and replacement calls merge instead of replacing', function () {
+test('payload and replacement calls merge instead of replacing', function (): void {
     $translatable = Translatable::make('k')
         ->fromPayload(['a' => 'x.a'])
         ->fromPayload(['b' => 'x.b'])
@@ -29,6 +29,6 @@ test('payload and replacement calls merge instead of replacing', function () {
     ]);
 });
 
-test('rt() returns a Translatable for the given key', function () {
+test('rt() returns a Translatable for the given key', function (): void {
     expect(rt('a.b')->jsonSerialize()['key'])->toBe('a.b');
 });

--- a/tests/Unit/Effects/AsEffectTest.php
+++ b/tests/Unit/Effects/AsEffectTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 use Lattice\Lattice\Effects\Attributes\AsEffect;
 use Lattice\Lattice\Effects\Enums\EffectType;
 
-it('returns the wire type from an enum case', function () {
-    expect((new AsEffect(EffectType::Toast))->wireType())->toBe('toast');
+it('returns the wire type from an enum case', function (): void {
+    expect(new AsEffect(EffectType::Toast)->wireType())->toBe('toast');
 });
 
-it('returns the wire type from a raw string', function () {
-    expect((new AsEffect('confetti'))->wireType())->toBe('confetti');
+it('returns the wire type from a raw string', function (): void {
+    expect(new AsEffect('confetti')->wireType())->toBe('confetti');
 });

--- a/tests/Unit/Effects/EffectRegistryTest.php
+++ b/tests/Unit/Effects/EffectRegistryTest.php
@@ -9,27 +9,27 @@ use Lattice\Lattice\Effects\EffectRegistry;
 #[AsEffect('toast')]
 final readonly class ConflictingToastEffect extends Effect {}
 
-it('registers an effect by its wire type', function () {
+it('registers an effect by its wire type', function (): void {
     $registry = new EffectRegistry;
     $registry->register(ToastEffect::class);
 
     expect($registry->all())->toBe(['toast' => ToastEffect::class]);
 });
 
-it('rejects a class without the AsEffect attribute', function () {
+it('rejects a class without the AsEffect attribute', function (): void {
     $registry = new EffectRegistry;
 
     $registry->register(stdClass::class);
 })->throws(InvalidArgumentException::class);
 
-it('rejects a different class claiming an already-used wire type', function () {
+it('rejects a different class claiming an already-used wire type', function (): void {
     $registry = new EffectRegistry;
     $registry->register(ToastEffect::class);
 
     $registry->register(ConflictingToastEffect::class);
 })->throws(InvalidArgumentException::class);
 
-it('re-registering the same class is a silent no-op', function () {
+it('re-registering the same class is a silent no-op', function (): void {
     $registry = new EffectRegistry;
     $registry->register(ToastEffect::class);
     $registry->register(ToastEffect::class);

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -27,7 +27,7 @@ it('serializes static options without search flags', function (): void {
 it('serializes the multiple and searchable flags but never the resolver', function (): void {
     $field = Select::make('tags', 'Tags')
         ->multiple()
-        ->searchable(fn (string $search) => []);
+        ->searchable(fn (string $search): array => []);
 
     $props = wire($field)['props'];
 
@@ -39,7 +39,7 @@ it('serializes the multiple and searchable flags but never the resolver', functi
 
 it('runs the search resolver and normalizes options to strings', function (): void {
     $field = Select::make('author_id', 'Author')
-        ->searchable(fn (string $search) => [
+        ->searchable(fn (string $search): array => [
             ['label' => 'Jane Doe', 'value' => 5],
             ['label' => 'Janet Roe', 'value' => 9],
         ]);
@@ -54,7 +54,7 @@ it('runs the search resolver and normalizes options to strings', function (): vo
 
 it('passes the query to the resolver', function (): void {
     $field = Select::make('city', 'City')
-        ->searchable(fn (string $search) => [
+        ->searchable(fn (string $search): array => [
             ['label' => strtoupper($search), 'value' => $search],
         ]);
 

--- a/tests/Unit/Forms/Conditions/ConditionTest.php
+++ b/tests/Unit/Forms/Conditions/ConditionTest.php
@@ -13,6 +13,6 @@ it('matches against form data', function (): void {
 });
 
 it('serializes to data', function (): void {
-    expect((new Condition('age', Op::GreaterThanOrEqual, 18))->jsonSerialize())
+    expect(new Condition('age', Op::GreaterThanOrEqual, 18)->jsonSerialize())
         ->toBe(['field' => 'age', 'operator' => 'gte', 'value' => 18]);
 });

--- a/tests/Unit/Forms/FieldResolutionTest.php
+++ b/tests/Unit/Forms/FieldResolutionTest.php
@@ -11,7 +11,7 @@ it('serializes dependsOn keys and the any-change marker', function (): void {
         ->dependsOn('country', fn ($component, FormData $d) => $component))['props'];
 
     $valueProps = wire(TextInput::make('total', 'Total')
-        ->value(fn (FormData $d) => $d->float('qty')))['props'];
+        ->value(fn (FormData $d): float => $d->float('qty')))['props'];
 
     expect($optionsProps['dependsOnKeys'])->toBe(['country'])
         ->and($valueProps['dependsOnAny'])->toBeTrue();
@@ -19,7 +19,7 @@ it('serializes dependsOn keys and the any-change marker', function (): void {
 
 it('resolves a value closure during resolution', function (): void {
     $field = TextInput::make('total', 'Total')
-        ->value(fn (FormData $d) => $d->float('qty') * $d->float('price'));
+        ->value(fn (FormData $d): float => $d->float('qty') * $d->float('price'));
 
     $field->applyResolution(FormData::make(['qty' => '3', 'price' => '4']), Request::create('/'));
 
@@ -54,7 +54,7 @@ it('runs dependsOn closures during resolution', function (): void {
 
 it('stores an editable computed default without making the field server-authoritative', function (): void {
     $field = TextInput::make('price')->value(
-        fn (FormData $row, FormData $form) => 42.0,
+        fn (FormData $row, FormData $form): float => 42.0,
         editable: true,
         resetOn: ['product'],
         refreshOn: ['@customer'],
@@ -71,7 +71,7 @@ it('stores an editable computed default without making the field server-authorit
 });
 
 it('keeps read-only value(fn) behavior unchanged', function (): void {
-    $field = TextInput::make('total')->value(fn (FormData $data) => 5.0);
+    $field = TextInput::make('total')->value(fn (FormData $data): float => 5.0);
 
     expect($field->isComputed())->toBeTrue()
         ->and($field->hasPrefill())->toBeFalse();

--- a/tests/Unit/Forms/FieldTest.php
+++ b/tests/Unit/Forms/FieldTest.php
@@ -31,7 +31,7 @@ it('resolves array rules', function (): void {
 });
 
 it('resolves closure rules with form data', function (): void {
-    $field = makeField()->rules(fn (FormData $data) => $data->get('type') === 'member'
+    $field = makeField()->rules(fn (FormData $data): array => $data->get('type') === 'member'
         ? ['required', 'numeric']
         : ['nullable']);
 
@@ -44,7 +44,7 @@ it('resolves closure rules with form data', function (): void {
 it('merges rules across calls, including closures', function (): void {
     $field = makeField()
         ->rules(['required'])
-        ->rules(fn () => ['string'])
+        ->rules(fn (): array => ['string'])
         ->rules(['max:10']);
 
     expect($field->resolveRules(FormData::make([]), Request::create('/')))

--- a/tests/Unit/Forms/FileUploadFieldTest.php
+++ b/tests/Unit/Forms/FileUploadFieldTest.php
@@ -139,7 +139,7 @@ it('builds file descriptors from a stored path on prefill', function (): void {
 
 it('prefers temporary urls for prefilled files when the disk supports them', function (): void {
     $fake = Storage::fake('s3');
-    $fake->buildTemporaryUrlsUsing(fn (string $path) => "https://signed.test/{$path}");
+    $fake->buildTemporaryUrlsUsing(fn (string $path): string => "https://signed.test/{$path}");
     Storage::disk('s3')->put('uploads/a.pdf', 'data');
 
     $field = FileUpload::make('document')->disk('s3');
@@ -162,7 +162,7 @@ it('builds descriptors for each stored path when multiple', function (): void {
 it('signs an upload returning key url headers and method', function (): void {
     $fake = Storage::fake('s3');
     $fake->buildTemporaryUploadUrlsUsing(
-        fn (string $path, $expiration, array $options = []) => ['url' => "https://s3.test/{$path}", 'headers' => ['x-test' => '1']],
+        fn (string $path, $expiration, array $options = []): array => ['url' => "https://s3.test/{$path}", 'headers' => ['x-test' => '1']],
     );
 
     $field = FileUpload::make('document')->disk('s3')->signedUpload();
@@ -203,7 +203,7 @@ it('rejects finalizing non-temporary signed upload keys', function (): void {
 
     $field = FileUpload::make('images')->disk('s3')->signedUpload();
 
-    expect(fn () => $field->finalizeSignedUploads(
+    expect(fn (): array => $field->finalizeSignedUploads(
         ['uploads/photo.jpg'],
         fn (): string => 'uploads/final.jpg',
     ))->toThrow(InvalidArgumentException::class);
@@ -212,7 +212,7 @@ it('rejects finalizing non-temporary signed upload keys', function (): void {
 it('rejects finalizing uploads when signed uploads are disabled', function (): void {
     $field = FileUpload::make('images');
 
-    expect(fn () => $field->finalizeSignedUploads(
+    expect(fn (): array => $field->finalizeSignedUploads(
         ['tmp/photo.jpg'],
         fn (): string => 'uploads/final.jpg',
     ))->toThrow(RuntimeException::class, 'Only signed uploads can be finalized.');
@@ -223,7 +223,7 @@ it('rejects finalizing signed upload keys that do not exist', function (): void 
 
     $field = FileUpload::make('images')->disk('s3')->signedUpload();
 
-    expect(fn () => $field->finalizeSignedUploads(
+    expect(fn (): array => $field->finalizeSignedUploads(
         ['tmp/missing.jpg'],
         fn (): string => 'uploads/final.jpg',
     ))->toThrow(InvalidArgumentException::class, 'Signed upload [tmp/missing.jpg] does not exist.');
@@ -235,7 +235,7 @@ it('rejects destinations inside the temporary upload prefix', function (): void 
 
     $field = FileUpload::make('images')->disk('s3')->signedUpload();
 
-    expect(fn () => $field->finalizeSignedUploads(
+    expect(fn (): array => $field->finalizeSignedUploads(
         ['tmp/photo.jpg'],
         fn (): string => 'tmp/final.jpg',
     ))->toThrow(InvalidArgumentException::class, 'Signed uploads must be finalized outside the temporary upload prefix.');
@@ -247,7 +247,7 @@ it('fails when the disk cannot move a finalized upload', function (): void {
 
     $field = FileUpload::make('images')->disk('s3')->signedUpload();
 
-    expect(fn () => $field->finalizeSignedUploads(
+    expect(fn (): array => $field->finalizeSignedUploads(
         ['tmp/photo.jpg'],
         fn (): string => 'uploads/final.jpg',
     ))->toThrow(RuntimeException::class, 'Unable to finalize signed upload [tmp/photo.jpg].');

--- a/tests/Unit/Forms/FormSerializationTest.php
+++ b/tests/Unit/Forms/FormSerializationTest.php
@@ -7,7 +7,7 @@ use Lattice\Lattice\Forms\Components\PasswordInput;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormData;
 
-test('forms serialize schema children like pages', function () {
+test('forms serialize schema children like pages', function (): void {
     expect(wire(Form::make('profile-form')->schema([
         Text::make('Profile details'),
     ])))
@@ -28,7 +28,7 @@ test('forms serialize schema children like pages', function () {
         ]);
 });
 
-test('password inputs can request automatic confirmation fields', function () {
+test('password inputs can request automatic confirmation fields', function (): void {
     expect(wire(PasswordInput::make('password', 'Password')
         ->required()
         ->passwordRules('minlength:8')
@@ -69,7 +69,7 @@ test('password inputs can request automatic confirmation fields', function () {
         ]);
 });
 
-test('editable computed fields serialize an explicit client prefill flag', function () {
+test('editable computed fields serialize an explicit client prefill flag', function (): void {
     $wire = wire(
         TextInput::make('price')->value(
             fn (FormData $data): string => (string) $data->get('suggested_price', ''),

--- a/tests/Unit/Http/AsPageAttributeTest.php
+++ b/tests/Unit/Http/AsPageAttributeTest.php
@@ -6,7 +6,7 @@ use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 
-test('AsPage attribute stores route metadata', function () {
+test('AsPage attribute stores route metadata', function (): void {
     $attribute = new AsPage(
         route: '/products/{product}/edit',
         name: 'products.edit',
@@ -22,7 +22,7 @@ test('AsPage attribute stores route metadata', function () {
         ->and($attribute->middleware)->toBe(['can:manage']);
 });
 
-test('AsPage attribute defaults every argument to null', function () {
+test('AsPage attribute defaults every argument to null', function (): void {
     $attribute = new AsPage;
 
     expect($attribute->route)->toBeNull()

--- a/tests/Unit/Http/BreadcrumbsTest.php
+++ b/tests/Unit/Http/BreadcrumbsTest.php
@@ -3,6 +3,6 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Layouts\Components\Breadcrumbs;
 
-it('serializes as a breadcrumbs component carrying no server data', function () {
+it('serializes as a breadcrumbs component carrying no server data', function (): void {
     expect(wire(Breadcrumbs::make())['type'])->toBe('breadcrumbs');
 });

--- a/tests/Unit/Http/PageListenersTest.php
+++ b/tests/Unit/Http/PageListenersTest.php
@@ -7,7 +7,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Realtime\Listen;
 
-test('pages serialize declared listeners when realtime is enabled', function () {
+test('pages serialize declared listeners when realtime is enabled', function (): void {
     config()->set('lattice.realtime.enabled', true);
 
     $page = new class extends Page
@@ -35,7 +35,7 @@ test('pages serialize declared listeners when realtime is enabled', function () 
         ]);
 });
 
-test('pages omit the listeners key when none are declared', function () {
+test('pages omit the listeners key when none are declared', function (): void {
     config()->set('lattice.realtime.enabled', true);
 
     $page = new class extends Page
@@ -50,7 +50,7 @@ test('pages omit the listeners key when none are declared', function () {
         ->not->toHaveKey('listeners');
 });
 
-test('pages omit listeners when realtime is disabled', function () {
+test('pages omit listeners when realtime is disabled', function (): void {
     config()->set('lattice.realtime.enabled', false);
 
     $page = new class extends Page

--- a/tests/Unit/Http/PageSerializationTest.php
+++ b/tests/Unit/Http/PageSerializationTest.php
@@ -9,7 +9,7 @@ use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Http\Page;
 
-test('pages serialize layout and container metadata', function () {
+test('pages serialize layout and container metadata', function (): void {
     $defaultPage = new class extends Page
     {
         public function render(PageSchema $schema): PageSchema
@@ -32,7 +32,7 @@ test('pages serialize layout and container metadata', function () {
         ->toMatchArray(['layout' => null, 'container' => 'default']);
 });
 
-test('the layout() method takes precedence over the page attribute', function () {
+test('the layout() method takes precedence over the page attribute', function (): void {
     $page = new #[AsPage(layout: PageLayout::App)] class extends Page
     {
         public function layout(): PageLayout
@@ -50,7 +50,7 @@ test('the layout() method takes precedence over the page attribute', function ()
         ->toMatchArray(['layout' => null]);
 });
 
-test('the container() method takes precedence over the page attribute', function () {
+test('the container() method takes precedence over the page attribute', function (): void {
     $page = new #[AsPage(container: PageContainer::Default)] class extends Page
     {
         public function container(): PageContainer
@@ -68,7 +68,7 @@ test('the container() method takes precedence over the page attribute', function
         ->toMatchArray(['container' => 'centered']);
 });
 
-test('pages serialize breadcrumb metadata', function () {
+test('pages serialize breadcrumb metadata', function (): void {
     $page = new class extends Page
     {
         public function breadcrumbs(): array
@@ -98,7 +98,7 @@ test('pages serialize breadcrumb metadata', function () {
         ]);
 });
 
-test('pages do not serialize shared i18n metadata', function () {
+test('pages do not serialize shared i18n metadata', function (): void {
     $page = new class extends Page
     {
         public function render(PageSchema $schema): PageSchema

--- a/tests/Unit/Layouts/Components/CalloutsTest.php
+++ b/tests/Unit/Layouts/Components/CalloutsTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Layouts\Components\Callouts;
 
-test('the callouts slot serializes to its wire type', function () {
+test('the callouts slot serializes to its wire type', function (): void {
     $wire = Callouts::make()->jsonSerialize();
 
     expect($wire['type'])->toBe('callouts')

--- a/tests/Unit/Layouts/Components/DropdownTest.php
+++ b/tests/Unit/Layouts/Components/DropdownTest.php
@@ -8,7 +8,7 @@ use Lattice\Lattice\Core\Enums\Placement;
 use Lattice\Lattice\Layouts\Components\Dropdown;
 use Lattice\Lattice\Layouts\Components\MenuItem;
 
-it('builds a dropdown with trigger components, placement and menu items', function () {
+it('builds a dropdown with trigger components, placement and menu items', function (): void {
     $dropdown = Dropdown::make('account-menu')
         ->placement(Placement::Top)
         ->trigger([

--- a/tests/Unit/Layouts/Components/TopbarTest.php
+++ b/tests/Unit/Layouts/Components/TopbarTest.php
@@ -5,20 +5,20 @@ use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Side;
 use Lattice\Lattice\Layouts\Components\Topbar;
 
-test('the topbar serializes to its wire type, not sticky by default', function () {
+test('the topbar serializes to its wire type, not sticky by default', function (): void {
     $wire = Topbar::make('app-topbar')->jsonSerialize();
 
     expect($wire['type'])->toBe('topbar')
         ->and($wire['props']['sticky'])->toBeFalse();
 });
 
-test('sticky() marks the topbar sticky', function () {
+test('sticky() marks the topbar sticky', function (): void {
     $wire = Topbar::make()->sticky()->jsonSerialize();
 
     expect($wire['props']['sticky'])->toBeTrue();
 });
 
-test('float() pushes a stack along the main axis', function () {
+test('float() pushes a stack along the main axis', function (): void {
     $wire = Stack::make()->float(Side::End)->jsonSerialize();
 
     expect($wire['props']['float'])->toBe('end');

--- a/tests/Unit/Realtime/ListenTest.php
+++ b/tests/Unit/Realtime/ListenTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Realtime\Listen;
 
-test('it serializes channel, visibility, events and a toast effect', function () {
+test('it serializes channel, visibility, events and a toast effect', function (): void {
     $listen = Listen::private('orders')
         ->on('OrderShipped')
         ->toast(rt('orders.shipped-live')->fromPayload(['id' => 'order.id']));
@@ -24,7 +24,7 @@ test('it serializes channel, visibility, events and a toast effect', function ()
     ]);
 });
 
-test('channel() builds a public listener and on() accepts an array, de-duplicating', function () {
+test('channel() builds a public listener and on() accepts an array, de-duplicating', function (): void {
     $listen = Listen::channel('inventory')->on(['StockLow', 'StockLow', 'StockOut'])->reloadPage();
 
     $array = json_decode(json_encode($listen), true);
@@ -34,7 +34,7 @@ test('channel() builds a public listener and on() accepts an array, de-duplicati
         ->and($array['effects'][0]['type'])->toBe('reloadPage');
 });
 
-test('presence() builds a presence listener', function () {
+test('presence() builds a presence listener', function (): void {
     $array = json_decode(json_encode(Listen::presence('room.1')->on('Joined')), true);
 
     expect($array['visibility'])->toBe('presence');

--- a/tests/Unit/Realtime/ListenerPayloadTest.php
+++ b/tests/Unit/Realtime/ListenerPayloadTest.php
@@ -5,7 +5,7 @@ use Lattice\Lattice\Effects\Effect;
 use Lattice\Lattice\Realtime\Enums\ChannelVisibility;
 use Lattice\Lattice\Realtime\ListenerPayload;
 
-test('it serializes a listener payload with the visibility enum value', function () {
+test('it serializes a listener payload with the visibility enum value', function (): void {
     $payload = new ListenerPayload('orders', ChannelVisibility::Private, ['OrderShipped'], [Effect::reloadPage()]);
 
     $array = json_decode(json_encode($payload), true);

--- a/tests/Unit/Remote/Components/DataListWireShapeTest.php
+++ b/tests/Unit/Remote/Components/DataListWireShapeTest.php
@@ -119,14 +119,14 @@ test('remote chat box component serializes remote access with a signed ref', fun
 });
 
 test('remote components require source and audience before remote access is serialized', function (): void {
-    expect(fn () => wire(
+    expect(fn (): array => wire(
         DataList::make('customers')
             ->source('fixtures.crm'),
     ))->toThrow(LogicException::class, 'must define source() and audience()');
 });
 
 test('remote components require an id before remote access is serialized', function (): void {
-    expect(fn () => wire(
+    expect(fn (): array => wire(
         (new RemoteChatBox)
             ->source('fixtures.crm')
             ->audience('https://crm.example.test'),

--- a/tests/Unit/Support/Evaluation/EvaluationContextTest.php
+++ b/tests/Unit/Support/Evaluation/EvaluationContextTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Http\Request;
 use Lattice\Lattice\Support\Evaluation\EvaluationContext;
 
-it('adds named utilities immutably', function () {
+it('adds named utilities immutably', function (): void {
     $base = new EvaluationContext;
     $with = $base->named('foo', 42);
 
@@ -14,7 +14,7 @@ it('adds named utilities immutably', function () {
         ->and($with->getNamed('foo'))->toBe(42);
 });
 
-it('stores and reads typed utilities', function () {
+it('stores and reads typed utilities', function (): void {
     $request = Request::create('/');
     $context = (new EvaluationContext)->typed(Request::class, $request);
 
@@ -22,7 +22,7 @@ it('stores and reads typed utilities', function () {
         ->and($context->getTyped(Request::class))->toBe($request);
 });
 
-it('lists available named utility names for diagnostics', function () {
+it('lists available named utility names for diagnostics', function (): void {
     $context = (new EvaluationContext)->named('a', 1)->named('b', 2);
 
     expect($context->names())->toBe(['a', 'b']);

--- a/tests/Unit/Support/Evaluation/EvaluatorTest.php
+++ b/tests/Unit/Support/Evaluation/EvaluatorTest.php
@@ -22,77 +22,77 @@ final class EvaluatorStub implements PingableStub
 
 interface UnboundEvaluatorContract {}
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->evaluator = new Evaluator(new Container);
 });
 
-it('returns non-closures unchanged', function () {
+it('returns non-closures unchanged', function (): void {
     expect($this->evaluator->resolve('static', new EvaluationContext))->toBe('static');
 });
 
-it('injects named utilities by parameter name', function () {
+it('injects named utilities by parameter name', function (): void {
     $context = (new EvaluationContext)->named('state', ['x' => 1]);
 
     expect($this->evaluator->resolve(fn ($state) => $state['x'], $context))->toBe(1);
 });
 
-it('injects named utilities regardless of parameter order', function () {
+it('injects named utilities regardless of parameter order', function (): void {
     $context = (new EvaluationContext)->named('a', 'A')->named('b', 'B');
 
-    expect($this->evaluator->resolve(fn ($b, $a) => $a.$b, $context))->toBe('AB');
+    expect($this->evaluator->resolve(fn ($b, $a): string => $a.$b, $context))->toBe('AB');
 });
 
-it('injects typed overrides by class', function () {
+it('injects typed overrides by class', function (): void {
     $request = Request::create('/?q=hi');
     $context = (new EvaluationContext)->typed(Request::class, $request);
 
     expect($this->evaluator->resolve(fn (Request $request) => $request->query('q'), $context))->toBe('hi');
 });
 
-it('resolves unknown typed parameters from the container', function () {
-    expect($this->evaluator->resolve(fn (EvaluatorStub $stub) => $stub->ping(), new EvaluationContext))->toBe('pong');
+it('resolves unknown typed parameters from the container', function (): void {
+    expect($this->evaluator->resolve(fn (EvaluatorStub $stub): string => $stub->ping(), new EvaluationContext))->toBe('pong');
 });
 
-it('prefers a named utility over the container for a typed parameter', function () {
+it('prefers a named utility over the container for a typed parameter', function (): void {
     $named = new EvaluatorStub('named');
     $context = (new EvaluationContext)->named('stub', $named);
 
-    expect($this->evaluator->resolve(fn (EvaluatorStub $stub) => $stub, $context))->toBe($named);
+    expect($this->evaluator->resolve(fn (EvaluatorStub $stub): EvaluatorStub => $stub, $context))->toBe($named);
 });
 
-it('falls back to a default value', function () {
+it('falls back to a default value', function (): void {
     expect($this->evaluator->resolve(fn ($missing = 'default') => $missing, new EvaluationContext))->toBe('default');
 });
 
-it('falls back to null for a nullable parameter', function () {
-    expect($this->evaluator->resolve(fn (?string $missing) => $missing, new EvaluationContext))->toBeNull();
+it('falls back to null for a nullable parameter', function (): void {
+    expect($this->evaluator->resolve(fn (?string $missing): ?string => $missing, new EvaluationContext))->toBeNull();
 });
 
-it('throws for an unresolvable parameter', function () {
-    $this->evaluator->resolve(fn (string $missing) => $missing, new EvaluationContext);
+it('throws for an unresolvable parameter', function (): void {
+    $this->evaluator->resolve(fn (string $missing): string => $missing, new EvaluationContext);
 })->throws(UnresolvableEvaluationParameter::class);
 
-it('throws a domain exception when a typed parameter is an unbound interface', function () {
-    $this->evaluator->resolve(fn (UnboundEvaluatorContract $service) => $service, new EvaluationContext);
+it('throws a domain exception when a typed parameter is an unbound interface', function (): void {
+    $this->evaluator->resolve(fn (UnboundEvaluatorContract $service): UnboundEvaluatorContract => $service, new EvaluationContext);
 })->throws(UnresolvableEvaluationParameter::class);
 
-it('resolves a typed parameter to an assignable context utility (contravariance)', function () {
+it('resolves a typed parameter to an assignable context utility (contravariance)', function (): void {
     $stub = new EvaluatorStub('assignable');
     $context = (new EvaluationContext)->typed(EvaluatorStub::class, $stub);
 
-    expect($this->evaluator->resolve(fn (PingableStub $service) => $service, $context))->toBe($stub);
+    expect($this->evaluator->resolve(fn (PingableStub $service): PingableStub => $service, $context))->toBe($stub);
 });
 
-it('does not autowire a non-autowirable base type and throws instead', function () {
+it('does not autowire a non-autowirable base type and throws instead', function (): void {
     $evaluator = new Evaluator(new Container, [EvaluatorStub::class]);
 
-    $evaluator->resolve(fn (EvaluatorStub $stub) => $stub, new EvaluationContext);
+    $evaluator->resolve(fn (EvaluatorStub $stub): EvaluatorStub => $stub, new EvaluationContext);
 })->throws(UnresolvableEvaluationParameter::class);
 
-it('resolves a non-autowirable type when it is provided via the context', function () {
+it('resolves a non-autowirable type when it is provided via the context', function (): void {
     $evaluator = new Evaluator(new Container, [EvaluatorStub::class]);
     $stub = new EvaluatorStub('provided');
     $context = (new EvaluationContext)->typed(EvaluatorStub::class, $stub);
 
-    expect($evaluator->resolve(fn (EvaluatorStub $stub) => $stub, $context))->toBe($stub);
+    expect($evaluator->resolve(fn (EvaluatorStub $stub): EvaluatorStub => $stub, $context))->toBe($stub);
 });

--- a/tests/Unit/Support/TypeScript/OxfmtFormatterTest.php
+++ b/tests/Unit/Support/TypeScript/OxfmtFormatterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\File;
 use Lattice\Lattice\Support\TypeScript\OxfmtFormatter;
 
-it('uses the consumer oxfmt binary before the package fallback', function () {
+it('uses the consumer oxfmt binary before the package fallback', function (): void {
     $nodeModules = base_path('node_modules');
     $binDirectory = $nodeModules.'/.bin';
     $binary = $binDirectory.'/oxfmt';

--- a/tests/Unit/Tables/ColumnTypeResolutionTest.php
+++ b/tests/Unit/Tables/ColumnTypeResolutionTest.php
@@ -9,15 +9,15 @@ use Lattice\Lattice\Tables\Columns\ColumnData;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleColumn;
 
-it('hydrates a built-in column type from the #[AsColumn] enum', function () {
+it('hydrates a built-in column type from the #[AsColumn] enum', function (): void {
     expect(BadgeColumn::make('status')->toData()->type)->toBe(ColumnType::Badge);
 });
 
-it('hydrates a custom column type as its raw string', function () {
-    expect((new SampleColumn('rating'))->toData()->type)->toBe('column.rating');
+it('hydrates a custom column type as its raw string', function (): void {
+    expect(new SampleColumn('rating')->toData()->type)->toBe('column.rating');
 });
 
-it('throws when a column is missing the #[AsColumn] attribute', function () {
+it('throws when a column is missing the #[AsColumn] attribute', function (): void {
     $column = new class('x') extends Column
     {
         public function toData(): ColumnData

--- a/tests/Unit/Tables/ColumnTypeResolutionTest.php
+++ b/tests/Unit/Tables/ColumnTypeResolutionTest.php
@@ -27,7 +27,6 @@ it('throws when a column is missing the #[AsColumn] attribute', function (): voi
                 label: 'X',
                 type: $this->resolvedType(),
                 width: ColumnWidth::Md,
-                props: null,
             );
         }
     };

--- a/tests/Unit/Tables/Columns/ColumnAlignmentTest.php
+++ b/tests/Unit/Tables/Columns/ColumnAlignmentTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 use Lattice\Lattice\Tables\Columns\TextColumn;
 use Lattice\Lattice\Tables\Enums\ColumnAlign;
 
-it('defaults a column to start alignment', function () {
+it('defaults a column to start alignment', function (): void {
     expect(wire(TextColumn::make('name'))['align'])->toBe('start');
 });
 
-it('lets a column override its alignment', function () {
+it('lets a column override its alignment', function (): void {
     expect(wire(TextColumn::make('name')->align(ColumnAlign::Center))['align'])->toBe('center');
 });

--- a/tests/Unit/Tables/Columns/ColumnDataTest.php
+++ b/tests/Unit/Tables/Columns/ColumnDataTest.php
@@ -5,7 +5,7 @@ use Lattice\Lattice\Core\Enums\ColumnWidth;
 use Lattice\Lattice\Tables\Columns\ColumnData;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
-it('serializes common fields plus a reflected props object', function () {
+it('serializes common fields plus a reflected props object', function (): void {
     $data = new ColumnData(
         key: 'status',
         label: 'Status',
@@ -27,7 +27,7 @@ it('serializes common fields plus a reflected props object', function () {
     ]);
 });
 
-it('serializes the default column width', function () {
+it('serializes the default column width', function (): void {
     $data = new ColumnData(
         key: 'status',
         label: 'Status',

--- a/tests/Unit/Tables/Columns/ColumnPropsTest.php
+++ b/tests/Unit/Tables/Columns/ColumnPropsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 
-it('reflects a column\'s public properties into the full props shape', function () {
+it('reflects a column\'s public properties into the full props shape', function (): void {
     expect(wire(TextColumn::make('name'))['props'])->toBe([
         'date' => null,
         'copyable' => false,
@@ -22,11 +22,11 @@ it('reflects a column\'s public properties into the full props shape', function 
     ]);
 });
 
-it('omits props for columns that expose no public properties', function () {
+it('omits props for columns that expose no public properties', function (): void {
     expect(wire(BooleanColumn::make('active'))['props'])->toBeNull();
 });
 
-it('keeps protected filter and sort state off the wire props', function () {
+it('keeps protected filter and sort state off the wire props', function (): void {
     $props = wire(TextColumn::make('name')->sortable()->filterable())['props'];
 
     expect($props)->toBe([

--- a/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
+++ b/tests/Unit/Tables/Columns/ColumnReflectionGuardTest.php
@@ -24,15 +24,15 @@ function publicColumnProps(string $class): array
 {
     return array_map(
         fn (ReflectionProperty $property): string => $property->getName(),
-        (new ReflectionClass($class))->getProperties(ReflectionProperty::IS_PUBLIC),
+        new ReflectionClass($class)->getProperties(ReflectionProperty::IS_PUBLIC),
     );
 }
 
-it('keeps the base Column free of public properties', function () {
+it('keeps the base Column free of public properties', function (): void {
     expect(publicColumnProps(Column::class))->toBe([]);
 });
 
-it('exposes only the intended wire props on each built-in column', function (string $class, array $expected) {
+it('exposes only the intended wire props on each built-in column', function (string $class, array $expected): void {
     expect(publicColumnProps($class))->toEqualCanonicalizing($expected);
 })->with([
     'text' => [TextColumn::class, ['date', 'copyable', 'link']],

--- a/tests/Unit/Tables/Columns/ColumnSelectFilterTest.php
+++ b/tests/Unit/Tables/Columns/ColumnSelectFilterTest.php
@@ -12,7 +12,7 @@ enum ColumnFilterStatus: string
     case Active = 'active';
 }
 
-test('a column filter accepts an associative value => label array', function () {
+test('a column filter accepts an associative value => label array', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions([
         'draft' => 'Draft',
         'active' => 'Active',
@@ -24,7 +24,7 @@ test('a column filter accepts an associative value => label array', function () 
     ]);
 });
 
-test('a column filter accepts an enum', function () {
+test('a column filter accepts an enum', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions(ColumnFilterStatus::class))['filter'];
 
     expect($filter['options'])->toBe([
@@ -33,7 +33,7 @@ test('a column filter accepts an enum', function () {
     ]);
 });
 
-test('a column with filter options serializes a select control', function () {
+test('a column with filter options serializes a select control', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions([
         ['label' => 'Draft', 'value' => 'draft'],
         ['label' => 'Active', 'value' => 'active'],
@@ -52,7 +52,7 @@ test('a column with filter options serializes a select control', function () {
     ]);
 });
 
-test('a multiple column select filter offers the in operators', function () {
+test('a multiple column select filter offers the in operators', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions([
         ['label' => 'Draft', 'value' => 'draft'],
     ], multiple: true))['filter'];
@@ -65,7 +65,7 @@ test('a multiple column select filter offers the in operators', function () {
     ]);
 });
 
-test('an operator column filter has no select control', function () {
+test('an operator column filter has no select control', function (): void {
     $filter = wire(TextColumn::make('name')->filterable())['filter'];
 
     expect($filter['control'])->toBeNull()
@@ -73,20 +73,20 @@ test('an operator column filter has no select control', function () {
         ->and($filter['multiple'])->toBeFalse();
 });
 
-test('a column filter can be made searchable', function () {
+test('a column filter can be made searchable', function (): void {
     $filter = wire(TextColumn::make('author_id')->filterOptions(inMemoryOptionSource(['1' => 'Ada', '2' => 'Linus']), searchable: true))['filter'];
 
     expect($filter['control'])->toBe('select')
         ->and($filter['searchable'])->toBeTrue();
 });
 
-test('a static column select filter is not searchable', function () {
+test('a static column select filter is not searchable', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions([['label' => 'A', 'value' => 'a']]))['filter'];
 
     expect($filter['searchable'])->toBeFalse();
 });
 
-test('a column filter resolves options from an option source', function () {
+test('a column filter resolves options from an option source', function (): void {
     $filter = wire(TextColumn::make('author_id')->filterOptions(inMemoryOptionSource(['1' => 'Ada', '2' => 'Linus'])))['filter'];
 
     expect($filter['control'])->toBe('select')
@@ -96,7 +96,7 @@ test('a column filter resolves options from an option source', function () {
         ]);
 });
 
-test('a column select filter restricts its available operators', function () {
+test('a column select filter restricts its available operators', function (): void {
     expect(TextColumn::make('status')->filterOptions([['label' => 'A', 'value' => 'a']])->availableOperators())
         ->toBe([Op::Equals, Op::NotEquals]);
 
@@ -104,7 +104,7 @@ test('a column select filter restricts its available operators', function () {
         ->toBe([Op::In, Op::NotIn]);
 });
 
-test('a column filter serializes clause options', function () {
+test('a column filter serializes clause options', function (): void {
     $filter = wire(BooleanColumn::make('featured')->filterOptions([
         ColumnFilterOption::clause('Yes', 'yes', Op::Equals, 'true'),
         ColumnFilterOption::clause('No', 'no', Op::Equals, 'false'),
@@ -139,7 +139,7 @@ test('a column filter serializes clause options', function () {
     ]);
 });
 
-test('a column filter range option serializes date bounds as clauses', function () {
+test('a column filter range option serializes date bounds as clauses', function (): void {
     $filter = wire(TextColumn::make('updated_at')->date()->filterOptions([
         ColumnFilterOption::range('This month', 'this-month', '2026-06-01', '2026-06-30'),
     ]))['filter'];

--- a/tests/Unit/Tables/Columns/MoneyColumnTest.php
+++ b/tests/Unit/Tables/Columns/MoneyColumnTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use Lattice\Lattice\Tables\Columns\MoneyColumn;
 use Lattice\Lattice\Tables\Enums\FilterType;
 
-it('serializes a static-currency money column', function () {
+it('serializes a static-currency money column', function (): void {
     $data = wire(MoneyColumn::make('total')->currency('EUR'));
 
     expect($data['type'])->toBe('column.money')
@@ -14,7 +14,7 @@ it('serializes a static-currency money column', function () {
         ->and($data['filter'] ?? null)->toBeNull();
 });
 
-it('serializes a per-row currency reference', function () {
+it('serializes a per-row currency reference', function (): void {
     $props = wire(MoneyColumn::make('total')->currencyField('currency')->decimals(0))['props'];
 
     expect($props['currencyField'])->toBe('currency')
@@ -22,7 +22,7 @@ it('serializes a per-row currency reference', function () {
         ->and($props['minimumFractionDigits'])->toBe(0);
 });
 
-it('filters money as a number', function () {
+it('filters money as a number', function (): void {
     $data = wire(MoneyColumn::make('total')->filterable());
 
     expect($data['filter']['type'])->toBe(FilterType::Number->value);

--- a/tests/Unit/Tables/Columns/NumericColumnTest.php
+++ b/tests/Unit/Tables/Columns/NumericColumnTest.php
@@ -5,31 +5,31 @@ use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Enums\FilterType;
 use Lattice\Lattice\Tables\Enums\NumberFormatUnit;
 
-it('defaults a numeric column to end alignment', function () {
+it('defaults a numeric column to end alignment', function (): void {
     expect(wire(NumberColumn::make('price'))['align'])->toBe('end');
 });
 
-it('emits fixed fraction digits', function () {
+it('emits fixed fraction digits', function (): void {
     $props = wire(NumberColumn::make('price')->decimals(2))['props'];
 
     expect($props['minimumFractionDigits'])->toBe(2)
         ->and($props['maximumFractionDigits'])->toBe(2);
 });
 
-it('emits a fraction-digit range', function () {
+it('emits a fraction-digit range', function (): void {
     $props = wire(NumberColumn::make('price')->decimals(0, 2))['props'];
 
     expect($props['minimumFractionDigits'])->toBe(0)
         ->and($props['maximumFractionDigits'])->toBe(2);
 });
 
-it('filters a numeric column as a number', function () {
+it('filters a numeric column as a number', function (): void {
     $data = wire(NumberColumn::make('price')->filterable());
 
     expect($data['filter']['type'])->toBe(FilterType::Number->value);
 });
 
-it('emits the Intl unit as its backed value', function () {
+it('emits the Intl unit as its backed value', function (): void {
     $props = wire(
         NumberColumn::make('progress')
             ->unit(NumberFormatUnit::Percent),

--- a/tests/Unit/Tables/Filters/FilterTypesTest.php
+++ b/tests/Unit/Tables/Filters/FilterTypesTest.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Tables\Filters\TernaryFilter;
 use Lattice\Lattice\Tables\TableQuery;
 use Workbench\App\Models\Product;
 
-test('ternary filter serializes its wire shape', function () {
+test('ternary filter serializes its wire shape', function (): void {
     expect(wire(TernaryFilter::make('featured')
         ->trueLabel('Featured')
         ->falseLabel('Not featured')))
@@ -26,7 +26,7 @@ test('ternary filter serializes its wire shape', function () {
         ]);
 });
 
-test('a ternary filter applies a boolean constraint', function () {
+test('a ternary filter applies a boolean constraint', function (): void {
     $builder = Product::query();
     TernaryFilter::make('featured')->apply($builder, 'true');
     expect($builder->toSql())->toContain('"featured" = ?')
@@ -37,7 +37,7 @@ test('a ternary filter applies a boolean constraint', function () {
     expect($other->getBindings())->toBe([false]);
 });
 
-test('a ternary filter runs custom queries when provided', function () {
+test('a ternary filter runs custom queries when provided', function (): void {
     $builder = Product::query();
 
     TernaryFilter::make('verified')
@@ -50,14 +50,14 @@ test('a ternary filter runs custom queries when provided', function () {
     expect($builder->toSql())->toContain('"verified_at" is not null');
 });
 
-test('a ternary filter rejects non-boolean values', function () {
+test('a ternary filter rejects non-boolean values', function (): void {
     $filter = TernaryFilter::make('featured');
     expect($filter->accepts('true'))->toBeTrue()
         ->and($filter->accepts('false'))->toBeTrue()
         ->and($filter->accepts('garbage'))->toBeFalse();
 });
 
-test('date range filter serializes its wire shape', function () {
+test('date range filter serializes its wire shape', function (): void {
     expect(wire(DateRangeFilter::make('created_at')->label('Created')))
         ->toBe([
             'key' => 'created_at',
@@ -67,7 +67,7 @@ test('date range filter serializes its wire shape', function () {
         ]);
 });
 
-test('a date range filter applies from and until bounds', function () {
+test('a date range filter applies from and until bounds', function (): void {
     $builder = Product::query();
 
     DateRangeFilter::make('created_at')->apply($builder, ['from' => '2026-01-01', 'until' => '2026-06-30']);
@@ -77,7 +77,7 @@ test('a date range filter applies from and until bounds', function () {
         ->and($builder->getBindings())->toBe(['2026-01-01', '2026-06-30']);
 });
 
-test('a date range filter applies only the provided bound', function () {
+test('a date range filter applies only the provided bound', function (): void {
     $builder = Product::query();
 
     DateRangeFilter::make('created_at')->apply($builder, ['from' => '2026-01-01']);
@@ -86,7 +86,7 @@ test('a date range filter applies only the provided bound', function () {
         ->and($builder->toSql())->not->toContain('<=');
 });
 
-test('a generic filter serializes as a toggle', function () {
+test('a generic filter serializes as a toggle', function (): void {
     expect(wire(Filter::make('high_value')->label('High value')))
         ->toBe([
             'key' => 'high_value',
@@ -96,7 +96,7 @@ test('a generic filter serializes as a toggle', function () {
         ]);
 });
 
-test('a generic filter runs its query closure when toggled on', function () {
+test('a generic filter runs its query closure when toggled on', function (): void {
     $builder = Product::query();
 
     Filter::make('high_value')
@@ -107,7 +107,7 @@ test('a generic filter runs its query closure when toggled on', function () {
         ->and($builder->getBindings())->toBe([1000]);
 });
 
-test('a generic filter is a no-op when toggled off', function () {
+test('a generic filter is a no-op when toggled off', function (): void {
     $builder = Product::query();
 
     Filter::make('high_value')
@@ -117,7 +117,7 @@ test('a generic filter is a no-op when toggled off', function () {
     expect($builder->toSql())->not->toContain('where');
 });
 
-test('a generic filter without a query applies a boolean constraint on its column', function () {
+test('a generic filter without a query applies a boolean constraint on its column', function (): void {
     $builder = Product::query();
 
     Filter::make('featured')->apply($builder, '1');
@@ -126,7 +126,7 @@ test('a generic filter without a query applies a boolean constraint on its colum
         ->and($builder->getBindings())->toBe([true]);
 });
 
-test('a ternary filter runs the false query branch', function () {
+test('a ternary filter runs the false query branch', function (): void {
     $builder = Product::query();
 
     TernaryFilter::make('verified')
@@ -139,7 +139,7 @@ test('a ternary filter runs the false query branch', function () {
     expect($builder->toSql())->toContain('"verified_at" is null');
 });
 
-test('a ternary filter ignores an unparseable value', function () {
+test('a ternary filter ignores an unparseable value', function (): void {
     $builder = Product::query();
 
     TernaryFilter::make('featured')->apply($builder, 'garbage');
@@ -147,7 +147,7 @@ test('a ternary filter ignores an unparseable value', function () {
     expect($builder->toSql())->not->toContain('where');
 });
 
-test('a date range filter ignores a non-array value', function () {
+test('a date range filter ignores a non-array value', function (): void {
     $filter = DateRangeFilter::make('created_at');
     $builder = Product::query();
 
@@ -157,7 +157,7 @@ test('a date range filter ignores a non-array value', function () {
         ->and($builder->toSql())->not->toContain('where');
 });
 
-test('a filter constrains the column named by attribute()', function () {
+test('a filter constrains the column named by attribute()', function (): void {
     $builder = Product::query();
 
     SelectFilter::make('state')->attribute('status')->apply($builder, 'active');
@@ -166,7 +166,7 @@ test('a filter constrains the column named by attribute()', function () {
         ->and($builder->getBindings())->toBe(['active']);
 });
 
-test('table query drops a table-filter value the filter rejects', function () {
+test('table query drops a table-filter value the filter rejects', function (): void {
     $request = Request::create('/', 'GET', ['tf' => ['featured' => 'garbage']]);
 
     $query = TableQuery::fromRequest($request, [], 'demo', 25, [TernaryFilter::make('featured')]);

--- a/tests/Unit/Tables/Filters/SelectFilterTest.php
+++ b/tests/Unit/Tables/Filters/SelectFilterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use Lattice\Lattice\Tables\Filters\SelectFilter;
 use Workbench\App\Models\Product;
 
-test('select filter serializes its wire shape', function () {
+test('select filter serializes its wire shape', function (): void {
     expect(wire(SelectFilter::make('status')
         ->label('Status')
         ->options([
@@ -27,11 +27,11 @@ test('select filter serializes its wire shape', function () {
         ]);
 });
 
-test('select filter defaults its label from the key', function () {
+test('select filter defaults its label from the key', function (): void {
     expect(wire(SelectFilter::make('order_status'))['label'])->toBe('Order Status');
 });
 
-test('a single select filter applies an equality constraint', function () {
+test('a single select filter applies an equality constraint', function (): void {
     $builder = Product::query();
 
     SelectFilter::make('status')->apply($builder, 'active');
@@ -40,7 +40,7 @@ test('a single select filter applies an equality constraint', function () {
         ->and($builder->getBindings())->toBe(['active']);
 });
 
-test('a multiple select filter applies a whereIn constraint', function () {
+test('a multiple select filter applies a whereIn constraint', function (): void {
     $builder = Product::query();
 
     SelectFilter::make('status')->multiple()->apply($builder, ['active', 'draft']);
@@ -49,7 +49,7 @@ test('a multiple select filter applies a whereIn constraint', function () {
         ->and($builder->getBindings())->toBe(['active', 'draft']);
 });
 
-test('a select filter without a value applies no constraint', function () {
+test('a select filter without a value applies no constraint', function (): void {
     $builder = Product::query();
 
     SelectFilter::make('status')->apply($builder, '');
@@ -57,7 +57,7 @@ test('a select filter without a value applies no constraint', function () {
     expect($builder->toSql())->not->toContain('where');
 });
 
-test('a multiple select filter with no selected values applies no constraint', function () {
+test('a multiple select filter with no selected values applies no constraint', function (): void {
     $builder = Product::query();
 
     SelectFilter::make('status')->multiple()->apply($builder, []);
@@ -65,7 +65,7 @@ test('a multiple select filter with no selected values applies no constraint', f
     expect($builder->toSql())->not->toContain('where');
 });
 
-test('a select filter accepts an associative value => label array', function () {
+test('a select filter accepts an associative value => label array', function (): void {
     $props = wire(SelectFilter::make('status')->options(['draft' => 'Draft', 'active' => 'Active']))['props'];
 
     expect($props['options'])->toBe([
@@ -74,7 +74,7 @@ test('a select filter accepts an associative value => label array', function () 
     ]);
 });
 
-test('a select filter resolves its options from an option source', function () {
+test('a select filter resolves its options from an option source', function (): void {
     $source = inMemoryOptionSource(['1' => 'Ada', '2' => 'Linus']);
 
     $props = wire(SelectFilter::make('author_id')->optionsFrom($source))['props'];

--- a/workbench/app/Chat/FakeConversationStore.php
+++ b/workbench/app/Chat/FakeConversationStore.php
@@ -49,12 +49,12 @@ final readonly class FakeConversationStore
     private function seed(): array
     {
         return [
-            (new ChatMessage('seed-user', ChatRole::User, [
+            new ChatMessage('seed-user', ChatRole::User, [
                 ChatPart::text('What can you help me with?'),
-            ]))->jsonSerialize(),
-            (new ChatMessage('seed-assistant', ChatRole::Assistant, [
+            ])->jsonSerialize(),
+            new ChatMessage('seed-assistant', ChatRole::Assistant, [
                 ChatPart::text('I can answer questions about this workbench and look things up for you.'),
-            ]))->jsonSerialize(),
+            ])->jsonSerialize(),
         ];
     }
 }

--- a/workbench/app/Forms/DependentDemoForm.php
+++ b/workbench/app/Forms/DependentDemoForm.php
@@ -43,7 +43,7 @@ class DependentDemoForm extends FormDefinition
                     ]),
                     TextInput::make('total', __('workbench.forms.dependent.total'))
                         ->readOnly()
-                        ->value(fn (FormData $data) => $data->float('qty') * $data->float('unit_price')),
+                        ->value(fn (FormData $data): float => $data->float('qty') * $data->float('unit_price')),
                     NumberInput::make('level', __('workbench.forms.dependent.level'))->slider()->min(0)->max(10),
                     DateInput::make('due', __('workbench.forms.dependent.due-date')),
                 ]),

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -56,7 +56,7 @@ class ProductForm extends FormDefinition
                             EloquentOptions::make(Product::class)
                                 ->label('name')
                                 ->limit(10)
-                                ->scope(fn ($query) => $product
+                                ->scope(fn ($query) => $product instanceof Product
                                     ? $query->whereKeyNot($product->getKey())
                                     : $query),
                         )

--- a/workbench/app/Forms/ShowcaseForm.php
+++ b/workbench/app/Forms/ShowcaseForm.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Attributes\AsForm;
 use Lattice\Lattice\Core\Components\Card;
 use Lattice\Lattice\Core\Components\Grid;
 use Lattice\Lattice\Core\Enums\Icon;
+use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Checkbox;
 use Lattice\Lattice\Forms\Components\Choice;
 use Lattice\Lattice\Forms\Components\DateInput;
@@ -128,12 +129,12 @@ class ShowcaseForm extends FormDefinition
                             ->orderBy('name')
                             ->limit(10)
                             ->get()
-                            ->map(fn (Product $product) => Select::option($product->name, (string) $product->id))
+                            ->map(fn (Product $product): Option => Select::option($product->name, (string) $product->id))
                             ->all())
                         ->resolveSelectedUsing(fn (array $values) => Product::query()
                             ->whereIn('id', $values)
                             ->get()
-                            ->map(fn (Product $product) => Select::option($product->name, (string) $product->id))
+                            ->map(fn (Product $product): Option => Select::option($product->name, (string) $product->id))
                             ->all())
                         ->rules(['nullable', 'array']),
                 ]),

--- a/workbench/app/Http/Controllers/ChatAgentController.php
+++ b/workbench/app/Http/Controllers/ChatAgentController.php
@@ -27,9 +27,9 @@ final readonly class ChatAgentController
         $message = trim((string) $request->input('message'));
 
         $this->store->append(
-            (new ChatMessage((string) Str::uuid(), ChatRole::User, [
+            new ChatMessage((string) Str::uuid(), ChatRole::User, [
                 ChatPart::text($message),
-            ]))->jsonSerialize(),
+            ])->jsonSerialize(),
         );
 
         return response()->stream(function () use ($message, $request): void {
@@ -54,11 +54,11 @@ final readonly class ChatAgentController
             $this->writeFrame(['type' => 'done']);
 
             $this->store->append(
-                (new ChatMessage((string) Str::uuid(), ChatRole::Assistant, [
+                new ChatMessage((string) Str::uuid(), ChatRole::Assistant, [
                     ChatPart::text(self::REPLY),
                     $toolCall,
                     ...$schema,
-                ]))->jsonSerialize(),
+                ])->jsonSerialize(),
             );
         }, 200, [
             'Cache-Control' => 'no-cache',

--- a/workbench/app/Http/Controllers/FakeRemoteChatHistoryController.php
+++ b/workbench/app/Http/Controllers/FakeRemoteChatHistoryController.php
@@ -17,9 +17,9 @@ final readonly class FakeRemoteChatHistoryController
 
         return response()->json([
             'messages' => [
-                (new ChatMessage('remote-assistant-1', ChatRole::Assistant, [
+                new ChatMessage('remote-assistant-1', ChatRole::Assistant, [
                     ChatPart::text('Remote todo history loaded with a browser token.'),
-                ]))->jsonSerialize(),
+                ])->jsonSerialize(),
             ],
         ]);
     }

--- a/workbench/app/Pages/BusinessPartnerEditPage.php
+++ b/workbench/app/Pages/BusinessPartnerEditPage.php
@@ -47,7 +47,7 @@ class BusinessPartnerEditPage extends WorkbenchPage
                         ->fill([
                             'name' => $businessPartner->name,
                             'email' => $businessPartner->email,
-                            'groups' => $businessPartner->groups->pluck('id')->map(fn ($id) => (string) $id)->all(),
+                            'groups' => $businessPartner->groups->pluck('id')->map(fn ($id): string => (string) $id)->all(),
                             'addresses' => $addresses,
                             'default_shipping_address_id' => $businessPartner->default_shipping_address_id !== null
                                 ? (string) $businessPartner->default_shipping_address_id

--- a/workbench/app/Pages/RealtimePage.php
+++ b/workbench/app/Pages/RealtimePage.php
@@ -24,6 +24,7 @@ final class RealtimePage extends WorkbenchPage
     /**
      * @return array<int, Listen>
      */
+    #[\Override]
     protected function listeners(): array
     {
         return [

--- a/workbench/app/Remote/WorkbenchTodoSource.php
+++ b/workbench/app/Remote/WorkbenchTodoSource.php
@@ -17,6 +17,7 @@ final class WorkbenchTodoSource extends RemoteSourceDefinition
         return RemoteSchemaEndpoint::file(dirname(__DIR__, 2).'/remote/todo-schema.json');
     }
 
+    #[\Override]
     public function issueBrowserToken(Request $request): BrowserToken
     {
         return new BrowserToken(

--- a/workbench/app/Support/TypeScript/MarkedTypeDiscovery.php
+++ b/workbench/app/Support/TypeScript/MarkedTypeDiscovery.php
@@ -32,7 +32,7 @@ final class MarkedTypeDiscovery
         $valueObjects = [];
 
         foreach ($classes as $class) {
-            if ((new ReflectionClass($class))->getAttributes(TypeScript::class) === []) {
+            if (new ReflectionClass($class)->getAttributes(TypeScript::class) === []) {
                 continue;
             }
 


### PR DESCRIPTION
## What & why

Two related testing/tooling improvements, plus the first Rector sweep.

### Typed assertion callbacks
Annotate the `tap` parameters of `form()`, `table()`, `action()`, `component()` and `field()` with their callable signatures (`Closure(FormAssertions): mixed`, …). PhpStorm and PHPStan now infer the callback's argument type, so `fn ($form) => $form->...` gets autocomplete and type-checking **without** annotating each closure or touching any call site.

### Rector config
Replace the bare `php83`-only `rector.php` with the project's PHP version (auto-detected 8.4) plus the `deadCode`, `codeQuality` and `typeDeclarations` prepared sets. Rector runs via `composer fix`, not the `check` gate.

### Applied the Rector sweep
Ran the new config across the codebase: `#[\Override]` attributes, closure return types, and assorted dead-code/code-quality rewrites.

One inference was wrong — `AddClosureParamTypeForArrayMapRector` typed the `array_map` row callback in `Builder::castValue()` as `int $original`, contradicting its `is_array($original)` guard. That param is left untyped and the rule is scope-skipped for that file, so Rector is idempotent (a re-run is a no-op).

## Verification
`composer check` green: PHPStan clean, **834 passed**.