### PR TITLE
test: stabilize the column filter popover browser test

### DIFF
--- a/tests/Browser/Tables/FilterTest.php
+++ b/tests/Browser/Tables/FilterTest.php
@@ -19,7 +19,7 @@ it('filters by text and clears via the filter chip', function (): void {
 
 it('adds a filter through the column popover', function (): void {
     $this->actingAs(workbenchTestUser());
-    seedWorkbenchUsers();
+    seedNamedWorkbenchUsers();
 
     visit('/')
         ->click('@filter-name')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -35,11 +35,11 @@ function discoverFixtures(): void
 }
 
 /**
- * Seed a deterministic set of workbench users for browser table tests: four
- * named users plus 26 generated ones, enough to exercise pagination and
- * infinite scroll.
+ * Seed the four named workbench users browser table tests assert against. Kept
+ * under one page so tables never auto-load a second page while the test
+ * interacts with them.
  */
-function seedWorkbenchUsers(): void
+function seedNamedWorkbenchUsers(): void
 {
     User::query()->delete();
 
@@ -49,6 +49,16 @@ function seedWorkbenchUsers(): void
             'email' => strtolower(explode(' ', $name)[0]).'@example.com',
         ]);
     }
+}
+
+/**
+ * Seed a deterministic set of workbench users for browser table tests: four
+ * named users plus 26 generated ones, enough to exercise pagination and
+ * infinite scroll.
+ */
+function seedWorkbenchUsers(): void
+{
+    seedNamedWorkbenchUsers();
 
     foreach (range(1, 26) as $number) {
         UserFactory::new()->create([


### PR DESCRIPTION
## What

The `Tables\FilterTest > it adds a filter through the column popover` browser test was flaking intermittently in CI (timeout on `fill('[aria-label="Name filter value"]')`).

## Why

The home `UsersTable` paginates **infinitely** (`PaginationType::Infinite`, 25/page) and `seedWorkbenchUsers()` seeds **30 rows**, so `hasMore` is true on load. The failing sequence:

1. `visit('/')` renders 25 rows, `processing=false`.
2. The test clicks `@filter-name` → popover opens, its draft input auto-focuses.
3. The infinite-scroll `IntersectionObserver` (`rootMargin: 240px`) fires → `loadMore()` → `setProcessing(true)`.
4. `processing` disables the popover's focused input → the browser blurs it → Radix closes the popover on focus-out.
5. `fill(...)` waits 5s for an input that no longer exists → timeout.

The CI failure screenshot confirms it: more than 25 rows had loaded (infinite-scroll fired) and the popover was closed. Locally the auto-load rarely lines up with the click, which is why it only flaked under CI load.

## Fix

This test only asserts on Grace Hopper and Ada Lovelace, so it doesn't need 30 rows. Seed a single page of named users (new `seedNamedWorkbenchUsers()` helper, reused by `seedWorkbenchUsers()`) so no second page auto-loads while the popover is open.

Verified: popover test green across repeated local runs; full `FilterTest` file green.