### PR TITLE
feat: resolve page render() dependencies through the container on the responsable path

### DIFF
--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -80,8 +80,25 @@ abstract class Page implements PageContract, Responsable
 
         abort_unless($this->authorize(app(Request::class)), 403);
 
-        $schema = $this->{$method}(...array_values($parameters));
+        return $this->pageResponse($method, $this->{$method}(...array_values($parameters)));
+    }
 
+    /**
+     * @param  Request  $request
+     */
+    public function toResponse($request): HttpResponse
+    {
+        abort_unless($this->authorize($request), 403);
+
+        // schema is passed so the container resolves render()'s other
+        // dependencies but does not rebuild PageSchema itself.
+        $schema = app()->call([$this, 'render'], ['schema' => PageSchema::make()]);
+
+        return $this->pageResponse('render', $schema)->toResponse($request);
+    }
+
+    private function pageResponse(string $method, mixed $schema): Response
+    {
         if (! $schema instanceof PageSchema) {
             throw new UnexpectedValueException(sprintf(
                 'Method %s::%s must return an instance of %s.',
@@ -92,18 +109,6 @@ abstract class Page implements PageContract, Responsable
         }
 
         return $this->response($schema);
-    }
-
-    /**
-     * Render the page as an HTTP response so it can be returned directly —
-     * for example from a Fortify view closure — instead of reaching through
-     * callAction().
-     *
-     * @param  Request  $request
-     */
-    public function toResponse($request): HttpResponse
-    {
-        return $this->callAction('render', [PageSchema::make(), $request])->toResponse($request);
     }
 
     protected function component(): string

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia;
@@ -213,6 +214,26 @@ test('a page can be returned directly and renders through the responsable contra
         );
 });
 
+test('directly returned pages resolve render dependencies through the container, including form requests', function (): void {
+    Route::get('responsable-form-request', fn (): Page => new WorkbenchFormRequestPage)
+        ->middleware('web')
+        ->name('responsable-form-request.show');
+
+    withoutVite();
+
+    get('/responsable-form-request?label=Injected')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('lattice/page')
+            ->where('lattice.schema.0.props.text', 'Injected via form request')
+        );
+
+    // The form request is resolved and validated on the responsable path too,
+    // so a missing required field fails validation rather than rendering.
+    get('/responsable-form-request')
+        ->assertStatus(302);
+});
+
 // ---------------------------------------------------------------------------
 // Inline fixture classes required only by this file
 // ---------------------------------------------------------------------------
@@ -278,6 +299,25 @@ final class WorkbenchPageDependency
     public function label(): string
     {
         return 'Injected';
+    }
+}
+
+final class WorkbenchPageFormRequest extends FormRequest
+{
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return ['label' => ['required', 'string']];
+    }
+}
+
+final class WorkbenchFormRequestPage extends Page
+{
+    public function render(PageSchema $schema, WorkbenchPageFormRequest $request): PageSchema
+    {
+        return $schema->component(Text::make($request->string('label').' via form request'));
     }
 }
 


### PR DESCRIPTION
## Problem

A page's `render()` gets full method injection — `PageSchema`, the request, route-model bindings, and **`FormRequest`s** (resolved *and validated*) — but only on the **route** path. Laravel's controller dispatcher resolves the method's dependencies before invoking it.

A page returned **directly as a `Responsable`** (e.g. from a Fortify view closure for the auth screens) goes through `Page::toResponse()`, which hardcoded the arguments:

```php
return $this->callAction('render', [PageSchema::make(), $request])->toResponse($request);
```

These are spread positionally, bypassing the container. So a `FormRequest`-typed `render()` parameter works on the route path but breaks on the responsable path (it receives the base `Request` by position, and never validates).

This is the sharp edge that stops "inject the request you actually need" (e.g. a Fortify `FormRequest` that reconciles state in `passedValidation()`) from being a blanket pattern for every page.

## Change

Resolve `render()` through the container in `toResponse()` as well, binding only `schema` explicitly so the `PageSchema::make()` instance is preserved while the request, `FormRequest`s, and any other binding inject uniformly:

```php
$schema = app()->call([$this, 'render'], ['schema' => PageSchema::make()]);
```

The route path is untouched (`callAction` still spreads the dispatcher-resolved params); the schema-type check is shared via a small private helper. No behavior change for existing pages — the request param still resolves to the current request — but `FormRequest` (and other typed dependencies) now inject on both paths.

## Tests

Added a test: a page returned directly via the `Responsable` contract whose `render()` takes a `FormRequest` now resolves and validates it — rendering with the injected value when valid, failing validation (302) when a required field is missing. The existing route-path injection and responsable tests still pass.

`composer check` green: Pint, PHPStan, Rector, 872 tests / 3232 assertions.