### PR TITLE
test: expand frontend (vitest) coverage

### DIFF
--- a/resources/js/clipboard/index.test.ts
+++ b/resources/js/clipboard/index.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard, useClipboard } from "./index";
+
+function stubClipboard(writeText: ((text: string) => Promise<void>) | undefined) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  });
+}
+
+afterEach(() => {
+  stubClipboard(undefined);
+  vi.restoreAllMocks();
+});
+
+describe("copyToClipboard", () => {
+  it("writes the text and reports success", async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("returns false when the clipboard API is unavailable", async () => {
+    stubClipboard(undefined);
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+  });
+
+  it("returns false when writing rejects", async () => {
+    stubClipboard(vi.fn<(text: string) => Promise<void>>().mockRejectedValue(new Error("denied")));
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+  });
+});
+
+describe("useClipboard", () => {
+  it("tracks the copied text after a successful copy", async () => {
+    stubClipboard(vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined));
+
+    const { result } = renderHook(() => useClipboard());
+    expect(result.current[0]).toBeNull();
+
+    let copied = false;
+    await act(async () => {
+      copied = await result.current[1]("copied value");
+    });
+
+    expect(copied).toBe(true);
+    expect(result.current[0]).toBe("copied value");
+  });
+
+  it("resets the copied text when a copy fails", async () => {
+    stubClipboard(undefined);
+
+    const { result } = renderHook(() => useClipboard());
+
+    let copied = true;
+    await act(async () => {
+      copied = await result.current[1]("never stored");
+    });
+
+    expect(copied).toBe(false);
+    expect(result.current[0]).toBeNull();
+  });
+});

--- a/resources/js/core/components/grid.test.tsx
+++ b/resources/js/core/components/grid.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import GridComponent from "./grid";
+
+function renderGrid(columns: number | null, key?: string) {
+  const node = { type: "grid", key, props: { columns } } as Node<"grid">;
+  return render(
+    <GridComponent node={node}>
+      <span>child</span>
+    </GridComponent>,
+  );
+}
+
+describe("GridComponent", () => {
+  it("renders its children inside a grid container", () => {
+    renderGrid(2);
+
+    expect(screen.getByText("child")).toBeInTheDocument();
+  });
+
+  it("defaults to a single column when columns is null", () => {
+    const { container } = renderGrid(null);
+    const grid = container.firstElementChild!;
+
+    expect(grid).toHaveClass("grid");
+    expect(grid).not.toHaveClass("md:grid-cols-2");
+  });
+
+  it("adds responsive column classes up to the requested count", () => {
+    const { container } = renderGrid(3);
+    const grid = container.firstElementChild!;
+
+    expect(grid).toHaveClass("md:grid-cols-2", "lg:grid-cols-3");
+    expect(grid).not.toHaveClass("xl:grid-cols-4");
+  });
+
+  it("clamps columns above 4 to four columns", () => {
+    const { container } = renderGrid(9);
+
+    expect(container.firstElementChild).toHaveClass("xl:grid-cols-4");
+  });
+
+  it("clamps columns below 1 to a single column", () => {
+    const { container } = renderGrid(0);
+
+    expect(container.firstElementChild).not.toHaveClass("md:grid-cols-2");
+  });
+
+  it("exposes the node identity for component targeting", () => {
+    const { container } = renderGrid(1, "summary");
+
+    expect(container.firstElementChild).toHaveAttribute("data-lattice-component", "summary");
+  });
+});

--- a/resources/js/core/components/heading.test.tsx
+++ b/resources/js/core/components/heading.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import HeadingComponent from "./heading";
+
+function renderHeading(level: number, text = "Title") {
+  const node = { type: "heading", props: { level, text } } as Node<"heading">;
+  return render(<HeadingComponent node={node}>{null}</HeadingComponent>);
+}
+
+describe("HeadingComponent", () => {
+  it.each([
+    [1, "H1"],
+    [2, "H2"],
+    [3, "H3"],
+    [4, "H4"],
+    [5, "H5"],
+    [6, "H6"],
+  ])("renders an h%i element", (level, role) => {
+    renderHeading(level, role);
+
+    expect(screen.getByRole("heading", { level }).tagName).toBe(`H${level}`);
+    expect(screen.getByText(role)).toBeInTheDocument();
+  });
+
+  it("clamps levels below 1 to an h1", () => {
+    renderHeading(0);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-2xl", "font-bold");
+  });
+
+  it("clamps levels above 6 to an h6", () => {
+    renderHeading(9);
+
+    expect(screen.getByRole("heading", { level: 6 })).toHaveClass("text-base");
+  });
+
+  it("uses the level-2 size class for h2", () => {
+    renderHeading(2);
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveClass("text-xl");
+  });
+});

--- a/resources/js/core/components/modal.test.tsx
+++ b/resources/js/core/components/modal.test.tsx
@@ -1,0 +1,71 @@
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
+import type { Node } from "@lattice-php/lattice/core/types";
+import ModalComponent from "./modal";
+
+function renderModal(node: Node<"modal">) {
+  return render(
+    <ModalComponent node={node}>
+      <p>Body content</p>
+    </ModalComponent>,
+  );
+}
+
+function fire(event: string, modal: string | null) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(event, { detail: { modal } }));
+  });
+}
+
+describe("ModalComponent", () => {
+  it("renders open immediately when the open prop is set", () => {
+    renderModal(
+      fakeNode({ type: "modal", id: "welcome", props: { open: true, title: "Welcome" } }),
+    );
+
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("stays closed until a matching open event arrives", () => {
+    renderModal(fakeNode({ type: "modal", id: "confirm", props: { title: "Confirm" } }));
+
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+
+    fire(LATTICE_EVENT.openModal, "confirm");
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
+
+  it("ignores open events aimed at a different modal", () => {
+    renderModal(fakeNode({ type: "modal", id: "confirm", props: { title: "Confirm" } }));
+
+    fire(LATTICE_EVENT.openModal, "other");
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+  });
+
+  it("opens on a broadcast event with no target modal", () => {
+    renderModal(fakeNode({ type: "modal", id: "confirm", props: { title: "Confirm" } }));
+
+    fire(LATTICE_EVENT.openModal, null);
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
+
+  it("closes on a matching close event", () => {
+    renderModal(
+      fakeNode({ type: "modal", id: "confirm", props: { open: true, title: "Confirm" } }),
+    );
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+
+    fire(LATTICE_EVENT.closeModal, "confirm");
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the default title and never opens when it has no id", () => {
+    renderModal(fakeNode({ type: "modal", props: {} }));
+
+    fire(LATTICE_EVENT.openModal, null);
+    expect(screen.queryByText("Dialog")).not.toBeInTheDocument();
+  });
+});

--- a/resources/js/core/components/segmented-control.test.tsx
+++ b/resources/js/core/components/segmented-control.test.tsx
@@ -38,4 +38,38 @@ describe("SegmentedControl", () => {
 
     window.removeEventListener("lattice:appearance-change", handleChange);
   });
+
+  it("renders nothing when there are no options", () => {
+    const node = fakeNode({
+      type: "segmented-control",
+      props: { name: "empty", options: [] },
+    });
+
+    const { container } = render(
+      <SegmentedControlComponent node={node}>{null}</SegmentedControlComponent>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("defaults to the first option and selects without emitting when no event is configured", () => {
+    const node = fakeNode({
+      type: "segmented-control",
+      props: {
+        name: "size",
+        options: [
+          { label: "Small", value: "s" },
+          { label: "Large", value: "l" },
+        ],
+      },
+    });
+
+    render(<SegmentedControlComponent node={node}>{null}</SegmentedControlComponent>);
+
+    expect(screen.getByRole("radio", { name: "Small" })).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Large" }));
+
+    expect(screen.getByRole("radio", { name: "Large" })).toHaveAttribute("aria-checked", "true");
+  });
 });

--- a/resources/js/core/components/segmented-pills.test.tsx
+++ b/resources/js/core/components/segmented-pills.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Option } from "@lattice-php/lattice/core/types";
+import { SegmentedPills } from "./segmented-pills";
+
+const options: Option[] = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+];
+
+describe("SegmentedPills", () => {
+  it("marks the selected pill and calls onSelect on click", () => {
+    const onSelect = vi.fn<(value: string) => void>();
+    render(<SegmentedPills name="theme" onSelect={onSelect} options={options} value="light" />);
+
+    expect(screen.getByRole("radio", { name: "Light" })).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Dark" }));
+    expect(onSelect).toHaveBeenCalledWith("dark");
+  });
+
+  it("falls back to a generic test id prefix when unnamed", () => {
+    render(
+      <SegmentedPills
+        onSelect={vi.fn<(value: string) => void>()}
+        options={options}
+        value="light"
+      />,
+    );
+
+    expect(screen.getByTestId("segment-dark")).toBeInTheDocument();
+  });
+
+  it("disables every pill when disabled", () => {
+    render(
+      <SegmentedPills
+        onSelect={vi.fn<(value: string) => void>()}
+        options={options}
+        value="light"
+        disabled
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "Light" })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "Dark" })).toBeDisabled();
+  });
+
+  it("does not steal focus when autoFocus is off", () => {
+    render(
+      <SegmentedPills
+        onSelect={vi.fn<(value: string) => void>()}
+        options={options}
+        value="light"
+      />,
+    );
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it("focuses the selected pill when autoFocus is on", () => {
+    render(
+      <SegmentedPills
+        onSelect={vi.fn<(value: string) => void>()}
+        options={options}
+        value="dark"
+        autoFocus
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "Dark" })).toHaveFocus();
+  });
+
+  it("focuses the first pill when autoFocus is on and nothing is selected", () => {
+    render(
+      <SegmentedPills
+        onSelect={vi.fn<(value: string) => void>()}
+        options={options}
+        value=""
+        autoFocus
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "Light" })).toHaveFocus();
+  });
+});

--- a/resources/js/core/use-column-resizing.test.tsx
+++ b/resources/js/core/use-column-resizing.test.tsx
@@ -42,6 +42,7 @@ function rect(width: number): DOMRect {
 
 function Harness({
   columnGapPx = 0,
+  enabled = true,
   hookColumns = columns,
   leadingTracks,
   onGetter,
@@ -50,6 +51,7 @@ function Harness({
   trailingTracks,
 }: {
   columnGapPx?: number;
+  enabled?: boolean;
   hookColumns?: SizableColumn[];
   leadingTracks?: string[];
   onGetter?: (getter: ResizeGetter) => void;
@@ -59,7 +61,7 @@ function Harness({
 }) {
   const { gridTemplateColumns, getResizeHandleProps, hasOverrides, resetColumns } =
     useColumnResizing({
-      enabled: true,
+      enabled,
       columns: hookColumns,
       columnGapPx,
       leadingTracks,
@@ -257,5 +259,201 @@ describe("useColumnResizing", () => {
 
     expect(getters.length).toBeGreaterThan(1);
     expect(new Set(getters).size).toBe(1);
+  });
+
+  it("ignores all interactions while disabled", () => {
+    render(<Harness enabled={false} />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+  });
+
+  it("does not render overrides into the grid while disabled", () => {
+    window.localStorage.setItem(
+      "lattice:table-columns:orders",
+      JSON.stringify({ columns: ["qty"], overrides: { qty: 200 } }),
+    );
+
+    render(<Harness enabled={false} storageKey="lattice:table-columns:orders" />);
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+  });
+
+  it("takes a larger keyboard step while holding shift", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight", shiftKey: true });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "160px" });
+  });
+
+  it("shrinks the column with ArrowLeft", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    fireEvent.keyDown(handle, { key: "ArrowLeft" });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "136px" });
+  });
+
+  it("clamps to the minimum width with Home", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "Home" });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "96px" });
+  });
+
+  it("clamps to the maximum width with End", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "End" });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "1024px" });
+  });
+
+  it("resets with Escape", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.keyDown(handle, { key: "ArrowRight" });
+    fireEvent.keyDown(handle, { key: "Escape" });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+  });
+
+  it("clears the drag on pointer up and ignores later moves", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
+    fireEvent.pointerUp(handle, { clientX: 180, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 400, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "208px" });
+  });
+
+  it("ignores a pointer up for a column that is not actively dragging", () => {
+    render(<Harness hookColumns={twoColumns} />);
+
+    const qtyHandle = screen.getByRole("separator", { name: "Resize Qty" });
+    const priceHandle = screen.getByRole("separator", { name: "Resize Price" });
+
+    fireEvent.pointerDown(qtyHandle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerUp(priceHandle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(qtyHandle, { clientX: 180, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({
+      gridTemplateColumns: "208px minmax(8rem, 1fr)",
+    });
+  });
+
+  it("falls back to the current width when the handle has no measured parent", () => {
+    render(<Harness />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+    const cell = screen.getByTestId("cell-qty");
+
+    vi.spyOn(cell, "getBoundingClientRect").mockReturnValue(rect(0));
+
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 140, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "168px" });
+  });
+
+  it("labels the handle with the column key when no label is set", () => {
+    const unlabeled: SizableColumn[] = [{ key: "sku", width: "sm" }];
+
+    render(<Harness hookColumns={unlabeled} />);
+
+    expect(screen.getByRole("separator", { name: "Resize sku" })).toBeInTheDocument();
+  });
+
+  it("measures fixed px tracks when capping the grid width", () => {
+    render(
+      <Harness
+        hookColumns={twoColumns}
+        leadingTracks={["40px"]}
+        trailingTracks={["unset"]}
+        columnGapPx={0}
+      />,
+    );
+
+    const grid = screen.getByTestId("grid");
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    vi.spyOn(grid, "getBoundingClientRect").mockReturnValue(rect(400));
+
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 1000, pointerId: 1 });
+
+    expect(grid).toHaveStyle({
+      gridTemplateColumns: "40px 232px minmax(8rem, 1fr) unset",
+    });
+  });
+
+  it("ignores stored overrides that are not finite numbers", () => {
+    window.localStorage.setItem(
+      "lattice:table-columns:orders",
+      JSON.stringify({ columns: ["qty"], overrides: { qty: "wide" } }),
+    );
+
+    render(<Harness storageKey="lattice:table-columns:orders" />);
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+    expect(window.localStorage.getItem("lattice:table-columns:orders")).toBeNull();
+  });
+
+  it("discards stored data that is not a column-width record", () => {
+    window.localStorage.setItem("lattice:table-columns:orders", "42");
+
+    render(<Harness storageKey="lattice:table-columns:orders" />);
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
+    expect(window.localStorage.getItem("lattice:table-columns:orders")).toBeNull();
+  });
+
+  it("falls back to a 16px root font size when the computed value is non-positive", () => {
+    render(<Harness hookColumns={twoColumns} leadingTracks={["1rem"]} columnGapPx={0} />);
+
+    const grid = screen.getByTestId("grid");
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    vi.spyOn(grid, "getBoundingClientRect").mockReturnValue(rect(400));
+    const realComputedStyle = window.getComputedStyle.bind(window);
+    const computed = vi
+      .spyOn(window, "getComputedStyle")
+      .mockImplementation((element: Element, pseudo?: string | null) =>
+        element === document.documentElement
+          ? ({ fontSize: "0px" } as never)
+          : realComputedStyle(element, pseudo),
+      );
+
+    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 1000, pointerId: 1 });
+
+    expect(grid).toHaveStyle({
+      gridTemplateColumns: "1rem 256px minmax(8rem, 1fr)",
+    });
+
+    computed.mockRestore();
   });
 });

--- a/resources/js/form/components/base/submit-button.test.tsx
+++ b/resources/js/form/components/base/submit-button.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FormProvider } from "../context";
+import { FormSubmitButton } from "./submit-button";
+
+type ContextOverrides = {
+  errors?: Record<string, string | undefined>;
+  fieldLabels?: Record<string, string>;
+  processing?: boolean;
+  componentId?: string;
+};
+
+function renderSubmit(overrides: ContextOverrides = {}) {
+  return render(
+    <FormProvider
+      value={{
+        action: "#",
+        clearErrors: () => {},
+        componentId: overrides.componentId,
+        componentRef: "",
+        errors: overrides.errors ?? {},
+        fieldLabels: overrides.fieldLabels ?? {},
+        precognitive: false,
+        processing: overrides.processing ?? false,
+        validate: () => {},
+      }}
+    >
+      <FormSubmitButton label="Save" summaryLabel="Fix these fields" />
+    </FormProvider>,
+  );
+}
+
+describe("FormSubmitButton", () => {
+  it("renders an enabled submit button when the form is valid", () => {
+    renderSubmit();
+
+    const button = screen.getByTestId("form-submit");
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent("Save");
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("links the button to its form via the component id", () => {
+    renderSubmit({ componentId: "checkout" });
+
+    expect(screen.getByTestId("form-submit")).toHaveAttribute("data-lattice-form", "checkout");
+  });
+
+  it("disables the button and shows a spinner while processing", () => {
+    renderSubmit({ processing: true });
+
+    const button = screen.getByTestId("form-submit");
+    expect(button).toBeDisabled();
+    expect(button.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("disables the button and summarises invalid fields when there are errors", () => {
+    renderSubmit({
+      errors: { email: "Required", name: undefined },
+      fieldLabels: { email: "Email address" },
+    });
+
+    expect(screen.getByTestId("form-submit")).toBeDisabled();
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Fix these fields");
+    expect(tooltip).toHaveTextContent("Email address");
+    expect(tooltip).toHaveTextContent("Required");
+  });
+
+  it("falls back to the field name when no label is registered", () => {
+    renderSubmit({ errors: { slug: "Taken" } });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("slug");
+  });
+});

--- a/resources/js/form/components/conditions.test.ts
+++ b/resources/js/form/components/conditions.test.ts
@@ -86,4 +86,44 @@ describe("evaluateConditions", () => {
     );
     expect(result.hidden).toBe(false);
   });
+
+  const shows = (operator: Condition["operator"], value: unknown, fieldValue: unknown) =>
+    !evaluateConditions({ visible: [{ field: "x", operator, value }] }, { x: fieldValue }, {})
+      .hidden;
+
+  it("compares booleans through filter_var semantics for eq", () => {
+    expect(shows("eq", true, "yes")).toBe(true);
+    expect(shows("eq", true, "0")).toBe(false);
+    expect(shows("eq", false, "")).toBe(true);
+  });
+
+  it("falls back to string comparison when values are null", () => {
+    expect(shows("eq", null, null)).toBe(true);
+    expect(shows("eq", "value", undefined)).toBe(false);
+    expect(shows("neq", "a", "b")).toBe(true);
+    expect(shows("neq", "a", "a")).toBe(false);
+  });
+
+  it("supports the numeric comparison operators", () => {
+    expect(shows("gt", 5, "6")).toBe(true);
+    expect(shows("lt", 5, "4")).toBe(true);
+    expect(shows("lte", 5, "5")).toBe(true);
+  });
+
+  it("wraps a non-array expected value for in and not_in", () => {
+    expect(shows("in", "free", "free")).toBe(true);
+    expect(shows("not_in", "paid", "free")).toBe(true);
+    expect(shows("not_in", ["free", "trial"], "free")).toBe(false);
+  });
+
+  it("coerces null actuals to an empty string for text operators", () => {
+    expect(shows("contains", "", null)).toBe(true);
+    expect(shows("starts_with", "", null)).toBe(true);
+    expect(shows("ends_with", "", null)).toBe(true);
+  });
+
+  it("treats equal dates as neither before nor after", () => {
+    expect(shows("before", "2024-01-01", "2024-01-01")).toBe(false);
+    expect(shows("after", "2024-01-01", "2024-01-01")).toBe(false);
+  });
 });

--- a/resources/js/form/components/fields/number-input.test.tsx
+++ b/resources/js/form/components/fields/number-input.test.tsx
@@ -68,3 +68,25 @@ describe("NumberInputComponent affixes", () => {
     expect(screen.getByLabelText("Price")).toHaveClass("rounded-l-none");
   });
 });
+
+describe("NumberInputComponent defaults", () => {
+  it("renders a slider without a label, min, max or step", () => {
+    renderField(fakeNode({ type: "field.number-input", props: { name: "level", slider: true } }), {
+      level: "3",
+    });
+
+    const slider = screen.getByRole("slider");
+    expect(slider).toHaveValue("3");
+    expect(slider).not.toHaveAttribute("min");
+    expect(slider).not.toHaveAttribute("max");
+    expect(slider).not.toHaveAttribute("step");
+  });
+
+  it("renders a bare number input when only a name is provided", () => {
+    renderField(fakeNode({ type: "field.number-input", props: { name: "qty" } }));
+
+    const input = document.querySelector('input[name="qty"]')!;
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).not.toHaveAttribute("min");
+  });
+});

--- a/resources/js/form/components/form-path.test.ts
+++ b/resources/js/form/components/form-path.test.ts
@@ -18,4 +18,28 @@ describe("form paths", () => {
     expect(getPath(next, "items.0.children.0.name")).toBe("B");
     expect(getPath(values, "items.0.children.0.name")).toBe("A");
   });
+
+  it("returns undefined when traversal hits a null along the path", () => {
+    expect(getPath({ a: null }, "a.b.c")).toBeUndefined();
+  });
+
+  it("returns an empty html name for a blank path", () => {
+    expect(toHtmlName("")).toBe("");
+  });
+
+  it("returns the values untouched when the path is empty", () => {
+    const values = { a: 1 };
+
+    expect(setPath(values, "", 2)).toBe(values);
+  });
+
+  it("builds fresh containers, using an array when the next segment is numeric", () => {
+    const withArray = setPath({}, "a.b.0", "A");
+    const withObject = setPath({}, "meta.title", "B");
+
+    expect(getPath(withArray, "a.b.0")).toBe("A");
+    expect(Array.isArray((withArray as { a: unknown }).a)).toBe(true);
+    expect(getPath(withObject, "meta.title")).toBe("B");
+    expect(Array.isArray((withObject as { meta: unknown }).meta)).toBe(false);
+  });
 });

--- a/resources/js/i18n/backend.test.ts
+++ b/resources/js/i18n/backend.test.ts
@@ -1,0 +1,125 @@
+import type { InitOptions } from "i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { I18nConfig } from "@lattice-php/lattice/types/generated";
+
+vi.mock("i18next-http-backend", () => ({ default: { type: "backend" } }));
+vi.mock("./config", () => ({ setConfig: vi.fn<(config: unknown) => void>() }));
+vi.mock("./locale", () => ({
+  localeHeader: vi.fn<() => Record<string, string>>(() => ({ "X-Locale": "de" })),
+}));
+vi.mock("./instance", () => ({
+  i18n: { use: vi.fn<(plugin: unknown) => void>() },
+  ensureI18n: vi.fn<(extend?: unknown) => Promise<unknown>>(() => Promise.resolve()),
+  preloadLanguages: vi.fn<(locales: readonly string[]) => Promise<void>>(() => Promise.resolve()),
+}));
+
+import { setConfig } from "./config";
+import { ensureI18n, i18n, preloadLanguages } from "./instance";
+import { localeHeader } from "./locale";
+import { configureI18n, enableBackend } from "./backend";
+
+const base: InitOptions = { ns: ["translation"] };
+
+function lastEnsureExtend(): (base: InitOptions) => InitOptions {
+  const calls = vi.mocked(ensureI18n).mock.calls;
+  return calls[calls.length - 1][0] as (base: InitOptions) => InitOptions;
+}
+
+function disabledConfig(overrides: Partial<I18nConfig> = {}): I18nConfig {
+  return {
+    enabled: false,
+    saveMissing: false,
+    locales: ["en"],
+    preloadLocales: [],
+    timezone: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("configureI18n", () => {
+  it("stores the config and skips the backend when i18n is disabled", async () => {
+    await configureI18n(disabledConfig(), { namespaces: ["forms"] });
+
+    expect(setConfig).toHaveBeenCalledWith(disabledConfig());
+    expect(i18n.use).not.toHaveBeenCalled();
+    expect(preloadLanguages).not.toHaveBeenCalled();
+    expect(lastEnsureExtend()(base).ns).toEqual(["forms"]);
+  });
+
+  it("keeps the base namespaces when none are provided", async () => {
+    await configureI18n(undefined);
+
+    expect(setConfig).toHaveBeenCalledWith(undefined);
+    expect(lastEnsureExtend()(base).ns).toEqual(["translation"]);
+  });
+
+  it("wires the HTTP backend and preloads locales when enabled", async () => {
+    const config = disabledConfig({
+      enabled: true,
+      saveMissing: true,
+      preloadLocales: ["en", "de"],
+    });
+
+    await configureI18n(config, { namespaces: ["forms"] });
+
+    expect(i18n.use).toHaveBeenCalledTimes(1);
+    expect(preloadLanguages).toHaveBeenCalledWith(["en", "de"]);
+    expect(lastEnsureExtend()(base)).toMatchObject({ ns: ["forms"], saveMissing: true });
+  });
+});
+
+describe("enableBackend", () => {
+  it("registers the HTTP backend with laravel-i18next defaults", async () => {
+    await enableBackend();
+
+    expect(i18n.use).toHaveBeenCalledTimes(1);
+
+    const options = lastEnsureExtend()(base);
+    expect(options).toMatchObject({
+      partialBundledLanguages: true,
+      saveMissing: false,
+    });
+    expect(options.backend).toMatchObject({
+      loadPath: "/locales/{{lng}}/{{ns}}.json",
+      addPath: "/locales/add/{{lng}}/{{ns}}",
+      withCredentials: true,
+    });
+  });
+
+  it("honours custom paths and namespaces", async () => {
+    await enableBackend({
+      namespaces: ["admin"],
+      loadPath: "/i18n/{{lng}}.json",
+      addPath: "/i18n/add",
+      saveMissing: true,
+    });
+
+    const options = lastEnsureExtend()(base);
+    expect(options.ns).toEqual(["admin"]);
+    expect(options.saveMissing).toBe(true);
+    expect(options.backend).toMatchObject({
+      loadPath: "/i18n/{{lng}}.json",
+      addPath: "/i18n/add",
+    });
+  });
+
+  it("merges the locale header with caller-provided headers", async () => {
+    await enableBackend({ customHeaders: () => ({ "X-CSRF": "token" }) });
+
+    const options = lastEnsureExtend()(base);
+    const headers = (
+      options.backend as { customHeaders: () => Record<string, string> }
+    ).customHeaders();
+
+    expect(localeHeader).toHaveBeenCalled();
+    expect(headers).toEqual({ "X-Locale": "de", "X-CSRF": "token" });
+  });
+});

--- a/resources/js/realtime/listeners.test.tsx
+++ b/resources/js/realtime/listeners.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ListenerPayload } from "@lattice-php/lattice/types/generated";
+import { RealtimeListeners } from "./listeners";
+
+const state = vi.hoisted(() => ({ shouldThrow: false }));
+
+vi.mock("./subscriptions", () => ({
+  default: ({ listeners }: { listeners: ListenerPayload[] }) => {
+    if (state.shouldThrow) {
+      throw new Error("Echo is unavailable");
+    }
+    return <div data-test="subscriptions">{listeners.length} listeners</div>;
+  },
+}));
+
+const listener: ListenerPayload = {
+  channel: "orders",
+  visibility: "public",
+  events: ["OrderShipped"],
+  effects: [],
+};
+
+beforeEach(() => {
+  state.shouldThrow = false;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RealtimeListeners", () => {
+  it("renders nothing when no listeners are declared", () => {
+    const { container } = render(<RealtimeListeners />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for an empty listener list", () => {
+    const { container } = render(<RealtimeListeners listeners={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("lazily mounts the subscriptions when listeners are present", async () => {
+    render(<RealtimeListeners listeners={[listener]} />);
+
+    expect(await screen.findByTestId("subscriptions")).toHaveTextContent("1 listeners");
+  });
+
+  it("swallows Echo failures and warns instead of crashing", async () => {
+    state.shouldThrow = true;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { container } = render(<RealtimeListeners listeners={[listener]} />);
+
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    expect(warn.mock.calls[0][0]).toContain("[lattice]");
+  });
+});

--- a/resources/js/realtime/subscriptions.test.tsx
+++ b/resources/js/realtime/subscriptions.test.tsx
@@ -71,4 +71,54 @@ describe("Subscriptions", () => {
     expect(toasts).toHaveLength(1);
     expect((toasts[0] as { message: string }).message).toContain("orders.shipped-live");
   });
+
+  it.each(["public", "private", "presence"] as const)(
+    "subscribes to %s channels and dispatches their effects",
+    (visibility) => {
+      const listeners: ListenerPayload[] = [
+        {
+          channel: "orders",
+          visibility,
+          events: ["OrderShipped"],
+          effects: [
+            {
+              type: "toast",
+              toast: {
+                variant: "success",
+                message: { key: "orders.live", payload: {}, replacements: {} },
+              },
+            } as never,
+          ],
+        },
+      ];
+
+      render(<Subscriptions listeners={listeners} />);
+      handlers.current?.({});
+
+      expect(toasts).toHaveLength(1);
+    },
+  );
+
+  it("passes non-toast effects through untouched, even for non-object payloads", () => {
+    const closed: unknown[] = [];
+    const collect = (event: Event) => closed.push((event as CustomEvent).detail);
+    window.addEventListener("lattice:close-modal", collect);
+
+    const listeners: ListenerPayload[] = [
+      {
+        channel: "orders",
+        visibility: "public",
+        events: ["OrderShipped"],
+        effects: [{ type: "closeModal", target: "checkout" } as never],
+      },
+    ];
+
+    render(<Subscriptions listeners={listeners} />);
+    handlers.current?.("not-an-object");
+
+    expect(closed).toHaveLength(1);
+    expect(toasts).toHaveLength(0);
+
+    window.removeEventListener("lattice:close-modal", collect);
+  });
 });

--- a/resources/js/table/bulk.test.ts
+++ b/resources/js/table/bulk.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { ActionNode } from "@lattice-php/lattice/types/generated";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import { getBulkActions } from "./bulk";
+
+describe("getBulkActions", () => {
+  it("returns an empty list when actions is undefined", () => {
+    expect(getBulkActions(undefined)).toEqual([]);
+  });
+
+  it("returns an empty list when actions is an empty array", () => {
+    expect(getBulkActions([])).toEqual([]);
+  });
+
+  it("skips action.group nodes", () => {
+    const group = fakeNode({
+      type: "action.group",
+      id: "group",
+      props: { label: "Group", orientation: null, ref: null },
+    }) as ActionNode;
+
+    expect(getBulkActions([group])).toEqual([]);
+  });
+
+  it("skips actions without an endpoint", () => {
+    const node = fakeNode({
+      type: "action",
+      id: "no-endpoint",
+      props: { label: "No endpoint" },
+    }) as ActionNode;
+
+    expect(getBulkActions([node])).toEqual([]);
+  });
+
+  it("maps a fully-specified action node", () => {
+    const node = fakeNode({
+      type: "action",
+      id: "archive",
+      props: {
+        label: "Archive",
+        method: "patch",
+        endpoint: "/bulk/archive",
+        ref: "the-ref",
+        variant: "destructive",
+        confirmation: {
+          title: "Sure?",
+          description: null,
+          confirmLabel: null,
+          cancelLabel: null,
+        },
+        form: null,
+      },
+    }) as ActionNode;
+
+    expect(getBulkActions([node])).toEqual([
+      {
+        id: "archive",
+        label: "Archive",
+        method: "patch",
+        endpoint: "/bulk/archive",
+        ref: "the-ref",
+        variant: "destructive",
+        confirmation: {
+          title: "Sure?",
+          description: null,
+          confirmLabel: null,
+          cancelLabel: null,
+        },
+        form: null,
+      },
+    ]);
+  });
+
+  it("applies defaults for every optional field when only endpoint is set", () => {
+    const node = fakeNode({
+      type: "action",
+      props: { endpoint: "/bulk/run" },
+    }) as ActionNode;
+
+    expect(getBulkActions([node])).toEqual([
+      {
+        id: "",
+        label: "Run action",
+        method: "post",
+        endpoint: "/bulk/run",
+        ref: "",
+        variant: "default",
+        confirmation: undefined,
+        form: undefined,
+      },
+    ]);
+  });
+
+  it("maps several nodes and drops the ones that should be skipped", () => {
+    const group = fakeNode({
+      type: "action.group",
+      id: "group",
+      props: { label: "Group", orientation: null, ref: null },
+    }) as ActionNode;
+    const noEndpoint = fakeNode({
+      type: "action",
+      id: "skip",
+      props: { label: "Skip" },
+    }) as ActionNode;
+    const ok = fakeNode({
+      type: "action",
+      id: "ok",
+      props: { label: "Ok", endpoint: "/bulk/ok" },
+    }) as ActionNode;
+
+    const result = getBulkActions([group, noEndpoint, ok]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("ok");
+  });
+});

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -1,0 +1,443 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";
+import { BulkBar } from "./bulk-bar";
+import type { BulkAction } from "../bulk";
+
+const http = vi.hoisted(() => ({
+  processing: false,
+  transformer: (data: Record<string, unknown>): Record<string, unknown> => data,
+  transform(fn: (data: Record<string, unknown>) => Record<string, unknown>): void {
+    this.transformer = fn;
+  },
+  patch: vi.fn<(url: string, options: unknown) => Promise<ActionResponse>>(async () => ({
+    effects: [],
+  })),
+  post: vi.fn<(url: string, options: unknown) => Promise<ActionResponse>>(async () => ({
+    effects: [],
+  })),
+}));
+
+vi.mock("@inertiajs/react", () => ({
+  useHttp: () => http,
+}));
+
+const runAction = vi.hoisted(() =>
+  vi.fn<(request: () => Promise<ActionResponse>, dispatch: unknown) => Promise<boolean>>(
+    async (request) => {
+      await request();
+
+      return true;
+    },
+  ),
+);
+
+vi.mock("@lattice-php/lattice/action/run-action", () => ({
+  runAction,
+}));
+
+const dispatch = vi.hoisted(() => vi.fn<(effects: unknown) => void>());
+
+vi.mock("@lattice-php/lattice/effects/use-effect-dispatcher", () => ({
+  useEffectDispatcher: () => dispatch,
+}));
+
+const getActionEffects = vi.hoisted(() =>
+  vi.fn<(effects: unknown) => unknown>((effects) => effects),
+);
+
+vi.mock("@lattice-php/lattice/effects/dispatch", () => ({
+  getActionEffects,
+}));
+
+type ConfirmProps = {
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+vi.mock("@lattice-php/lattice/core/components/confirm-dialog", () => ({
+  ConfirmDialog: (props: ConfirmProps) => (
+    <div data-test="confirm-dialog">
+      <span data-test="confirm-title">{props.title}</span>
+      <span data-test="confirm-description">{props.description ?? "(none)"}</span>
+      <span data-test="confirm-confirm-label">{props.confirmLabel}</span>
+      <span data-test="confirm-cancel-label">{props.cancelLabel}</span>
+      <button type="button" data-test="confirm-accept" onClick={props.onConfirm}>
+        accept
+      </button>
+      <button type="button" data-test="confirm-cancel" onClick={props.onCancel}>
+        cancel
+      </button>
+    </div>
+  ),
+}));
+
+type ActionFormProps = {
+  cancelLabel: string;
+  description?: string;
+  extraData: Record<string, unknown>;
+  submitLabel: string;
+  title: string;
+  onClose: () => void;
+  onSuccess: (response: ActionResponse) => void;
+};
+
+vi.mock("@lattice-php/lattice/action/components/action-form", () => ({
+  ActionForm: (props: ActionFormProps) => (
+    <div data-test="action-form">
+      <span data-test="form-title">{props.title}</span>
+      <span data-test="form-description">{props.description ?? "(none)"}</span>
+      <span data-test="form-cancel-label">{props.cancelLabel}</span>
+      <span data-test="form-submit-label">{props.submitLabel}</span>
+      <span data-test="form-extra">{JSON.stringify(props.extraData)}</span>
+      <button
+        type="button"
+        data-test="form-success"
+        onClick={() => props.onSuccess({ effects: [{ type: "reloadPage" }] })}
+      >
+        success
+      </button>
+      <button type="button" data-test="form-close" onClick={props.onClose}>
+        close
+      </button>
+    </div>
+  ),
+}));
+
+function action(partial: Partial<BulkAction> & Pick<BulkAction, "id">): BulkAction {
+  return {
+    label: "Run",
+    method: "post",
+    endpoint: "/bulk/run",
+    ref: "",
+    variant: "default",
+    confirmation: null,
+    form: null,
+    ...partial,
+  };
+}
+
+function renderBar(props: Partial<Parameters<typeof BulkBar>[0]> = {}) {
+  const onSelectAllMatching = vi.fn<() => void>();
+  const onCompleted = vi.fn<() => void>();
+
+  render(
+    <BulkBar
+      actions={[action({ id: "archive" })]}
+      selectedKeys={["1", "2"]}
+      allMatching={false}
+      query={{ filter: "status:eq:active" }}
+      canSelectAllMatching={false}
+      onSelectAllMatching={onSelectAllMatching}
+      onCompleted={onCompleted}
+      {...props}
+    />,
+  );
+
+  return { onSelectAllMatching, onCompleted };
+}
+
+describe("BulkBar", () => {
+  beforeEach(() => {
+    http.processing = false;
+  });
+
+  afterEach(() => {
+    http.patch.mockClear();
+    http.post.mockClear();
+    runAction.mockClear();
+    dispatch.mockClear();
+    getActionEffects.mockClear();
+    runAction.mockImplementation(async (request) => {
+      await request();
+
+      return true;
+    });
+  });
+
+  it("shows the selected count when not selecting all matching", () => {
+    renderBar({ selectedKeys: ["1", "2", "3"] });
+
+    expect(screen.getByText("3 selected")).toBeVisible();
+  });
+
+  it("shows the all-selected count using total when selecting all matching", () => {
+    renderBar({ allMatching: true, total: 42, selectedKeys: ["1"] });
+
+    expect(screen.getByText("All 42 selected")).toBeVisible();
+  });
+
+  it("falls back to the selected length when total is missing for all matching", () => {
+    renderBar({ allMatching: true, selectedKeys: ["1", "2"] });
+
+    expect(screen.getByText("All 2 selected")).toBeVisible();
+  });
+
+  it("hides the select-all-matching button when it is not allowed", () => {
+    renderBar({ canSelectAllMatching: false });
+
+    expect(screen.queryByTestId("bulk-select-all-matching")).toBeNull();
+  });
+
+  it("renders and fires the select-all-matching button when allowed", () => {
+    const { onSelectAllMatching } = renderBar({ canSelectAllMatching: true, total: 50 });
+
+    const button = screen.getByTestId("bulk-select-all-matching");
+    expect(button).toHaveTextContent("Select all 50 matching");
+
+    fireEvent.click(button);
+
+    expect(onSelectAllMatching).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits a plain action with the selected keys payload", async () => {
+    const { onCompleted } = renderBar({
+      actions: [action({ id: "archive", method: "patch", endpoint: "/bulk/archive" })],
+      selectedKeys: ["7"],
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+    await waitFor(() =>
+      expect(http.patch).toHaveBeenCalledWith("/bulk/archive", expect.anything()),
+    );
+    expect(http.transformer({})).toEqual({ selected: ["7"] });
+    await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
+  });
+
+  it("sends an empty ref header when the action has no ref", async () => {
+    renderBar({
+      actions: [
+        action({ id: "archive", method: "patch", endpoint: "/bulk/archive", ref: null as never }),
+      ],
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+    await waitFor(() => expect(http.patch).toHaveBeenCalled());
+    const [, options] = http.patch.mock.calls[0] ?? [];
+    expect((options as { headers: Record<string, string> }).headers).not.toHaveProperty(
+      "X-Lattice-Ref",
+    );
+  });
+
+  it("submits all-matching actions with the query payload", async () => {
+    const { onCompleted } = renderBar({
+      allMatching: true,
+      query: { filter: "status:eq:active", tf: { featured: "true" } },
+      actions: [action({ id: "archive" })],
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+    await waitFor(() => expect(http.post).toHaveBeenCalled());
+    expect(http.transformer({})).toEqual({
+      allMatching: true,
+      filter: "status:eq:active",
+      tf: { featured: "true" },
+    });
+    await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not complete when the request fails", async () => {
+    runAction.mockImplementation(async () => false);
+    const { onCompleted } = renderBar({ actions: [action({ id: "archive" })] });
+
+    fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+    await waitFor(() => expect(runAction).toHaveBeenCalled());
+    expect(onCompleted).not.toHaveBeenCalled();
+  });
+
+  it("disables the action buttons and shows a spinner while processing", () => {
+    http.processing = true;
+    renderBar({ actions: [action({ id: "archive" })] });
+
+    expect(screen.getByTestId("bulk-action-archive")).toBeDisabled();
+  });
+
+  describe("confirmation flow", () => {
+    it("opens a confirm dialog with explicit confirmation values", () => {
+      renderBar({
+        actions: [
+          action({
+            id: "archive",
+            label: "Archive",
+            confirmation: {
+              title: "Archive items?",
+              description: "This cannot be undone.",
+              confirmLabel: "Yes archive",
+              cancelLabel: "No",
+            },
+          }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+      expect(screen.getByTestId("confirm-title")).toHaveTextContent("Archive items?");
+      expect(screen.getByTestId("confirm-description")).toHaveTextContent("This cannot be undone.");
+      expect(screen.getByTestId("confirm-confirm-label")).toHaveTextContent("Yes archive");
+      expect(screen.getByTestId("confirm-cancel-label")).toHaveTextContent("No");
+    });
+
+    it("falls back to the action label and defaults when confirmation fields are missing", () => {
+      renderBar({
+        actions: [
+          action({
+            id: "archive",
+            label: "Archive",
+            confirmation: {
+              title: null,
+              description: null,
+              confirmLabel: null,
+              cancelLabel: null,
+            } as never,
+          }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+      expect(screen.getByTestId("confirm-title")).toHaveTextContent("Archive");
+      expect(screen.getByTestId("confirm-description")).toHaveTextContent("(none)");
+      expect(screen.getByTestId("confirm-confirm-label")).toHaveTextContent("Archive");
+      expect(screen.getByTestId("confirm-cancel-label")).toHaveTextContent("Cancel");
+    });
+
+    it("submits and closes when the confirmation is accepted", async () => {
+      const { onCompleted } = renderBar({
+        actions: [
+          action({
+            id: "archive",
+            confirmation: {
+              title: "Sure?",
+              description: null,
+              confirmLabel: null,
+              cancelLabel: null,
+            },
+          }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-archive"));
+      fireEvent.click(screen.getByTestId("confirm-accept"));
+
+      await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.queryByTestId("confirm-dialog")).toBeNull());
+    });
+
+    it("closes without submitting when the confirmation is cancelled", () => {
+      const { onCompleted } = renderBar({
+        actions: [
+          action({
+            id: "archive",
+            confirmation: {
+              title: "Sure?",
+              description: null,
+              confirmLabel: null,
+              cancelLabel: null,
+            },
+          }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-archive"));
+      fireEvent.click(screen.getByTestId("confirm-cancel"));
+
+      expect(screen.queryByTestId("confirm-dialog")).toBeNull();
+      expect(onCompleted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("form flow", () => {
+    const formNode = { type: "form", schema: [] } as unknown as BulkAction["form"];
+
+    it("opens the action form with explicit confirmation labels and the selection payload", () => {
+      renderBar({
+        allMatching: false,
+        selectedKeys: ["9"],
+        actions: [
+          action({
+            id: "tag",
+            label: "Tag",
+            form: formNode,
+            confirmation: {
+              title: "Tag form",
+              description: "Pick a tag",
+              confirmLabel: "Apply",
+              cancelLabel: "Dismiss",
+            },
+          }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-tag"));
+
+      expect(screen.getByTestId("form-title")).toHaveTextContent("Tag form");
+      expect(screen.getByTestId("form-description")).toHaveTextContent("Pick a tag");
+      expect(screen.getByTestId("form-submit-label")).toHaveTextContent("Apply");
+      expect(screen.getByTestId("form-cancel-label")).toHaveTextContent("Dismiss");
+      expect(screen.getByTestId("form-extra")).toHaveTextContent(
+        JSON.stringify({ selected: ["9"] }),
+      );
+    });
+
+    it("falls back to the action label and defaults when the form has no confirmation", () => {
+      renderBar({
+        actions: [action({ id: "tag", label: "Tag", form: formNode, confirmation: null })],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-tag"));
+
+      expect(screen.getByTestId("form-title")).toHaveTextContent("Tag");
+      expect(screen.getByTestId("form-description")).toHaveTextContent("(none)");
+      expect(screen.getByTestId("form-submit-label")).toHaveTextContent("Tag");
+      expect(screen.getByTestId("form-cancel-label")).toHaveTextContent("Cancel");
+    });
+
+    it("dispatches effects, closes and completes on form success", async () => {
+      const { onCompleted } = renderBar({
+        actions: [action({ id: "tag", form: formNode, confirmation: null })],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-tag"));
+      fireEvent.click(screen.getByTestId("form-success"));
+
+      expect(getActionEffects).toHaveBeenCalledWith([{ type: "reloadPage" }]);
+      expect(dispatch).toHaveBeenCalledWith([{ type: "reloadPage" }]);
+      await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
+      expect(screen.queryByTestId("action-form")).toBeNull();
+    });
+
+    it("closes the form without completing on cancel", () => {
+      const { onCompleted } = renderBar({
+        actions: [action({ id: "tag", form: formNode, confirmation: null })],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-tag"));
+      fireEvent.click(screen.getByTestId("form-close"));
+
+      expect(screen.queryByTestId("action-form")).toBeNull();
+      expect(onCompleted).not.toHaveBeenCalled();
+    });
+
+    it("uses the all-matching payload as the form extra data", () => {
+      renderBar({
+        allMatching: true,
+        query: { filter: "status:eq:active" },
+        actions: [action({ id: "tag", form: formNode, confirmation: null })],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-tag"));
+
+      expect(screen.getByTestId("form-extra")).toHaveTextContent(
+        JSON.stringify({ allMatching: true, filter: "status:eq:active" }),
+      );
+    });
+  });
+});

--- a/resources/js/table/components/column-filter-control.test.tsx
+++ b/resources/js/table/components/column-filter-control.test.tsx
@@ -1,0 +1,499 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ColumnFilter, Op } from "@lattice-php/lattice/types/generated";
+import type { FilterClause, TableColumn } from "../types";
+import { ColumnFilterControl } from "./column-filter-control";
+
+function textFilter(overrides: Partial<ColumnFilter> = {}): ColumnFilter {
+  return {
+    enabled: true,
+    type: "text",
+    operators: ["eq", "neq", "contains", "empty"],
+    defaultOperator: "eq",
+    control: null,
+    options: [],
+    multiple: false,
+    searchable: false,
+    clauseOptions: [],
+    ...overrides,
+  };
+}
+
+function col(filter: ColumnFilter | null): TableColumn {
+  return {
+    key: "name",
+    label: "Name",
+    type: "column.text",
+    width: "md",
+    sortable: null,
+    filter,
+    columns: null,
+    props: null,
+    align: "start",
+  };
+}
+
+function clause(operator: Op, value: string): FilterClause {
+  return { field: "name", operator, value };
+}
+
+type Handlers = {
+  onAdd: ReturnType<typeof vi.fn<(clause: FilterClause) => void>>;
+  onUpdate: ReturnType<typeof vi.fn<(index: number, clause: FilterClause) => void>>;
+  onRemove: ReturnType<typeof vi.fn<(index: number) => void>>;
+  onReplace: ReturnType<typeof vi.fn<(field: string, clauses: FilterClause[]) => void>>;
+};
+
+function handlers(): Handlers {
+  return {
+    onAdd: vi.fn<(clause: FilterClause) => void>(),
+    onUpdate: vi.fn<(index: number, clause: FilterClause) => void>(),
+    onRemove: vi.fn<(index: number) => void>(),
+    onReplace: vi.fn<(field: string, clauses: FilterClause[]) => void>(),
+  };
+}
+
+function renderControl(
+  column: TableColumn,
+  clauses: { clause: FilterClause; index: number }[],
+  h: Handlers,
+  processing = false,
+) {
+  return render(
+    <ColumnFilterControl
+      column={column}
+      clauses={clauses}
+      processing={processing}
+      onAdd={h.onAdd}
+      onUpdate={h.onUpdate}
+      onRemove={h.onRemove}
+      onReplace={h.onReplace}
+    />,
+  );
+}
+
+describe("ColumnFilterControl", () => {
+  it("renders nothing when the column has no filter", () => {
+    const h = handlers();
+    const { container } = renderControl(col(null), [], h);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("delegates select-control columns to the select filter", () => {
+    const h = handlers();
+    renderControl(col(textFilter({ control: "select" })), [], h);
+
+    expect(screen.queryByRole("button", { name: "Name filters" })).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Name" })).toBeInTheDocument();
+  });
+
+  describe("select control", () => {
+    function selectFilter(overrides: Partial<ColumnFilter> = {}): ColumnFilter {
+      return textFilter({
+        control: "select",
+        operators: ["eq", "neq"],
+        defaultOperator: "eq",
+        options: [
+          { label: "Active", value: "active" },
+          { label: "Draft", value: "draft" },
+        ],
+        clauseOptions: [],
+        ...overrides,
+      });
+    }
+
+    it("defaults clause options to empty when the filter omits them", () => {
+      const h = handlers();
+      const filter = selectFilter({
+        clauseOptions: undefined as unknown as ColumnFilter["clauseOptions"],
+      });
+
+      renderControl(col(filter), [], h);
+
+      fireEvent.change(screen.getByRole("combobox", { name: "Name" }), {
+        target: { value: "active" },
+      });
+
+      expect(h.onReplace).toHaveBeenCalledWith("name", [
+        { field: "name", operator: "eq", value: "active" },
+      ]);
+    });
+
+    it("clears all clauses when the selection is emptied", () => {
+      const h = handlers();
+      renderControl(col(selectFilter()), [{ clause: clause("eq", "active"), index: 0 }], h);
+
+      fireEvent.change(screen.getByRole("combobox", { name: "Name" }), { target: { value: "" } });
+
+      expect(h.onReplace).toHaveBeenCalledWith("name", []);
+    });
+
+    it("emits a single clause for a plain selection", () => {
+      const h = handlers();
+      renderControl(col(selectFilter()), [], h);
+
+      fireEvent.change(screen.getByRole("combobox", { name: "Name" }), {
+        target: { value: "active" },
+      });
+
+      expect(h.onReplace).toHaveBeenCalledWith("name", [
+        { field: "name", operator: "eq", value: "active" },
+      ]);
+    });
+
+    it("expands a clause option into its underlying clauses", () => {
+      const h = handlers();
+      const filter = selectFilter({
+        options: [{ label: "Unset", value: "unset" }],
+        clauseOptions: [
+          { label: "Unset", value: "unset", clauses: [{ operator: "empty", value: "" }] },
+        ],
+      });
+
+      renderControl(col(filter), [], h);
+
+      fireEvent.change(screen.getByRole("combobox", { name: "Name" }), {
+        target: { value: "unset" },
+      });
+
+      expect(h.onReplace).toHaveBeenCalledWith("name", [
+        { field: "name", operator: "empty", value: "" },
+      ]);
+    });
+
+    it("reflects the active clause-option as the current selection", () => {
+      const h = handlers();
+      const filter = selectFilter({
+        options: [{ label: "Unset", value: "unset" }],
+        clauseOptions: [
+          { label: "Unset", value: "unset", clauses: [{ operator: "empty", value: "" }] },
+        ],
+      });
+
+      renderControl(col(filter), [{ clause: clause("empty", ""), index: 0 }], h);
+
+      expect(screen.getByRole("combobox", { name: "Name" })).toHaveValue("unset");
+    });
+
+    it("reflects a plain active clause as the current selection", () => {
+      const h = handlers();
+      renderControl(col(selectFilter()), [{ clause: clause("eq", "draft"), index: 0 }], h);
+
+      expect(screen.getByRole("combobox", { name: "Name" })).toHaveValue("draft");
+    });
+
+    it("derives a multi-select value from the comma-joined clause value", () => {
+      const h = handlers();
+      const filter = selectFilter({
+        operators: ["in", "not_in"],
+        defaultOperator: "in",
+        multiple: true,
+      });
+
+      renderControl(col(filter), [{ clause: clause("in", "active,draft"), index: 0 }], h);
+
+      fireEvent.click(screen.getByRole("button", { name: "Name" }));
+
+      expect(screen.getByRole("checkbox", { name: "Active" })).toBeChecked();
+      expect(screen.getByRole("checkbox", { name: "Draft" })).toBeChecked();
+    });
+
+    it("serializes a multi-select array selection into a comma-joined clause", () => {
+      const h = handlers();
+      const filter = selectFilter({
+        operators: ["in", "not_in"],
+        defaultOperator: "in",
+        multiple: true,
+      });
+
+      renderControl(col(filter), [], h);
+
+      fireEvent.click(screen.getByRole("button", { name: "Name" }));
+      fireEvent.click(screen.getByRole("checkbox", { name: "Active" }));
+
+      expect(h.onReplace).toHaveBeenCalledWith("name", [
+        { field: "name", operator: "in", value: "active" },
+      ]);
+    });
+
+    it("treats an empty multi-select clause as no selection", () => {
+      const h = handlers();
+      const filter = selectFilter({
+        operators: ["in", "not_in"],
+        defaultOperator: "in",
+        multiple: true,
+      });
+
+      renderControl(col(filter), [], h);
+
+      fireEvent.click(screen.getByRole("button", { name: "Name" }));
+
+      expect(screen.getByRole("checkbox", { name: "Active" })).not.toBeChecked();
+    });
+  });
+
+  it("adds a new clause when committing a value with no primary clause", () => {
+    const h = handlers();
+    renderControl(col(textFilter()), [], h);
+
+    const input = screen.getByTestId("filter-name-value");
+    fireEvent.change(input, { target: { value: "ada" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(h.onAdd).toHaveBeenCalledWith({ field: "name", operator: "eq", value: "ada" });
+    expect(h.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("updates the primary clause when committing a new value", () => {
+    const h = handlers();
+    renderControl(col(textFilter()), [{ clause: clause("eq", "old"), index: 2 }], h);
+
+    const input = screen.getByTestId("filter-name-value");
+    fireEvent.change(input, { target: { value: "new" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(h.onUpdate).toHaveBeenCalledWith(2, { field: "name", operator: "eq", value: "new" });
+    expect(h.onAdd).not.toHaveBeenCalled();
+  });
+
+  it("removes the primary clause when its value is cleared to empty", () => {
+    const h = handlers();
+    renderControl(col(textFilter()), [{ clause: clause("eq", "old"), index: 5 }], h);
+
+    fireEvent.click(screen.getByTestId("filter-name-value-clear"));
+
+    expect(h.onRemove).toHaveBeenCalledWith(5);
+  });
+
+  it("falls back to the first clause when none match the default operator", () => {
+    const h = handlers();
+    renderControl(col(textFilter()), [{ clause: clause("neq", "x"), index: 3 }], h);
+
+    expect(screen.getByTestId("filter-name-value")).toHaveValue("x");
+  });
+
+  it("falls back to the text type and the eq operator when the filter omits both", () => {
+    const h = handlers();
+    renderControl(
+      col(
+        textFilter({
+          type: undefined as unknown as ColumnFilter["type"],
+          operators: undefined as unknown as Op[],
+          defaultOperator: undefined as unknown as Op,
+        }),
+      ),
+      [],
+      h,
+    );
+
+    const input = screen.getByTestId("filter-name-value");
+    expect(input).toHaveAttribute("type", "text");
+
+    fireEvent.change(input, { target: { value: "z" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(h.onAdd).toHaveBeenCalledWith({ field: "name", operator: "eq", value: "z" });
+
+    fireEvent.click(screen.getByTestId("filter-name"));
+
+    expect(screen.getByLabelText("Name filter value")).toHaveAttribute("type", "text");
+  });
+
+  it("renders a number input for a number-typed filter", () => {
+    const h = handlers();
+    renderControl(col(textFilter({ type: "number" })), [], h);
+
+    expect(screen.getByTestId("filter-name-value")).toHaveAttribute("type", "number");
+  });
+
+  it("does nothing when an empty value is committed with no primary clause", () => {
+    const h = handlers();
+    renderControl(col(textFilter()), [], h);
+
+    const input = screen.getByTestId("filter-name-value");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(h.onRemove).not.toHaveBeenCalled();
+    expect(h.onAdd).not.toHaveBeenCalled();
+    expect(h.onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("uses the first operator as default when no defaultOperator is configured", () => {
+    const h = handlers();
+    renderControl(col(textFilter({ defaultOperator: undefined as unknown as Op })), [], h);
+
+    const input = screen.getByTestId("filter-name-value");
+    fireEvent.change(input, { target: { value: "z" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(h.onAdd).toHaveBeenCalledWith({ field: "name", operator: "eq", value: "z" });
+  });
+
+  it("shows a count badge reflecting the number of active clauses", () => {
+    const h = handlers();
+    renderControl(
+      col(textFilter()),
+      [
+        { clause: clause("eq", "a"), index: 0 },
+        { clause: clause("neq", "b"), index: 1 },
+      ],
+      h,
+    );
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("disables the trigger and inputs while processing", () => {
+    const h = handlers();
+    renderControl(col(textFilter()), [], h, true);
+
+    expect(screen.getByTestId("filter-name")).toBeDisabled();
+  });
+
+  describe("clause list popover", () => {
+    function openPopover() {
+      fireEvent.click(screen.getByTestId("filter-name"));
+    }
+
+    it("renders an operator select for existing clauses and updates the operator", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [{ clause: clause("eq", "a"), index: 0 }], h);
+
+      openPopover();
+
+      const operator = screen.getByTestId("filter-name-operator");
+      fireEvent.change(operator, { target: { value: "neq" } });
+
+      expect(h.onUpdate).toHaveBeenCalledWith(0, { field: "name", operator: "neq", value: "a" });
+    });
+
+    it("removes an existing clause when its value is emptied", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [{ clause: clause("eq", "a"), index: 0 }], h);
+
+      openPopover();
+
+      const valueInputs = screen.getAllByLabelText("Name filter value");
+      fireEvent.change(valueInputs[0], { target: { value: "" } });
+      fireEvent.blur(valueInputs[0]);
+
+      expect(h.onRemove).toHaveBeenCalledWith(0);
+    });
+
+    it("updates an existing clause when its value changes", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [{ clause: clause("eq", "a"), index: 0 }], h);
+
+      openPopover();
+
+      const valueInputs = screen.getAllByLabelText("Name filter value");
+      fireEvent.change(valueInputs[0], { target: { value: "b" } });
+      fireEvent.blur(valueInputs[0]);
+
+      expect(h.onUpdate).toHaveBeenCalledWith(0, { field: "name", operator: "eq", value: "b" });
+    });
+
+    it("removes an existing clause via the trash button", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [{ clause: clause("eq", "a"), index: 4 }], h);
+
+      openPopover();
+
+      fireEvent.click(screen.getByTestId("filter-name-remove"));
+
+      expect(h.onRemove).toHaveBeenCalledWith(4);
+    });
+
+    it("renders a static operator label when only one operator is allowed", () => {
+      const h = handlers();
+      renderControl(
+        col(textFilter({ operators: ["eq"], defaultOperator: "eq" })),
+        [{ clause: clause("eq", "a"), index: 0 }],
+        h,
+      );
+
+      openPopover();
+
+      expect(screen.queryByTestId("filter-name-operator")).not.toBeInTheDocument();
+    });
+
+    it("starts in adding mode when there are no clauses and adds on value commit", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [], h);
+
+      openPopover();
+
+      const valueInput = screen.getByLabelText("Name filter value");
+      fireEvent.change(valueInput, { target: { value: "draft" } });
+      fireEvent.blur(valueInput);
+
+      expect(h.onAdd).toHaveBeenCalledWith({ field: "name", operator: "eq", value: "draft" });
+    });
+
+    it("ignores an empty value commit while adding", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [], h);
+
+      openPopover();
+
+      const valueInput = screen.getByLabelText("Name filter value");
+      fireEvent.focus(valueInput);
+      fireEvent.blur(valueInput);
+
+      expect(h.onAdd).not.toHaveBeenCalled();
+    });
+
+    it("immediately adds a valueless clause when its operator is chosen while adding", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [], h);
+
+      openPopover();
+
+      const operator = screen.getByTestId("filter-name-operator");
+      fireEvent.change(operator, { target: { value: "empty" } });
+
+      expect(h.onAdd).toHaveBeenCalledWith({ field: "name", operator: "empty", value: "" });
+    });
+
+    it("keeps the draft operator when a value-bearing operator is chosen while adding", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [], h);
+
+      openPopover();
+
+      const operator = screen.getByTestId("filter-name-operator");
+      fireEvent.change(operator, { target: { value: "contains" } });
+
+      expect(h.onAdd).not.toHaveBeenCalled();
+
+      const valueInput = screen.getByLabelText("Name filter value");
+      fireEvent.change(valueInput, { target: { value: "foo" } });
+      fireEvent.blur(valueInput);
+
+      expect(h.onAdd).toHaveBeenCalledWith({ field: "name", operator: "contains", value: "foo" });
+    });
+
+    it("does not render a value input for a valueless existing clause", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [{ clause: clause("empty", ""), index: 0 }], h);
+
+      openPopover();
+
+      expect(screen.queryByLabelText("Name filter value")).not.toBeInTheDocument();
+    });
+
+    it("opens a fresh adding row via the add button", () => {
+      const h = handlers();
+      renderControl(col(textFilter()), [{ clause: clause("eq", "a"), index: 0 }], h);
+
+      openPopover();
+
+      expect(screen.getAllByLabelText("Name filter value")).toHaveLength(1);
+
+      fireEvent.click(screen.getByTestId("filter-name-add"));
+
+      expect(screen.getAllByLabelText("Name filter value")).toHaveLength(2);
+    });
+  });
+});

--- a/resources/js/table/format.test.ts
+++ b/resources/js/table/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatCell, preciseDateTime } from "./format";
+import type { TableColumn, TableRow } from "./types";
+import { formatCell, formatDateValue, preciseDateTime, resolveLink } from "./format";
 
 const dateColumn = {
   key: "created",
@@ -40,5 +41,82 @@ describe("preciseDateTime", () => {
 
   it("returns an empty string for an invalid value", () => {
     expect(preciseDateTime("not-a-date", { timeZone: "UTC" })).toBe("");
+  });
+});
+
+describe("formatCell primitives", () => {
+  it("returns an empty string for null and undefined", () => {
+    expect(formatCell(null)).toBe("");
+    expect(formatCell(undefined)).toBe("");
+  });
+
+  it("stringifies primitives directly", () => {
+    expect(formatCell("hello")).toBe("hello");
+    expect(formatCell(42)).toBe("42");
+    expect(formatCell(true)).toBe("true");
+  });
+
+  it("JSON-encodes non-primitive values", () => {
+    expect(formatCell({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe("formatDateValue", () => {
+  it("returns the raw value when the date cannot be parsed", () => {
+    expect(formatDateValue("not-a-date", { dateStyle: "medium", timeStyle: null })).toBe(
+      "not-a-date",
+    );
+  });
+
+  it("applies only the styles that are configured", () => {
+    const dateOnly = formatDateValue(
+      "2026-06-18T00:30:00Z",
+      { dateStyle: "short", timeStyle: null },
+      {
+        locale: "en-GB",
+        timeZone: "UTC",
+      },
+    );
+    const timeOnly = formatDateValue(
+      "2026-06-18T00:30:00Z",
+      { dateStyle: null, timeStyle: "short" },
+      {
+        locale: "en-GB",
+        timeZone: "UTC",
+      },
+    );
+
+    expect(dateOnly).toContain("2026");
+    expect(timeOnly).toContain("00:30");
+  });
+});
+
+describe("resolveLink", () => {
+  const column = (link: unknown): TableColumn =>
+    ({ key: "name", label: "Name", props: { link } }) as never;
+  const row: TableRow = { id: 7, name: "Ada" } as never;
+
+  it("returns null when the column has no link", () => {
+    expect(resolveLink(column(null), row, "Ada")).toBeNull();
+  });
+
+  it("returns null when the resolved href is empty", () => {
+    expect(resolveLink(column({ href: null }), row, "")).toBeNull();
+  });
+
+  it("interpolates the value and row tokens into the href", () => {
+    expect(resolveLink(column({ href: "/users/{id}?q={value}" }), row, "Ada & Co")).toBe(
+      "/users/7?q=Ada%20%26%20Co",
+    );
+  });
+
+  it("coerces missing row tokens to an empty string", () => {
+    expect(resolveLink(column({ href: "/x/{missing}" }), row, "v")).toBe("/x/");
+  });
+
+  it("falls back to the cell value when no explicit href is set", () => {
+    expect(resolveLink(column({ href: null }), row, "https://example.test")).toBe(
+      "https://example.test",
+    );
   });
 });


### PR DESCRIPTION
## What & why

Codecov's `vitest` flag was reporting ~81%, well below the backend's ~95%. That number is **branch-inclusive** coverage — the real gap was uncovered branches, plus a handful of components/utilities only exercised by Pest browser tests (which don't instrument JS) and so invisible to Codecov.

This PR adds and extends **vitest unit tests only** (no production code touched) to close those gaps.

## Coverage progression (local lcov)

| Metric | Before | After |
|---|---|---|
| **Branches** (Codecov's number) | 81.97% | **87.30%** |
| Lines | 90.01% | 93.30% |
| Statements | 89.84% | 93.05% |
| Functions | 89.08% | 91.51% |

## What was added

- **Zero/near-zero files:** heading, grid, submit-button, clipboard, i18n backend, realtime listeners/subscriptions.
- **Partial-branch flips** on already-executed lines: conditions, table format (+`resolveLink`), form paths, number-input, segmented-control/pills, modal.
- **High-miss table internals:** bulk-action bar + builder, column filter control, and the column-resizing hook (pointer/keyboard paths, clamping, storage sanitisation).

## Notes

- All 804 vitest tests pass; full JS gate green (oxlint, tsc, type-coverage 99.82%, library build).
- We landed at **87.3% branches** rather than the 90% target — a deliberate stopping point. The remaining path to 90% is the larger table/form components (`use-table`, `builder`/`repeater`, `data-list`, `action-form`, `tabs`/`section`, `sidebar`) and two heavier hooks (`use-form-resolver`, `use-controlled-field`), which can follow up.