### PR TITLE
feat: timezone-aware datetime display + Intl date formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,8 +221,24 @@ jobs:
 
       - run: npm run build
 
-      - name: Install Playwright Chromium
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browser and system deps
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Pest (browser coverage)
         run: composer test:browser:coverage

--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -71,6 +71,7 @@ pagination for [tables](/tables/overview/).
   enums={[
     "ColumnType",
     "ColumnAlign",
+    "DateTimeStyle",
     "NumberFormatUnit",
     "FilterType",
     "FilterControl",

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -699,6 +699,28 @@
             }
         ]
     },
+    "Lattice\\Lattice\\Tables\\Enums\\DateTimeStyle": {
+        "name": "DateTimeStyle",
+        "namespace": "Lattice\\Lattice\\Tables\\Enums",
+        "cases": [
+            {
+                "name": "Full",
+                "value": "full"
+            },
+            {
+                "name": "Long",
+                "value": "long"
+            },
+            {
+                "name": "Medium",
+                "value": "medium"
+            },
+            {
+                "name": "Short",
+                "value": "short"
+            }
+        ]
+    },
     "Lattice\\Lattice\\Tables\\Enums\\FilterControl": {
         "name": "FilterControl",
         "namespace": "Lattice\\Lattice\\Tables\\Enums",

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -95,7 +95,8 @@
                         "badge": null,
                         "copyable": false,
                         "date": {
-                            "format": "Y-m-d"
+                            "dateStyle": "medium",
+                            "timeStyle": "medium"
                         },
                         "link": null,
                         "multiple": null

--- a/resources/boost/skills/lattice-tables/SKILL.md
+++ b/resources/boost/skills/lattice-tables/SKILL.md
@@ -28,7 +28,7 @@ class ProductsTable extends EloquentTableDefinition
         return [
             TextColumn::make('name')->sortable()->filterable(),
             NumberColumn::make('price')->sortable()->filterable(),
-            TextColumn::make('updated_at')->date('Y-m-d')->sortable(),
+            TextColumn::make('updated_at')->dateTime()->sortable(),
         ];
     }
 
@@ -47,7 +47,7 @@ class ProductsTable extends EloquentTableDefinition
 
 Columns live in `Lattice\Lattice\Tables\Columns`. `Column::make('key')` reads `$row['key']`; the label defaults to the humanized key (override with `->label()`).
 
-- **`TextColumn`** — `->date('Y-m-d H:i')`, `->copyable()`, `->link('/products/{value}')` (`{value}` is substituted; pass `external: true` for outbound).
+- **`TextColumn`** — `->date()`, `->time()`, `->dateTime()` (style: `full|long|medium|short`, e.g. `->dateTime(DateTimeStyle::Short)`), `->copyable()`, `->link('/products/{value}')` (`{value}` is substituted; pass `external: true` for outbound).
 - **`NumberColumn`** — right-aligns and formats the value as a number; `->decimals(2)` fixes fraction digits (`->decimals(0, 2)` for a range); `->unit(NumberFormatUnit::Percent)` adds a locale-correct unit (percent, kilogram, byte, …). Filters as a number.
 - **`MoneyColumn`** — formats as a currency amount; `->currency('EUR')` for a fixed currency or `->currencyField('currency')` to read the currency from another row field; symbol placement and decimals follow the viewer's locale.
 - **`BooleanColumn`** — renders a check or cross; filters as a boolean.

--- a/resources/js/core/components/chart.tsx
+++ b/resources/js/core/components/chart.tsx
@@ -124,7 +124,7 @@ function CartesianChart({ props }: { props: ChartProps }) {
   const RechartsChart = cartesianChartFor(series);
 
   return (
-    <ResponsiveContainer width="100%" height={props.height}>
+    <ResponsiveContainer width="100%" height={props.height} debounce={100}>
       <RechartsChart data={props.data} margin={chartMargin}>
         {props.grid && <CartesianGrid strokeDasharray="3 3" stroke="var(--lt-border)" />}
         {props.xAxis && props.categoryKey !== null && (
@@ -191,7 +191,7 @@ function CartesianChart({ props }: { props: ChartProps }) {
 
 function PieChartView({ props, series }: { props: ChartProps; series: ChartSeries }) {
   return (
-    <ResponsiveContainer width="100%" height={props.height}>
+    <ResponsiveContainer width="100%" height={props.height} debounce={100}>
       <PieChart margin={chartMargin}>
         {props.tooltip && <Tooltip />}
         {props.legend && <Legend {...compactLegendProps} />}

--- a/resources/js/events/event-names.ts
+++ b/resources/js/events/event-names.ts
@@ -16,6 +16,7 @@ export const LATTICE_EVENT = {
   toggleSidebar: "lattice:toggle-sidebar",
   appearanceChange: "lattice:appearance-change",
   localeChange: "lattice:locale-change",
+  timezoneChange: "lattice:timezone-change",
   actionError: "lattice:action-error",
 } as const;
 

--- a/resources/js/i18n/config.test.ts
+++ b/resources/js/i18n/config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { activeTimezoneForTest, setConfig } from "./config";
+
+describe("i18n config store", () => {
+  it("stores the timezone from the shared config", () => {
+    setConfig({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en"],
+      preloadLocales: [],
+      timezone: "Europe/Berlin",
+    });
+
+    expect(activeTimezoneForTest()).toBe("Europe/Berlin");
+  });
+
+  it("falls back to null when no timezone is shared", () => {
+    setConfig({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en"],
+      preloadLocales: [],
+      timezone: null,
+    });
+
+    expect(activeTimezoneForTest()).toBeNull();
+  });
+});

--- a/resources/js/i18n/config.test.ts
+++ b/resources/js/i18n/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { activeTimezoneForTest, setConfig } from "./config";
+import { configTimezone, setConfig } from "./config";
 
 describe("i18n config store", () => {
   it("stores the timezone from the shared config", () => {
@@ -11,7 +11,7 @@ describe("i18n config store", () => {
       timezone: "Europe/Berlin",
     });
 
-    expect(activeTimezoneForTest()).toBe("Europe/Berlin");
+    expect(configTimezone()).toBe("Europe/Berlin");
   });
 
   it("falls back to null when no timezone is shared", () => {
@@ -23,6 +23,6 @@ describe("i18n config store", () => {
       timezone: null,
     });
 
-    expect(activeTimezoneForTest()).toBeNull();
+    expect(configTimezone()).toBeNull();
   });
 });

--- a/resources/js/i18n/config.ts
+++ b/resources/js/i18n/config.ts
@@ -47,10 +47,6 @@ export function setConfig(config: I18nConfig | undefined): void {
   notify();
 }
 
-export function activeTimezoneForTest(): string | null {
-  return active.timezone;
-}
-
 export function configTimezone(): string | null {
   return active.timezone;
 }

--- a/resources/js/i18n/config.ts
+++ b/resources/js/i18n/config.ts
@@ -51,6 +51,18 @@ export function activeTimezoneForTest(): string | null {
   return active.timezone;
 }
 
+export function configTimezone(): string | null {
+  return active.timezone;
+}
+
+export function subscribeConfig(callback: () => void): () => void {
+  listeners.add(callback);
+
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
 export function useConfig(): Config {
   return useSyncExternalStore(subscribe, snapshot, () => fallback);
 }

--- a/resources/js/i18n/config.ts
+++ b/resources/js/i18n/config.ts
@@ -3,9 +3,10 @@ import { useSyncExternalStore } from "react";
 
 export type Config = {
   readonly locales: readonly string[];
+  readonly timezone: string | null;
 };
 
-const fallback: Config = { locales: [] };
+const fallback: Config = { locales: [], timezone: null };
 const listeners = new Set<() => void>();
 
 let active: Config = fallback;
@@ -36,13 +37,18 @@ function notify(): void {
 
 export function setConfig(config: I18nConfig | undefined): void {
   const locales = normalizeLocales(config?.locales);
+  const timezone = config?.timezone ?? null;
 
-  if (sameLocales(active.locales, locales)) {
+  if (sameLocales(active.locales, locales) && active.timezone === timezone) {
     return;
   }
 
-  active = { locales };
+  active = { locales, timezone };
   notify();
+}
+
+export function activeTimezoneForTest(): string | null {
+  return active.timezone;
 }
 
 export function useConfig(): Config {

--- a/resources/js/i18n/date-time.test.tsx
+++ b/resources/js/i18n/date-time.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { setConfig } from "./config";
+import { DateTime } from "./date-time";
+import { setTimezone } from "./timezone";
+
+afterEach(() => {
+  setConfig(undefined);
+  setTimezone("");
+});
+
+describe("<DateTime>", () => {
+  it("renders a time element with a precise title in the active timezone", () => {
+    setTimezone("Europe/Berlin");
+
+    const { container } = render(<DateTime value="2026-06-18T00:30:00Z" />);
+    const time = container.querySelector("time");
+
+    expect(time).not.toBeNull();
+    expect(time?.getAttribute("dateTime")).toBe("2026-06-18T00:30:00.000Z");
+    expect(time?.getAttribute("title")).toContain("Europe/Berlin");
+  });
+});

--- a/resources/js/i18n/date-time.test.tsx
+++ b/resources/js/i18n/date-time.test.tsx
@@ -20,4 +20,20 @@ describe("<DateTime>", () => {
     expect(time?.getAttribute("dateTime")).toBe("2026-06-18T00:30:00.000Z");
     expect(time?.getAttribute("title")).toContain("Europe/Berlin");
   });
+
+  it("renders nothing for a null value", () => {
+    const { container } = render(<DateTime value={null} />);
+
+    expect(container.querySelector("time")).toBeNull();
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders an unparseable value verbatim without date or title attributes", () => {
+    const { container } = render(<DateTime value="not-a-date" />);
+    const time = container.querySelector("time");
+
+    expect(time?.textContent).toBe("not-a-date");
+    expect(time?.getAttribute("dateTime")).toBeNull();
+    expect(time?.getAttribute("title")).toBeNull();
+  });
 });

--- a/resources/js/i18n/date-time.tsx
+++ b/resources/js/i18n/date-time.tsx
@@ -1,17 +1,19 @@
 import type { ReactNode } from "react";
-import { type FormatOptions, formatCell, preciseDateTime } from "../table/format";
+import { type FormatOptions, formatDateValue, preciseDateTime } from "../table/format";
 import { useLocale } from "./locale";
 import { useTimezone } from "./timezone";
 
 export type DateTimeProps = {
   value: unknown;
-  format?: string | null;
+  dateStyle?: string | null;
+  timeStyle?: string | null;
 };
 
-const dateColumn = (format: string | null) =>
-  ({ key: "", label: "", props: { date: { format } } }) as never;
-
-export function DateTime({ value, format = null }: DateTimeProps): ReactNode {
+export function DateTime({
+  value,
+  dateStyle = "medium",
+  timeStyle = "short",
+}: DateTimeProps): ReactNode {
   const { locale } = useLocale();
   const { timezone } = useTimezone();
 
@@ -20,7 +22,7 @@ export function DateTime({ value, format = null }: DateTimeProps): ReactNode {
   }
 
   const options: FormatOptions = { locale, timeZone: timezone };
-  const text = formatCell(value, dateColumn(format), options);
+  const text = formatDateValue(value, { dateStyle, timeStyle }, options);
   const iso = isoOrNull(value);
   const title = preciseDateTime(value, options);
 

--- a/resources/js/i18n/date-time.tsx
+++ b/resources/js/i18n/date-time.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { type FormatOptions, formatCell, preciseDateTime } from "../table/format";
+import { useLocale } from "./locale";
+import { useTimezone } from "./timezone";
+
+export type DateTimeProps = {
+  value: unknown;
+  format?: string | null;
+};
+
+const dateColumn = (format: string | null) =>
+  ({ key: "", label: "", props: { date: { format } } }) as never;
+
+export function DateTime({ value, format = null }: DateTimeProps): ReactNode {
+  const { locale } = useLocale();
+  const { timezone } = useTimezone();
+
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  const options: FormatOptions = { locale, timeZone: timezone };
+  const text = formatCell(value, dateColumn(format), options);
+  const iso = isoOrNull(value);
+  const title = preciseDateTime(value, options);
+
+  return (
+    <time dateTime={iso ?? undefined} title={title || undefined}>
+      {text}
+    </time>
+  );
+}
+
+function isoOrNull(value: unknown): string | null {
+  const date = new Date(String(value));
+
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}

--- a/resources/js/i18n/index.ts
+++ b/resources/js/i18n/index.ts
@@ -14,3 +14,5 @@ export type {
 export type { UseLocaleReturn } from "./locale";
 export { currentTimezone, setTimezone, useTimezone } from "./timezone";
 export type { UseTimezoneReturn } from "./timezone";
+export { DateTime } from "./date-time";
+export type { DateTimeProps } from "./date-time";

--- a/resources/js/i18n/index.ts
+++ b/resources/js/i18n/index.ts
@@ -12,3 +12,5 @@ export type {
   UseLocaleOptionsReturn,
 } from "./locale-switcher";
 export type { UseLocaleReturn } from "./locale";
+export { currentTimezone, setTimezone, useTimezone } from "./timezone";
+export type { UseTimezoneReturn } from "./timezone";

--- a/resources/js/i18n/instance.test.tsx
+++ b/resources/js/i18n/instance.test.tsx
@@ -73,6 +73,7 @@ describe("i18n instance", () => {
       saveMissing: false,
       locales: ["en", "de"],
       preloadLocales: [],
+      timezone: null,
     });
 
     render(<LocaleProbe />);

--- a/resources/js/i18n/locale-switcher.test.tsx
+++ b/resources/js/i18n/locale-switcher.test.tsx
@@ -31,6 +31,7 @@ describe("locale switcher helpers", () => {
       saveMissing: false,
       locales: ["en", "de"],
       preloadLocales: [],
+      timezone: null,
     });
 
     render(<LocaleOptionsProbe />);
@@ -56,6 +57,7 @@ describe("locale switcher helpers", () => {
       saveMissing: false,
       locales: ["en", "de"],
       preloadLocales: [],
+      timezone: null,
     });
 
     render(

--- a/resources/js/i18n/page-props.ts
+++ b/resources/js/i18n/page-props.ts
@@ -15,7 +15,7 @@ function isI18nConfig(value: unknown): value is I18nConfig {
     typeof value.saveMissing === "boolean" &&
     isStringArray(value.locales) &&
     isStringArray(value.preloadLocales) &&
-    (value.timezone === null || typeof value.timezone === "string")
+    (value.timezone === undefined || value.timezone === null || typeof value.timezone === "string")
   );
 }
 

--- a/resources/js/i18n/page-props.ts
+++ b/resources/js/i18n/page-props.ts
@@ -14,7 +14,8 @@ function isI18nConfig(value: unknown): value is I18nConfig {
     typeof value.enabled === "boolean" &&
     typeof value.saveMissing === "boolean" &&
     isStringArray(value.locales) &&
-    isStringArray(value.preloadLocales)
+    isStringArray(value.preloadLocales) &&
+    (value.timezone === null || typeof value.timezone === "string")
   );
 }
 

--- a/resources/js/i18n/timezone.test.ts
+++ b/resources/js/i18n/timezone.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setConfig } from "./config";
+import { currentTimezone, setTimezone } from "./timezone";
+
+afterEach(() => {
+  setConfig(undefined);
+  setTimezone("");
+});
+
+describe("timezone store", () => {
+  it("prefers the server-provided timezone", () => {
+    setConfig({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en"],
+      preloadLocales: [],
+      timezone: "Europe/Berlin",
+    });
+
+    expect(currentTimezone()).toBe("Europe/Berlin");
+  });
+
+  it("falls back to the browser timezone when the server has none", () => {
+    setConfig({
+      enabled: false,
+      saveMissing: false,
+      locales: ["en"],
+      preloadLocales: [],
+      timezone: null,
+    });
+
+    const browserZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    expect(currentTimezone()).toBe(browserZone);
+  });
+
+  it("uses an explicit override once set", () => {
+    setTimezone("America/New_York");
+
+    expect(currentTimezone()).toBe("America/New_York");
+  });
+});

--- a/resources/js/i18n/timezone.ts
+++ b/resources/js/i18n/timezone.ts
@@ -1,0 +1,75 @@
+import { useSyncExternalStore } from "react";
+import { LATTICE_EVENT } from "../events/event-names";
+import { configTimezone, subscribeConfig } from "./config";
+
+export type UseTimezoneReturn = {
+  readonly timezone: string;
+  readonly setTimezone: (timezone: string) => void;
+};
+
+const fallback = "UTC";
+const listeners = new Set<() => void>();
+
+let override: string | undefined;
+
+function detectedTimezone(): string {
+  if (typeof Intl === "undefined") {
+    return fallback;
+  }
+
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function snapshot(): string {
+  return override ?? configTimezone() ?? detectedTimezone();
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function notify(): void {
+  listeners.forEach((listener) => listener());
+}
+
+subscribeConfig(() => notify());
+
+function dispatch(timezone: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(LATTICE_EVENT.timezoneChange, { detail: { timezone } }));
+}
+
+export function currentTimezone(): string {
+  return snapshot();
+}
+
+export function setTimezone(timezone: string): void {
+  const previous = currentTimezone();
+  const next = timezone.trim();
+
+  override = next === "" ? undefined : next;
+
+  if (currentTimezone() === previous) {
+    return;
+  }
+
+  notify();
+  dispatch(currentTimezone());
+}
+
+export function useTimezone(): UseTimezoneReturn {
+  const timezone = useSyncExternalStore(subscribe, snapshot, () => fallback);
+
+  return { timezone, setTimezone } as const;
+}

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -92,7 +92,9 @@ function PlainTextCell({ column, props, row, value }: ColumnCellArgs<"column.tex
   }
 
   if (dateProps && !href && !props.copyable && value !== null && value !== undefined) {
-    return <DateTime value={value} format={dateProps.format ?? null} />;
+    return (
+      <DateTime value={value} dateStyle={dateProps.dateStyle} timeStyle={dateProps.timeStyle} />
+    );
   }
 
   if (!props.copyable) {

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -63,10 +63,6 @@ function PlainTextCell({ column, props, row, value }: ColumnCellArgs<"column.tex
   const text = formatCell(value, column);
   const [copied, setCopied] = useState(false);
 
-  if (dateProps && !href && !props.copyable && value !== null && value !== undefined) {
-    return <DateTime value={value} format={dateProps.format ?? null} />;
-  }
-
   const content = href ? (
     <a
       className="underline underline-offset-2"
@@ -93,6 +89,10 @@ function PlainTextCell({ column, props, row, value }: ColumnCellArgs<"column.tex
   function handleCopy(): void {
     void copyToClipboard(text);
     setCopied(true);
+  }
+
+  if (dateProps && !href && !props.copyable && value !== null && value !== undefined) {
+    return <DateTime value={value} format={dateProps.format ?? null} />;
   }
 
   if (!props.copyable) {

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -1,9 +1,11 @@
 import { copyToClipboard } from "@lattice-php/lattice/clipboard";
+import { DateTime } from "@lattice-php/lattice/i18n";
 import { Icon } from "@lattice-php/lattice/icons";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { type ReactNode, useEffect, useState } from "react";
 import { formatCell, resolveLink } from "../../format";
 import type { ColumnCellArgs, ColumnCellComponent } from "../../registry";
+import type { ColumnPropsOf } from "../../types";
 
 type TextProps = ColumnCellArgs<"column.text">["props"];
 
@@ -56,9 +58,15 @@ function SingleBadgeCell({ column, props, row, value }: ColumnCellArgs<"column.t
 }
 
 function PlainTextCell({ column, props, row, value }: ColumnCellArgs<"column.text">): ReactNode {
+  const dateProps = (column.props as ColumnPropsOf<"column.text"> | null)?.date;
+  const href = resolveLink(column, row, value);
   const text = formatCell(value, column);
   const [copied, setCopied] = useState(false);
-  const href = resolveLink(column, row, value);
+
+  if (dateProps && !href && !props.copyable && value !== null && value !== undefined) {
+    return <DateTime value={value} format={dateProps.format ?? null} />;
+  }
+
   const content = href ? (
     <a
       className="underline underline-offset-2"

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -69,7 +69,8 @@ describe("Lattice table component", () => {
             label: "Created",
             props: {
               date: {
-                format: "Y-m-d H:i",
+                dateStyle: "medium",
+                timeStyle: "short",
               },
             },
           }),
@@ -125,7 +126,9 @@ describe("Lattice table component", () => {
 
     expect(screen.getByRole("cell", { name: "Taylor" })).toBeVisible();
     expect(screen.getByRole("cell", { name: "Active" })).toBeVisible();
-    expect(screen.getByRole("cell", { name: "2025-01-01 09:15" })).toBeVisible();
+    const createdCell = screen.getByRole("cell", { name: /2025/ });
+    expect(createdCell).toBeVisible();
+    expect(createdCell.querySelector("time")).not.toBeNull();
     expect(screen.getByRole("link", { name: "taylor@example.com" })).toHaveAttribute(
       "href",
       "mailto:taylor%40example.com",

--- a/resources/js/table/format.test.ts
+++ b/resources/js/table/format.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { formatCell, preciseDateTime } from "./format";
 
-const dateColumn = { key: "created", label: "Created", props: { date: { format: null } } } as never;
+const dateColumn = {
+  key: "created",
+  label: "Created",
+  props: { date: { dateStyle: "medium", timeStyle: "short" } },
+} as never;
 
 describe("formatCell date rendering", () => {
   it("renders the default date format in the requested timezone", () => {

--- a/resources/js/table/format.test.ts
+++ b/resources/js/table/format.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { formatCell, preciseDateTime } from "./format";
+
+const dateColumn = { key: "created", label: "Created", props: { date: { format: null } } } as never;
+
+describe("formatCell date rendering", () => {
+  it("renders the default date format in the requested timezone", () => {
+    const berlin = formatCell("2026-06-18T00:30:00Z", dateColumn, {
+      locale: "en-GB",
+      timeZone: "Europe/Berlin",
+    });
+
+    expect(berlin).toContain("02:30");
+  });
+
+  it("renders the same instant differently in another timezone", () => {
+    const newYork = formatCell("2026-06-18T00:30:00Z", dateColumn, {
+      locale: "en-GB",
+      timeZone: "America/New_York",
+    });
+
+    expect(newYork).toContain("20:30");
+  });
+});
+
+describe("preciseDateTime", () => {
+  it("includes the IANA zone id and a year", () => {
+    const text = preciseDateTime("2026-06-18T00:30:00Z", {
+      locale: "en-GB",
+      timeZone: "Europe/Berlin",
+    });
+
+    expect(text).toContain("2026");
+    expect(text).toContain("Europe/Berlin");
+  });
+
+  it("returns an empty string for an invalid value", () => {
+    expect(preciseDateTime("not-a-date", { timeZone: "UTC" })).toBe("");
+  });
+});

--- a/resources/js/table/format.ts
+++ b/resources/js/table/format.ts
@@ -5,6 +5,8 @@ export type FormatOptions = {
   timeZone?: string;
 };
 
+export type DateConfig = { dateStyle: string | null; timeStyle: string | null };
+
 export function formatCell(value: unknown, column?: TableColumn, options?: FormatOptions): string {
   if (value === null || value === undefined) {
     return "";
@@ -13,7 +15,7 @@ export function formatCell(value: unknown, column?: TableColumn, options?: Forma
   const date = (column?.props as ColumnPropsOf<"column.text"> | null)?.date;
 
   if (date) {
-    return formatDate(value, date.format ?? null, options);
+    return formatDateValue(value, date, options);
   }
 
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
@@ -23,35 +25,24 @@ export function formatCell(value: unknown, column?: TableColumn, options?: Forma
   return JSON.stringify(value);
 }
 
-function formatDate(value: unknown, format: string | null, options?: FormatOptions): string {
-  const date = new Date(String(value));
+export function formatDateValue(value: unknown, date: DateConfig, options?: FormatOptions): string {
+  const parsed = new Date(String(value));
 
-  if (Number.isNaN(date.getTime())) {
-    return formatCell(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return String(value ?? "");
   }
 
-  if (!format) {
-    return new Intl.DateTimeFormat(options?.locale, {
-      dateStyle: "medium",
-      timeStyle: "short",
-      timeZone: options?.timeZone,
-    }).format(date);
+  const intl: Intl.DateTimeFormatOptions = { timeZone: options?.timeZone };
+
+  if (date.dateStyle) {
+    intl.dateStyle = date.dateStyle as Intl.DateTimeFormatOptions["dateStyle"];
   }
 
-  const replacements: Record<string, string> = {
-    Y: String(date.getFullYear()),
-    y: String(date.getFullYear()).slice(-2),
-    m: String(date.getMonth() + 1).padStart(2, "0"),
-    n: String(date.getMonth() + 1),
-    d: String(date.getDate()).padStart(2, "0"),
-    j: String(date.getDate()),
-    H: String(date.getHours()).padStart(2, "0"),
-    G: String(date.getHours()),
-    i: String(date.getMinutes()).padStart(2, "0"),
-    s: String(date.getSeconds()).padStart(2, "0"),
-  };
+  if (date.timeStyle) {
+    intl.timeStyle = date.timeStyle as Intl.DateTimeFormatOptions["timeStyle"];
+  }
 
-  return format.replace(/[YymndjHGis]/g, (token) => replacements[token] ?? token);
+  return new Intl.DateTimeFormat(options?.locale, intl).format(parsed);
 }
 
 export function preciseDateTime(value: unknown, options?: FormatOptions): string {

--- a/resources/js/table/format.ts
+++ b/resources/js/table/format.ts
@@ -1,6 +1,11 @@
 import type { ColumnPropsOf, TableColumn, TableRow } from "./types";
 
-export function formatCell(value: unknown, column?: TableColumn): string {
+export type FormatOptions = {
+  locale?: string;
+  timeZone?: string;
+};
+
+export function formatCell(value: unknown, column?: TableColumn, options?: FormatOptions): string {
   if (value === null || value === undefined) {
     return "";
   }
@@ -8,7 +13,7 @@ export function formatCell(value: unknown, column?: TableColumn): string {
   const date = (column?.props as ColumnPropsOf<"column.text"> | null)?.date;
 
   if (date) {
-    return formatDate(value, date.format ?? null);
+    return formatDate(value, date.format ?? null, options);
   }
 
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
@@ -18,7 +23,7 @@ export function formatCell(value: unknown, column?: TableColumn): string {
   return JSON.stringify(value);
 }
 
-function formatDate(value: unknown, format: string | null): string {
+function formatDate(value: unknown, format: string | null, options?: FormatOptions): string {
   const date = new Date(String(value));
 
   if (Number.isNaN(date.getTime())) {
@@ -26,9 +31,10 @@ function formatDate(value: unknown, format: string | null): string {
   }
 
   if (!format) {
-    return new Intl.DateTimeFormat(undefined, {
+    return new Intl.DateTimeFormat(options?.locale, {
       dateStyle: "medium",
       timeStyle: "short",
+      timeZone: options?.timeZone,
     }).format(date);
   }
 
@@ -46,6 +52,27 @@ function formatDate(value: unknown, format: string | null): string {
   };
 
   return format.replace(/[YymndjHGis]/g, (token) => replacements[token] ?? token);
+}
+
+export function preciseDateTime(value: unknown, options?: FormatOptions): string {
+  const date = new Date(String(value));
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  const formatted = new Intl.DateTimeFormat(options?.locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone: options?.timeZone,
+    timeZoneName: "short",
+  }).format(date);
+
+  return options?.timeZone ? `${formatted} (${options.timeZone})` : formatted;
 }
 
 export function resolveLink(column: TableColumn, row: TableRow, value: unknown): string | null {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -693,6 +693,7 @@ export type I18nConfig = {
   readonly saveMissing: boolean;
   readonly locales: string[];
   readonly preloadLocales: string[];
+  readonly timezone: string | null;
 };
 export type Icon = {
   class: string | null;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -432,6 +432,7 @@ export type DateInput = {
   tooltip: string | null;
   value: unknown;
 };
+export type DateTimeStyle = "full" | "long" | "medium" | "short";
 export type DownloadEffect = {
   readonly url: string;
 };
@@ -1176,7 +1177,8 @@ export type TextColumn = {
   } | null;
   copyable: boolean;
   date: {
-    format: string | null;
+    dateStyle: string | null;
+    timeStyle: string | null;
   } | null;
   link: {
     href: string | null;

--- a/src/Contracts/HasTimezonePreference.php
+++ b/src/Contracts/HasTimezonePreference.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Contracts;
+
+interface HasTimezonePreference
+{
+    public function preferredTimezone(): ?string;
+}

--- a/src/Http/I18nConfig.php
+++ b/src/Http/I18nConfig.php
@@ -18,23 +18,25 @@ final readonly class I18nConfig implements JsonSerializable
         public bool $saveMissing,
         public array $locales,
         public array $preloadLocales,
+        public ?string $timezone = null,
     ) {}
 
     /**
      * @param  array<int, string>|null  $locales
      */
-    public static function fromConfig(?array $locales = null): self
+    public static function fromConfig(?array $locales = null, ?string $timezone = null): self
     {
         return new self(
             enabled: (bool) config('i18next.routes.enabled', false),
             saveMissing: (bool) config('i18next.save_missing.enabled', false),
             locales: $locales ?? self::configuredList('lattice.i18n.locales'),
             preloadLocales: self::configuredList('lattice.i18n.preload_locales'),
+            timezone: $timezone,
         );
     }
 
     /**
-     * @return array{enabled: bool, saveMissing: bool, locales: array<int, string>, preloadLocales: array<int, string>}
+     * @return array{enabled: bool, saveMissing: bool, locales: array<int, string>, preloadLocales: array<int, string>, timezone: string|null}
      */
     public function jsonSerialize(): array
     {
@@ -43,6 +45,7 @@ final readonly class I18nConfig implements JsonSerializable
             'saveMissing' => $this->saveMissing,
             'locales' => $this->locales,
             'preloadLocales' => $this->preloadLocales,
+            'timezone' => $this->timezone,
         ];
     }
 

--- a/src/Http/Middleware/SetLocale.php
+++ b/src/Http/Middleware/SetLocale.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Inertia\Inertia;
+use Lattice\Lattice\Contracts\HasTimezonePreference;
 use Lattice\Lattice\Http\I18nConfig;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,7 +16,7 @@ final class SetLocale
 {
     public function handle(Request $request, Closure $next): Response
     {
-        $config = I18nConfig::fromConfig();
+        $config = I18nConfig::fromConfig(timezone: $this->userTimezone($request));
         $locales = $config->locales;
 
         $this->shareConfig($config);
@@ -58,6 +59,19 @@ final class SetLocale
         $preferred = $request->getPreferredLanguage($locales);
 
         return is_string($preferred) && in_array($preferred, $locales, true) ? $preferred : null;
+    }
+
+    private function userTimezone(Request $request): ?string
+    {
+        $user = $request->user();
+
+        if (! $user instanceof HasTimezonePreference) {
+            return null;
+        }
+
+        $timezone = $user->preferredTimezone();
+
+        return is_string($timezone) && $timezone !== '' ? $timezone : null;
     }
 
     private function userLocale(Request $request): ?string

--- a/src/Tables/Columns/TextColumn.php
+++ b/src/Tables/Columns/TextColumn.php
@@ -7,6 +7,7 @@ use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
 use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
 use Lattice\Lattice\Tables\Enums\ColumnType;
+use Lattice\Lattice\Tables\Enums\DateTimeStyle;
 use Lattice\Lattice\Tables\Enums\FilterType;
 
 #[AsColumn(ColumnType::Text)]
@@ -16,7 +17,7 @@ class TextColumn extends Column implements Filterable, Sortable
     use IsSortable;
 
     /**
-     * @var array{format: string|null}|null
+     * @var array{dateStyle: string|null, timeStyle: string|null}|null
      */
     public ?array $date = null;
 
@@ -34,9 +35,23 @@ class TextColumn extends Column implements Filterable, Sortable
 
     public ?string $multiple = null;
 
-    public function date(?string $format = null): static
+    public function date(DateTimeStyle $style = DateTimeStyle::Medium): static
     {
-        $this->date = ['format' => $format];
+        $this->date = ['dateStyle' => $style->value, 'timeStyle' => null];
+
+        return $this;
+    }
+
+    public function time(DateTimeStyle $style = DateTimeStyle::Medium): static
+    {
+        $this->date = ['dateStyle' => null, 'timeStyle' => $style->value];
+
+        return $this;
+    }
+
+    public function dateTime(DateTimeStyle $style = DateTimeStyle::Medium): static
+    {
+        $this->date = ['dateStyle' => $style->value, 'timeStyle' => $style->value];
 
         return $this;
     }

--- a/src/Tables/Enums/DateTimeStyle.php
+++ b/src/Tables/Enums/DateTimeStyle.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tables\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum DateTimeStyle: string
+{
+    case Full = 'full';
+    case Long = 'long';
+    case Medium = 'medium';
+    case Short = 'short';
+}

--- a/tests/Browser/Table/DateColumnTest.php
+++ b/tests/Browser/Table/DateColumnTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+it('renders a date cell with a precise timezone tooltip', function (): void {
+    $this->actingAs(workbenchTestUser());
+    seedWorkbenchUsers();
+
+    visit('/')
+        ->assertPresent('time[title]')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/I18n/I18nConfigTest.php
+++ b/tests/Feature/I18n/I18nConfigTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Http\I18nConfig;
+
+it('serializes a null timezone by default', function (): void {
+    config(['lattice.i18n.locales' => ['en', 'de']]);
+
+    expect(I18nConfig::fromConfig()->jsonSerialize())
+        ->toHaveKey('timezone')
+        ->and(I18nConfig::fromConfig()->jsonSerialize()['timezone'])->toBeNull();
+});
+
+it('serializes the timezone passed to fromConfig', function (): void {
+    config(['lattice.i18n.locales' => ['en', 'de']]);
+
+    expect(I18nConfig::fromConfig(timezone: 'Europe/Berlin')->jsonSerialize()['timezone'])
+        ->toBe('Europe/Berlin');
+});

--- a/tests/Feature/I18n/TimezoneMiddlewareTest.php
+++ b/tests/Feature/I18n/TimezoneMiddlewareTest.php
@@ -23,7 +23,7 @@ it('shares the authenticated user timezone preference', function (): void {
     {
         protected $table = 'users';
 
-        public function preferredTimezone(): ?string
+        public function preferredTimezone(): string
         {
             return 'Europe/Berlin';
         }

--- a/tests/Feature/I18n/TimezoneMiddlewareTest.php
+++ b/tests/Feature/I18n/TimezoneMiddlewareTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Inertia\Testing\AssertableInertia;
+use Lattice\Lattice\Contracts\HasTimezonePreference;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+it('shares a null timezone when the user does not implement HasTimezonePreference', function (): void {
+    withoutVite();
+    $this->actingAs(workbenchTestUser());
+
+    get('/')->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+        ->where('lattice.i18n.timezone', null));
+});
+
+it('shares the authenticated user timezone preference', function (): void {
+    withoutVite();
+
+    $user = new class extends Authenticatable implements HasTimezonePreference
+    {
+        protected $table = 'users';
+
+        public function preferredTimezone(): ?string
+        {
+            return 'Europe/Berlin';
+        }
+    };
+
+    $this->actingAs($user);
+
+    get('/')->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+        ->where('lattice.i18n.timezone', 'Europe/Berlin'));
+});

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -344,7 +344,7 @@ test('registered table responses expose only declared columns row identity and g
 test('text columns serialize display modifiers', function (): void {
     expect(wire(TextColumn::make('published_at')
         ->label('Published')
-        ->date('Y-m-d')
+        ->dateTime()
         ->copyable()
         ->link('/posts/{id}')))
         ->toMatchArray([
@@ -352,7 +352,7 @@ test('text columns serialize display modifiers', function (): void {
             'label' => 'Published',
             'type' => 'column.text',
             'props' => [
-                'date' => ['format' => 'Y-m-d'],
+                'date' => ['dateStyle' => 'medium', 'timeStyle' => 'medium'],
                 'copyable' => true,
                 'link' => ['href' => '/posts/{id}', 'external' => false],
                 'badge' => null,
@@ -371,13 +371,13 @@ test('workbench users table exposes timestamp columns for each row', function ()
             'key' => 'created_at',
             'label' => 'Created at',
             'sortable' => true,
-            'props' => ['date' => ['format' => 'Y-m-d H:i:s'], 'copyable' => false, 'link' => null, 'badge' => null, 'multiple' => null],
+            'props' => ['date' => ['dateStyle' => 'medium', 'timeStyle' => 'medium'], 'copyable' => false, 'link' => null, 'badge' => null, 'multiple' => null],
         ])
         ->and($columns[3])->toMatchArray([
             'key' => 'updated_at',
             'label' => 'Updated at',
             'sortable' => true,
-            'props' => ['date' => ['format' => 'Y-m-d H:i:s'], 'copyable' => false, 'link' => null, 'badge' => null, 'multiple' => null],
+            'props' => ['date' => ['dateStyle' => 'medium', 'timeStyle' => 'medium'], 'copyable' => false, 'link' => null, 'badge' => null, 'multiple' => null],
         ]);
 });
 

--- a/tests/Feature/TimezonePreferenceTest.php
+++ b/tests/Feature/TimezonePreferenceTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Hash;
+use Inertia\Testing\AssertableInertia;
+use Workbench\App\Models\User;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+function createWorkbenchTimezoneUser(?string $timezone): User
+{
+    return User::query()->create([
+        'name' => 'Timezone User',
+        'email' => 'timezone-user@example.com',
+        'email_verified_at' => now(),
+        'password' => Hash::make('password'),
+        'timezone' => $timezone,
+    ]);
+}
+
+test('an authenticated user timezone preference is shared to the frontend', function (): void {
+    withoutVite();
+    $this->actingAs(createWorkbenchTimezoneUser('Europe/Berlin'));
+
+    get('/')->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+        ->where('lattice.i18n.timezone', 'Europe/Berlin'));
+});
+
+test('a user without a timezone preference shares null', function (): void {
+    withoutVite();
+    $this->actingAs(createWorkbenchTimezoneUser(null));
+
+    get('/')->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+        ->where('lattice.i18n.timezone', null));
+});

--- a/tests/Unit/Docs/TableDocsTest.php
+++ b/tests/Unit/Docs/TableDocsTest.php
@@ -22,7 +22,7 @@ describe('docs fixtures', function (): void {
                     TextColumn::make('name')->label('Name')->sortable()->filterable(),
                     NumberColumn::make('price')->label('Price')->sortable()->filterable(),
                     BooleanColumn::make('featured')->label('Featured'),
-                    TextColumn::make('updated_at')->label('Updated')->date('Y-m-d')->sortable(),
+                    TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable(),
                 ])
                 ->result(
                     TableResult::fromItems(collect([

--- a/tests/Unit/Tables/Columns/ColumnPropsTest.php
+++ b/tests/Unit/Tables/Columns/ColumnPropsTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Enums\DateTimeStyle;
 
 it('reflects a column\'s public properties into the full props shape', function (): void {
     expect(wire(TextColumn::make('name'))['props'])->toBe([
@@ -24,6 +25,17 @@ it('reflects a column\'s public properties into the full props shape', function 
         'badge' => ['colorKey' => 'color'],
         'multiple' => 'name',
     ]);
+});
+
+it('maps each date style method to its dateStyle/timeStyle shape', function (): void {
+    expect(wire(TextColumn::make('at')->date())['props']['date'])
+        ->toBe(['dateStyle' => 'medium', 'timeStyle' => null]);
+
+    expect(wire(TextColumn::make('at')->time(DateTimeStyle::Short))['props']['date'])
+        ->toBe(['dateStyle' => null, 'timeStyle' => 'short']);
+
+    expect(wire(TextColumn::make('at')->dateTime(DateTimeStyle::Long))['props']['date'])
+        ->toBe(['dateStyle' => 'long', 'timeStyle' => 'long']);
 });
 
 it('omits props for columns that expose no public properties', function (): void {

--- a/tests/Unit/Tables/Columns/ColumnPropsTest.php
+++ b/tests/Unit/Tables/Columns/ColumnPropsTest.php
@@ -14,11 +14,11 @@ it('reflects a column\'s public properties into the full props shape', function 
     ]);
 
     $configured = wire(
-        TextColumn::make('tags')->date('Y-m-d')->copyable()->link('/x', external: true)->badge('color')->multiple('name'),
+        TextColumn::make('tags')->dateTime()->copyable()->link('/x', external: true)->badge('color')->multiple('name'),
     );
 
     expect($configured['props'])->toBe([
-        'date' => ['format' => 'Y-m-d'],
+        'date' => ['dateStyle' => 'medium', 'timeStyle' => 'medium'],
         'copyable' => true,
         'link' => ['href' => '/x', 'external' => true],
         'badge' => ['colorKey' => 'color'],

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -5,11 +5,13 @@ namespace Workbench\App\Models;
 
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Lattice\Lattice\Contracts\HasTimezonePreference;
 
 /**
  * @property string|null $locale
+ * @property string|null $timezone
  */
-class User extends Authenticatable implements HasLocalePreference
+class User extends Authenticatable implements HasLocalePreference, HasTimezonePreference
 {
     protected $table = 'users';
 
@@ -22,6 +24,7 @@ class User extends Authenticatable implements HasLocalePreference
         'email_verified_at',
         'password',
         'locale',
+        'timezone',
     ];
 
     /**
@@ -46,6 +49,13 @@ class User extends Authenticatable implements HasLocalePreference
         return is_string($locale) && $locale !== '' ? $locale : null;
     }
 
+    public function preferredTimezone(): ?string
+    {
+        $timezone = $this->getAttribute('timezone');
+
+        return is_string($timezone) && $timezone !== '' ? $timezone : null;
+    }
+
     /**
      * @return array<string, string>
      */
@@ -56,6 +66,7 @@ class User extends Authenticatable implements HasLocalePreference
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'locale' => 'string',
+            'timezone' => 'string',
         ];
     }
 }

--- a/workbench/app/Tables/BaseUsersTable.php
+++ b/workbench/app/Tables/BaseUsersTable.php
@@ -22,8 +22,8 @@ abstract class BaseUsersTable extends EloquentTableDefinition
         return [
             TextColumn::make('name')->label(__('workbench.tables.columns.name'))->sortable()->filterable(),
             TextColumn::make('email')->label(__('workbench.tables.columns.email'))->sortable()->filterable()->link('mailto:{value}')->copyable(),
-            TextColumn::make('created_at')->label(__('workbench.tables.columns.created-at'))->sortable()->date('Y-m-d H:i:s'),
-            TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->date('Y-m-d H:i:s'),
+            TextColumn::make('created_at')->label(__('workbench.tables.columns.created-at'))->sortable()->dateTime(),
+            TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->dateTime(),
         ];
     }
 

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -53,7 +53,7 @@ class ProductsTable extends EloquentTableDefinition
             ])->colorMap(['draft' => 'gray', 'active' => 'green', 'archived' => 'red']),
             BooleanColumn::make('featured')->label(__('workbench.tables.columns.featured'))->sortable()->filterable(),
             TextColumn::make('tags')->label(__('workbench.tables.columns.tags'))->multiple('name')->badge('color')->filterable(),
-            TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->date('Y-m-d H:i:s')->filterable(),
+            TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->dateTime()->filterable(),
         ];
     }
 

--- a/workbench/app/Tables/UsersTable.php
+++ b/workbench/app/Tables/UsersTable.php
@@ -25,8 +25,8 @@ class UsersTable extends EloquentTableDefinition
         return [
             TextColumn::make('name')->label(__('workbench.tables.columns.name'))->sortable()->filterable(),
             TextColumn::make('email')->label(__('workbench.tables.columns.email'))->sortable()->filterable()->link('mailto:{value}')->copyable(),
-            TextColumn::make('created_at')->label(__('workbench.tables.columns.created-at'))->sortable()->date('Y-m-d H:i:s'),
-            TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->date('Y-m-d H:i:s'),
+            TextColumn::make('created_at')->label(__('workbench.tables.columns.created-at'))->sortable()->dateTime(),
+            TextColumn::make('updated_at')->label(__('workbench.tables.columns.updated-at'))->sortable()->dateTime(),
         ];
     }
 

--- a/workbench/database/migrations/2026_06_18_000000_add_timezone_to_users_table.php
+++ b/workbench/database/migrations/2026_06_18_000000_add_timezone_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('timezone')->nullable()->after('locale');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('timezone');
+        });
+    }
+};


### PR DESCRIPTION
Display datetimes in each user's timezone and replace the PHP-token date format with locale- and timezone-aware Intl style presets.

## Backend
- `I18nConfig` carries `timezone` (`string | null`); `SetLocale` middleware delivers the authenticated user's stored preference into the shared `lattice.i18n.timezone` prop. Display-only: **no** timezone header, cookie, or middleware resolution chain.
- New `HasTimezonePreference` contract; workbench `User` stores a nullable `timezone` column (null = fall through to browser detection).

## Frontend
- `timezone.ts` client store resolves `config → browser Intl → UTC` and re-renders date cells **without a page revisit**.
- Exported `<DateTime>` component renders a `<time>` element in the active locale + timezone, with a native `title` tooltip showing the precise time + timezone name. The table date cell uses it.

## Date formatting convention
Replaces `TextColumn::date('Y-m-d H:i:s')` (PHP tokens, browser zone) with three Intl-preset methods, all locale + timezone aware:
- `->date(style)`, `->time(style)`, `->dateTime(style)`
- `style` = `DateTimeStyle::{Full|Long|Medium|Short}`, default `Medium`

Before: `->date('Y-m-d H:i:s')` → `2026-06-18 14:32:00` (always browser zone, not localized)
After: `->dateTime()` → `Jun 18, 2026, 2:32 PM` (en) / `18.06.2026, 14:32` (de), converted to the user's timezone; hover shows `Jun 18, 2026, 14:32:07 CEST (Europe/Berlin)`.

## Verification
`composer check` (Pint, PHPStan, 858 tests) and `npm run check` (lint, format, tsc, Vitest, library build) green; generated TypeScript types and docs fixtures regenerated and idempotent.