### PR TITLE
feat: responsive sidebar with off-canvas mobile drawer

### DIFF
--- a/docs/content/docs/core/navigation.md
+++ b/docs/content/docs/core/navigation.md
@@ -13,7 +13,10 @@ see [Layouts](/core/layouts/) for the shell they sit in.
 The sidebar's links are `Menu` and `MenuItem` components:
 
 - `Sidebar::make()->collapsible()->items([...])` — the shell sidebar; `collapsible()` remembers its
-  open state.
+  open state. Below the `md` breakpoint it becomes an off-canvas drawer instead of consuming layout
+  width.
+- The sidebar renders no toggle button itself. Place one wherever you like (typically the `Topbar`)
+  with a `Button` that fires the `toggleSidebar` effect on the client — see below.
 - `Menu::make()->items([...])` — a list of menu items.
 - `MenuItem::make($label)->href($url)->icon($icon)` — a link. Nest a group with `->children([...])`.
 - `MenuItem::fromPage(SomePage::class)` — builds an item that links to a page's route automatically,
@@ -33,6 +36,26 @@ use Lattice\Lattice\Core\Enums\HttpMethod;
 
 MenuItem::make('Log out')->href(route('logout', absolute: false))->icon('log-out')->method(HttpMethod::Post);
 ```
+
+## Toggling the sidebar
+
+A `Button` can dispatch effects on the client when clicked — no request to the server. The
+`toggleSidebar` effect collapses the rail on desktop and opens the off-canvas drawer on mobile, so
+the toggle button can live anywhere (here, in the `Topbar`):
+
+```php
+use Lattice\Lattice\Core\Components\Button;
+use Lattice\Lattice\Core\Enums\ButtonVariant;
+use Lattice\Lattice\Effects\Effect;
+
+Button::make('Toggle sidebar', 'sidebar-toggle')
+    ->icon('panel-left')
+    ->variant(ButtonVariant::Ghost)
+    ->effects(Effect::toggleSidebar('app-sidebar'));
+```
+
+`->effects()` accepts any effect, giving a button instant client-side behavior (open a modal, show a
+toast, reset a form) without a round-trip.
 
 ## Dropdowns
 

--- a/docs/fixtures/components.buttons.json
+++ b/docs/fixtures/components.buttons.json
@@ -13,7 +13,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Default",
                     "variant": "default"
                 },
@@ -22,7 +24,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Secondary",
                     "variant": "secondary"
                 },
@@ -31,7 +35,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Success",
                     "variant": "success"
                 },
@@ -40,7 +46,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Info",
                     "variant": "info"
                 },
@@ -49,7 +57,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Destructive",
                     "variant": "destructive"
                 },
@@ -58,7 +68,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Outline",
                     "variant": "outline"
                 },
@@ -67,7 +79,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Ghost",
                     "variant": "ghost"
                 },

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -44,7 +44,9 @@
             {
                 "props": {
                     "buttonType": "button",
+                    "effects": [],
                     "href": null,
+                    "icon": null,
                     "label": "Invite member",
                     "variant": "default"
                 },

--- a/docs/fixtures/components.section.json
+++ b/docs/fixtures/components.section.json
@@ -8,7 +8,9 @@
                 {
                     "props": {
                         "buttonType": "button",
+                        "effects": [],
                         "href": null,
+                        "icon": null,
                         "label": "Invite member",
                         "variant": "outline"
                     },

--- a/resources/js/core/components/button.test.tsx
+++ b/resources/js/core/components/button.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { Button } from "./button";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import type { Node } from "@lattice-php/lattice/core/types";
+import ButtonComponent, { Button } from "./button";
 
 describe("Button variants", () => {
   it("applies the success variant classes", () => {
@@ -13,5 +18,40 @@ describe("Button variants", () => {
     render(<Button variant="info">Details</Button>);
 
     expect(screen.getByRole("button")).toHaveClass("bg-lt-info", "text-lt-info-fg");
+  });
+});
+
+describe("ButtonComponent client effects", () => {
+  const registry = createRegistry({
+    components: { button: eagerComponent(ButtonComponent) },
+    name: "test/button",
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("dispatches its effects on click without a server request", () => {
+    const node: Node = {
+      key: "sidebar-toggle",
+      props: {
+        buttonType: "button",
+        effects: [{ type: "toggleSidebar", target: "app-sidebar" }],
+        icon: "panel-left",
+        label: "Toggle sidebar",
+      },
+      type: "button",
+    };
+    const listener = vi.fn<(event: Event) => void>();
+    window.addEventListener(LATTICE_EVENT.toggleSidebar, listener);
+
+    renderWithRegistry(<Renderer nodes={[node]} />, registry);
+    fireEvent.click(screen.getByRole("button", { name: "Toggle sidebar" }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect((listener.mock.calls[0][0] as CustomEvent).detail).toMatchObject({
+      type: "toggleSidebar",
+      target: "app-sidebar",
+    });
+
+    window.removeEventListener(LATTICE_EVENT.toggleSidebar, listener);
   });
 });

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -3,8 +3,11 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { getActionEffects } from "@lattice-php/lattice/effects/dispatch";
+import { IconRenderer } from "@lattice-php/lattice/icons";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";
 import type { ButtonVariant } from "@lattice-php/lattice/types/generated";
 
 export type { ButtonVariant };
@@ -64,9 +67,11 @@ function Button({
 }
 
 const ButtonComponent: RendererComponent<"button"> = ({ node }) => {
-  const { href, label } = node.props;
+  const { href, label, icon } = node.props;
+  const effects = node.props.effects ?? [];
   const variant = node.props.variant ?? "default";
   const testId = nodeIdentity(node);
+  const dispatch = useEffectDispatcher();
 
   if (href) {
     return (
@@ -76,9 +81,18 @@ const ButtonComponent: RendererComponent<"button"> = ({ node }) => {
     );
   }
 
+  const hasEffects = effects.length > 0;
+
   return (
-    <Button data-test={testId} type={node.props.buttonType} variant={variant} size="default">
-      {label}
+    <Button
+      aria-label={icon ? label || undefined : undefined}
+      data-test={testId}
+      onClick={hasEffects ? () => dispatch(getActionEffects(effects)) : undefined}
+      size={icon ? "icon" : "default"}
+      type={node.props.buttonType}
+      variant={variant}
+    >
+      {icon ? <IconRenderer className="size-lt-icon-md" icon={icon} /> : label}
     </Button>
   );
 };

--- a/resources/js/core/components/button.tsx
+++ b/resources/js/core/components/button.tsx
@@ -85,14 +85,20 @@ const ButtonComponent: RendererComponent<"button"> = ({ node }) => {
 
   return (
     <Button
-      aria-label={icon ? label || undefined : undefined}
       data-test={testId}
       onClick={hasEffects ? () => dispatch(getActionEffects(effects)) : undefined}
       size={icon ? "icon" : "default"}
       type={node.props.buttonType}
       variant={variant}
     >
-      {icon ? <IconRenderer className="size-lt-icon-md" icon={icon} /> : label}
+      {icon ? (
+        <>
+          <IconRenderer className="size-lt-icon-md" icon={icon} />
+          {label ? <span className="sr-only">{label}</span> : null}
+        </>
+      ) : (
+        label
+      )}
     </Button>
   );
 };

--- a/resources/js/effects/registry.test.ts
+++ b/resources/js/effects/registry.test.ts
@@ -162,4 +162,15 @@ describe("builtinEffectHandlers", () => {
     window.removeEventListener(LATTICE_EVENT.resetForm, listener);
     expect(received).toEqual([{ type: "resetForm", form: "teams.create" }]);
   });
+
+  it("toggleSidebar bridges to the lattice:toggle-sidebar DOM event with the target as detail", () => {
+    const received: unknown[] = [];
+    const listener = (event: Event) => received.push((event as CustomEvent).detail);
+    window.addEventListener(LATTICE_EVENT.toggleSidebar, listener);
+
+    builtinEffectHandlers.toggleSidebar({ type: "toggleSidebar", target: "app-sidebar" } as never);
+
+    window.removeEventListener(LATTICE_EVENT.toggleSidebar, listener);
+    expect(received).toEqual([{ type: "toggleSidebar", target: "app-sidebar" }]);
+  });
 });

--- a/resources/js/effects/registry.ts
+++ b/resources/js/effects/registry.ts
@@ -77,6 +77,7 @@ export const builtinEffectHandlers: EffectHandlerRegistry = {
   openModal: bridge(LATTICE_EVENT.openModal),
   closeModal: bridge(LATTICE_EVENT.closeModal),
   resetForm: bridge(LATTICE_EVENT.resetForm),
+  toggleSidebar: bridge(LATTICE_EVENT.toggleSidebar),
 };
 
 export function mergeEffectHandlers(

--- a/resources/js/events/event-names.ts
+++ b/resources/js/events/event-names.ts
@@ -13,6 +13,7 @@ export const LATTICE_EVENT = {
   openModal: "lattice:open-modal",
   closeModal: "lattice:close-modal",
   resetForm: "lattice:reset-form",
+  toggleSidebar: "lattice:toggle-sidebar",
   appearanceChange: "lattice:appearance-change",
   localeChange: "lattice:locale-change",
   actionError: "lattice:action-error",

--- a/resources/js/layout/sidebar.test.tsx
+++ b/resources/js/layout/sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
 import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import type { Node } from "@lattice-php/lattice/core/types";
@@ -17,53 +18,62 @@ function renderSidebar(props: { collapsible: boolean; rememberState: boolean }) 
   return renderWithRegistry(<Renderer nodes={[node]} />, registry);
 }
 
+function dispatchToggle(): void {
+  fireEvent(
+    window,
+    new CustomEvent(LATTICE_EVENT.toggleSidebar, { detail: { target: "app-sidebar" } }),
+  );
+}
+
 describe("Sidebar", () => {
   afterEach(() => window.localStorage.clear());
 
-  it("renders a fixed-width aside with no toggle when not collapsible", () => {
+  it("renders an aside with no built-in toggle button", () => {
     renderSidebar({ collapsible: false, rememberState: false });
 
-    expect(screen.getByRole("complementary")).toHaveClass(
-      "sticky",
-      "top-0",
-      "h-svh",
-      "w-64",
-      "shrink-0",
-    );
+    expect(screen.getByRole("complementary")).toHaveClass("fixed", "md:sticky", "md:w-64");
+    expect(screen.getByRole("complementary")).toHaveAttribute("data-collapsed", "false");
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("collapses to the icon rail when the toggle is clicked", () => {
+  it("collapses to the icon rail when a toggle event targets it", () => {
     renderSidebar({ collapsible: true, rememberState: false });
 
-    expect(screen.getByRole("complementary")).toHaveClass(
-      "w-64",
-      "overflow-x-hidden",
-      "overflow-y-auto",
+    expect(screen.getByRole("complementary")).toHaveClass("md:w-64");
+
+    dispatchToggle();
+
+    expect(screen.getByRole("complementary")).toHaveClass("md:w-16", "md:overflow-visible");
+    expect(screen.getByRole("complementary")).toHaveAttribute("data-collapsed", "true");
+  });
+
+  it("ignores toggle events aimed at a different sidebar", () => {
+    renderSidebar({ collapsible: true, rememberState: false });
+
+    fireEvent(
+      window,
+      new CustomEvent(LATTICE_EVENT.toggleSidebar, { detail: { target: "other" } }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
-
-    expect(screen.getByRole("complementary")).toHaveClass("w-16", "overflow-visible");
-    expect(screen.getByRole("button", { name: "Expand sidebar" })).toBeVisible();
+    expect(screen.getByRole("complementary")).toHaveAttribute("data-collapsed", "false");
   });
 
   it("remembers the collapsed state when rememberState is on", () => {
     const { unmount } = renderSidebar({ collapsible: true, rememberState: true });
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+    dispatchToggle();
     expect(window.localStorage.getItem("lattice:sidebar:app-sidebar")).toBe("true");
 
     unmount();
     renderSidebar({ collapsible: true, rememberState: true });
 
-    expect(screen.getByRole("complementary")).toHaveClass("w-16");
+    expect(screen.getByRole("complementary")).toHaveClass("md:w-16");
   });
 
   it("does not persist the collapsed state when rememberState is off", () => {
     renderSidebar({ collapsible: true, rememberState: false });
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+    dispatchToggle();
 
     expect(window.localStorage.getItem("lattice:sidebar:app-sidebar")).toBeNull();
   });

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -1,9 +1,12 @@
-import { Icon } from "@lattice-php/lattice/icons";
-import { useState } from "react";
+import { router } from "@inertiajs/react";
+import { useEffect, useState } from "react";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { CollapsedContext } from "../core/collapsed-context";
+import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import { cn } from "@lattice-php/lattice/lib/utils";
+
+const DESKTOP_QUERY = "(min-width: 768px)";
 
 function readStored(key: string, remember: boolean): boolean {
   if (!remember || typeof window === "undefined") {
@@ -13,54 +16,120 @@ function readStored(key: string, remember: boolean): boolean {
   return window.localStorage.getItem(key) === "true";
 }
 
+function matchesTarget(event: Event, identity: string | undefined): boolean {
+  const target = (event as CustomEvent<{ target?: string }>).detail?.target;
+
+  return target == null || target === identity;
+}
+
+function useIsDesktop(): boolean {
+  const supported = () => typeof window !== "undefined" && typeof window.matchMedia === "function";
+  const [isDesktop, setIsDesktop] = useState(() =>
+    supported() ? window.matchMedia(DESKTOP_QUERY).matches : true,
+  );
+
+  useEffect(() => {
+    if (!supported()) {
+      return;
+    }
+
+    const query = window.matchMedia(DESKTOP_QUERY);
+    const update = (): void => setIsDesktop(query.matches);
+
+    update();
+    query.addEventListener("change", update);
+
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return isDesktop;
+}
+
 const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
   const collapsible = node.props.collapsible;
   const rememberState = node.props.rememberState;
   const identity = nodeIdentity(node);
   const storageKey = `lattice:sidebar:${identity ?? "default"}`;
+  const isDesktop = useIsDesktop();
 
   const [collapsed, setCollapsed] = useState(() =>
     readStored(storageKey, collapsible && rememberState),
   );
+  const [mobileOpen, setMobileOpen] = useState(false);
 
-  function toggle(): void {
-    setCollapsed((value) => {
-      const next = !value;
-
-      if (rememberState && typeof window !== "undefined") {
-        window.localStorage.setItem(storageKey, String(next));
+  useEffect(() => {
+    function toggle(event: Event): void {
+      if (!matchesTarget(event, identity)) {
+        return;
       }
 
-      return next;
-    });
-  }
+      if (window.matchMedia?.(DESKTOP_QUERY).matches ?? true) {
+        if (!collapsible) {
+          return;
+        }
 
-  const isCollapsed = collapsible && collapsed;
+        setCollapsed((value) => {
+          const next = !value;
+
+          if (rememberState && typeof window !== "undefined") {
+            window.localStorage.setItem(storageKey, String(next));
+          }
+
+          return next;
+        });
+      } else {
+        setMobileOpen((open) => !open);
+      }
+    }
+
+    window.addEventListener(LATTICE_EVENT.toggleSidebar, toggle);
+
+    return () => window.removeEventListener(LATTICE_EVENT.toggleSidebar, toggle);
+  }, [identity, collapsible, rememberState, storageKey]);
+
+  useEffect(() => router.on("navigate", () => setMobileOpen(false)), []);
+
+  useEffect(() => {
+    if (!mobileOpen) {
+      return;
+    }
+
+    function close(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        setMobileOpen(false);
+      }
+    }
+
+    window.addEventListener("keydown", close);
+
+    return () => window.removeEventListener("keydown", close);
+  }, [mobileOpen]);
+
+  const isCollapsed = collapsible && collapsed && isDesktop;
 
   return (
     <CollapsedContext.Provider value={isCollapsed}>
+      {mobileOpen ? (
+        <div
+          aria-hidden="true"
+          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          data-test="sidebar-backdrop"
+          onClick={() => setMobileOpen(false)}
+        />
+      ) : null}
       <aside
         className={cn(
-          "sticky top-0 flex h-svh shrink-0 flex-col gap-4 border-r border-lt-border p-4 transition-[width]",
-          isCollapsed ? "w-16 overflow-visible" : "w-64 overflow-x-hidden overflow-y-auto",
+          "fixed inset-y-0 left-0 z-40 flex h-svh w-72 max-w-[80vw] shrink-0 flex-col gap-4 border-r border-lt-border bg-lt-bg p-4 transition-transform",
+          "md:sticky md:top-0 md:z-auto md:max-w-none md:translate-x-0 md:transition-[width]",
+          mobileOpen ? "translate-x-0" : "-translate-x-full",
+          isCollapsed
+            ? "md:w-16 md:overflow-visible"
+            : "md:w-64 md:overflow-x-hidden md:overflow-y-auto",
         )}
+        data-collapsed={isCollapsed ? "true" : "false"}
         data-lattice-component={identity}
+        data-test="sidebar"
       >
-        {collapsible ? (
-          <button
-            aria-expanded={!isCollapsed}
-            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-            data-test="sidebar-toggle"
-            className={cn(
-              "inline-flex items-center rounded-lt-sm p-2 text-lt-fg transition-colors hover:bg-lt-muted",
-              isCollapsed ? "self-center" : "self-end",
-            )}
-            onClick={toggle}
-            type="button"
-          >
-            <Icon name="panel-left" aria-hidden="true" className="size-lt-icon-md shrink-0" />
-          </button>
-        ) : null}
         {children}
       </aside>
     </CollapsedContext.Provider>

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -104,7 +104,9 @@ export type BulkAction = {
 };
 export type Button = {
   buttonType: ButtonType;
+  effects: Effect[];
   href: string | null;
+  icon: string | null;
   label: string;
   variant: ButtonVariant | null;
 };
@@ -467,7 +469,10 @@ export type Effect =
     } & ResetFormEffect)
   | ({
       type: "toast";
-    } & ToastEffect);
+    } & ToastEffect)
+  | ({
+      type: "toggleSidebar";
+    } & ToggleSidebarEffect);
 export type FieldType =
   | "field.builder"
   | "field.checkbox"
@@ -1217,6 +1222,9 @@ export type ToastMessage = {
   action: Node | null;
   variant: Variant;
   message: Translatable | string;
+};
+export type ToggleSidebarEffect = {
+  readonly target: string | null;
 };
 export type ToolCallPart = {
   args: Record<string, unknown>;

--- a/src/Core/Components/Button.php
+++ b/src/Core/Components/Button.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Components;
 
+use BackedEnum;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Core\Concerns\HasVariant;
 use Lattice\Lattice\Core\Enums\ButtonType;
+use Lattice\Lattice\Effects\Contracts\Effect;
 
 #[AsComponent('button')]
 class Button extends Component
@@ -16,7 +18,18 @@ class Button extends Component
 
     public ?string $href = null;
 
+    public ?string $icon = null;
+
     public ButtonType $buttonType = ButtonType::Button;
+
+    /**
+     * Effects dispatched on the client when the button is clicked, with no
+     * request to the server. Use the {@see Effect} factories, e.g.
+     * `->effects(Effect::toggleSidebar('app-sidebar'))`.
+     *
+     * @var array<int, Effect>
+     */
+    public array $effects = [];
 
     public static function make(string $label, ?string $key = null): static
     {
@@ -29,6 +42,20 @@ class Button extends Component
     public function href(string $href): static
     {
         $this->href = $href;
+
+        return $this;
+    }
+
+    public function icon(BackedEnum|string $icon): static
+    {
+        $this->icon = $this->enumValue($icon);
+
+        return $this;
+    }
+
+    public function effects(Effect ...$effects): static
+    {
+        $this->effects = $effects;
 
         return $this;
     }

--- a/src/Effects/Builtin/ToggleSidebarEffect.php
+++ b/src/Effects/Builtin/ToggleSidebarEffect.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Effects\Builtin;
+
+use Lattice\Lattice\Core\Components\Button;
+use Lattice\Lattice\Effects\Attributes\AsEffect;
+use Lattice\Lattice\Effects\Effect;
+
+/**
+ * Toggles a sidebar entirely on the client: it collapses the icon rail on
+ * desktop and opens the off-canvas drawer on smaller screens. Dispatch it from
+ * a {@see Button} via `->effects(...)` so the
+ * trigger can live anywhere in the layout.
+ */
+#[AsEffect('toggleSidebar')]
+final readonly class ToggleSidebarEffect extends Effect
+{
+    public function __construct(
+        public ?string $target = null,
+    ) {}
+}

--- a/src/Effects/Effect.php
+++ b/src/Effects/Effect.php
@@ -19,6 +19,7 @@ use Lattice\Lattice\Effects\Builtin\ReloadComponentEffect;
 use Lattice\Lattice\Effects\Builtin\ReloadPageEffect;
 use Lattice\Lattice\Effects\Builtin\ResetFormEffect;
 use Lattice\Lattice\Effects\Builtin\ToastEffect;
+use Lattice\Lattice\Effects\Builtin\ToggleSidebarEffect;
 use Lattice\Lattice\Effects\Contracts\Effect as EffectContract;
 
 abstract readonly class Effect implements EffectContract
@@ -79,6 +80,11 @@ abstract readonly class Effect implements EffectContract
     public static function localeChange(string $locale): LocaleChangeEffect
     {
         return new LocaleChangeEffect($locale);
+    }
+
+    public static function toggleSidebar(?string $target = null): ToggleSidebarEffect
+    {
+        return new ToggleSidebarEffect($target);
     }
 
     /**

--- a/tests/Browser/Layout/ChatLayoutToggleTest.php
+++ b/tests/Browser/Layout/ChatLayoutToggleTest.php
@@ -6,15 +6,15 @@ it('reveals the docked chat panel when the chat layout is toggled', function ():
     $this->actingAs(workbenchTestUser());
 
     visit('/')
-        ->assertSee('Reveal chat in a side rail')
         ->assertVisible('@assistant-chat-trigger')
         ->assertMissing('@chat-box')
+        ->click('@user-menu')
+        ->assertSee('Reveal chat in a side rail')
         ->click('@chat-layout-toggle')
-        ->assertSee('Dock chat back to floating')
         ->assertVisible('@chat-box')
         ->assertMissing('@assistant-chat-trigger')
+        ->assertSee('Dock chat back to floating')
         ->click('@chat-layout-toggle')
-        ->assertSee('Reveal chat in a side rail')
         ->assertVisible('@assistant-chat-trigger')
         ->assertMissing('@chat-box')
         ->assertNoSmoke();

--- a/tests/Browser/Layout/DropdownTest.php
+++ b/tests/Browser/Layout/DropdownTest.php
@@ -15,7 +15,7 @@ it('keeps the user dropdown usable when the sidebar is collapsed', function (): 
     $this->actingAs(workbenchTestUser());
     visit('/')
         ->click('@sidebar-toggle')
-        ->assertPresent('[aria-label="Expand sidebar"]')
+        ->assertPresent('[data-test="sidebar"][data-collapsed="true"]')
         ->click('@user-menu')
         ->assertSee('Log out')
         ->assertNoSmoke();

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -32,11 +32,25 @@ it('collapses to an icon rail and opens a group submenu as a flyout', function (
     Product::factory()->create(['name' => 'Desk Lamp']);
 
     visit('/')
+        ->assertPresent('[data-test="sidebar"][data-collapsed="false"]')
         ->click('@sidebar-toggle')
-        ->assertPresent('[aria-label="Expand sidebar"]')
+        ->assertPresent('[data-test="sidebar"][data-collapsed="true"]')
         ->click('@menu-commerce')
         ->click('@menu-products')
         ->assertSee('Desk Lamp')
-        ->assertPresent('[aria-label="Expand sidebar"]')
+        ->assertPresent('[data-test="sidebar"][data-collapsed="true"]')
+        ->assertNoSmoke();
+});
+
+it('opens the sidebar as an off-canvas drawer on mobile', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    visit('/')
+        ->on()->mobile()
+        ->assertMissing('[data-test="sidebar-backdrop"]')
+        ->click('@sidebar-toggle')
+        ->assertPresent('[data-test="sidebar-backdrop"]')
+        ->click('@menu-tabs')
+        ->assertMissing('[data-test="sidebar-backdrop"]')
         ->assertNoSmoke();
 });

--- a/tests/Feature/Effects/BuiltinRegistrationTest.php
+++ b/tests/Feature/Effects/BuiltinRegistrationTest.php
@@ -7,6 +7,6 @@ it('auto-registers all built-in effects in the container', function (): void {
     $registry = app(EffectRegistry::class);
 
     expect(array_keys($registry->all()))
-        ->toContain('toast', 'callout', 'redirect', 'download', 'openModal', 'closeModal', 'reloadPage', 'reloadComponent', 'resetForm', 'localeChange')
-        ->and($registry->all())->toHaveCount(10);
+        ->toContain('toast', 'callout', 'redirect', 'download', 'openModal', 'closeModal', 'reloadPage', 'reloadComponent', 'resetForm', 'localeChange', 'toggleSidebar')
+        ->and($registry->all())->toHaveCount(11);
 });

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Attributes\AsLayout;
 use Lattice\Lattice\Chat\Components\ChatBox;
 use Lattice\Lattice\Core\Components\Badge;
+use Lattice\Lattice\Core\Components\Button;
 use Lattice\Lattice\Core\Components\FloatingPanel;
 use Lattice\Lattice\Core\Components\RawBlock;
 use Lattice\Lattice\Core\Components\Stack;
@@ -21,6 +22,7 @@ use Lattice\Lattice\Core\Enums\Placement;
 use Lattice\Lattice\Core\Enums\Side;
 use Lattice\Lattice\Core\Enums\Width;
 use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Effects\Effect;
 use Lattice\Lattice\Layouts\Components\Breadcrumbs;
 use Lattice\Lattice\Layouts\Components\Dropdown;
 use Lattice\Lattice\Layouts\Components\Menu;
@@ -66,7 +68,6 @@ class AppLayout extends LayoutDefinition
                             RawBlock::make('chat-scroll-clearance')->html('<div class="h-24" aria-hidden="true"></div>'),
                         ]),
                 ]),
-            $this->chatLayoutTogglePanel(),
             FloatingPanel::make('assistant-chat')
                 ->placement(FloatingPlacement::BottomEnd)
                 ->trigger([
@@ -117,6 +118,10 @@ class AppLayout extends LayoutDefinition
     protected function topbar(): Topbar
     {
         return Topbar::make('app-topbar')->sticky()->items([
+            Button::make(__('workbench.navigation.toggle-sidebar'), 'sidebar-toggle')
+                ->icon('panel-left')
+                ->variant(ButtonVariant::Ghost)
+                ->effects(Effect::toggleSidebar('app-sidebar')),
             Stack::make('topbar-end')
                 ->direction('row')
                 ->align(Align::Center)
@@ -152,8 +157,19 @@ class AppLayout extends LayoutDefinition
                     ]),
             ])
             ->items([
+                $this->chatLayoutToggle(),
                 MenuItem::make(__('workbench.navigation.log-out'), 'log-out')->href('/logout')->method(HttpMethod::Post),
             ]);
+    }
+
+    protected function chatLayoutToggle(): ActionComponent
+    {
+        $inline = (bool) session('workbench.chat_inline', false);
+
+        return ActionComponent::use(ToggleChatLayoutAction::class)
+            ->key('chat-layout-toggle')
+            ->variant(ButtonVariant::Ghost)
+            ->label($inline ? __('workbench.chat-layout.hide') : __('workbench.chat-layout.reveal'));
     }
 
     protected function localeSwitcher(): Dropdown
@@ -179,20 +195,6 @@ class AppLayout extends LayoutDefinition
                     ->label(__('workbench.language.de'))
                     ->variant(ButtonVariant::Ghost)
                     ->context(['locale' => 'de']),
-            ]);
-    }
-
-    protected function chatLayoutTogglePanel(): FloatingPanel
-    {
-        $inline = (bool) session('workbench.chat_inline', false);
-
-        return FloatingPanel::make('chat-layout-toggle-panel')
-            ->label(__('workbench.chat-layout.label'))
-            ->placement(FloatingPlacement::TopStart)
-            ->schema([
-                ActionComponent::use(ToggleChatLayoutAction::class)
-                    ->key('chat-layout-toggle')
-                    ->label($inline ? __('workbench.chat-layout.hide') : __('workbench.chat-layout.reveal')),
             ]);
     }
 

--- a/workbench/app/Layouts/ChatLayout.php
+++ b/workbench/app/Layouts/ChatLayout.php
@@ -37,7 +37,6 @@ final class ChatLayout extends AppLayout
                             $this->chatBox()->fill(),
                         ]),
                 ]),
-            $this->chatLayoutTogglePanel(),
         ]);
     }
 }

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -325,6 +325,7 @@ return [
         'showcase' => 'Showcase',
         'tables' => 'Tabellen',
         'tabs' => 'Tabs',
+        'toggle-sidebar' => 'Seitenleiste umschalten',
     ],
     'pages' => [
         'builder' => [

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -325,6 +325,7 @@ return [
         'showcase' => 'Showcase',
         'tables' => 'Tables',
         'tabs' => 'Tabs',
+        'toggle-sidebar' => 'Toggle sidebar',
     ],
     'pages' => [
         'builder' => [

--- a/workbench/resources/icons/plug.svg
+++ b/workbench/resources/icons/plug.svg
@@ -1,0 +1,18 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-plug"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 22v-5" />
+  <path d="M15 8V2" />
+  <path d="M17 8a1 1 0 0 1 1 1v4a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V9a1 1 0 0 1 1-1z" />
+  <path d="M9 8V2" />
+</svg>

--- a/workbench/resources/js/sprite-icons.ts
+++ b/workbench/resources/js/sprite-icons.ts
@@ -41,6 +41,7 @@ export const iconNames = [
   "panel-left",
   "pencil",
   "pencil-line",
+  "plug",
   "plus",
   "quote",
   "rotate-ccw",
@@ -101,6 +102,7 @@ declare module "@lattice-php/lattice" {
     "panel-left": true;
     pencil: true;
     "pencil-line": true;
+    plug: true;
     plus: true;
     quote: true;
     "rotate-ccw": true;


### PR DESCRIPTION
## What & why

The app sidebar was a fixed 256px in-flow column with no responsive behavior — on phones it squeezed content into ~134px and caused ~56px of horizontal overflow, and its collapse toggle was unreachable behind a floating panel. This makes the sidebar mobile-friendly and decouples its toggle.

### Responsive sidebar
- **< `md`:** off-canvas drawer — hidden by default, slides in over a backdrop, consumes **zero layout width**. Closes on backdrop tap, Escape, and navigation.
- **≥ `md`:** unchanged — in-flow sticky collapsible icon rail (state still persisted to `localStorage`).

### Client-side effects on `Button` (the toggle mechanism)
- `Button::make(...)->effects(Effect::...())` dispatches one or more Lattice effects **purely on the client** when clicked — no request to the backend. Reuses the existing effect dispatcher (same one realtime listeners use), so `toast`, `openModal`, `resetForm`, etc. all work.
- New typed `toggleSidebar` effect (`Effect::toggleSidebar('app-sidebar')`) drives the sidebar: collapses the rail on desktop, opens the drawer on mobile. The trigger can live anywhere — the workbench places it in the topbar.
- `Button` also gained `icon()` (icon-only rendering with the label as its accessible name).

### Workbench chrome
- Moved the chat-layout toggle from a floating panel (which overlapped content on mobile) into the user menu.
- Added the missing `plug` workbench icon (the Remote-Schema menu item referenced it but no SVG existed, producing a console error).

## Verification
- `npm run check` (lint, types, type-coverage, Vitest, library build) — green
- `composer check` (Pint, PHPStan, Rector, 844 Pest tests) — green
- Browser suite incl. a new mobile-drawer test (open via hamburger, backdrop/navigation close, desktop rail collapse) — green

## Notes for reviewers
- This is an API change: `Sidebar::make()->collapsible()` no longer renders a built-in toggle — place a `Button` with the `toggleSidebar` effect (documented in `core/navigation`).