### PR TITLE
feat: createLatticeApp helper, Responsable pages, and optional realtime peer build fix

### DIFF
--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -1,0 +1,90 @@
+import type { Page as InertiaPage } from "@inertiajs/core";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createInertiaApp = vi.hoisted(() => vi.fn<(options?: unknown) => void>());
+
+vi.mock("@inertiajs/react", () => ({ createInertiaApp }));
+
+import { createLatticeApp } from "./create-app";
+import { pageComponentName } from "./inertia";
+import Page from "./page";
+import { Provider } from "./provider";
+
+type CapturedOptions = {
+  resolve: (name: string) => unknown;
+  layout: (name: string, page: InertiaPage) => unknown;
+  withApp: (node: ReactElement) => ReactElement;
+  strictMode: boolean;
+  title?: (title: string) => string;
+};
+
+function captureOptions(): CapturedOptions {
+  return createInertiaApp.mock.calls[0]?.[0] as CapturedOptions;
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn<(query: string) => MediaQueryList>(
+      () =>
+        ({
+          matches: false,
+          addEventListener: vi.fn<() => void>(),
+          removeEventListener: vi.fn<() => void>(),
+        }) as unknown as MediaQueryList,
+    ),
+  );
+});
+
+afterEach(() => {
+  createInertiaApp.mockReset();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("createLatticeApp", () => {
+  it("resolves server-driven lattice pages", () => {
+    createLatticeApp();
+
+    expect(captureOptions().resolve(pageComponentName)).toEqual({ default: Page });
+  });
+
+  it("resolves normal inertia pages from the provided glob", async () => {
+    const Dashboard = (): null => null;
+
+    createLatticeApp({
+      pages: { "./pages/Dashboard.tsx": () => Promise.resolve(Dashboard) },
+    });
+
+    await expect(captureOptions().resolve("Dashboard")).resolves.toBe(Dashboard);
+  });
+
+  it("wraps the app in the Provider so toasts use Lattice's own Toaster", () => {
+    const sprite = { href: "/sprite.svg" };
+
+    createLatticeApp({ sprite });
+
+    const wrapped = captureOptions().withApp(<div />);
+
+    expect(wrapped.type).toBe(Provider);
+    expect((wrapped.props as { sprite: unknown }).sprite).toBe(sprite);
+  });
+
+  it("defaults strictMode on and forwards other inertia options", () => {
+    const title = (value: string): string => value;
+
+    createLatticeApp({ title });
+
+    const options = captureOptions();
+
+    expect(options.strictMode).toBe(true);
+    expect(options.title).toBe(title);
+  });
+
+  it("initializes the theme", () => {
+    createLatticeApp();
+
+    expect(localStorage.getItem("appearance")).toBe("system");
+  });
+});

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -1,0 +1,56 @@
+import { createInertiaApp } from "@inertiajs/react";
+import type { ReactElement } from "react";
+import { initializeTheme } from "./appearance";
+import type { Registry } from "./core/registry";
+import type { SpriteValue } from "./icons/sprite";
+import {
+  createLayoutResolver,
+  createPageResolver,
+  type CreateLayoutResolverOptions,
+  type PageModules,
+} from "./inertia";
+import { Provider } from "./provider";
+
+type InertiaAppOptions = NonNullable<Parameters<typeof createInertiaApp>[0]>;
+
+export type CreateLatticeAppOptions = Omit<
+  InertiaAppOptions,
+  "resolve" | "layout" | "setup" | "withApp" | "pages"
+> & {
+  registry?: Registry;
+  sprite?: SpriteValue;
+  /** Normal Inertia page modules, e.g. `import.meta.glob('./pages/**\/*.tsx')`. */
+  pages?: PageModules;
+  defaultLayout?: CreateLayoutResolverOptions["defaultLayout"];
+};
+
+/**
+ * Bootstrap an Inertia app with the Lattice shell: the page/layout resolvers
+ * (server-driven Lattice pages and normal Inertia pages alike), the Provider —
+ * registry, sprite, flash toasts via Lattice's own Toaster — and theme
+ * initialization. Forwards any other createInertiaApp option.
+ */
+export function createLatticeApp({
+  registry,
+  sprite,
+  pages = {},
+  defaultLayout,
+  strictMode = true,
+  ...inertiaOptions
+}: CreateLatticeAppOptions = {}) {
+  const app = createInertiaApp({
+    ...inertiaOptions,
+    strictMode,
+    resolve: createPageResolver(pages),
+    layout: createLayoutResolver({ defaultLayout }),
+    withApp: (node: ReactElement): ReactElement => (
+      <Provider registry={registry} sprite={sprite}>
+        {node}
+      </Provider>
+    ),
+  });
+
+  initializeTheme();
+
+  return app;
+}

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -11,6 +11,7 @@ export { useEffectDispatcher } from "./effects/use-effect-dispatcher";
 export { builtinEffectHandlers, effectHandler, mergeEffectHandlers } from "./effects/registry";
 export { initializeTheme, useAppearance } from "./appearance";
 export { copyToClipboard, useClipboard } from "./clipboard";
+export { createLatticeApp, type CreateLatticeAppOptions } from "./create-app";
 export { EventBridge } from "./events/event-bridge";
 export { Icon, IconRenderer, IconRendererProvider, SpriteProvider } from "./icons";
 export {

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -1,12 +1,32 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { searchForWorkspaceRoot } from "vite";
+import type { Plugin } from "vite";
 import { describe, expect, it } from "vitest";
-import { latticeConfig } from "./vite";
+import { lattice, latticeConfig } from "./vite";
 
 type PackageJson = {
   exports: Record<string, unknown>;
 };
+
+type ResolveIdFn = (
+  this: { resolve: (id: string, importer?: string, options?: unknown) => Promise<unknown> },
+  id: string,
+) => Promise<string | null>;
+
+type LoadFn = (id: string) => string | null;
+
+function optionalPeersPlugin(): Plugin {
+  const plugin = (lattice({ icons: false }) as Plugin[]).find(
+    (candidate) => candidate?.name === "lattice:optional-peers",
+  );
+
+  if (!plugin) {
+    throw new Error("optional-peers plugin not registered");
+  }
+
+  return plugin;
+}
 
 describe("lattice Vite helper", () => {
   it("configures package-link mode without reading an environment variable", () => {
@@ -54,6 +74,37 @@ describe("lattice Vite helper", () => {
         },
       },
     });
+  });
+
+  it("stubs an absent optional Echo peer so consumers can still build", async () => {
+    const plugin = optionalPeersPlugin();
+    const resolveId = plugin.resolveId as unknown as ResolveIdFn;
+    const load = plugin.load as unknown as LoadFn;
+
+    const stubId = await resolveId.call({ resolve: async () => null }, "@laravel/echo-react");
+
+    expect(stubId).toBe("\0lattice-optional-peer/@laravel/echo-react");
+
+    const code = load(stubId as string);
+
+    expect(code).toContain("export const useEcho =");
+    expect(code).toContain("export const useEchoPublic =");
+    expect(code).toContain("export const useEchoPresence =");
+  });
+
+  it("defers to the real package when the optional Echo peer is installed", async () => {
+    const plugin = optionalPeersPlugin();
+    const resolveId = plugin.resolveId as unknown as ResolveIdFn;
+    const load = plugin.load as unknown as LoadFn;
+
+    const resolved = await resolveId.call(
+      { resolve: async () => ({ id: "/node_modules/@laravel/echo-react/index.js" }) },
+      "@laravel/echo-react",
+    );
+
+    expect(resolved).toBeNull();
+    expect(await resolveId.call({ resolve: async () => null }, "react")).toBeNull();
+    expect(load("react")).toBeNull();
   });
 
   it("keeps package exports explicit and internal test helpers private", () => {

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -34,7 +34,7 @@ type Roots = {
 };
 
 export function lattice(options: LatticeViteOptions = {}): PluginOption[] {
-  const plugins: PluginOption[] = [corePlugin(options)];
+  const plugins: PluginOption[] = [corePlugin(options), optionalPeersPlugin()];
   const iconOptions = resolveIconOptions(options);
 
   if (iconOptions) {
@@ -88,6 +88,50 @@ function corePlugin(options: LatticeViteOptions): Plugin {
     name: "lattice",
     config() {
       return latticeConfig(options);
+    },
+  };
+}
+
+const OPTIONAL_PEER_STUB_PREFIX = "\0lattice-optional-peer/";
+
+/**
+ * Real-time listeners statically import their optional Echo peers. A consumer
+ * that never uses real-time should still build, so stub a missing peer with
+ * hooks that throw — the `RealtimeListeners` error boundary then degrades
+ * gracefully and warns to install the peer, exactly as when it is absent.
+ */
+const OPTIONAL_PEER_STUBS: Record<string, string> = {
+  "@laravel/echo-react": [
+    "const missing = () => {",
+    "  throw new Error(",
+    '    "[lattice] Real-time listeners require @laravel/echo-react. Install it and call configureEcho().",',
+    "  );",
+    "};",
+    "export const useEcho = missing;",
+    "export const useEchoPublic = missing;",
+    "export const useEchoPresence = missing;",
+  ].join("\n"),
+};
+
+function optionalPeersPlugin(): Plugin {
+  return {
+    name: "lattice:optional-peers",
+    enforce: "pre",
+    async resolveId(id) {
+      if (!Object.prototype.hasOwnProperty.call(OPTIONAL_PEER_STUBS, id)) {
+        return null;
+      }
+
+      const installed = await this.resolve(id, undefined, { skipSelf: true });
+
+      return installed ? null : `${OPTIONAL_PEER_STUB_PREFIX}${id}`;
+    },
+    load(id) {
+      if (!id.startsWith(OPTIONAL_PEER_STUB_PREFIX)) {
+        return null;
+      }
+
+      return OPTIONAL_PEER_STUBS[id.slice(OPTIONAL_PEER_STUB_PREFIX.length)] ?? null;
     },
   };
 }

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Http;
 
 use BackedEnum;
 use BadMethodCallException;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -15,9 +16,10 @@ use Lattice\Lattice\Core\PageMetadata;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Realtime\Listen;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use UnexpectedValueException;
 
-abstract class Page implements PageContract
+abstract class Page implements PageContract, Responsable
 {
     public function title(): ?string
     {
@@ -90,6 +92,18 @@ abstract class Page implements PageContract
         }
 
         return $this->response($schema);
+    }
+
+    /**
+     * Render the page as an HTTP response so it can be returned directly —
+     * for example from a Fortify view closure — instead of reaching through
+     * callAction().
+     *
+     * @param  Request  $request
+     */
+    public function toResponse($request): HttpResponse
+    {
+        return $this->callAction('render', [PageSchema::make(), $request])->toResponse($request);
     }
 
     protected function component(): string

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -198,6 +198,21 @@ test('workbench tables page serializes lazy tables for each pagination type', fu
         ->etc());
 });
 
+test('a page can be returned directly and renders through the responsable contract', function (): void {
+    Route::get('responsable-page', fn (): Page => new WorkbenchTabsPage)
+        ->middleware('web')
+        ->name('responsable-page.show');
+
+    withoutVite();
+
+    get('/responsable-page')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('lattice/page')
+            ->where('lattice.schema.0.props.defaultValue', 'profile')
+        );
+});
+
 // ---------------------------------------------------------------------------
 // Inline fixture classes required only by this file
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Three independent DX improvements surfaced while building a starter kit on top of the published package. One commit each.

## `Page` implements `Responsable`

A page can be returned directly — `return new SomePage` — from a controller or a Fortify view closure, instead of reaching through `callAction('render', [PageSchema::make()])`. `toResponse()` renders the page and resolves the Inertia response to a final HTTP response.

## `createLatticeApp` bootstrap helper

Collapses the repetitive `createInertiaApp` wiring into one call: the page/layout resolvers (server-driven Lattice pages **and** normal Inertia pages), the `Provider` (registry, sprite, and flash toasts via Lattice's own `Toaster`), and theme initialization. Any other `createInertiaApp` option is forwarded.

## Stub absent optional realtime peers in the Vite plugin

The page renderer always mounts `RealtimeListeners`, whose lazy chunk statically imports `@laravel/echo-react`. Consumers that don't use realtime — and so don't install the optional peer — could not run a production build. The `lattice()` plugin now resolves a throwing stub for a missing optional peer, so the build succeeds and the existing error boundary still degrades gracefully at runtime.

## Verification

- `composer check` — Pint, PHPStan, Pest (845 passed)
- `npm run check` — oxlint, oxfmt, tsc, type-coverage, Vitest (636 passed), build:lib
- New tests: `PageTest` responsable case, `create-app.test.tsx`, optional-peer stub cases in `vite.test.ts`