### PR TITLE
feat(tables): relation columns by dotted key — with()/whereHas/subquery sort

### DIFF
--- a/src/Tables/EloquentTableSource.php
+++ b/src/Tables/EloquentTableSource.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables;
@@ -6,6 +7,7 @@ namespace Lattice\Lattice\Tables;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Tables\Columns\Column;
@@ -16,7 +18,9 @@ use Lattice\Lattice\Tables\Filters\BaseFilter;
 
 /**
  * The built-in Eloquent table source. Applies a TableQuery's filters and sorts
- * to a query builder and paginates the result.
+ * to a query builder and paginates the result. Columns keyed by a dotted path
+ * into a to-one relation (`businessPartner.name`) are resolved to a constrained
+ * eager load, a `whereHas` filter, and a correlated-subquery sort.
  *
  * @template TModel of Model
  */
@@ -37,16 +41,24 @@ final readonly class EloquentTableSource implements TableSource
 
     public function query(TableQuery $query): TableResult
     {
-        $builder = $this->applyQuery(($this->builder)($query), $query);
+        $builder = ($this->builder)($query);
+        $relations = $this->relationColumns($builder->getModel());
+
+        $this->eagerLoadRelations($builder, $relations);
+        $this->applyQuery($builder, $query, $relations);
+
+        $project = $this->rowProjector($relations);
 
         return match ($this->pagination) {
-            PaginationType::None => TableResult::fromItems($builder->get(), PaginationType::None),
+            PaginationType::None => TableResult::fromItems(
+                $builder->get()->map($project),
+            ),
             PaginationType::Infinite, PaginationType::Simple => TableResult::fromSimplePaginator(
-                $builder->simplePaginate(perPage: $query->perPage, page: $query->page),
+                $builder->simplePaginate(perPage: $query->perPage, page: $query->page)->through($project),
                 $this->pagination,
             ),
             PaginationType::Table => TableResult::fromPaginator(
-                $builder->paginate(perPage: $query->perPage, page: $query->page),
+                $builder->paginate(perPage: $query->perPage, page: $query->page)->through($project),
             ),
         };
     }
@@ -56,7 +68,11 @@ final readonly class EloquentTableSource implements TableSource
      */
     public function resolveMatching(TableQuery $query): Collection
     {
-        return $this->applyQuery(($this->builder)($query), $query)->get();
+        $builder = ($this->builder)($query);
+
+        $this->applyQuery($builder, $query, $this->relationColumns($builder->getModel()));
+
+        return $builder->get();
     }
 
     /**
@@ -76,24 +92,35 @@ final readonly class EloquentTableSource implements TableSource
 
     /**
      * @param  Builder<TModel>  $builder
-     * @return Builder<TModel>
+     * @param  array<string, RelationColumn>  $relations
      */
-    private function applyQuery(Builder $builder, TableQuery $query): Builder
+    private function applyQuery(Builder $builder, TableQuery $query, array $relations): void
     {
         $columns = Column::index($this->columns);
 
         foreach ($query->filters as $clause) {
             $column = $columns->get($clause->field);
 
-            if ($column instanceof Filterable) {
-                $this->filterApplier->apply(
-                    Op::from($clause->operator),
-                    $builder,
-                    $column->filterType(),
-                    $clause->field,
-                    $clause->value,
-                );
+            if (! $column instanceof Filterable) {
+                continue;
             }
+
+            $operator = Op::from($clause->operator);
+            $relation = $relations[$clause->field] ?? null;
+
+            if ($relation instanceof RelationColumn) {
+                $relation->applyFilter($builder, fn (Builder $related) => $this->filterApplier->apply(
+                    $operator,
+                    $related,
+                    $column->filterType(),
+                    $relation->field,
+                    $clause->value,
+                ));
+
+                continue;
+            }
+
+            $this->filterApplier->apply($operator, $builder, $column->filterType(), $clause->field, $clause->value);
         }
 
         $filters = collect($this->filters)->keyBy(fn (BaseFilter $filter): string => $filter->key);
@@ -107,9 +134,123 @@ final readonly class EloquentTableSource implements TableSource
         }
 
         foreach ($query->sorts as $sort) {
+            $relation = $relations[$sort->key] ?? null;
+
+            if ($relation instanceof RelationColumn) {
+                $relation->applySort($builder, $sort->direction->value);
+
+                continue;
+            }
+
             $builder->orderBy($sort->key, $sort->direction->value);
         }
+    }
 
-        return $builder;
+    /**
+     * @return array<string, RelationColumn>
+     */
+    private function relationColumns(Model $model): array
+    {
+        $relations = [];
+
+        foreach ($this->columns as $column) {
+            $relation = RelationColumn::resolve($model, $column->key());
+
+            if ($relation instanceof RelationColumn) {
+                $relations[$column->key()] = $relation;
+            }
+        }
+
+        return $relations;
+    }
+
+    /**
+     * @param  Builder<TModel>  $builder
+     * @param  array<string, RelationColumn>  $relations
+     */
+    private function eagerLoadRelations(Builder $builder, array $relations): void
+    {
+        if ($relations === []) {
+            return;
+        }
+
+        /** @var array<string, list<string>> $columnsByRelation */
+        $columnsByRelation = [];
+
+        foreach ($relations as $relation) {
+            $columnsByRelation[$relation->relation] = array_merge(
+                $columnsByRelation[$relation->relation] ?? [],
+                $relation->relatedColumns(),
+            );
+
+            $this->keepBaseColumn($builder, $relation->baseKey());
+        }
+
+        $eager = [];
+
+        foreach ($columnsByRelation as $name => $columns) {
+            $select = array_values(array_unique($columns));
+            $eager[$name] = static fn (Relation $related): Relation => $related->select($select);
+        }
+
+        $builder->with($eager);
+    }
+
+    /**
+     * Ensure an explicit base select() keeps the key the relation matches on; a
+     * `SELECT *` already has it.
+     *
+     * @param  Builder<TModel>  $builder
+     */
+    private function keepBaseColumn(Builder $builder, string $column): void
+    {
+        $selected = $builder->getQuery()->columns;
+
+        if ($selected === null) {
+            return;
+        }
+
+        $table = $builder->getModel()->getTable();
+
+        if (in_array('*', $selected, true) || in_array($table.'.*', $selected, true)) {
+            return;
+        }
+
+        if (in_array($column, $selected, true) || in_array($table.'.'.$column, $selected, true)) {
+            return;
+        }
+
+        $builder->addSelect($table.'.'.$column);
+    }
+
+    /**
+     * A row mapper that flattens each relation column's value onto a flat key
+     * (and hides the nested relation it loaded). Returns the model untouched when
+     * there are no relation columns, so non-relation tables keep serializing
+     * through TableResult exactly as before.
+     *
+     * @param  array<string, RelationColumn>  $relations
+     * @return Closure(Model): (array<string, mixed>|Model)
+     */
+    private function rowProjector(array $relations): Closure
+    {
+        if ($relations === []) {
+            return static fn (Model $model): Model => $model;
+        }
+
+        $relationNames = array_values(array_unique(array_map(
+            static fn (RelationColumn $relation): string => $relation->relation,
+            $relations,
+        )));
+
+        return function (Model $model) use ($relations, $relationNames): array {
+            $row = $model->makeHidden($relationNames)->toArray();
+
+            foreach ($relations as $relation) {
+                $row[$relation->key] = $relation->value($model);
+            }
+
+            return $row;
+        };
     }
 }

--- a/src/Tables/Enums/FilterType.php
+++ b/src/Tables/Enums/FilterType.php
@@ -5,7 +5,6 @@ namespace Lattice\Lattice\Tables\Enums;
 
 use DateTimeImmutable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
 
@@ -75,9 +74,7 @@ enum FilterType: string
     }
 
     /**
-     * @template TModel of Model
-     *
-     * @param  Builder<TModel>  $builder
+     * @param  Builder<*>  $builder
      */
     public function applyEquals(Builder $builder, string $field, string $value): void
     {
@@ -89,9 +86,7 @@ enum FilterType: string
     }
 
     /**
-     * @template TModel of Model
-     *
-     * @param  Builder<TModel>  $builder
+     * @param  Builder<*>  $builder
      */
     private function applyBooleanEquals(Builder $builder, string $field, string $value): void
     {

--- a/src/Tables/FilterApplier.php
+++ b/src/Tables/FilterApplier.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Tables\Enums\FilterType;
 
@@ -16,9 +15,7 @@ use Lattice\Lattice\Tables\Enums\FilterType;
 final class FilterApplier
 {
     /**
-     * @template TModel of Model
-     *
-     * @param  Builder<TModel>  $builder
+     * @param  Builder<*>  $builder
      */
     public function apply(Op $operator, Builder $builder, FilterType $filterType, string $field, string $value): void
     {
@@ -62,9 +59,7 @@ final class FilterApplier
     }
 
     /**
-     * @template TModel of Model
-     *
-     * @param  Builder<TModel>  $builder
+     * @param  Builder<*>  $builder
      */
     private function compare(Builder $builder, FilterType $filterType, string $field, string $sqlOperator, string $value): void
     {

--- a/src/Tables/RelationColumn.php
+++ b/src/Tables/RelationColumn.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * A column keyed by a dotted path into a to-one relation, e.g.
+ * `businessPartner.name`. Resolves the relation against the model and compiles
+ * each table concern to its idiomatic Eloquent: a constrained eager load for
+ * display, a `whereHas` for filtering, and a correlated subquery for sorting —
+ * so authors get relation columns without hand-writing aggregates.
+ *
+ * v1 handles a single relation segment of a BelongsTo or HasOne. Anything else
+ * (no dot, multi-level, to-many, or a non-relation segment) resolves to null and
+ * the key is left untouched.
+ */
+final readonly class RelationColumn
+{
+    /**
+     * @param  BelongsTo<Model, Model>|HasOne<Model, Model>  $relationInstance
+     */
+    private function __construct(
+        public string $key,
+        public string $relation,
+        public string $field,
+        private BelongsTo|HasOne $relationInstance,
+    ) {}
+
+    public static function resolve(Model $model, string $key): ?self
+    {
+        if (! str_contains($key, '.')) {
+            return null;
+        }
+
+        [$relation, $field] = explode('.', $key, 2);
+
+        if ($field === '' || str_contains($field, '.') || ! $model->isRelation($relation)) {
+            return null;
+        }
+
+        $instance = $model->{$relation}();
+
+        if (! $instance instanceof BelongsTo && ! $instance instanceof HasOne) {
+            return null;
+        }
+
+        return new self($key, $relation, $field, $instance);
+    }
+
+    public function value(Model $model): mixed
+    {
+        return data_get($model, $this->key);
+    }
+
+    /**
+     * The related-table columns the constrained eager load must select: the leaf
+     * field plus the key the relation matches on.
+     *
+     * @return list<string>
+     */
+    public function relatedColumns(): array
+    {
+        $matchKey = $this->relationInstance instanceof BelongsTo
+            ? $this->relationInstance->getOwnerKeyName()
+            : $this->relationInstance->getForeignKeyName();
+
+        return array_values(array_unique([$matchKey, $this->field]));
+    }
+
+    /**
+     * The base-table column the eager load matches against, which must survive an
+     * explicit select() on the base query.
+     */
+    public function baseKey(): string
+    {
+        return $this->relationInstance instanceof BelongsTo
+            ? $this->relationInstance->getForeignKeyName()
+            : $this->relationInstance->getLocalKeyName();
+    }
+
+    /**
+     * @param  Builder<*>  $builder
+     * @param  Closure(Builder<*>): void  $constrain
+     */
+    public function applyFilter(Builder $builder, Closure $constrain): void
+    {
+        $builder->whereHas($this->relation, $constrain);
+    }
+
+    /**
+     * @param  Builder<*>  $builder
+     */
+    public function applySort(Builder $builder, string $direction): void
+    {
+        $related = $this->relationInstance->getRelated();
+        $baseTable = $builder->getModel()->getTable();
+        $relatedTable = $related->getTable();
+
+        $subquery = $related->newQuery()->select($this->field);
+
+        if ($this->relationInstance instanceof BelongsTo) {
+            $subquery->whereColumn(
+                $relatedTable.'.'.$this->relationInstance->getOwnerKeyName(),
+                $baseTable.'.'.$this->relationInstance->getForeignKeyName(),
+            );
+        } else {
+            $subquery
+                ->whereColumn(
+                    $relatedTable.'.'.$this->relationInstance->getForeignKeyName(),
+                    $baseTable.'.'.$this->relationInstance->getLocalKeyName(),
+                )
+                ->limit(1);
+        }
+
+        $builder->orderBy($subquery, $direction);
+    }
+}

--- a/tests/Feature/Tables/RelationColumnTest.php
+++ b/tests/Feature/Tables/RelationColumnTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Lattice\Lattice\Tables\TableQuery;
+use Workbench\App\Models\BusinessPartner;
+use Workbench\App\Models\SalesOrder;
+use Workbench\App\Tables\SalesOrdersTable;
+
+/**
+ * @param  array<string, string>  $params
+ * @return array<int, array<string, mixed>>
+ */
+function salesOrderRows(array $params = []): array
+{
+    $table = new SalesOrdersTable;
+
+    $query = TableQuery::fromRequest(
+        Request::create('/', 'GET', $params),
+        $table->columns(),
+        'workbench.sales-orders',
+    );
+
+    return $table->source()->query($query)->jsonSerialize()['data'];
+}
+
+test('a relation column eager-loads its value onto a flat key without N+1', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $globex = BusinessPartner::factory()->create(['name' => 'Globex']);
+    SalesOrder::factory()->count(3)->create(['business_partner_id' => $acme->getKey()]);
+    SalesOrder::factory()->count(2)->create(['business_partner_id' => $globex->getKey()]);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $rows = salesOrderRows();
+
+    expect($rows)->toHaveCount(5)
+        ->and($rows[0])->toHaveKey('businessPartner.name')
+        ->and($rows[0])->not->toHaveKey('business_partner');
+
+    // One query loads every partner, regardless of row count — no N+1.
+    $partnerQueries = collect(DB::getQueryLog())
+        ->filter(fn (array $log): bool => str_contains((string) $log['query'], 'business_partners'))
+        ->count();
+
+    expect($partnerQueries)->toBe(1);
+});
+
+test('a relation column filters through whereHas', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $globex = BusinessPartner::factory()->create(['name' => 'Globex']);
+    SalesOrder::factory()->create(['business_partner_id' => $acme->getKey(), 'number' => 'SO-A']);
+    SalesOrder::factory()->create(['business_partner_id' => $globex->getKey(), 'number' => 'SO-G']);
+
+    $rows = salesOrderRows(['filter' => 'businessPartner.name:contains:Acme']);
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['number'])->toBe('SO-A')
+        ->and($rows[0]['businessPartner.name'])->toBe('Acme');
+});
+
+test('a relation column sorts through a correlated subquery', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $globex = BusinessPartner::factory()->create(['name' => 'Globex']);
+    SalesOrder::factory()->create(['business_partner_id' => $acme->getKey(), 'number' => 'SO-A']);
+    SalesOrder::factory()->create(['business_partner_id' => $globex->getKey(), 'number' => 'SO-G']);
+
+    $rows = salesOrderRows(['sort' => '-businessPartner.name']);
+
+    expect(array_column($rows, 'number'))->toBe(['SO-G', 'SO-A']);
+});

--- a/workbench/app/Tables/SalesOrdersTable.php
+++ b/workbench/app/Tables/SalesOrdersTable.php
@@ -31,7 +31,7 @@ class SalesOrdersTable extends EloquentTableDefinition
     {
         return [
             TextColumn::make('number')->label(__('workbench.commerce.sales-orders.columns.number'))->sortable()->filterable(),
-            TextColumn::make('business_partner_name')->label(__('workbench.commerce.sales-orders.columns.business-partner')),
+            TextColumn::make('businessPartner.name')->label(__('workbench.commerce.sales-orders.columns.business-partner'))->sortable()->filterable(),
             StatusBadgeColumn::make('status')
                 ->label(__('workbench.commerce.sales-orders.columns.status'))
                 ->filterable(Op::Equals)
@@ -47,7 +47,6 @@ class SalesOrdersTable extends EloquentTableDefinition
     {
         $builder = SalesOrder::query()
             ->select(['id', 'business_partner_id', 'number', 'status'])
-            ->withAggregate('businessPartner', 'name')
             ->selectSub(
                 SalesOrderLine::query()
                     ->select(DB::raw('coalesce(sum(quantity * unit_price), 0)'))


### PR DESCRIPTION
Lets a table column reference a to-one relation by dotted key — `TextColumn::make('businessPartner.name')` — instead of hand-writing `withAggregate`/`selectSub`. The relation is auto-detected against the model and each concern compiles to idiomatic Eloquent.

## Before / after (workbench `SalesOrdersTable`)

```php
// before — manual aggregate, display-only
TextColumn::make('business_partner_name')
SalesOrder::query()->select([...])->withAggregate('businessPartner', 'name')

// after — real column, sortable + filterable
TextColumn::make('businessPartner.name')->sortable()->filterable()
SalesOrder::query()->select([...])           // no aggregate needed
```

## What each concern compiles to

| Concern | Compiles to | Why |
|---|---|---|
| **Display** | constrained `with(['businessPartner' => fn($q) => $q->select(['id','name'])])`, value flattened onto `row['businessPartner.name']` (nested relation hidden) | one eager-load query → **no N+1**, only the leaf column → no over-fetch, **React reads the flat key unchanged** |
| **Filter** | `whereHas('businessPartner', fn($q) => $q->where('name', …))` | sidesteps the "can't use a SELECT alias in WHERE" problem |
| **Sort** | correlated subquery in `ORDER BY` | no join, no row duplication |

The base query keeps its explicit `select()` — the FK the relation matches on is re-added if the author left it out. `FilterApplier`/`FilterType` now take `Builder<*>` so the same operator SQL runs against either the base query or a `whereHas` subquery.

## Scope (v1)
Single-level **to-one** relations (`BelongsTo`/`HasOne`). Non-relation dotted keys, multi-level paths (`order.partner.name`) and to-many aggregates (counts, `tags`) are left untouched — `withCount`/`withAggregate` stay the tool for those.

## Verification
`composer check` green (PHPStan, Rector, **838 pest**). New `RelationColumnTest` asserts: the flat value + **one** `business_partners` query for many rows (no N+1), a `whereHas` filter, and a subquery sort. No React/TS or wire-shape changes.

> Research note: the dotted-key sugar deliberately replaces the aggregate idiom for *display/sort/filter of a single related field*; it does not try to be `withCount`/full-relation loading.