### PR TITLE
feat: definition generators (page/form/table/action/…) and a single JS registry

### DIFF
--- a/src/Console/Commands/Concerns/GeneratesComponentPair.php
+++ b/src/Console/Commands/Concerns/GeneratesComponentPair.php
@@ -16,13 +16,13 @@ trait GeneratesComponentPair
     /**
      * @param  array<string, string>  $replacements
      */
-    protected function writeStub(string $stub, string $targetPath, array $replacements): void
+    protected function writeStub(string $stub, string $targetPath, array $replacements, bool $force = false): void
     {
         $stubPath = __DIR__.'/../../stubs/'.$stub;
         $contents = strtr(File::get($stubPath), $this->placeholders($replacements));
 
-        if (File::exists($targetPath)) {
-            $this->components->warn('File already exists, skipping: '.$targetPath);
+        if (File::exists($targetPath) && ! $force) {
+            $this->components->warn('File already exists, skipping (use --force to overwrite): '.$targetPath);
 
             return;
         }

--- a/src/Console/Commands/MakeActionCommand.php
+++ b/src/Console/Commands/MakeActionCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeActionCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:action {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice action';
+
+    protected string $type = 'Action';
+
+    protected string $directory = 'Actions';
+
+    protected string $stub = 'action.php.stub';
+}

--- a/src/Console/Commands/MakeBulkActionCommand.php
+++ b/src/Console/Commands/MakeBulkActionCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeBulkActionCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:bulk-action {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice bulk action';
+
+    protected string $type = 'Bulk action';
+
+    protected string $directory = 'Actions';
+
+    protected string $stub = 'bulk-action.php.stub';
+}

--- a/src/Console/Commands/MakeColumnCommand.php
+++ b/src/Console/Commands/MakeColumnCommand.php
@@ -12,7 +12,7 @@ final class MakeColumnCommand extends Command
 {
     use GeneratesComponentPair;
 
-    protected $signature = 'lattice:column {name} {--type=}';
+    protected $signature = 'lattice:column {name} {--type=} {--force}';
 
     protected $description = 'Scaffold a custom Lattice table column (PHP + React cell)';
 
@@ -23,21 +23,20 @@ final class MakeColumnCommand extends Command
         $attributeType = ColumnType::localType($type);
         $wireType = ColumnType::wireType($type);
         $kebab = Str::kebab($name);
+        $force = (bool) $this->option('force');
 
         $this->writeStub(
             'column.php.stub',
             app_path('Tables/Columns/'.$name.'.php'),
-            ['namespace' => 'App\\Tables\\Columns', 'class' => $name, 'type' => $attributeType],
-        );
+            ['namespace' => 'App\\Tables\\Columns', 'class' => $name, 'type' => $attributeType], force: $force);
 
         $this->writeStub(
             'column.tsx.stub',
-            resource_path('js/lattice/columns/'.$kebab.'.tsx'),
-            ['class' => $name, 'type' => $type],
-        );
+            resource_path('js/columns/'.$kebab.'.tsx'),
+            ['class' => $name, 'type' => $type], force: $force);
 
         $this->registerInPlugin(
-            resource_path('js/lattice/columns.ts'),
+            resource_path('js/registry.ts'),
             $wireType,
             $name.'Cell',
             './columns/'.$kebab,

--- a/src/Console/Commands/MakeComponentCommand.php
+++ b/src/Console/Commands/MakeComponentCommand.php
@@ -11,7 +11,7 @@ final class MakeComponentCommand extends Command
 {
     use GeneratesComponentPair;
 
-    protected $signature = 'lattice:component {name} {--type=}';
+    protected $signature = 'lattice:component {name} {--type=} {--force}';
 
     protected $description = 'Scaffold a custom Lattice UI component (PHP + React)';
 
@@ -20,21 +20,20 @@ final class MakeComponentCommand extends Command
         $name = $this->argument('name');
         $type = $this->option('type') ?: $this->typeFromName($name, '');
         $kebab = Str::kebab($name);
+        $force = (bool) $this->option('force');
 
         $this->writeStub(
             'component.php.stub',
             app_path('Components/'.$name.'.php'),
-            ['namespace' => 'App\\Components', 'class' => $name, 'type' => $type],
-        );
+            ['namespace' => 'App\\Components', 'class' => $name, 'type' => $type], force: $force);
 
         $this->writeStub(
             'component.tsx.stub',
-            resource_path('js/lattice/components/'.$kebab.'.tsx'),
-            ['class' => $name, 'type' => $type],
-        );
+            resource_path('js/components/'.$kebab.'.tsx'),
+            ['class' => $name, 'type' => $type], force: $force);
 
         $this->registerInPlugin(
-            resource_path('js/lattice/plugin.ts'),
+            resource_path('js/registry.ts'),
             $type,
             $name.'Component',
             './components/'.$kebab,

--- a/src/Console/Commands/MakeDefinitionCommand.php
+++ b/src/Console/Commands/MakeDefinitionCommand.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+/**
+ * Base for the PHP-only definition generators (page, form, table, action, …).
+ * Each subclass sets {@see $type}, {@see $directory}, and {@see $stub}; the
+ * class is written to app/{directory}/{Name}.php, supporting nested names
+ * (e.g. `Teams/CreateTeam`) and an opt-in `--force` overwrite.
+ */
+abstract class MakeDefinitionCommand extends Command
+{
+    /** Human label, e.g. "Page". */
+    protected string $type;
+
+    /** Target directory under app/, e.g. "Pages". */
+    protected string $directory;
+
+    /** Stub filename, e.g. "page.php.stub". */
+    protected string $stub;
+
+    public function handle(): int
+    {
+        $name = ltrim(str_replace('/', '\\', (string) $this->argument('name')), '\\');
+        $class = class_basename($name);
+        $subNamespace = trim(Str::beforeLast($name, $class), '\\');
+
+        $namespace = 'App\\'.$this->directory.($subNamespace !== '' ? '\\'.$subNamespace : '');
+        $target = app_path($this->directory.'/'.str_replace('\\', '/', $name).'.php');
+
+        if (File::exists($target) && ! $this->option('force')) {
+            $this->components->warn($this->type.' already exists: '.$target.' (use --force to overwrite)');
+
+            return self::FAILURE;
+        }
+
+        $contents = strtr(File::get(__DIR__.'/../stubs/'.$this->stub), [
+            '{{ namespace }}' => $namespace,
+            '{{ class }}' => $class,
+            '{{ key }}' => Str::kebab($class),
+        ]);
+
+        File::ensureDirectoryExists(dirname($target));
+        File::put($target, $contents);
+
+        $this->components->info($this->type.' ['.$namespace.'\\'.$class.'] created.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/MakeFieldCommand.php
+++ b/src/Console/Commands/MakeFieldCommand.php
@@ -12,7 +12,7 @@ final class MakeFieldCommand extends Command
 {
     use GeneratesComponentPair;
 
-    protected $signature = 'lattice:field {name} {--type=}';
+    protected $signature = 'lattice:field {name} {--type=} {--force}';
 
     protected $description = 'Scaffold a custom Lattice form field (PHP + React)';
 
@@ -23,21 +23,20 @@ final class MakeFieldCommand extends Command
         $attributeType = FieldType::localType($type);
         $wireType = FieldType::wireType($type);
         $kebab = Str::kebab($name);
+        $force = (bool) $this->option('force');
 
         $this->writeStub(
             'field.php.stub',
             app_path('Forms/Fields/'.$name.'.php'),
-            ['namespace' => 'App\\Forms\\Fields', 'class' => $name, 'type' => $attributeType],
-        );
+            ['namespace' => 'App\\Forms\\Fields', 'class' => $name, 'type' => $attributeType], force: $force);
 
         $this->writeStub(
             'field.tsx.stub',
-            resource_path('js/lattice/fields/'.$kebab.'.tsx'),
-            ['class' => $name, 'type' => $wireType],
-        );
+            resource_path('js/fields/'.$kebab.'.tsx'),
+            ['class' => $name, 'type' => $wireType], force: $force);
 
         $this->registerInPlugin(
-            resource_path('js/lattice/plugin.ts'),
+            resource_path('js/registry.ts'),
             $wireType,
             $name.'Component',
             './fields/'.$kebab,

--- a/src/Console/Commands/MakeFormCommand.php
+++ b/src/Console/Commands/MakeFormCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeFormCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:form {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice form';
+
+    protected string $type = 'Form';
+
+    protected string $directory = 'Forms';
+
+    protected string $stub = 'form.php.stub';
+}

--- a/src/Console/Commands/MakeFragmentCommand.php
+++ b/src/Console/Commands/MakeFragmentCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeFragmentCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:fragment {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice fragment';
+
+    protected string $type = 'Fragment';
+
+    protected string $directory = 'Fragments';
+
+    protected string $stub = 'fragment.php.stub';
+}

--- a/src/Console/Commands/MakeLayoutCommand.php
+++ b/src/Console/Commands/MakeLayoutCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeLayoutCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:layout {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice layout';
+
+    protected string $type = 'Layout';
+
+    protected string $directory = 'Layouts';
+
+    protected string $stub = 'layout.php.stub';
+}

--- a/src/Console/Commands/MakePageCommand.php
+++ b/src/Console/Commands/MakePageCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakePageCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:page {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice page';
+
+    protected string $type = 'Page';
+
+    protected string $directory = 'Pages';
+
+    protected string $stub = 'page.php.stub';
+}

--- a/src/Console/Commands/MakeRemoteSourceCommand.php
+++ b/src/Console/Commands/MakeRemoteSourceCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeRemoteSourceCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:remote-source {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice remote source';
+
+    protected string $type = 'Remote source';
+
+    protected string $directory = 'Remote';
+
+    protected string $stub = 'remote-source.php.stub';
+}

--- a/src/Console/Commands/MakeTableCommand.php
+++ b/src/Console/Commands/MakeTableCommand.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Console\Commands;
+
+final class MakeTableCommand extends MakeDefinitionCommand
+{
+    protected $signature = 'lattice:table {name} {--force}';
+
+    protected $description = 'Scaffold a Lattice table';
+
+    protected string $type = 'Table';
+
+    protected string $directory = 'Tables';
+
+    protected string $stub = 'table.php.stub';
+}

--- a/src/Console/stubs/action.php.stub
+++ b/src/Console/stubs/action.php.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\AsAction;
+
+#[AsAction('{{ key }}')]
+class {{ class }} extends ActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action->label('{{ class }}');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+}

--- a/src/Console/stubs/bulk-action.php.stub
+++ b/src/Console/stubs/bulk-action.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\AsBulkAction;
+
+#[AsBulkAction('{{ key }}')]
+class {{ class }} extends BulkActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action->label('{{ class }}');
+    }
+
+    /**
+     * @param  Collection<int, \Illuminate\Database\Eloquent\Model>  $records
+     */
+    public function handle(Collection $records, Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+}

--- a/src/Console/stubs/form.php.stub
+++ b/src/Console/stubs/form.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Http\LatticeResponse;
+
+#[AsForm('{{ key }}')]
+class {{ class }} extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([
+            //
+        ]);
+    }
+
+    public function handle(Request $request): LatticeResponse
+    {
+        $this->validate($request);
+
+        return $this->respond()->back();
+    }
+}

--- a/src/Console/stubs/fragment.php.stub
+++ b/src/Console/stubs/fragment.php.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Lattice\Lattice\Attributes\AsFragment;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Fragments\FragmentDefinition;
+
+#[AsFragment('{{ key }}')]
+class {{ class }} extends FragmentDefinition
+{
+    public function schema(PageSchema $schema): PageSchema
+    {
+        return $schema;
+    }
+}

--- a/src/Console/stubs/layout.php.stub
+++ b/src/Console/stubs/layout.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsLayout;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Layouts\LayoutDefinition;
+
+#[AsLayout('{{ key }}')]
+class {{ class }} extends LayoutDefinition
+{
+    public function schema(PageSchema $schema, Request $request): PageSchema
+    {
+        return $schema;
+    }
+}

--- a/src/Console/stubs/page.php.stub
+++ b/src/Console/stubs/page.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page;
+
+#[AsPage(route: '{{ key }}', name: '{{ key }}')]
+class {{ class }} extends Page
+{
+    public function render(PageSchema $schema, Request $request): PageSchema
+    {
+        return $schema;
+    }
+}

--- a/src/Console/stubs/remote-source.php.stub
+++ b/src/Console/stubs/remote-source.php.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsRemoteSource;
+use Lattice\Lattice\Remote\RemoteSourceDefinition;
+
+#[AsRemoteSource('{{ key }}')]
+class {{ class }} extends RemoteSourceDefinition
+{
+    /**
+     * @return array<int, mixed>
+     */
+    public function schema(Request $request): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/Console/stubs/table.php.stub
+++ b/src/Console/stubs/table.php.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Attributes\AsTable;
+use Lattice\Lattice\Tables\Columns\Column;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Sources\Eloquent\EloquentTableDefinition;
+use Lattice\Lattice\Tables\TableQuery;
+
+#[AsTable('{{ key }}')]
+class {{ class }} extends EloquentTableDefinition
+{
+    /**
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('id')->label('ID'),
+        ];
+    }
+
+    public function builder(TableQuery $query): Builder
+    {
+        // TODO: return the Eloquent query for this table, e.g. \App\Models\Example::query();
+        throw new \RuntimeException('Implement builder() for {{ class }}.');
+    }
+}

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -14,9 +14,17 @@ use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionRegistry;
 use Lattice\Lattice\Console\Commands\DiscoverCacheCommand;
 use Lattice\Lattice\Console\Commands\DiscoverClearCommand;
+use Lattice\Lattice\Console\Commands\MakeActionCommand;
+use Lattice\Lattice\Console\Commands\MakeBulkActionCommand;
 use Lattice\Lattice\Console\Commands\MakeColumnCommand;
 use Lattice\Lattice\Console\Commands\MakeComponentCommand;
 use Lattice\Lattice\Console\Commands\MakeFieldCommand;
+use Lattice\Lattice\Console\Commands\MakeFormCommand;
+use Lattice\Lattice\Console\Commands\MakeFragmentCommand;
+use Lattice\Lattice\Console\Commands\MakeLayoutCommand;
+use Lattice\Lattice\Console\Commands\MakePageCommand;
+use Lattice\Lattice\Console\Commands\MakeRemoteSourceCommand;
+use Lattice\Lattice\Console\Commands\MakeTableCommand;
 use Lattice\Lattice\Console\Commands\TypeScriptCommand;
 use Lattice\Lattice\Core\Components\Component;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
@@ -50,9 +58,17 @@ final class LatticeServiceProvider extends PackageServiceProvider
             ->hasRoute('web')
             ->hasConsoleCommands([
                 TypeScriptCommand::class,
-                MakeFieldCommand::class,
                 MakeComponentCommand::class,
+                MakeFieldCommand::class,
                 MakeColumnCommand::class,
+                MakePageCommand::class,
+                MakeFormCommand::class,
+                MakeTableCommand::class,
+                MakeActionCommand::class,
+                MakeBulkActionCommand::class,
+                MakeFragmentCommand::class,
+                MakeLayoutCommand::class,
+                MakeRemoteSourceCommand::class,
                 DiscoverCacheCommand::class,
                 DiscoverClearCommand::class,
             ]);
@@ -100,8 +116,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../stubs/lattice/plugin.ts' => resource_path('js/lattice/plugin.ts'),
-                __DIR__.'/../stubs/lattice/columns.ts' => resource_path('js/lattice/columns.ts'),
+                __DIR__.'/../stubs/registry.ts' => resource_path('js/registry.ts'),
             ], 'lattice-js');
         }
 

--- a/stubs/lattice/columns.ts
+++ b/stubs/lattice/columns.ts
@@ -1,8 +1,0 @@
-import { createPlugin } from "@lattice-php/lattice";
-
-// Register your custom table column cell renderers here.
-// `php artisan lattice:column` appends entries automatically.
-export const appColumns = createPlugin({
-  name: "app",
-  columns: {},
-});

--- a/stubs/lattice/plugin.ts
+++ b/stubs/lattice/plugin.ts
@@ -1,8 +1,0 @@
-import { createPlugin } from "@lattice-php/lattice";
-
-// Register your custom Lattice components and fields here.
-// `php artisan lattice:field` and `lattice:component` append entries automatically.
-export const appPlugin = createPlugin({
-  name: "app",
-  components: {},
-});

--- a/stubs/registry.ts
+++ b/stubs/registry.ts
@@ -1,0 +1,13 @@
+import { createPlugin, extendRegistry, registry as packageRegistry } from "@lattice-php/lattice";
+
+// Register your custom Lattice components, fields, and table column cells here.
+// `php artisan lattice:component`, `lattice:field`, and `lattice:column` append
+// entries automatically.
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({
+    name: "app",
+    components: {},
+    columns: {},
+  }),
+);

--- a/tests/Feature/Console/MakeColumnCommandTest.php
+++ b/tests/Feature/Console/MakeColumnCommandTest.php
@@ -8,14 +8,13 @@ use function Pest\Laravel\artisan;
 function withColumnScaffold(Closure $callback): mixed
 {
     return withScaffoldWorkspace(function () use ($callback): mixed {
-        File::put(resource_path('js/lattice/columns.ts'),
-            "import { createPlugin } from \"@lattice-php/lattice\";\n\nexport const appColumns = createPlugin({\n  name: \"app\",\n  columns: {},\n});\n");
+        File::put(resource_path('js/registry.ts'), latticeRegistryStub());
 
         return $callback();
     });
 }
 
-it('scaffolds a column class, a cell tsx and registers it in columns.ts', function (): void {
+it('scaffolds a column class, a cell tsx and registers it in registry.ts', function (): void {
     withColumnScaffold(function (): void {
         artisan('lattice:column', ['name' => 'StatusBadge'])->assertSuccessful();
 
@@ -29,11 +28,11 @@ it('scaffolds a column class, a cell tsx and registers it in columns.ts', functi
 
         expect(File::exists(app_path('Tables/Columns/StatusBadgeProps.php')))->toBeFalse();
 
-        expect(File::get(resource_path('js/lattice/columns/status-badge.tsx')))
+        expect(File::get(resource_path('js/columns/status-badge.tsx')))
             ->toContain('ColumnCellComponent')
             ->toContain('StatusBadgeCell');
 
-        $columns = File::get(resource_path('js/lattice/columns.ts'));
+        $columns = File::get(resource_path('js/registry.ts'));
         expect($columns)
             ->toContain('import { StatusBadgeCell } from "./columns/status-badge";')
             ->toContain('"column.status-badge": StatusBadgeCell');
@@ -44,10 +43,10 @@ it('is idempotent and honors --type', function (): void {
     withColumnScaffold(function (): void {
         artisan('lattice:column', ['name' => 'StatusBadge'])->assertSuccessful();
         artisan('lattice:column', ['name' => 'StatusBadge'])->assertSuccessful();
-        expect(substr_count(File::get(resource_path('js/lattice/columns.ts')), '"column.status-badge": StatusBadgeCell'))->toBe(1);
+        expect(substr_count(File::get(resource_path('js/registry.ts')), '"column.status-badge": StatusBadgeCell'))->toBe(1);
 
         artisan('lattice:column', ['name' => 'Priority', '--type' => 'prio'])->assertSuccessful();
         expect(File::get(app_path('Tables/Columns/Priority.php')))->toContain("#[AsColumn(type: 'prio')]");
-        expect(File::get(resource_path('js/lattice/columns.ts')))->toContain('"column.prio": PriorityCell');
+        expect(File::get(resource_path('js/registry.ts')))->toContain('"column.prio": PriorityCell');
     });
 });

--- a/tests/Feature/Console/MakeComponentCommandTest.php
+++ b/tests/Feature/Console/MakeComponentCommandTest.php
@@ -8,8 +8,7 @@ use function Pest\Laravel\artisan;
 function withComponentScaffold(Closure $callback): mixed
 {
     return withScaffoldWorkspace(function () use ($callback): mixed {
-        File::put(resource_path('js/lattice/plugin.ts'),
-            "import { createPlugin } from \"@lattice-php/lattice\";\n\nexport const appPlugin = createPlugin({\n  name: \"app\",\n  components: {},\n});\n");
+        File::put(resource_path('js/registry.ts'), latticeRegistryStub());
 
         return $callback();
     });
@@ -26,10 +25,10 @@ it('scaffolds a component class with the AsComponent attribute and registers it'
             ->toContain("#[AsComponent('rating')]")
             ->toContain('class Rating extends Component');
 
-        expect(File::get(resource_path('js/lattice/components/rating.tsx')))
+        expect(File::get(resource_path('js/components/rating.tsx')))
             ->toContain('RendererComponent<"rating">');
 
-        expect(File::get(resource_path('js/lattice/plugin.ts')))
+        expect(File::get(resource_path('js/registry.ts')))
             ->toContain('import { RatingComponent } from "./components/rating";')
             ->toContain('"rating": eagerComponent(RatingComponent)');
     });

--- a/tests/Feature/Console/MakeDefinitionCommandTest.php
+++ b/tests/Feature/Console/MakeDefinitionCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+
+use function Pest\Laravel\artisan;
+
+it('scaffolds each definition type into its app directory', function (string $command, string $dir, string $base): void {
+    withScaffoldWorkspace(function () use ($command, $dir, $base): void {
+        artisan($command, ['name' => 'Example'])->assertSuccessful();
+
+        expect(File::get(app_path($dir.'/Example.php')))
+            ->toContain('namespace App\\'.str_replace('/', '\\', $dir).';')
+            ->toContain('class Example extends '.$base);
+    });
+})->with([
+    'page' => ['lattice:page', 'Pages', 'Page'],
+    'form' => ['lattice:form', 'Forms', 'FormDefinition'],
+    'table' => ['lattice:table', 'Tables', 'EloquentTableDefinition'],
+    'action' => ['lattice:action', 'Actions', 'ActionDefinition'],
+    'bulk-action' => ['lattice:bulk-action', 'Actions', 'BulkActionDefinition'],
+    'fragment' => ['lattice:fragment', 'Fragments', 'FragmentDefinition'],
+    'layout' => ['lattice:layout', 'Layouts', 'LayoutDefinition'],
+    'remote-source' => ['lattice:remote-source', 'Remote', 'RemoteSourceDefinition'],
+]);
+
+it('supports nested names', function (): void {
+    withScaffoldWorkspace(function (): void {
+        artisan('lattice:form', ['name' => 'Settings/ProfileForm'])->assertSuccessful();
+
+        expect(File::get(app_path('Forms/Settings/ProfileForm.php')))
+            ->toContain('namespace App\\Forms\\Settings;')
+            ->toContain('class ProfileForm extends FormDefinition');
+    });
+});
+
+it('skips an existing definition without --force and overwrites with it', function (): void {
+    withScaffoldWorkspace(function (): void {
+        artisan('lattice:page', ['name' => 'Home'])->assertSuccessful();
+        File::put(app_path('Pages/Home.php'), '<?php // stale');
+
+        artisan('lattice:page', ['name' => 'Home'])->assertFailed();
+        expect(File::get(app_path('Pages/Home.php')))->toBe('<?php // stale');
+
+        artisan('lattice:page', ['name' => 'Home', '--force' => true])->assertSuccessful();
+        expect(File::get(app_path('Pages/Home.php')))->toContain('class Home extends Page');
+    });
+});

--- a/tests/Feature/Console/MakeFieldCommandTest.php
+++ b/tests/Feature/Console/MakeFieldCommandTest.php
@@ -8,8 +8,7 @@ use function Pest\Laravel\artisan;
 function withFieldScaffold(Closure $callback): mixed
 {
     return withScaffoldWorkspace(function () use ($callback): mixed {
-        File::put(resource_path('js/lattice/plugin.ts'),
-            "import { createPlugin } from \"@lattice-php/lattice\";\n\nexport const appPlugin = createPlugin({\n  name: \"app\",\n  components: {},\n});\n");
+        File::put(resource_path('js/registry.ts'), latticeRegistryStub());
 
         return $callback();
     });
@@ -26,10 +25,10 @@ it('scaffolds a field PHP class, a tsx renderer, registers it and derives the ty
             ->toContain("#[AsField(type: 'color-picker')]")
             ->toContain('class ColorPicker extends Field');
 
-        $tsx = File::get(resource_path('js/lattice/fields/color-picker.tsx'));
+        $tsx = File::get(resource_path('js/fields/color-picker.tsx'));
         expect($tsx)->toContain('RendererComponent<"field.color-picker">');
 
-        $plugin = File::get(resource_path('js/lattice/plugin.ts'));
+        $plugin = File::get(resource_path('js/registry.ts'));
         expect($plugin)
             ->toContain('eagerComponent')
             ->toContain('import { ColorPickerComponent } from "./fields/color-picker";')
@@ -42,7 +41,7 @@ it('is idempotent — re-running does not duplicate the registration', function 
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
 
-        $plugin = File::get(resource_path('js/lattice/plugin.ts'));
+        $plugin = File::get(resource_path('js/registry.ts'));
         expect(substr_count($plugin, '"field.color-picker": eagerComponent'))->toBe(1)
             ->and(substr_count($plugin, 'import { ColorPickerComponent }'))->toBe(1);
     });
@@ -55,10 +54,10 @@ it('honors a --type override', function (): void {
         expect(File::get(app_path('Forms/Fields/Swatch.php')))
             ->toContain("#[AsField(type: 'color')]");
 
-        expect(File::get(resource_path('js/lattice/fields/swatch.tsx')))
+        expect(File::get(resource_path('js/fields/swatch.tsx')))
             ->toContain('RendererComponent<"field.color">');
 
-        expect(File::get(resource_path('js/lattice/plugin.ts')))
+        expect(File::get(resource_path('js/registry.ts')))
             ->toContain('"field.color": eagerComponent(SwatchComponent)');
     });
 });
@@ -68,16 +67,12 @@ it('registers multiple distinct fields without clobbering earlier ones', functio
         artisan('lattice:field', ['name' => 'ColorPicker'])->assertSuccessful();
         artisan('lattice:field', ['name' => 'StarRating'])->assertSuccessful();
 
-        $plugin = File::get(resource_path('js/lattice/plugin.ts'));
+        $plugin = File::get(resource_path('js/registry.ts'));
 
         expect($plugin)
             ->toContain('"field.color-picker": eagerComponent(ColorPickerComponent)')
             ->toContain('"field.star-rating": eagerComponent(StarRatingComponent)')
             ->toContain('import { ColorPickerComponent } from "./fields/color-picker";')
             ->toContain('import { StarRatingComponent } from "./fields/star-rating";');
-
-        // Assert exact 4-space indentation for both entries — locks the indentation bug fix
-        expect($plugin)
-            ->toContain("  components: {\n    \"field.color-picker\": eagerComponent(ColorPickerComponent),\n    \"field.star-rating\": eagerComponent(StarRatingComponent),\n  },");
     });
 });

--- a/tests/Feature/Console/PublishJsScaffoldTest.php
+++ b/tests/Feature/Console/PublishJsScaffoldTest.php
@@ -14,8 +14,7 @@ function withPublishedJsScaffold(Closure $callback): mixed
         $publishGroups = ServiceProvider::$publishGroups;
 
         $paths = [
-            dirname(__DIR__, 3).'/stubs/lattice/plugin.ts' => resource_path('js/lattice/plugin.ts'),
-            dirname(__DIR__, 3).'/stubs/lattice/columns.ts' => resource_path('js/lattice/columns.ts'),
+            dirname(__DIR__, 3).'/stubs/registry.ts' => resource_path('js/registry.ts'),
         ];
 
         ServiceProvider::$publishes[LatticeServiceProvider::class] = $paths;
@@ -30,16 +29,16 @@ function withPublishedJsScaffold(Closure $callback): mixed
     });
 }
 
-it('publishes the JS scaffold under resources/js/lattice', function (): void {
+it('publishes a single registry scaffold to resources/js', function (): void {
     withPublishedJsScaffold(function (): void {
-        File::delete(resource_path('js/lattice/plugin.ts'));
-        File::delete(resource_path('js/lattice/columns.ts'));
+        File::delete(resource_path('js/registry.ts'));
 
         artisan('vendor:publish', ['--tag' => 'lattice-js', '--force' => true])->assertSuccessful();
 
-        expect(File::exists(resource_path('js/lattice/plugin.ts')))->toBeTrue()
-            ->and(File::exists(resource_path('js/lattice/columns.ts')))->toBeTrue()
-            ->and(File::get(resource_path('js/lattice/plugin.ts')))->toContain('createPlugin')
-            ->and(File::get(resource_path('js/lattice/columns.ts')))->toContain('createPlugin');
+        expect(File::exists(resource_path('js/registry.ts')))->toBeTrue()
+            ->and(File::get(resource_path('js/registry.ts')))
+            ->toContain('extendRegistry')
+            ->toContain('components: {}')
+            ->toContain('columns: {}');
     });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -161,6 +161,26 @@ function withScaffoldWorkspace(Closure $callback): mixed
 }
 
 /**
+ * The published single-registry scaffold the make commands append to.
+ */
+function latticeRegistryStub(): string
+{
+    return <<<'TS'
+import { createPlugin, extendRegistry, registry as packageRegistry } from "@lattice-php/lattice";
+
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({
+    name: "app",
+    components: {},
+    columns: {},
+  }),
+);
+
+TS;
+}
+
+/**
  * Extract the signed ref from a serialized interactive component.
  *
  * @param  array<string, mixed>  $component


### PR DESCRIPTION
## Generators for every definition type

Only `component`/`field`/`column` had `make` commands. This adds the missing ones for the PHP definition types consumers write most:

`lattice:page`, `lattice:form`, `lattice:table`, `lattice:action`, `lattice:bulk-action`, `lattice:fragment`, `lattice:layout`, `lattice:remote-source` → scaffold into `app/{Pages,Forms,Tables,Actions,Fragments,Layouts,Remote}/{Name}.php`, with nested names (`lattice:form Settings/ProfileForm`).

## Flat JS layout + one registry

The component/field/column generators now write React files to `resources/js/{components,fields,columns}/` (was `resources/js/lattice/…`) and register into a **single `resources/js/registry.ts`** (was a separate `plugin.ts` + `columns.ts`). The `lattice-js` publish tag now publishes that one `registry.ts`.

PHP fields/columns stay nested (`app/Forms/Fields`, `app/Tables/Columns`) since PHP has the parent Form/Table classes; JS only has the field/column renderers, so it's flat — matching the kit's reorganised layout.

## `--force`

All generators (new and existing) accept `--force` to overwrite an existing file; without it they skip.

## Verification

- `composer check` — Pint, PHPStan, Rector, Pest (871 passed)
- Updated the existing command tests for the new paths/registry; new `MakeDefinitionCommandTest` covers all 8 definition generators, nested names, and `--force`.