### PR TITLE
feat: apply appearance changes in the Provider for turnkey theme switching

### DIFF
--- a/resources/js/appearance/index.ts
+++ b/resources/js/appearance/index.ts
@@ -75,6 +75,17 @@ const handleSystemThemeChange = (): void => {
   notify();
 };
 
+export function updateAppearance(mode: Appearance): void {
+  currentAppearance = mode;
+
+  localStorage.setItem("appearance", mode);
+
+  setCookie("appearance", mode);
+
+  applyTheme(mode);
+  notify();
+}
+
 export function initializeTheme(): void {
   if (typeof window === "undefined") {
     return;
@@ -105,17 +116,6 @@ export function useAppearance(): UseAppearanceReturn {
 
   const resolvedAppearance: ResolvedAppearance =
     appearance === "system" ? systemAppearance : appearance;
-
-  const updateAppearance = (mode: Appearance): void => {
-    currentAppearance = mode;
-
-    localStorage.setItem("appearance", mode);
-
-    setCookie("appearance", mode);
-
-    applyTheme(mode);
-    notify();
-  };
 
   return { appearance, resolvedAppearance, updateAppearance } as const;
 }

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -9,7 +9,7 @@ export {
 } from "./effects/dispatch";
 export { useEffectDispatcher } from "./effects/use-effect-dispatcher";
 export { builtinEffectHandlers, effectHandler, mergeEffectHandlers } from "./effects/registry";
-export { initializeTheme, useAppearance } from "./appearance";
+export { initializeTheme, updateAppearance, useAppearance } from "./appearance";
 export { copyToClipboard, useClipboard } from "./clipboard";
 export { createLatticeApp, type CreateLatticeAppOptions } from "./create-app";
 export { EventBridge } from "./events/event-bridge";

--- a/resources/js/provider.test.tsx
+++ b/resources/js/provider.test.tsx
@@ -1,0 +1,45 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { Provider } from "./provider";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn<(query: string) => MediaQueryList>(
+      () =>
+        ({
+          matches: false,
+          addEventListener: vi.fn<() => void>(),
+          removeEventListener: vi.fn<() => void>(),
+        }) as unknown as MediaQueryList,
+    ),
+  );
+});
+
+afterEach(() => {
+  document.documentElement.classList.remove("dark");
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+function emitAppearance(value: unknown): void {
+  act(() => {
+    window.dispatchEvent(new CustomEvent("lattice:appearance-change", { detail: { value } }));
+  });
+}
+
+it("applies an appearance change emitted on the appearance-change event", () => {
+  render(<Provider toaster={false}>{null}</Provider>);
+
+  emitAppearance("dark");
+
+  expect(document.documentElement.classList.contains("dark")).toBe(true);
+});
+
+it("ignores appearance-change events carrying an unknown value", () => {
+  render(<Provider toaster={false}>{null}</Provider>);
+
+  emitAppearance("not-a-real-appearance");
+
+  expect(document.documentElement.classList.contains("dark")).toBe(false);
+});

--- a/resources/js/provider.tsx
+++ b/resources/js/provider.tsx
@@ -5,6 +5,8 @@ import { registry as defaultRegistry } from "./registry";
 import type { Registry } from "./core/registry";
 import { RegistryContext, setDefaultRegistry } from "./core/registry-context";
 import { Toaster } from "./toast";
+import { updateAppearance } from "./appearance";
+import { EventBridge } from "./events/event-bridge";
 import { useFlashEffects } from "./effects/use-flash-effects";
 
 // Register the default registry so selectors work outside <Provider>.
@@ -31,6 +33,7 @@ export function Provider({
     <RegistryContext.Provider value={registry}>
       <SpriteProvider sprite={sprite}>
         {children}
+        <EventBridge onAppearanceChange={updateAppearance} />
         {toaster ? <Toaster /> : null}
       </SpriteProvider>
     </RegistryContext.Provider>


### PR DESCRIPTION
The `Provider` already drains flash effects and renders the Toaster, but it ignored appearance-change events. So an app using `createLatticeApp` (which renders only the `Provider`) had no way to wire a theme switcher — it still needed its own `EventBridge`, defeating the point of the helper.

The Provider now listens for the `lattice:appearance-change` event (emitted by an appearance switcher, e.g. `SegmentedControl->emits(...)`) and applies it. With this, `createLatticeApp` is turnkey for theme switching — no app-level EventBridge needed.

`updateAppearance` is lifted from inside the `useAppearance` hook to a module-level export, used in a client-only effect (via `EventBridge`). So the Provider never calls `matchMedia` at render — it stays SSR-safe and doesn't force every test that renders through the Provider to stub `matchMedia`.

## Verification

- `npm run check` — oxlint, oxfmt, tsc, type-coverage, Vitest, build:lib
- New `provider.test.tsx` covers applying a valid appearance change and ignoring an unknown value.