### PR TITLE
docs: add flow diagrams to forms, tables, fragments, and actions

### DIFF
--- a/docs/content/docs/actions/overview.mdx
+++ b/docs/content/docs/actions/overview.mdx
@@ -3,9 +3,39 @@ title: Actions
 description: Server-run actions that respond to a click and return effects — toasts, redirects, refreshes, and modals — to the client.
 ---
 
+import Mermaid from "@components/Mermaid.astro";
+
 An action runs on the server in response to a click and returns **effects** the client dispatches: a
 toast, a redirect, a component or page refresh, opening a modal. An action can both change data and
 drive the UI that follows.
+
+## How an action runs
+
+A click posts the action's signed reference to its endpoint. The server verifies the reference (and the
+trusted context baked into it), authorizes, runs `handle()`, and returns an `ActionResult` whose
+effects the client then dispatches:
+
+<Mermaid
+  title="Click to server-run work to client effects"
+  code={`sequenceDiagram
+    autonumber
+    actor U as User
+    participant B as Browser (React)
+    participant L as Lattice backend (action endpoint)
+    U->>B: Open the page
+    B->>L: GET page
+    L-->>B: Page payload — action trigger (signed ref + context)
+    U->>B: Click (confirm if required)
+    B->>L: POST action endpoint with signed ref
+    L->>L: verify ref + trusted context, authorize()
+    alt authorized
+        L->>L: handle() — run the work
+        L-->>B: ActionResult — effects
+        B->>U: Dispatch effects (toast, redirect, reload, modal)
+    else denied
+        L-->>B: 403
+    end`}
+/>
 
 ## Defining an action
 

--- a/docs/content/docs/core/fragments.mdx
+++ b/docs/content/docs/core/fragments.mdx
@@ -3,9 +3,38 @@ title: Fragments
 description: A self-contained piece of UI resolved on its own endpoint, so it can load and reload independently of the page.
 ---
 
+import Mermaid from "@components/Mermaid.astro";
+
 A fragment is a slice of UI that resolves on its own — separate from the page that hosts it. Because
 it has its own endpoint, it can load lazily and be reloaded on its own, which makes it a good fit for
 expensive panels, deferred content, or UI an [action](/actions/overview/) wants to refresh.
+
+## How a fragment loads
+
+The page ships only a placeholder. The fragment fetches its own schema from its endpoint when it
+mounts, and the same endpoint lets an [action](/actions/overview/) reload it later without touching the
+rest of the page:
+
+<Mermaid
+  title="Lazy load and independent reload"
+  code={`sequenceDiagram
+    autonumber
+    actor U as User
+    participant B as Browser (React)
+    participant L as Lattice backend (fragment endpoint)
+    U->>B: Open the page
+    B->>L: GET page
+    L-->>B: Page payload — fragment placeholder (id + ref)
+    Note over B: on mount
+    B->>L: GET fragment endpoint with signed ref
+    L->>L: authorize, run schema()
+    L-->>B: fragment nodes
+    B->>U: Swap placeholder for the rendered fragment
+    U->>B: Run an action returning reloadComponent(id)
+    B->>L: GET fragment endpoint again
+    L-->>B: fresh fragment nodes
+    B->>U: Re-render just the fragment`}
+/>
 
 ## Defining a fragment
 

--- a/docs/content/docs/forms/overview.mdx
+++ b/docs/content/docs/forms/overview.mdx
@@ -3,6 +3,8 @@ title: Forms
 description: Define fields in PHP, render them with Inertia, and validate on a dedicated server endpoint — live, through Precognition.
 ---
 
+import Mermaid from "@components/Mermaid.astro";
+
 A form is a PHP class that declares its fields and handles its own submission. You define the schema
 once; Lattice renders the React inputs, posts to a dedicated [endpoint](/advanced/security/), validates with Laravel, and
 runs your handler. Validation runs live as the user types, using the exact same rules.
@@ -73,6 +75,32 @@ Form::use(ProfileForm::class)
 
 Every form posts to its own endpoint, resolved from its `#[AsForm]` id. The request is signed, so a
 form only accepts submissions for the schema it actually rendered. `FormController` routes the request:
+
+<Mermaid
+  title="One form endpoint, routed by request kind"
+  code={`sequenceDiagram
+    autonumber
+    actor U as User
+    participant B as Browser (React)
+    participant L as Lattice backend (form endpoint)
+    U->>B: Open the page
+    B->>L: GET page
+    L-->>B: Page payload — signed form schema (fields + rules)
+    U->>B: Interact (type, search, change a dependent field)
+    B->>L: POST form endpoint with signed ref
+    Note over L: one endpoint, routed by request kind
+    alt searchable Select (_search)
+        L-->>B: matching options
+    else dependent field (_resolve)
+        L-->>B: recomputed field nodes + values
+    else live validation (Precognition)
+        L-->>B: 204 valid / 422 messages
+    else submit
+        L->>L: validate() then handle()
+        L-->>B: redirect / JSON / effects
+    end
+    B->>U: Show result`}
+/>
 
 1. A **search** request (a searchable `Select` fetching options) returns matching options.
 2. A **resolve** request (a [dependent field](/forms/conditional-fields/) recomputing) returns the

--- a/docs/content/docs/tables/overview.mdx
+++ b/docs/content/docs/tables/overview.mdx
@@ -4,6 +4,7 @@ description: Listings with columns, sorting, filtering, pagination, and row and 
 ---
 
 import ComponentExample from "@components/ComponentExample.astro";
+import Mermaid from "@components/Mermaid.astro";
 
 A table is a listing backed by a **data source**. You declare columns in PHP; Lattice renders the
 React table and handles sorting, filtering, and pagination, fetching rows from the table's [endpoint](/advanced/security/).
@@ -30,6 +31,34 @@ implementing the source interface.
 
 }`}
 fixture="table.overview"
+/>
+
+## How a table loads data
+
+Every sort, filter, and page change is a fresh `GET` to the table's endpoint. The request becomes a
+`TableQuery` that the data source turns into rows — so the React table never holds the full dataset, it
+asks for the page it needs:
+
+<Mermaid
+  title="Fetching a page of rows through the data source"
+  code={`sequenceDiagram
+    autonumber
+    actor U as User
+    participant B as Browser (React)
+    participant L as Lattice backend (table endpoint)
+    participant D as Data source
+    U->>B: Open the page
+    B->>L: GET page
+    L-->>B: Page payload — signed table (columns + ref)
+    B->>L: GET table endpoint — sort, filter, page
+    L->>L: build TableQuery from the request
+    L->>D: source.query(TableQuery)
+    D-->>L: TableResult — rows + pagination
+    L-->>B: rows + pagination metadata
+    B->>U: Render the table
+    U->>B: Sort / filter / paginate
+    B->>L: GET table endpoint — updated query
+    Note over B,L: same round-trip, new TableQuery`}
 />
 
 ## Defining a table


### PR DESCRIPTION
Adds a mermaid sequence diagram to the Forms, Tables, Fragments, and Actions overview pages, in the same style as the Remote page. Each diagram opens with the user navigating to the page, then shows that feature's distinctive round-trip.

## What changed
- **Forms** (`forms/overview`) — one form endpoint routed by request kind (`_search` / `_resolve` / Precognition / submit).
- **Tables** (`tables/overview`) — a page of rows fetched through the pluggable data source (`TableQuery` → `source.query()` → `TableResult`).
- **Fragments** (`core/fragments`) — lazy load on mount and independent reload via `reloadComponent`.
- **Actions** (`actions/overview`) — click → verify ref + authorize → `handle()` → `ActionResult` effects.
- Converted `forms/overview`, `actions/overview`, and `core/fragments` from `.md` to `.mdx` to embed the `Mermaid` component (`tables/overview` was already `.mdx`). Routes are extension-agnostic, so no sidebar changes.

Endpoints/flows verified against `routes/web.php` and `FormController`. Builds on the `Mermaid.astro` component from #168.

## Verification
- `npm run docs:build` passes (55 pages).
- All four diagrams confirmed rendering to sequence SVGs in-browser, each starting with **Open the page → GET page**.