### PR TITLE
test(browser): isolate and de-flake infinite pagination coverage

### DIFF
--- a/tests/Browser/Tables/PaginationTest.php
+++ b/tests/Browser/Tables/PaginationTest.php
@@ -5,7 +5,10 @@ it('shows pagination modes in lazily loaded tabs', function (): void {
     $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
+    // A short viewport keeps the infinite-scroll sentinel below the fold so its
+    // IntersectionObserver cannot auto-load page two before we assert "Load more".
     visit('/tables')
+        ->resize(1280, 720)
         ->assertSee('Pagination modes')
         ->assertSee('No pagination')
         ->assertSee('Maya Chen')
@@ -41,7 +44,10 @@ it('loads more rows in infinite mode', function (): void {
     $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
+    // A short viewport keeps the infinite-scroll sentinel below the fold so its
+    // IntersectionObserver cannot auto-load page two before the explicit click.
     visit('/tables')
+        ->resize(1280, 720)
         ->click('@tab-infinite')
         ->assertDontSee('Browser User 26')
         ->click('@pagination-load-more')

--- a/tests/Browser/Tables/UsersTableTest.php
+++ b/tests/Browser/Tables/UsersTableTest.php
@@ -18,17 +18,6 @@ it('lists users with their columns', function (): void {
         ->assertNoSmoke();
 });
 
-it('loads more users in the infinite table', function (): void {
-    $this->actingAs(workbenchTestUser());
-    seedWorkbenchUsers();
-
-    visit('/')
-        ->assertDontSee('Browser User 26')
-        ->click('@pagination-load-more')
-        ->assertSee('Browser User 26')
-        ->assertNoSmoke();
-});
-
 it('sorts and clears sorting', function (): void {
     $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();


### PR DESCRIPTION
## Problem
`UsersTableTest › loads more users in the infinite table` was flaky. Two causes compounded:

1. **Auto-loader races the assertion.** The home table uses `PaginationType::Infinite`, whose `IntersectionObserver` (`use-table.ts`, `rootMargin: 240px`) calls `loadMore()` on its own when the *Load more* sentinel nears the viewport. The test's `assertDontSee('Browser User 26')` precondition races that observer.
2. **Heavy host page.** The table sits below three `Fragment::lazy` charts on the home page, so layout shift and `assertNoSmoke()` add unrelated flakiness.

## Fix
Infinite scroll is already covered in isolation on the lightweight `/tables` page (`PaginationTest`), so:

- Remove the duplicate `loads more users in the infinite table` test from `UsersTableTest`. The home table keeps the sort / columns / copy / resize coverage, none of which scroll to the sentinel.
- Pin `resize(1280, 720)` on the two `/tables` infinite tests so 25 rows overflow and the sentinel stays below the fold until the explicit click — the auto-loader can no longer pre-fire.

## Verification
`PaginationTest` + `UsersTableTest` pass, and `PaginationTest` was run 3× consecutively with no failures.