### PR TITLE
docs: correct obsolete and inaccurate API references

### DIFF
--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -176,7 +176,8 @@ run through the normal client-side effect pipeline in order.
 
 The result serializes to `{ ok, data, effects }`. Each effect carries a `type` discriminant
 (`toast`, `callout`, `reloadComponent`, `reloadPage`, `redirect`, `download`, `openModal`,
-`closeModal`, `resetForm`, `localeChange`) and its payload; the client dispatches them in order.
+`closeModal`, `resetForm`, `localeChange`, `toggleSidebar`) and its payload; the client dispatches them
+in order.
 Each `type` is declared once on its PHP class via `#[AsEffect('…')]` and generated into the
 discriminated `Effect` union, so the PHP helpers and the client dispatcher stay in lockstep.
 

--- a/docs/content/docs/advanced/bundle-size.mdx
+++ b/docs/content/docs/advanced/bundle-size.mdx
@@ -43,6 +43,7 @@ Lattice's marginal cost even though they show up in the entry chunk below.
 The breakdown above is JavaScript only. Lattice also ships a stylesheet you import into your Tailwind
 entry with `@import "@lattice-php/lattice/css"`. The source file is small — theme tokens plus a few
 component styles — but it carries an `@source` directive, so your own Tailwind build scans Lattice's
-components and generates the utility classes they use. The compiled CSS for the workbench app (the same
-build measured above, exercising every feature) is roughly **50&nbsp;KB raw / 9.5&nbsp;KB gzipped**,
-and like the JS its real cost depends on which components you actually render.
+components and generates the utility classes they use. The compiled CSS Lattice contributes to the
+workbench app (the same build measured above, exercising every feature) lands in the tens of kilobytes
+raw — a handful gzipped — and like the JS its real cost depends on which components you actually render
+and your own Tailwind configuration.

--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -29,6 +29,7 @@ layout primitives.
     "FloatingPlacement",
     "Side",
     "TabsAlignment",
+    "RowLayout",
   ]}
 />
 
@@ -86,7 +87,7 @@ pagination for [tables](/tables/overview/).
 The row layout and built-in row actions used by the [repeater and builder](/forms/fields/repeater/)
 fields, plus the field-type vocabulary.
 
-<EnumTable enums={["FieldType", "RowLayout", "RowActionType"]} showNamespace />
+<EnumTable enums={["FieldType", "RowActionType"]} showNamespace />
 
 ## Charts
 

--- a/docs/content/docs/contributing/local-development.md
+++ b/docs/content/docs/contributing/local-development.md
@@ -21,11 +21,11 @@ composer install
 npm install
 ```
 
-Serve the workbench:
+Serve the workbench in two terminals — `composer serve` runs the PHP server (building the workbench app first), and `npm run dev` runs Vite for hot-reloading the React and CSS:
 
 ```bash
-composer serve
-npm run dev
+composer serve   # PHP server
+npm run dev      # Vite HMR (separate terminal)
 ```
 
 The workbench compiles Lattice directly from `resources/js` and imports the stylesheet directly from `resources/css/lattice.css`, so frontend changes are picked up by Vite without running the package build.

--- a/docs/content/docs/core/components.mdx
+++ b/docs/content/docs/core/components.mdx
@@ -138,7 +138,7 @@ Link::make('Documentation')->href('https://latticephp.com');
 - **`Tabs`** + **`Tab`** render a tab strip. `Tabs::make()->defaultValue('overview')->schema([...])`
   holds `Tab::make('value', 'Label')->schema([...])` children. `->orientation(Orientation::Vertical)`
   moves the strip to the side, and the active tab is kept in the URL query string — `->queryKey('tab')`
-  sets the parameter name. A tab's content renders lazily on first open.
+  sets the parameter name (defaults to `tabs`). A tab's content renders lazily on first open.
 - **`->alignment(TabsAlignment::…)`** controls how the strip sits. Horizontal tabs default to
   `Stretch` (tabs share the full width); `Start`, `Center`, and `End` shrink the strip to its content
   and pin it left, centre, or right. Vertical tabs only read `End` to move the strip to the right of the

--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -351,6 +351,7 @@ type I18nConfig = {
   saveMissing: boolean; // should missing keys be reported back?
   locales: string[]; // supported locale codes from config('lattice.i18n.locales')
   preloadLocales: string[]; // locales eagerly loaded at startup, from config('lattice.i18n.preload_locales')
+  timezone: string | null; // the app/user timezone, when resolved
 };
 ```
 

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -12,6 +12,7 @@ component of your own.
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Tables\Components\Table;
 
 #[AsPage(route: '/products')]
@@ -112,6 +113,20 @@ abstract class AppPage extends Page {}
 
 #[AsPage(route: '/products', name: 'products.index')]
 class ProductsPage extends AppPage {} // inherits the App layout, container, and middleware
+```
+
+## Layout and container at request time
+
+The attribute sets the layout and container statically. To decide them per request — a different shell
+for a guest versus an authenticated user, say — override `layout()` or `container()` on the page.
+Returning a non-null value (a `PageLayout`/`PageContainer` case or a registered key) takes precedence
+over the attribute; returning `null` defers to it.
+
+```php
+public function layout(): PageLayout|string|null
+{
+    return request()->user() ? PageLayout::App : PageLayout::Auth;
+}
 ```
 
 ## Discovery and registration

--- a/docs/content/docs/extending/custom-columns.md
+++ b/docs/content/docs/extending/custom-columns.md
@@ -13,7 +13,7 @@ If you have not done this yet:
 php artisan vendor:publish --tag=lattice-js
 ```
 
-This writes `resources/js/lattice/columns.ts` (and `plugin.ts` for fields/components) if they do not already exist.
+This writes a single `resources/js/registry.ts` if it does not already exist — the one place custom fields, components, and columns are registered.
 
 ## 2. Generate the column
 
@@ -24,8 +24,8 @@ php artisan lattice:column StatusBadge
 This creates:
 
 - `app/Tables/Columns/StatusBadge.php` — the PHP column class.
-- `resources/js/lattice/columns/status-badge.tsx` — the React cell renderer stub.
-- An entry in `resources/js/lattice/columns.ts` wiring them together.
+- `resources/js/columns/status-badge.tsx` — the React cell renderer stub.
+- An entry under `columns` in `resources/js/registry.ts` wiring them together.
 - Runs `lattice:typescript` to refresh the generated types file.
 
 The PHP attribute receives the short identifier `status-badge`; the wire type is `column.status-badge`.
@@ -118,50 +118,50 @@ export const StatusBadgeCell: ColumnCellComponent = ({ props, value }) => {
 };
 ```
 
-To drop the cast, type the cell as `ColumnCellComponent<"column.status-badge">` and register it with `columnCell()` (the column equivalent of `eagerComponent`). After `lattice:typescript`, `props` is narrowed to your column's generated props:
+To drop the cast, type the cell as `ColumnCellComponent<"column.status-badge">`. After `lattice:typescript`, `props` is narrowed to your column's generated props:
 
 ```tsx
-import { columnCell } from "@lattice-php/lattice";
 import type { ColumnCellComponent } from "@lattice-php/lattice";
 
 export const StatusBadgeCell: ColumnCellComponent<"column.status-badge"> = ({ props, value }) => {
   const map = props.colorMap ?? colorClasses; // typed, no cast
   // ...
 };
-
-// register the typed cell:
-//   columns: { "column.status-badge": columnCell(StatusBadgeCell) }
 ```
 
-## 5. The column plugin registration
+The generator registers column cells **bare** (`"column.status-badge": StatusBadgeCell`). The optional `columnCell()` helper is a type-narrowing identity wrapper — `columnCell(StatusBadgeCell)` — for when you want the registry entry itself type-checked against the column's props; it changes nothing at runtime.
 
-The generator appended an entry to `resources/js/lattice/columns.ts`:
+## 5. The registry entry
+
+The generator appended an entry under `columns` in `resources/js/registry.ts`:
 
 ```ts
-import { createPlugin } from "@lattice-php/lattice";
+import { createPlugin, extendRegistry, registry as packageRegistry } from "@lattice-php/lattice";
 import { StatusBadgeCell } from "./columns/status-badge";
 
-export const appColumns = createPlugin({
-  name: "app",
-  columns: {
-    "column.status-badge": StatusBadgeCell,
-  },
-});
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({
+    name: "app",
+    components: {},
+    columns: {
+      "column.status-badge": StatusBadgeCell,
+    },
+  }),
+);
 ```
 
-## 6. Wire columns in app.tsx
+## 6. Wire the registry in app.tsx
 
-Extend the built-in registry with your column plugin and pass that registry to `Provider`:
+`registry.ts` already merges your column onto the built-in registry, so import its exported `registry` and pass it to `Provider`:
 
 ```tsx
 import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
 import { createRoot } from "react-dom/client";
 import LatticePage from "@lattice-php/lattice/page";
-import { extendRegistry, Provider, registry } from "@lattice-php/lattice";
-import { appColumns } from "./lattice/columns";
-
-const appRegistry = extendRegistry(registry, appColumns);
+import { Provider } from "@lattice-php/lattice";
+import { registry } from "./registry";
 
 createInertiaApp({
   resolve: (name) => {
@@ -172,7 +172,7 @@ createInertiaApp({
   setup({ el, App, props }) {
     if (!el) return;
     createRoot(el).render(
-      <Provider registry={appRegistry}>
+      <Provider registry={registry}>
         <App {...props} />
       </Provider>,
     );
@@ -180,7 +180,7 @@ createInertiaApp({
 });
 ```
 
-If you also have custom fields or components, pass all of those plugins to the same `extendRegistry(registry, ...)` call.
+Custom fields, components, and columns all live in this same `registry.ts` — there is no second registry to merge.
 
 ## 7. Generate TypeScript types
 

--- a/docs/content/docs/extending/custom-fields.md
+++ b/docs/content/docs/extending/custom-fields.md
@@ -7,13 +7,13 @@ This walkthrough adds a `ColorPicker` field — a native `<input type="color">` 
 
 ## 1. Publish the JS scaffold
 
-If you have not done this yet, publish the two registration files the generators expect:
+If you have not done this yet, publish the registration file the generators expect:
 
 ```bash
 php artisan vendor:publish --tag=lattice-js
 ```
 
-This writes `resources/js/lattice/plugin.ts` (for fields and components) and `resources/js/lattice/columns.ts` (for columns) if they do not already exist.
+This writes a single `resources/js/registry.ts` if it does not already exist — the one place custom fields, components, and columns are registered.
 
 ## 2. Generate the field
 
@@ -24,8 +24,8 @@ php artisan lattice:field ColorPicker
 This creates:
 
 - `app/Forms/Fields/ColorPicker.php` — the PHP class.
-- `resources/js/lattice/fields/color-picker.tsx` — the React renderer stub.
-- An entry in `resources/js/lattice/plugin.ts` wiring them together.
+- `resources/js/fields/color-picker.tsx` — the React renderer stub.
+- An entry under `components` in `resources/js/registry.ts` wiring them together.
 - Runs `lattice:typescript` to refresh the generated types file.
 
 The PHP attribute receives the short identifier `color-picker`; the wire type is `field.color-picker`.
@@ -94,50 +94,50 @@ export const ColorPickerComponent: RendererComponent<"field.color-picker"> = ({ 
 
 `node.props` contains all the serialized field data — name, value, label, required, and any extra properties you added to the PHP class.
 
-## 5. The plugin registration
+## 5. The registry entry
 
-The generator appended an entry to `resources/js/lattice/plugin.ts`:
+The generator appended an entry to `resources/js/registry.ts`, wrapping the renderer in `eagerComponent`:
 
 ```ts
-import { createPlugin } from "@lattice-php/lattice";
+import {
+  createPlugin,
+  eagerComponent,
+  extendRegistry,
+  registry as packageRegistry,
+} from "@lattice-php/lattice";
 import { ColorPickerComponent } from "./fields/color-picker";
 
-export const appPlugin = createPlugin({
-  name: "app",
-  components: {
-    "field.color-picker": ColorPickerComponent,
-  },
-});
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({
+    name: "app",
+    components: {
+      "field.color-picker": eagerComponent(ColorPickerComponent),
+    },
+    columns: {},
+  }),
+);
 ```
 
-`createPlugin` accepts any number of component type keys. You can also use `lazyComponent` for code-split renderers:
+`createPlugin` accepts any number of component type keys. Use `lazyComponent` instead for a code-split renderer — its loader must resolve to a module with a `default` export:
 
 ```ts
-import { createPlugin, lazyComponent } from "@lattice-php/lattice";
-
-export const appPlugin = createPlugin({
-  name: "app",
-  components: {
-    "field.color-picker": lazyComponent(() =>
-      import("./fields/color-picker").then((m) => m.ColorPickerComponent),
-    ),
-  },
-});
+"field.color-picker": lazyComponent(async () => ({
+  default: (await import("./fields/color-picker")).ColorPickerComponent,
+})),
 ```
 
-## 6. Wire the plugin in app.tsx
+## 6. Wire the registry in app.tsx
 
-Pass your plugin to `extendRegistry` and wrap the app in `Provider` with the extended registry:
+`registry.ts` already merges your plugin onto the built-in registry, so import its exported `registry` and pass it to `Provider`:
 
 ```tsx
 import "../css/app.css";
 import { createInertiaApp } from "@inertiajs/react";
 import { createRoot } from "react-dom/client";
 import LatticePage from "@lattice-php/lattice/page";
-import { extendRegistry, Provider, registry } from "@lattice-php/lattice";
-import { appPlugin } from "./lattice/plugin";
-
-const appRegistry = extendRegistry(registry, appPlugin);
+import { Provider } from "@lattice-php/lattice";
+import { registry } from "./registry";
 
 createInertiaApp({
   resolve: (name) => {
@@ -148,7 +148,7 @@ createInertiaApp({
   setup({ el, App, props }) {
     if (!el) return;
     createRoot(el).render(
-      <Provider registry={appRegistry}>
+      <Provider registry={registry}>
         <App {...props} />
       </Provider>,
     );

--- a/docs/content/docs/extending/overview.md
+++ b/docs/content/docs/extending/overview.md
@@ -31,17 +31,17 @@ That string — `"field.color-picker"` — is the only coupling between the PHP 
 
 ## Three extension points
 
-| Kind         | PHP base class                              | Registry                            |
-| ------------ | ------------------------------------------- | ----------------------------------- |
-| Form field   | `Lattice\Lattice\Forms\Components\Field`    | Node registry (`plugin.ts`)         |
-| UI component | `Lattice\Lattice\Core\Components\Component` | Node registry (`plugin.ts`)         |
-| Table column | `Lattice\Lattice\Tables\Columns\Column`     | Column-cell registry (`columns.ts`) |
+| Kind         | PHP base class                              | Registry block                   |
+| ------------ | ------------------------------------------- | -------------------------------- |
+| Form field   | `Lattice\Lattice\Forms\Components\Field`    | `components` (node registry)     |
+| UI component | `Lattice\Lattice\Core\Components\Component` | `components` (node registry)     |
+| Table column | `Lattice\Lattice\Tables\Columns\Column`     | `columns` (column-cell registry) |
 
-Form fields and UI components share the **node registry** — the renderer walks the component tree and resolves each `type` to a `RendererComponent`. Table columns use a separate **column-cell registry** because only the cell needs a custom renderer; the table chrome (header, sorting, filtering) is provided by Lattice.
+All three register in a single file — `resources/js/registry.ts`, published by `php artisan vendor:publish --tag=lattice-js`. It calls `createPlugin({ components: {}, columns: {} })` and merges it onto the package registry with `extendRegistry`. Form fields and UI components share the **node registry** (the `components` block) — the renderer walks the component tree and resolves each `type` to a `RendererComponent`. Table columns use the separate **column-cell registry** (the `columns` block) because only the cell needs a custom renderer; the table chrome (header, sorting, filtering) is provided by Lattice.
 
 ## Generators scaffold both sides
 
-The `lattice:field`, `lattice:component`, and `lattice:column` commands generate the PHP class, the `.tsx` renderer, and insert the registration entry — so you get a working pair to build on:
+The `lattice:field`, `lattice:component`, and `lattice:column` commands generate the PHP class, the `.tsx` renderer (under `resources/js/fields/`, `components/`, or `columns/`), and append the registration entry to `resources/js/registry.ts` — so you get a working pair to build on:
 
 ```bash
 php artisan lattice:field ColorPicker

--- a/docs/content/docs/extending/registry-and-types.md
+++ b/docs/content/docs/extending/registry-and-types.md
@@ -5,18 +5,32 @@ description: The React registry API and the TypeScript augmentation system for c
 
 ## The JS scaffold
 
-Before registering custom components or columns, publish the two scaffold files:
+Before registering custom components or columns, publish the scaffold file:
 
 ```bash
 php artisan vendor:publish --tag=lattice-js
 ```
 
-This writes:
+This writes a single `resources/js/registry.ts`. It calls `createPlugin` with empty `components` and
+`columns` blocks and merges it onto the built-in registry with `extendRegistry`, exporting the result
+as `registry`:
 
-- `resources/js/lattice/plugin.ts` — node registry plugin for custom fields and components.
-- `resources/js/lattice/columns.ts` — column-cell registry plugin for custom column cells.
+```ts
+import { createPlugin, extendRegistry, registry as packageRegistry } from "@lattice-php/lattice";
 
-The generators (`lattice:field`, `lattice:component`, `lattice:column`) append entries to the appropriate file automatically. You only need to publish once.
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({
+    name: "app",
+    components: {}, // custom fields and UI components
+    columns: {}, // custom column cells
+  }),
+);
+```
+
+The generators (`lattice:field`, `lattice:component`, `lattice:column`) append their entries to this
+file automatically — fields and components under `components`, columns under `columns`. You only need
+to publish once, and you pass the exported `registry` to `Provider`.
 
 ## Node registry API
 
@@ -42,16 +56,20 @@ export const appPlugin = createPlugin({
 
 ### extendRegistry
 
-Merges a plugin into an existing registry, returning a new registry without mutating the original:
+Merges a plugin into an existing registry, returning a new registry without mutating the original. The
+published `resources/js/registry.ts` already calls it for you — this is the pattern it uses:
 
 ```ts
-import { extendRegistry, registry } from "@lattice-php/lattice";
-import { appPlugin } from "./lattice/plugin";
+import { createPlugin, extendRegistry, registry as packageRegistry } from "@lattice-php/lattice";
 
-const appRegistry = extendRegistry(registry, appPlugin);
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({ name: "app", components: {}, columns: {} }),
+);
 ```
 
-`registry` is Lattice's built-in registry. Pass `appRegistry` to `Provider`.
+`packageRegistry` is Lattice's built-in registry. Pass the extended `registry` to `Provider`. Call
+`extendRegistry` again yourself only if you keep additional plugins in their own files.
 
 ### createRegistry
 
@@ -112,28 +130,27 @@ The column-cell registry maps type strings to `ColumnCellComponent` functions.
 
 ### Column plugins
 
-Column cell renderers use the same plugin object as components. Put them under the `columns` key:
+Column cell renderers use the same plugin object as components. They go under the `columns` key of the
+same `resources/js/registry.ts` (registered bare — `columnCell()` is optional, see below):
 
 ```ts
-import { createPlugin } from "@lattice-php/lattice";
+import { createPlugin, extendRegistry, registry as packageRegistry } from "@lattice-php/lattice";
 import { StatusBadgeCell } from "./columns/status-badge";
 
-export const appColumns = createPlugin({
-  name: "app",
-  columns: {
-    "column.status-badge": StatusBadgeCell,
-  },
-});
+export const registry = extendRegistry(
+  packageRegistry,
+  createPlugin({
+    name: "app",
+    components: {},
+    columns: {
+      "column.status-badge": StatusBadgeCell,
+    },
+  }),
+);
 ```
 
-Merge column plugins into the same registry you pass to `Provider`:
-
-```ts
-import { extendRegistry, registry } from "@lattice-php/lattice";
-import { appColumns } from "./lattice/columns";
-
-const appRegistry = extendRegistry(registry, appColumns);
-```
+The same exported `registry` carries both your components and your column cells — there is no second
+registry to merge.
 
 ### useColumnRegistry
 

--- a/docs/content/docs/forms/fields/file-upload.mdx
+++ b/docs/content/docs/forms/fields/file-upload.mdx
@@ -80,8 +80,8 @@ FileUpload::make('document')
 
 ## Reading the value in `handle()`
 
-A submitted file arrives as an `UploadedFile` (or an array of them for `->multiple()`); a signed upload
-arrives as the object key string. Store it however you like:
+A submitted file arrives as an `UploadedFile` (or an array of them for `->multiple()`); store it
+however you like:
 
 ```php
 public function handle(Request $request): Response
@@ -95,6 +95,32 @@ public function handle(Request $request): Response
     // persist $data['avatar'] ...
 }
 ```
+
+### Finalizing a signed upload
+
+A signed upload arrives as a **temporary** object key under `lattice.files.temp_prefix`, not the final
+path — temporary objects are cleaned up, so you must promote the key out of the temp prefix before
+persisting it. Call `finalizeSignedUploads()` on the same field, passing the submitted keys and a
+closure that returns each file's destination path. It moves the object and returns the finalized
+`disk`, `path`, `name`, `mime_type`, and `size` for each file:
+
+```php
+$finalized = FileUpload::make('document')->disk('s3')->signedUpload()
+    ->finalizeSignedUploads(
+        (array) $data['document'],
+        fn (string $key, array $meta): string => "documents/{$request->user()->id}.{$meta['extension']}",
+    );
+
+foreach ($finalized as $upload) {
+    // $upload['disk'], $upload['path'], $upload['name'], $upload['mime_type'], $upload['size']
+}
+```
+
+<Warning>
+  `finalizeSignedUploads()` throws if the destination stays inside the temporary prefix — return a
+  path outside `lattice.files.temp_prefix`. Storing the raw temporary key would persist a file that
+  gets swept away.
+</Warning>
 
 ## Removing existing files
 

--- a/docs/content/docs/forms/fields/number-input.mdx
+++ b/docs/content/docs/forms/fields/number-input.mdx
@@ -45,7 +45,8 @@ NumberInput::make('unit_price', 'Unit price')
 ## Affixes
 
 `->prefix()` and `->suffix()` add a currency symbol, unit, or icon to the input. See
-[affixes on Text input](/forms/fields/text-input/#affixes) for the full rules.
+[affixes on Text input](/forms/fields/text-input/#affixes) for the full rules. Affixes apply to the
+spinner variant only — they are not rendered in [slider](#slider) mode.
 
 ```php
 NumberInput::make('price', 'Price')->prefix('$')->suffix('USD');

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -84,8 +84,9 @@ more naturally for short tips. It renders muted, below the input and above any v
 
 ## Read-only
 
-`->readOnly()` shows the value but prevents editing. Unlike `disabled`, a read-only field is still
-submitted.
+`->readOnly()` shows the value but prevents editing. Like a disabled field, a read-only field's typed
+value is not trusted on submit — Lattice drops user input for locked fields and only submits a
+server-set `->value()` (as in the example below).
 
 <ComponentExample
   php={`TextInput::make('slug', 'Slug')

--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -58,7 +58,7 @@ Select::make('status', 'Status')->enum(OrderStatus::class);
 
 ## Searchable
 
-`->searchable()` turns the select into a [server-driven search](/advanced/security/). The resolver receives `$search` (the
+`->searchable()` turns the select into a server-driven search. The resolver receives `$search` (the
 query string) and returns the matching options; it may also inject `$get`/`$state`/`$component` and
 any container type such as `Request`. The option value is the entity identifier and is fully
 controlled by the resolver, so it scales to large datasets without shipping every option to the
@@ -94,7 +94,7 @@ Backing a select with an Eloquent model is the common case, so `->optionsFrom()`
 `EloquentOptions` is the shipped source:
 
 ```php
-use Lattice\Lattice\Forms\EloquentOptions;
+use Lattice\Lattice\Core\EloquentOptions;
 
 Select::make('author_id', 'Author')
     ->optionsFrom(EloquentOptions::make(User::class)->label('name'));

--- a/docs/content/docs/forms/overview.mdx
+++ b/docs/content/docs/forms/overview.mdx
@@ -30,7 +30,7 @@ class ProfileForm extends FormDefinition
     {
         return $form->schema([
             TextInput::make('name', 'Name')->rules(['required', 'string', 'max:255']),
-            TextInput::make('email', 'Email')->email()->rules(['required', 'email']),
+            TextInput::make('email', 'Email')->email()->rules(['required']),
         ]);
     }
 
@@ -109,7 +109,8 @@ form only accepts submissions for the schema it actually rendered. `FormControll
 4. Otherwise the submission is validated and passed to `handle()`.
 
 `$this->validate($request)` runs the field rules and returns the validated, cast data as an array —
-visible-only, with hidden and disabled values stripped. Your `handle()` returns any Laravel
+visible-only, with hidden values and locked (disabled or read-only) user input stripped; a
+server-set `->value()` on a locked field still comes through. Your `handle()` returns any Laravel
 `Response` or `Responsable`: a redirect, a JSON payload, or a [toast effect](/actions/overview/).
 
 ## Resetting after submit

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -50,7 +50,7 @@ The browser needs the Lattice React renderer to turn the server's component tree
 npm install @lattice-php/lattice
 ```
 
-The renderer's UI libraries (Radix, TipTap, i18n, and styling utilities) come with it. Only `react`, `react-dom`, and `@inertiajs/react` are peer dependencies you already have in a Laravel React app. Styling is driven by Tailwind CSS v4:
+The renderer's UI libraries (Radix, TipTap, i18n, and styling utilities) come with it. `react`, `react-dom`, and `@inertiajs/react` are required peer dependencies you already have in a Laravel React app; `@laravel/echo-react` and `pusher-js` are optional peers, needed only if you use Lattice's [realtime](/core/realtime/) layer. Styling is driven by Tailwind CSS v4:
 
 ```bash
 npm install -D tailwindcss @tailwindcss/vite tw-animate-css
@@ -62,7 +62,7 @@ Lattice targets React 19, Inertia v3, Tailwind 4, and TipTap 3. The npm package 
 
 ### Version compatibility
 
-Keep the Composer and npm package lines aligned. For pre-1.0 releases, install the same minor line on both sides, such as `lattice-php/lattice:^0.2` with `@lattice-php/lattice@^0.2`. From 1.0 onward, keep the major versions matched, such as `1.x` with `1.x` or `2.x` with `2.x`.
+Keep the Composer and npm package lines aligned. For pre-1.0 releases, install the same `0.x` minor line on both sides, e.g. `lattice-php/lattice:^0.7` with `@lattice-php/lattice@^0.7`. From 1.0 onward, keep the major versions matched, such as `1.x` with `1.x` or `2.x` with `2.x`.
 
 The split is intentional: React, React DOM, and Inertia stay as peer dependencies so the application owns its SPA runtime, while Lattice bundles its renderer internals.
 
@@ -129,7 +129,26 @@ The component tokens (`--lt-*`) fall back to sensible defaults, so the UI is sty
 
 ### Register the Inertia renderer
 
-Every Lattice route resolves to the same Inertia page component, `lattice/page`, which the package provides. In your Inertia entrypoint, use Lattice's page resolver, import the sprite Vite exposes, and wrap the app in `Provider`:
+Every Lattice route resolves to the same Inertia page component, `lattice/page`, which the package provides. The quickest setup is `createLatticeApp`, a one-call helper that wires the Lattice page and layout resolvers, the `Provider` (registry, sprite, and flash toasts), and theme initialization in one go:
+
+```tsx
+// resources/js/app.tsx
+/// <reference types="@lattice-php/lattice/svg-sprite-client" />
+import "../css/app.css";
+import { createLatticeApp } from "@lattice-php/lattice";
+import sprite from "virtual:svg-sprite";
+
+createLatticeApp({
+  sprite,
+  pages: import.meta.glob("./Pages/**/*.tsx"),
+});
+```
+
+It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`.
+
+#### Manual wiring
+
+If you need full control of the Inertia bootstrap, wire the pieces yourself: use Lattice's page resolver, import the sprite Vite exposes, and wrap the app in `Provider`:
 
 ```tsx
 // resources/js/app.tsx

--- a/docs/content/docs/tables/columns.mdx
+++ b/docs/content/docs/tables/columns.mdx
@@ -21,11 +21,13 @@ TextColumn::make('name')->label('Full name');
   php={`TextColumn::make('name')->sortable()->filterable();
 NumberColumn::make('price')->sortable()->filterable();
 BooleanColumn::make('featured');
-TextColumn::make('updated_at')->date('Y-m-d')->sortable();`}
+TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable();`}
   fixture="table.overview"
 />
 
-- `->date()` formats a date value; pass a format string such as `->date('Y-m-d H:i')`.
+- `->date()`, `->time()`, and `->dateTime()` format a date/time value for the viewer's locale. Pass a
+  [`DateTimeStyle`](/advanced/enums/#tables) case — `Short`, `Medium` (the default), `Long`, or `Full` —
+  to control the style, e.g. `->dateTime(DateTimeStyle::Short)`.
 - `->copyable()` adds a click-to-copy affordance to the cell.
 - `->link('/products/{value}')` renders the value as a link; `{value}` is substituted with the cell
   value. Pass `external: true` for an outbound link.

--- a/docs/content/docs/tables/overview.mdx
+++ b/docs/content/docs/tables/overview.mdx
@@ -20,7 +20,7 @@ implementing the source interface.
             TextColumn::make('name')->sortable()->filterable(),
             NumberColumn::make('price')->sortable()->filterable(),
             BooleanColumn::make('featured'),
-            TextColumn::make('updated_at')->date('Y-m-d')->sortable(),
+            TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable(),
         ];
     }
 

--- a/docs/content/docs/tables/sorting-filtering-pagination.mdx
+++ b/docs/content/docs/tables/sorting-filtering-pagination.mdx
@@ -13,7 +13,7 @@ applies them.
 <ComponentExample
   php={`TextColumn::make('name')->sortable()->filterable();
 NumberColumn::make('price')->sortable()->filterable();
-TextColumn::make('updated_at')->date('Y-m-d')->sortable();`}
+TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable();`}
   fixture="table.overview"
 />
 
@@ -64,8 +64,8 @@ TextColumn::make('sku')->filterable(Op::Equals, [Op::Equals, Op::NotEquals]);
 ```
 
 A column's filter capability serializes as a `ColumnFilter` (`{ enabled, type, operators,
-defaultOperator, control, options, multiple }`) so the React filter control knows which inputs and
-operators to render. Open the **Tree** tab on the example above to see it.
+defaultOperator, control, options, multiple, searchable, clauseOptions }`) so the React filter control
+knows which inputs and operators to render. Open the **Tree** tab on the example above to see it.
 
 ### Filtering by a fixed set of options
 

--- a/docs/content/docs/testing/overview.md
+++ b/docs/content/docs/testing/overview.md
@@ -218,8 +218,7 @@ $this->assertLatticeComponent($action)
 
 ## Test selectors
 
-Lattice uses `data-test` as its standard test-hook attribute (83 usages in production source).
-`data-testid` is **not** used.
+Lattice uses `data-test` as its standard test-hook attribute. `data-testid` is **not** used.
 
 **Pest browser tests** target `data-test` via the `@shorthand` selector. `->click('@foo')` is
 equivalent to clicking `[data-test="foo"]`.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -5,15 +5,15 @@ Lattice (`lattice-php/lattice`) is a server-driven UI layer for Laravel apps run
 ### The model
 
 - A **page** is a PHP class that builds a tree of component definitions; one React component (`lattice/page`) renders it over Inertia by resolving each node against a registry.
-- **Forms, tables, actions, and fragments** are PHP classes tagged with an attribute (`#[Form]`, `#[Table]`, `#[Action]`, `#[BulkAction]`, `#[Fragment]`). Lattice **discovers** them under the paths in `config('lattice.discover')` (your `app/` directory by default) and exposes each at a stable, signed endpoint (e.g. `lattice/forms/{form}`, `lattice/tables/{table}`). The rendered components call back into those endpoints for submits, paging, and clicks.
+- **Forms, tables, actions, and fragments** are PHP classes tagged with an attribute (`#[AsForm]`, `#[AsTable]`, `#[AsAction]`, `#[AsBulkAction]`, `#[AsFragment]`). Lattice **discovers** them under the paths in `config('lattice.discover')` (your `app/` directory by default) and exposes each at a stable, signed endpoint (e.g. `lattice/forms/{form}`, `lattice/tables/{table}`). The rendered components call back into those endpoints for submits, paging, and clicks.
 
 ### Building a page
 
-A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. Annotate it with `#[Page(route: '…')]`; Lattice discovers the page and registers its route automatically — no controller, route file entry, or Inertia page component to write by hand.
+A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. Annotate it with `#[AsPage(route: '…')]`; Lattice discovers the page and registers its route automatically — no controller, route file entry, or Inertia page component to write by hand.
 
 @verbatim
 <code-snippet name="A page and its route" lang="php">
-use Lattice\Lattice\Attributes\Page;
+use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Enums\Gap;
@@ -22,7 +22,7 @@ use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Http\Page as BasePage;
 use Lattice\Lattice\Tables\Components\Table;
 
-#[Page(route: '/products', layout: PageLayout::App, middleware: ['web'])]
+#[AsPage(route: '/products', layout: PageLayout::App, middleware: ['web'])]
 final class ProductsPage extends BasePage
 {
     public function title(): string
@@ -59,7 +59,7 @@ Drop a form or a table into the tree with `Form::use(MyForm::class)` and `Table:
 ### Conventions
 
 - Definitions (forms, tables, actions, pages) live under a discover path (`app/` by default) and follow normal PSR-4 namespacing — e.g. `App\Forms\ProfileForm`, `App\Tables\ProductsTable`. Discovery scans recursively, so the sub-folder is your choice.
-- Always give a definition a **stable id** in its attribute: `#[Form('app.profile.form')]`. Endpoints and signed refs derive from it; changing it breaks existing references.
+- Always give a definition a **stable id** in its attribute: `#[AsForm('app.profile.form')]`. Endpoints and signed refs derive from it; changing it breaks existing references.
 - After changing the PHP wire format (enums / value objects) or adding custom components, regenerate the TypeScript types with `php artisan lattice:typescript`.
 - Scaffold custom UI with the `make` commands below — each generates a paired PHP builder and React `.tsx` component.
 - Use Boost's `search-docs` tool for Laravel/Inertia/Pest specifics.

--- a/resources/boost/skills/lattice-actions/SKILL.md
+++ b/resources/boost/skills/lattice-actions/SKILL.md
@@ -9,18 +9,18 @@ An action runs on the server in response to a click and returns **effects** the 
 
 ## Defining an action
 
-Extend `ActionDefinition` with `definition()` (describe the trigger) and `handle()` (do the work, return an `ActionResult`). The `#[Action('id')]` attribute gives it a stable id. Note the import alias — the attribute and the `Action` component share a name:
+Extend `ActionDefinition` with `definition()` (describe the trigger) and `handle()` (do the work, return an `ActionResult`). The `#[AsAction('id')]` attribute gives it a stable id — distinct from the `Action` component you build in `definition()`:
 
 ```php
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action;
-use Lattice\Lattice\Attributes\Action as ActionAttribute;
+use Lattice\Lattice\Attributes\AsAction;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Variant;
 
-#[ActionAttribute('app.products.archive')]
+#[AsAction('app.products.archive')]
 class ArchiveProductAction extends ActionDefinition
 {
     public function definition(Action $action): Action
@@ -51,7 +51,7 @@ class ArchiveProductAction extends ActionDefinition
 | --- | --- |
 | `->toast($message, $variant?)` | Show a toast (`Variant::Success`/`Error`/`Warning`/`Info`; defaults to success; message and variant are order-insensitive). |
 | `->callout($callout)` | Show a persistent in-flow banner in the layout's `Callouts::make()` slot. Pass a `Callout` value object (`Lattice\Lattice\Core\Values\Callout`). |
-| `->reloadComponent($id)` | Re-fetch one component — pass a `#[Table]`/component id so only it refreshes. |
+| `->reloadComponent($id)` | Re-fetch one component — pass a `#[AsTable]`/component id so only it refreshes. |
 | `->reloadPage()` | Reload the current page's props. |
 | `->redirect($url)` | Navigate to a URL. |
 | `->download($url)` | Trigger a file download. |
@@ -140,9 +140,9 @@ use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\BulkActionDefinition;
 use Lattice\Lattice\Actions\Components\Action;
-use Lattice\Lattice\Attributes\BulkAction as BulkActionAttribute;
+use Lattice\Lattice\Attributes\AsBulkAction;
 
-#[BulkActionAttribute('app.products.archive-selected')]
+#[AsBulkAction('app.products.archive-selected')]
 class ArchiveSelectedProductsAction extends BulkActionDefinition
 {
     public function definition(Action $action): Action
@@ -171,8 +171,8 @@ See the **`lattice-tables`** skill for the table wiring.
 
 ## Common mistakes
 
-- **Confusing the attribute and the component** — `#[Action]`/`#[BulkAction]` live in `Lattice\Lattice\Attributes` (alias them on import); `Action::use()`/`BulkAction::use()` are components in `Lattice\Lattice\Actions\Components`.
-- **`reloadComponent()` with the wrong id** — pass the target component's `#[Table]`/component id, not the action's id.
+- **Confusing the attribute and the component** — `#[AsAction]`/`#[AsBulkAction]` live in `Lattice\Lattice\Attributes`; `Action::use()`/`BulkAction::use()` are components in `Lattice\Lattice\Actions\Components`.
+- **`reloadComponent()` with the wrong id** — pass the target component's `#[AsTable]`/component id, not the action's id.
 - **Reading context off the raw request** — use `$this->context($request, $key)`; it is the signed, trusted copy.
-- **No `#[Action('id')]` / `#[BulkAction('id')]`** → the action is not discovered and has no endpoint.
+- **No `#[AsAction('id')]` / `#[AsBulkAction('id')]`** → the action is not discovered and has no endpoint.
 - **Callout not appearing** — the active layout's `schema()` must include `Callouts::make()`; without it the effect is silently dropped.

--- a/resources/boost/skills/lattice-forms/SKILL.md
+++ b/resources/boost/skills/lattice-forms/SKILL.md
@@ -9,24 +9,24 @@ A Lattice form is a PHP class that declares its fields and handles its own submi
 
 ## Defining a form
 
-Extend `FormDefinition` and implement `definition()` (build the schema) and `handle()` (process a valid submit). The `#[Form('id')]` attribute gives a stable id so the form is discovered and addressed at `lattice/forms/{form}`.
+Extend `FormDefinition` and implement `definition()` (build the schema) and `handle()` (process a valid submit). The `#[AsForm('id')]` attribute gives a stable id so the form is discovered and addressed at `lattice/forms/{form}`.
 
 ```php
 use Illuminate\Http\Request;
-use Lattice\Lattice\Attributes\Form;
+use Lattice\Lattice\Attributes\AsForm;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
 
-#[Form('app.profile.form')]
+#[AsForm('app.profile.form')]
 class ProfileForm extends FormDefinition
 {
     public function definition(FormComponent $form, Request $request): FormComponent
     {
         return $form->schema([
             TextInput::make('name', 'Name')->rules(['required', 'string', 'max:255']),
-            TextInput::make('email', 'Email')->email()->rules(['required', 'email']),
+            TextInput::make('email', 'Email')->email()->rules(['required']),
         ]);
     }
 
@@ -55,7 +55,7 @@ Options shared by **every** field (they extend the base `Field`):
 | `->required()` | Required indicator + `required` rule. |
 | `->rules([...])` | Laravel validation rules for this field. |
 | `->disabled()` | Non-interactive **and not submitted**. |
-| `->readOnly()` | Shown, not editable, **still submitted**. |
+| `->readOnly()` | Shown, not editable. Like disabled, typed input is **not submitted** — only a server-set `->value()` survives. |
 | `->hidden()` / `->visible($bool)` | Remove / show the field. |
 
 ### Select and Choice options
@@ -96,7 +96,7 @@ Select::make('author_id', 'Author')
 
 ## Validation
 
-Attach Laravel rules per field with `->rules([...])` (or `->required()`). In `handle()`, call `$this->validate($request)` — it runs the field rules and returns the validated, cast data as an array (**visible-only**; hidden and disabled values are stripped).
+Attach Laravel rules per field with `->rules([...])` (or `->required()`). In `handle()`, call `$this->validate($request)` — it runs the field rules and returns the validated, cast data as an array (**visible-only**; hidden values and locked (disabled or read-only) user input are stripped, but a server-set `->value()` on a locked field survives).
 
 Turn on **live validation** by calling `->precognitive(500)` (debounce ms) in `definition()`. It validates as the user types using the exact same ruleset — nothing to keep in sync.
 
@@ -160,10 +160,10 @@ Every form posts to its signed endpoint; `FormController` routes the request: a 
 
 ## Common mistakes
 
-- **No `#[Form('id')]` attribute** → the form is not discovered and has no endpoint.
+- **No `#[AsForm('id')]` attribute** → the form is not discovered and has no endpoint.
 - **Validating only in `handle()`** instead of per-field `->rules()` → no live validation; the client can't reflect the rules.
-- **Expecting `disabled()` values in the validated data** — they are stripped. Use `->readOnly()` when the value must still be submitted.
+- **Expecting `disabled()` or `readOnly()` typed values in the validated data** — locked fields are stripped; only a server-set `->value()` survives. Set the value server-side in `definition()` or `handle()`.
 - **Relying on a conditionally hidden field's value** — a field hidden by `visibleWhen` (or `->hidden()`) is stripped from `validate()`'s result, so it is absent from the array. Default it in `handle()` if you still need a value.
-- **Changing a `#[Form]` id later** → breaks already-rendered references.
+- **Changing a `#[AsForm]` id later** → breaks already-rendered references.
 
 Need an action behind a button, a row, or a selection? See the **`lattice-actions`** skill.

--- a/resources/boost/skills/lattice-tables/SKILL.md
+++ b/resources/boost/skills/lattice-tables/SKILL.md
@@ -9,18 +9,18 @@ A Lattice table is a listing backed by a **data source**. You declare columns in
 
 ## Defining a table
 
-For a database-backed table, extend `EloquentTableDefinition` and implement `columns()` + `builder()`. The `#[Table('id')]` attribute gives a stable id so the table is discovered and addressed by its endpoint.
+For a database-backed table, extend `EloquentTableDefinition` and implement `columns()` + `builder()`. The `#[AsTable('id')]` attribute gives a stable id so the table is discovered and addressed by its endpoint.
 
 ```php
 use Illuminate\Database\Eloquent\Builder;
-use Lattice\Lattice\Attributes\Table;
+use Lattice\Lattice\Attributes\AsTable;
 use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
-use Lattice\Lattice\Tables\EloquentTableDefinition;
+use Lattice\Lattice\Tables\Sources\Eloquent\EloquentTableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 
 /** @extends EloquentTableDefinition<Product> */
-#[Table('app.products')]
+#[AsTable('app.products')]
 class ProductsTable extends EloquentTableDefinition
 {
     public function columns(): array
@@ -119,4 +119,4 @@ A table only *attaches* actions and their context; the action classes themselves
 
 - **Making a computed/accessor column `sortable()`/`filterable()`** → it maps to a non-existent DB column. Keep it display-only or use a custom source.
 - **Filtering/sorting by hand in `builder()`** → Lattice already applies the request's filters and sorts; `builder()` is only the base query.
-- **No `#[Table('id')]` attribute** → the table is not discovered and has no endpoint.
+- **No `#[AsTable('id')]` attribute** → the table is not discovered and has no endpoint.


### PR DESCRIPTION
A documentation accuracy pass over the whole docs site **and** the shipped Boost guidelines/skills, cross-checked against the current code.

## Docs site
- **Tables** — `TextColumn::date()/time()/dateTime()` take a `DateTimeStyle` enum, not a format string; the `->date('Y-m-d')` examples didn't compile. Fixed across overview/columns/sorting pages.
- **Extending** — rewrote the scaffold story: a single `resources/js/registry.ts` (not `plugin.ts`/`columns.ts`), generated renderers under `resources/js/{fields,components,columns}/`, and corrected both `lazyComponent` examples to resolve to `{ default }`.
- **Forms** — read-only typed input is stripped like disabled (only a server-set `->value()` survives); fixed the inverted "still submitted" claim and the `validate()` strip description.
- **Select** — `EloquentOptions` is in `Lattice\Lattice\Core`; removed a misleading link.
- **File upload** — documented `finalizeSignedUploads()` for signed uploads (the temp key must be promoted out of the temp prefix).
- **Installation** — lead with the `createLatticeApp` one-call helper; note the optional `@laravel/echo-react`/`pusher-js` realtime peers.
- Assorted accuracy/clarity: pages `layout()`/`container()` overrides, i18n `timezone` prop, enum grouping, effect discriminants, Tabs `queryKey` default, number-input slider/affix note, version examples, testing/contributing notes.

## Boost guidelines & skills
- The core guideline and the form/table/action skills used the **obsolete short attribute names** `#[Page]`/`#[Form]`/`#[Table]`/`#[Action]`/`#[BulkAction]`/`#[Fragment]`, which no longer exist — corrected to `#[AsPage]`/`#[AsForm]`/`#[AsTable]`/`#[AsAction]`/`#[AsBulkAction]`/`#[AsFragment]` (these would fatal as written).
- Fixed the `EloquentTableDefinition` namespace (`Tables\Sources\Eloquent`) and the same read-only "still submitted" claim.

`npm run docs:build` passes (broken links/MDX fail the build).