### PR TITLE
feat: generalize the form response into a reusable LatticeResponse

### DIFF
--- a/src/Effects/EffectFlasher.php
+++ b/src/Effects/EffectFlasher.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Effects;
 
 use Inertia\Inertia;
 use Lattice\Lattice\Effects\Contracts\Effect;
+use Lattice\Lattice\Http\LatticeResponse;
 
 /**
  * Accumulates effects across a request and flashes them, as a single array,
@@ -27,6 +28,15 @@ final class EffectFlasher
         array_push($this->effects, ...$effects);
 
         Inertia::flash('latticeEffects', $this->effects);
+    }
+
+    /**
+     * Start a fluent response that queues effects and redirects — for plain
+     * controllers, returned the same way an action returns an ActionResult.
+     */
+    public function respond(): LatticeResponse
+    {
+        return LatticeResponse::make();
     }
 
     /**

--- a/src/Facades/Effects.php
+++ b/src/Facades/Effects.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Effects\EffectFlasher;
 
 /**
  * @method static void flash(\Lattice\Lattice\Effects\Contracts\Effect ...$effects)
+ * @method static \Lattice\Lattice\Http\LatticeResponse respond()
  *
  * @see EffectFlasher
  */

--- a/src/Forms/FormDefinition.php
+++ b/src/Forms/FormDefinition.php
@@ -15,6 +15,7 @@ use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Concerns\ResolvesFormFields;
 use Lattice\Lattice\Forms\Contracts\HandlesUploads;
 use Lattice\Lattice\Forms\Contracts\ProvidesForm;
+use Lattice\Lattice\Http\LatticeResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class FormDefinition extends Definition implements HandlesUploads, ProvidesForm
@@ -26,19 +27,19 @@ abstract class FormDefinition extends Definition implements HandlesUploads, Prov
     abstract public function handle(Request $request): Response|Responsable;
 
     /**
-     * Start a fluent form response — queue effects and a redirect.
+     * Start a fluent response — queue effects and a redirect.
      */
-    protected function respond(): FormResponse
+    protected function respond(): LatticeResponse
     {
-        return FormResponse::make();
+        return LatticeResponse::make();
     }
 
     /**
-     * Start a fluent form response with a toast already queued.
+     * Start a fluent response with a toast already queued.
      */
-    protected function toast(string|Translatable|ToastMessage|Variant $message, Variant|string|null $variant = null): FormResponse
+    protected function toast(string|Translatable|ToastMessage|Variant $message, Variant|string|null $variant = null): LatticeResponse
     {
-        return FormResponse::make()->toast($message, $variant);
+        return LatticeResponse::make()->toast($message, $variant);
     }
 
     /**

--- a/src/Forms/FormResponse.php
+++ b/src/Forms/FormResponse.php
@@ -3,101 +3,11 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Forms;
 
-use BackedEnum;
-use Closure;
-use Illuminate\Contracts\Support\Responsable;
-use Lattice\Lattice\Core\Enums\Variant;
-use Lattice\Lattice\Core\Values\Callout;
-use Lattice\Lattice\Core\Values\ToastMessage;
-use Lattice\Lattice\Core\Values\Translatable;
-use Lattice\Lattice\Effects\Contracts\Effect as EffectContract;
-use Lattice\Lattice\Effects\Effect;
-use Lattice\Lattice\Facades\Effects;
-use Symfony\Component\HttpFoundation\Response;
+use Lattice\Lattice\Http\LatticeResponse;
 
 /**
- * A fluent response for a form handler: queue effects (toasts, callouts, a page
- * reload, …) and a redirect. The effects survive the redirect through the
- * `latticeEffects` flash bag, so the form flow gets the same ergonomics
- * ActionResult gives the inline action flow. Defaults to redirecting back.
+ * @deprecated Use {@see LatticeResponse}. The fluent
+ * effect response is shared by form handlers, controllers, and any other
+ * endpoint — it is no longer form-specific.
  */
-final readonly class FormResponse implements Responsable
-{
-    /**
-     * @param  array<int, EffectContract>  $effects
-     * @param  (Closure(): Response)|null  $redirect
-     */
-    private function __construct(
-        private array $effects = [],
-        private ?Closure $redirect = null,
-    ) {}
-
-    public static function make(): self
-    {
-        return new self;
-    }
-
-    public function effect(EffectContract $effect): self
-    {
-        return new self([...$this->effects, $effect], $this->redirect);
-    }
-
-    public function toast(string|Translatable|ToastMessage|Variant $message, Variant|string|null $variant = null): self
-    {
-        return $this->effect(Effect::toast($message, $variant));
-    }
-
-    public function callout(Callout $callout): self
-    {
-        return $this->effect(Effect::callout($callout));
-    }
-
-    public function reloadPage(): self
-    {
-        return $this->effect(Effect::reloadPage());
-    }
-
-    public function reloadComponent(string $component): self
-    {
-        return $this->effect(Effect::reloadComponent($component));
-    }
-
-    public function closeModal(?string $modal = null): self
-    {
-        return $this->effect(Effect::closeModal($modal));
-    }
-
-    /**
-     * @param  array<string, mixed>|string  $parameters
-     */
-    public function toRoute(BackedEnum|string $route, array|string $parameters = []): self
-    {
-        $name = $route instanceof BackedEnum ? (string) $route->value : $route;
-
-        return $this->withRedirect(fn (): Response => to_route($name, $parameters));
-    }
-
-    public function to(string $url): self
-    {
-        return $this->withRedirect(fn (): Response => redirect()->to($url));
-    }
-
-    public function back(): self
-    {
-        return $this->withRedirect(fn (): Response => redirect()->back());
-    }
-
-    public function toResponse($request): Response
-    {
-        if ($this->effects !== []) {
-            Effects::flash(...$this->effects);
-        }
-
-        return ($this->redirect ?? fn (): Response => redirect()->back())();
-    }
-
-    private function withRedirect(Closure $redirect): self
-    {
-        return new self($this->effects, $redirect);
-    }
-}
+final readonly class FormResponse extends LatticeResponse {}

--- a/src/Http/LatticeResponse.php
+++ b/src/Http/LatticeResponse.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http;
+
+use BackedEnum;
+use Closure;
+use Illuminate\Contracts\Support\Responsable;
+use Lattice\Lattice\Core\Enums\Variant;
+use Lattice\Lattice\Core\Values\Callout;
+use Lattice\Lattice\Core\Values\ToastMessage;
+use Lattice\Lattice\Core\Values\Translatable;
+use Lattice\Lattice\Effects\Contracts\Effect as EffectContract;
+use Lattice\Lattice\Effects\Effect;
+use Lattice\Lattice\Facades\Effects;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A fluent, Responsable result for any endpoint — a controller, a form handler,
+ * anywhere: queue effects (toasts, callouts, a component or page reload, a
+ * modal close, …) and a redirect. The effects survive the redirect through the
+ * `latticeEffects` flash bag, giving plain controllers the same ergonomics
+ * ActionResult gives actions. Defaults to redirecting back.
+ *
+ * @phpstan-consistent-constructor
+ */
+readonly class LatticeResponse implements Responsable
+{
+    /**
+     * @param  array<int, EffectContract>  $effects
+     * @param  (Closure(): Response)|null  $redirect
+     */
+    protected function __construct(
+        private array $effects = [],
+        private ?Closure $redirect = null,
+    ) {}
+
+    public static function make(): static
+    {
+        return new static;
+    }
+
+    public function effect(EffectContract $effect): static
+    {
+        return new static([...$this->effects, $effect], $this->redirect);
+    }
+
+    public function toast(string|Translatable|ToastMessage|Variant $message, Variant|string|null $variant = null): static
+    {
+        return $this->effect(Effect::toast($message, $variant));
+    }
+
+    public function callout(Callout $callout): static
+    {
+        return $this->effect(Effect::callout($callout));
+    }
+
+    public function reloadPage(): static
+    {
+        return $this->effect(Effect::reloadPage());
+    }
+
+    public function reloadComponent(string $component): static
+    {
+        return $this->effect(Effect::reloadComponent($component));
+    }
+
+    public function closeModal(?string $modal = null): static
+    {
+        return $this->effect(Effect::closeModal($modal));
+    }
+
+    /**
+     * @param  array<string, mixed>|string  $parameters
+     */
+    public function toRoute(BackedEnum|string $route, array|string $parameters = []): static
+    {
+        $name = $route instanceof BackedEnum ? (string) $route->value : $route;
+
+        return $this->withRedirect(fn (): Response => to_route($name, $parameters));
+    }
+
+    public function to(string $url): static
+    {
+        return $this->withRedirect(fn (): Response => redirect()->to($url));
+    }
+
+    public function back(): static
+    {
+        return $this->withRedirect(fn (): Response => redirect()->back());
+    }
+
+    public function toResponse($request): Response
+    {
+        if ($this->effects !== []) {
+            Effects::flash(...$this->effects);
+        }
+
+        return ($this->redirect ?? fn (): Response => redirect()->back())();
+    }
+
+    private function withRedirect(Closure $redirect): static
+    {
+        return new static($this->effects, $redirect);
+    }
+}

--- a/tests/Feature/Http/LatticeResponseTest.php
+++ b/tests/Feature/Http/LatticeResponseTest.php
@@ -7,19 +7,21 @@ use Lattice\Lattice\Core\Enums\Variant;
 use Lattice\Lattice\Core\Values\Callout;
 use Lattice\Lattice\Effects\Effect;
 use Lattice\Lattice\Effects\EffectFlasher;
+use Lattice\Lattice\Facades\Effects;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Forms\FormResponse;
+use Lattice\Lattice\Http\LatticeResponse;
 
 beforeEach(function (): void {
     app()->forgetScopedInstances();
     Route::get('after-save', fn (): string => 'ok')->middleware('web')->name('after-save');
 });
 
-test('a form response flashes its effects and redirects to a route', function (): void {
-    $response = FormResponse::make()
+test('a lattice response flashes its effects and redirects to a route', function (): void {
+    $response = LatticeResponse::make()
         ->toast('Saved.', Variant::Success)
-        ->reloadPage()
+        ->reloadComponent('settings.passkeys')
         ->toRoute('after-save')
         ->toResponse(request());
 
@@ -28,11 +30,42 @@ test('a form response flashes its effects and redirects to a route', function ()
     expect(app(EffectFlasher::class)->all())->toHaveCount(2);
 });
 
-test('a form response redirects back by default and flashes nothing', function (): void {
-    $response = FormResponse::make()->toResponse(request());
+test('a lattice response redirects back by default and flashes nothing', function (): void {
+    $response = LatticeResponse::make()->toResponse(request());
 
     expect($response->getStatusCode())->toBe(302);
     expect(app(EffectFlasher::class)->all())->toBe([]);
+});
+
+test('a lattice response queues every effect helper and redirects to a url', function (): void {
+    $response = LatticeResponse::make()
+        ->callout(Callout::make(Variant::Info, 'Heads up'))
+        ->reloadPage()
+        ->closeModal('two-factor')
+        ->effect(Effect::reloadComponent('teams.members'))
+        ->to('/dashboard')
+        ->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect($response->headers->get('Location'))->toContain('/dashboard');
+    expect(app(EffectFlasher::class)->all())->toHaveCount(4);
+});
+
+test('Effects::respond starts a fluent response', function (): void {
+    $response = Effects::respond()
+        ->toast('Done.')
+        ->toRoute('after-save')
+        ->toResponse(request());
+
+    expect($response->headers->get('Location'))->toBe(route('after-save'));
+    expect(app(EffectFlasher::class)->all())->toHaveCount(1);
+});
+
+test('the deprecated FormResponse alias still builds a working response', function (): void {
+    $response = FormResponse::make()->toast('Saved.')->toRoute('after-save')->toResponse(request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect($response->headers->get('Location'))->toBe(route('after-save'));
 });
 
 test('FormDefinition::toast starts a fluent response from the handler', function (): void {
@@ -41,20 +74,6 @@ test('FormDefinition::toast starts a fluent response from the handler', function
     expect($response->getStatusCode())->toBe(302);
     expect($response->headers->get('Location'))->toBe(route('after-save'));
     expect(app(EffectFlasher::class)->all())->toHaveCount(1);
-});
-
-test('a form response queues every effect helper and redirects to a url', function (): void {
-    $response = FormResponse::make()
-        ->callout(Callout::make(Variant::Info, 'Heads up'))
-        ->reloadComponent('settings.passkeys')
-        ->closeModal('two-factor')
-        ->effect(Effect::reloadPage())
-        ->to('/dashboard')
-        ->toResponse(request());
-
-    expect($response->getStatusCode())->toBe(302);
-    expect($response->headers->get('Location'))->toContain('/dashboard');
-    expect(app(EffectFlasher::class)->all())->toHaveCount(4);
 });
 
 test('FormDefinition::respond starts an empty fluent response from the handler', function (): void {
@@ -72,7 +91,7 @@ final class FlashForm extends FormDefinition
         return $form;
     }
 
-    public function handle(Request $request): FormResponse
+    public function handle(Request $request): LatticeResponse
     {
         return $this->toast('Saved.', Variant::Success)->toRoute('after-save');
     }
@@ -85,7 +104,7 @@ final class RespondForm extends FormDefinition
         return $form;
     }
 
-    public function handle(Request $request): FormResponse
+    public function handle(Request $request): LatticeResponse
     {
         return $this->respond()->reloadPage()->toRoute('after-save');
     }


### PR DESCRIPTION
## The gap

0.5 (correctly) made effects flow through the server response — `ActionResult` for action `handle()`s, `Effects::flash(...)` for everything else. But there was no *ergonomic* path for a plain **controller** to return effects + a redirect. The fluent builder that does exactly this (`FormResponse`) was trapped in the `Forms` namespace, so controllers behind a table/row action were stuck with `Effects::flash(Effect::toast(...), Effect::reloadComponent(...)); return to_route(...);`.

## Change

Lift `FormResponse`'s mechanics into `Lattice\Lattice\Http\LatticeResponse` — a fluent, `Responsable` builder any endpoint can return. Effects survive the redirect via the existing `latticeEffects` flash bag.

```php
// in a controller behind a table action
return Effects::respond()
    ->toast(__('Member removed.'), Variant::Success)
    ->reloadComponent('teams.members')
    ->back();
```

- New `Lattice::`… not used — the discovery facade stays for registration. Surfaced instead via `Effects::respond()` (next to `Effects::flash()`) and `LatticeResponse::make()`.
- `FormDefinition::respond()` / `$this->toast()` now return `LatticeResponse`.
- `FormResponse` (shipped in 0.5.0) stays as a `@deprecated` subclass alias — existing usage keeps working.

This closes a real ergonomics gap for every controller-backed action and makes the action / form / controller effect story symmetric.

## Verification

- `composer check` — Pint, PHPStan, Rector, Pest (861 passed)
- New `tests/Feature/Http/LatticeResponseTest.php` covers `LatticeResponse`, `Effects::respond()`, the `FormDefinition` helpers, and the deprecated `FormResponse` alias.