### PR TITLE
feat: fluent form response helpers and an OTP field

### DIFF
--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -582,6 +582,10 @@
                 "value": "field.number-input"
             },
             {
+                "name": "Otp",
+                "value": "field.otp"
+            },
+            {
                 "name": "PasswordInput",
                 "value": "field.password-input"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "clsx": "^2.1.1",
         "i18next": "^26.3.1",
         "i18next-http-backend": "^4.0.0",
+        "input-otp": "^1.4.2",
         "recharts": "^3.8.1",
         "starlight-llms-txt": "^0.10.0",
         "tailwind-merge": "^3.0.1"
@@ -11540,6 +11541,16 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/input-otp": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+      "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/internmap": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "clsx": "^2.1.1",
     "i18next": "^26.3.1",
     "i18next-http-backend": "^4.0.0",
+    "input-otp": "^1.4.2",
     "recharts": "^3.8.1",
     "starlight-llms-txt": "^0.10.0",
     "tailwind-merge": "^3.0.1"

--- a/resources/js/form/components/base/input-otp.tsx
+++ b/resources/js/form/components/base/input-otp.tsx
@@ -1,0 +1,55 @@
+import { OTPInput, REGEXP_ONLY_DIGITS, type SlotProps } from "input-otp";
+import type { ComponentProps } from "react";
+import { cn } from "@lattice-php/lattice/lib/utils";
+
+function Slot({ char, hasFakeCaret, isActive }: SlotProps) {
+  return (
+    <div
+      className={cn(
+        "relative flex h-lt-control-md w-10 items-center justify-center border-y border-r border-lt-input text-base shadow-lt-xs transition-all first:rounded-l-lt-sm first:border-l last:rounded-r-lt-sm",
+        isActive && "z-10 border-lt-ring ring-lt-ring/50 ring-[3px]",
+      )}
+    >
+      {char}
+      {hasFakeCaret ? (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="bg-lt-fg h-5 w-px animate-pulse" />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type InputOTPProps = Omit<
+  ComponentProps<typeof OTPInput>,
+  "children" | "maxLength" | "render"
+> & {
+  length: number;
+};
+
+/** A segmented one-time-code input styled to match Lattice's control surfaces. */
+export function InputOTP({
+  length,
+  containerClassName,
+  pattern = REGEXP_ONLY_DIGITS,
+  ...props
+}: InputOTPProps) {
+  return (
+    <OTPInput
+      maxLength={length}
+      pattern={pattern}
+      containerClassName={cn(
+        "flex items-center gap-2 has-[:disabled]:opacity-50",
+        containerClassName,
+      )}
+      render={({ slots }) => (
+        <div className="flex items-center">
+          {slots.map((slot, index) => (
+            <Slot key={index} {...slot} />
+          ))}
+        </div>
+      )}
+      {...props}
+    />
+  );
+}

--- a/resources/js/form/components/fields/otp-input.test.tsx
+++ b/resources/js/form/components/fields/otp-input.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import { FormValuesProvider } from "../values";
+import { OtpInputComponent } from "./otp-input";
+
+function renderField(node: Node<"field.otp">, initial: Record<string, unknown> = {}) {
+  return render(
+    <FormValuesProvider initial={initial}>
+      <OtpInputComponent node={node}>{null}</OtpInputComponent>
+    </FormValuesProvider>,
+  );
+}
+
+describe("OtpInputComponent", () => {
+  it("renders a one-time-code input with the configured length", () => {
+    renderField(fakeNode({ type: "field.otp", props: { name: "code", label: "Code", length: 4 } }));
+
+    expect(screen.getByRole("textbox")).toHaveAttribute("maxlength", "4");
+  });
+
+  it("commits the entered code and renders it in the slots", () => {
+    renderField(fakeNode({ type: "field.otp", props: { name: "code", label: "Code", length: 4 } }));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "12" } });
+
+    expect(input).toHaveValue("12");
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("hides when its visible condition fails", () => {
+    renderField(
+      fakeNode({
+        type: "field.otp",
+        props: {
+          name: "code",
+          label: "Code",
+          length: 6,
+          conditions: { visible: [{ field: "mode", operator: "eq", value: "2fa" }] },
+        },
+      }),
+      { mode: "off" },
+    );
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/resources/js/form/components/fields/otp-input.tsx
+++ b/resources/js/form/components/fields/otp-input.tsx
@@ -1,0 +1,24 @@
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { InputOTP } from "../base/input-otp";
+import { SimpleField } from "./simple-field";
+
+export const OtpInputComponent: RendererComponent<"field.otp"> = ({ node }) => {
+  const props = node.props;
+
+  return (
+    <SimpleField node={node} label={props.label ?? ""}>
+      {({ name, testId, value, readOnly, disabled, commit }) => (
+        <InputOTP
+          autoFocus={props.autoFocus ?? false}
+          data-test={testId}
+          disabled={disabled || readOnly}
+          id={name}
+          length={props.length}
+          name={name}
+          onChange={(next) => commit(next)}
+          value={value}
+        />
+      )}
+    </SimpleField>
+  );
+};

--- a/resources/js/form/components/index.ts
+++ b/resources/js/form/components/index.ts
@@ -6,6 +6,7 @@ export { FileUploadComponent } from "./fields/file-upload";
 export { FormComponent } from "./form";
 export { HiddenInputComponent } from "./fields/hidden-input";
 export { NumberInputComponent } from "./fields/number-input";
+export { OtpInputComponent } from "./fields/otp-input";
 export { PasswordInputComponent } from "./fields/password-input";
 export { RepeaterComponent } from "./fields/repeater";
 export { SelectComponent } from "./fields/select";

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -11,6 +11,7 @@ type FormComponentName =
   | "FormComponent"
   | "HiddenInputComponent"
   | "NumberInputComponent"
+  | "OtpInputComponent"
   | "PasswordInputComponent"
   | "RepeaterComponent"
   | "SelectComponent"
@@ -43,6 +44,7 @@ export const formComponents = createPlugin({
     "field.file-upload": lazyComponent(loadFormComponent("FileUploadComponent")),
     "field.hidden-input": lazyComponent(loadFormComponent("HiddenInputComponent")),
     "field.number-input": lazyComponent(loadFormComponent("NumberInputComponent")),
+    "field.otp": lazyComponent(loadFormComponent("OtpInputComponent")),
     "field.password-input": lazyComponent(loadFormComponent("PasswordInputComponent")),
     "field.repeater": lazyComponent(loadFormComponent("RepeaterComponent")),
     // Loaded from its own module so TipTap is split into a separate chunk,

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -481,6 +481,7 @@ export type FieldType =
   | "field.file-upload"
   | "field.hidden-input"
   | "field.number-input"
+  | "field.otp"
   | "field.password-input"
   | "field.repeater"
   | "field.rich-editor"
@@ -595,6 +596,11 @@ export type FormFieldNode =
       type: "field.number-input";
       key?: string;
       props: NumberInput;
+    }
+  | {
+      type: "field.otp";
+      key?: string;
+      props: OtpInput;
     }
   | {
       type: "field.password-input";
@@ -874,6 +880,31 @@ export type Option = {
   readonly value: string;
 };
 export type Orientation = "horizontal" | "vertical";
+export type OtpInput = {
+  autoFocus: boolean;
+  columnWidth: ColumnWidth;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean;
+  dependsOnKeys: string[] | null;
+  disabled: boolean;
+  editablePrefill: boolean;
+  helperText: string | null;
+  hidden: boolean;
+  label: string | null;
+  length: number;
+  name: string;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean;
+  required: boolean;
+  tooltip: string | null;
+  value: unknown;
+};
 export type Outlet = Record<string, never>;
 export type PageContainer = "centered" | "default";
 export type PageLayout = "app" | "auth" | "none";

--- a/src/Forms/Components/OtpInput.php
+++ b/src/Forms/Components/OtpInput.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Lattice\Lattice\Core\Concerns\HasAutoFocus;
+use Lattice\Lattice\Forms\Attributes\AsField;
+use Lattice\Lattice\Forms\Enums\FieldType;
+
+#[AsField(FieldType::Otp)]
+class OtpInput extends Field
+{
+    use HasAutoFocus;
+
+    public int $length = 6;
+
+    public function length(int $length): static
+    {
+        $this->length = $length;
+
+        return $this;
+    }
+}

--- a/src/Forms/Enums/FieldType.php
+++ b/src/Forms/Enums/FieldType.php
@@ -17,6 +17,7 @@ enum FieldType: string
     case FileUpload = 'field.file-upload';
     case HiddenInput = 'field.hidden-input';
     case NumberInput = 'field.number-input';
+    case Otp = 'field.otp';
     case PasswordInput = 'field.password-input';
     case Repeater = 'field.repeater';
     case RichEditor = 'field.rich-editor';

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -7,6 +7,9 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Core\Definition;
+use Lattice\Lattice\Core\Enums\Variant;
+use Lattice\Lattice\Core\Values\ToastMessage;
+use Lattice\Lattice\Core\Values\Translatable;
 use Lattice\Lattice\Forms\Components\Field;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Concerns\ResolvesFormFields;
@@ -21,6 +24,22 @@ abstract class FormDefinition extends Definition implements HandlesUploads, Prov
     abstract public function definition(Form $form, Request $request): Form;
 
     abstract public function handle(Request $request): Response|Responsable;
+
+    /**
+     * Start a fluent form response — queue effects and a redirect.
+     */
+    protected function respond(): FormResponse
+    {
+        return FormResponse::make();
+    }
+
+    /**
+     * Start a fluent form response with a toast already queued.
+     */
+    protected function toast(string|Translatable|ToastMessage|Variant $message, Variant|string|null $variant = null): FormResponse
+    {
+        return FormResponse::make()->toast($message, $variant);
+    }
 
     /**
      * @return array<string, mixed>

--- a/src/Forms/FormResponse.php
+++ b/src/Forms/FormResponse.php
@@ -1,0 +1,103 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms;
+
+use BackedEnum;
+use Closure;
+use Illuminate\Contracts\Support\Responsable;
+use Lattice\Lattice\Core\Enums\Variant;
+use Lattice\Lattice\Core\Values\Callout;
+use Lattice\Lattice\Core\Values\ToastMessage;
+use Lattice\Lattice\Core\Values\Translatable;
+use Lattice\Lattice\Effects\Contracts\Effect as EffectContract;
+use Lattice\Lattice\Effects\Effect;
+use Lattice\Lattice\Facades\Effects;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A fluent response for a form handler: queue effects (toasts, callouts, a page
+ * reload, …) and a redirect. The effects survive the redirect through the
+ * `latticeEffects` flash bag, so the form flow gets the same ergonomics
+ * ActionResult gives the inline action flow. Defaults to redirecting back.
+ */
+final readonly class FormResponse implements Responsable
+{
+    /**
+     * @param  array<int, EffectContract>  $effects
+     * @param  (Closure(): Response)|null  $redirect
+     */
+    private function __construct(
+        private array $effects = [],
+        private ?Closure $redirect = null,
+    ) {}
+
+    public static function make(): self
+    {
+        return new self;
+    }
+
+    public function effect(EffectContract $effect): self
+    {
+        return new self([...$this->effects, $effect], $this->redirect);
+    }
+
+    public function toast(string|Translatable|ToastMessage|Variant $message, Variant|string|null $variant = null): self
+    {
+        return $this->effect(Effect::toast($message, $variant));
+    }
+
+    public function callout(Callout $callout): self
+    {
+        return $this->effect(Effect::callout($callout));
+    }
+
+    public function reloadPage(): self
+    {
+        return $this->effect(Effect::reloadPage());
+    }
+
+    public function reloadComponent(string $component): self
+    {
+        return $this->effect(Effect::reloadComponent($component));
+    }
+
+    public function closeModal(?string $modal = null): self
+    {
+        return $this->effect(Effect::closeModal($modal));
+    }
+
+    /**
+     * @param  array<string, mixed>|string  $parameters
+     */
+    public function toRoute(BackedEnum|string $route, array|string $parameters = []): self
+    {
+        $name = $route instanceof BackedEnum ? (string) $route->value : $route;
+
+        return $this->withRedirect(fn (): Response => to_route($name, $parameters));
+    }
+
+    public function to(string $url): self
+    {
+        return $this->withRedirect(fn (): Response => redirect()->to($url));
+    }
+
+    public function back(): self
+    {
+        return $this->withRedirect(fn (): Response => redirect()->back());
+    }
+
+    public function toResponse($request): Response
+    {
+        if ($this->effects !== []) {
+            Effects::flash(...$this->effects);
+        }
+
+        return ($this->redirect ?? fn (): Response => redirect()->back())();
+    }
+
+    private function withRedirect(Closure $redirect): self
+    {
+        return new self($this->effects, $redirect);
+    }
+}

--- a/tests/Feature/Forms/FormResponseTest.php
+++ b/tests/Feature/Forms/FormResponseTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Core\Enums\Variant;
+use Lattice\Lattice\Core\Values\Callout;
+use Lattice\Lattice\Effects\Effect;
+use Lattice\Lattice\Effects\EffectFlasher;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Forms\FormResponse;
+
+beforeEach(function (): void {
+    app()->forgetScopedInstances();
+    Route::get('after-save', fn (): string => 'ok')->middleware('web')->name('after-save');
+});
+
+test('a form response flashes its effects and redirects to a route', function (): void {
+    $response = FormResponse::make()
+        ->toast('Saved.', Variant::Success)
+        ->reloadPage()
+        ->toRoute('after-save')
+        ->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect($response->headers->get('Location'))->toBe(route('after-save'));
+    expect(app(EffectFlasher::class)->all())->toHaveCount(2);
+});
+
+test('a form response redirects back by default and flashes nothing', function (): void {
+    $response = FormResponse::make()->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect(app(EffectFlasher::class)->all())->toBe([]);
+});
+
+test('FormDefinition::toast starts a fluent response from the handler', function (): void {
+    $response = (new FlashForm)->handle(request())->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect($response->headers->get('Location'))->toBe(route('after-save'));
+    expect(app(EffectFlasher::class)->all())->toHaveCount(1);
+});
+
+test('a form response queues every effect helper and redirects to a url', function (): void {
+    $response = FormResponse::make()
+        ->callout(Callout::make(Variant::Info, 'Heads up'))
+        ->reloadComponent('settings.passkeys')
+        ->closeModal('two-factor')
+        ->effect(Effect::reloadPage())
+        ->to('/dashboard')
+        ->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect($response->headers->get('Location'))->toContain('/dashboard');
+    expect(app(EffectFlasher::class)->all())->toHaveCount(4);
+});
+
+test('FormDefinition::respond starts an empty fluent response from the handler', function (): void {
+    $response = (new RespondForm)->handle(request())->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect($response->headers->get('Location'))->toBe(route('after-save'));
+    expect(app(EffectFlasher::class)->all())->toHaveCount(1);
+});
+
+final class FlashForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form;
+    }
+
+    public function handle(Request $request): FormResponse
+    {
+        return $this->toast('Saved.', Variant::Success)->toRoute('after-save');
+    }
+}
+
+final class RespondForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form;
+    }
+
+    public function handle(Request $request): FormResponse
+    {
+        return $this->respond()->reloadPage()->toRoute('after-save');
+    }
+}

--- a/tests/Unit/Forms/OtpInputTest.php
+++ b/tests/Unit/Forms/OtpInputTest.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\OtpInput;
+
+test('otp input serializes its wire type and default length', function (): void {
+    $wire = wire(OtpInput::make('code', 'Code'));
+
+    expect($wire['type'])->toBe('field.otp');
+    expect($wire['props']['length'])->toBe(6);
+});
+
+test('otp input length is configurable', function (): void {
+    expect(wire(OtpInput::make('code', 'Code')->length(4))['props']['length'])->toBe(4);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -179,6 +179,7 @@ export default defineConfig(({ mode }) => {
                 /^@tiptap\//,
                 /^clsx($|\/)/,
                 /^class-variance-authority($|\/)/,
+                /^input-otp($|\/)/,
                 /^tailwind-merge($|\/)/,
                 /^vite($|\/)/,
                 /^@laravel\/echo-react($|\/)/,


### PR DESCRIPTION
Two self-contained additions for 0.5.0, one commit each. (The Fortify auth companion stays out of scope — it remains custom in consuming apps for now.)

## A — fluent form response helpers

Actions have a rich fluent `ActionResult` (`->toast()`, `->redirect()`, `->reloadPage()`…), but form handlers had nothing — every form hand-rolled the Inertia flash + redirect. `FormResponse` mirrors that ergonomics for the redirect flow: queue effects and a redirect target, and the effects survive the redirect through the existing `latticeEffects` flash bag. `FormDefinition` exposes `$this->respond()` and `$this->toast()` to start the chain:

```php
public function handle(Request $request): FormResponse
{
    // …
    return $this->toast(__('Saved.'), Variant::Success)->toRoute('settings.edit');
}
```

Defaults to redirecting back when no target is set.

## B — OTP field + `InputOTP` primitive

A new `field.otp` schema component and an `InputOTP` React primitive (built on `input-otp`), styled to match Lattice's control surfaces. The biggest missing form primitive — consumers hand-rolled a segmented one-time-code input purely for 2FA. Generic well beyond auth (email/verification codes).

```php
OtpInput::make('code', __('Code'))->length(6);
```

`input-otp` is declared as a dependency and externalized from the library build, like the other UI deps.

## Verification

- `composer check` — Pint, PHPStan, Rector, Pest (850 passed)
- `npm run check` — oxlint, oxfmt, tsc, type-coverage, Vitest, build:lib
- New tests: `FormResponseTest`, `OtpInputTest` (PHP) and `otp-input.test.tsx` (Vitest); generated types + docs fixtures regenerated for `field.otp`.

Note: the OTP field has unit + component coverage but is not yet dogfooded in the workbench (no browser test). Happy to add a workbench demo + browser test if wanted.