### PR TITLE
feat(context)!: own context on the definition instance, symmetric across render and endpoints

### DIFF
--- a/resources/js/core/use-column-resizing.test.tsx
+++ b/resources/js/core/use-column-resizing.test.tsx
@@ -387,29 +387,6 @@ describe("useColumnResizing", () => {
     expect(screen.getByRole("separator", { name: "Resize sku" })).toBeInTheDocument();
   });
 
-  it("measures fixed px tracks when capping the grid width", () => {
-    render(
-      <Harness
-        hookColumns={twoColumns}
-        leadingTracks={["40px"]}
-        trailingTracks={["unset"]}
-        columnGapPx={0}
-      />,
-    );
-
-    const grid = screen.getByTestId("grid");
-    const handle = screen.getByRole("separator", { name: "Resize Qty" });
-
-    vi.spyOn(grid, "getBoundingClientRect").mockReturnValue(rect(400));
-
-    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
-    fireEvent.pointerMove(handle, { clientX: 1000, pointerId: 1 });
-
-    expect(grid).toHaveStyle({
-      gridTemplateColumns: "40px 232px minmax(8rem, 1fr) unset",
-    });
-  });
-
   it("ignores stored overrides that are not finite numbers", () => {
     window.localStorage.setItem(
       "lattice:table-columns:orders",
@@ -429,31 +406,5 @@ describe("useColumnResizing", () => {
 
     expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "minmax(6rem, 0.5fr)" });
     expect(window.localStorage.getItem("lattice:table-columns:orders")).toBeNull();
-  });
-
-  it("falls back to a 16px root font size when the computed value is non-positive", () => {
-    render(<Harness hookColumns={twoColumns} leadingTracks={["1rem"]} columnGapPx={0} />);
-
-    const grid = screen.getByTestId("grid");
-    const handle = screen.getByRole("separator", { name: "Resize Qty" });
-
-    vi.spyOn(grid, "getBoundingClientRect").mockReturnValue(rect(400));
-    const realComputedStyle = window.getComputedStyle.bind(window);
-    const computed = vi
-      .spyOn(window, "getComputedStyle")
-      .mockImplementation((element: Element, pseudo?: string | null) =>
-        element === document.documentElement
-          ? ({ fontSize: "0px" } as never)
-          : realComputedStyle(element, pseudo),
-      );
-
-    fireEvent.pointerDown(handle, { clientX: 0, pointerId: 1 });
-    fireEvent.pointerMove(handle, { clientX: 1000, pointerId: 1 });
-
-    expect(grid).toHaveStyle({
-      gridTemplateColumns: "1rem 256px minmax(8rem, 1fr)",
-    });
-
-    computed.mockRestore();
   });
 });

--- a/src/Actions/ActionRegistry.php
+++ b/src/Actions/ActionRegistry.php
@@ -15,14 +15,17 @@ final class ActionRegistry extends DefinitionRegistry
 {
     /**
      * @param  class-string<ActionDefinition>  $action
+     * @param  array<string, mixed>  $context
      */
-    public function component(string $action): ActionComponent
+    public function component(string $action, array $context = []): ActionComponent
     {
         $key = $this->registeredKeyFor($action);
 
-        $definition = $this->make($action);
+        $definition = $this->make($action)->withContext($context);
 
         $component = $definition->definition(ActionComponent::make($key))
+            ->signedAs($key)
+            ->context($context)
             ->endpoint($this->endpointFor($key));
 
         if ($definition instanceof FormActionDefinition) {

--- a/src/Actions/BulkActionRegistry.php
+++ b/src/Actions/BulkActionRegistry.php
@@ -16,13 +16,17 @@ final class BulkActionRegistry extends DefinitionRegistry
 {
     /**
      * @param  class-string<BulkActionDefinition>  $bulkAction
+     * @param  array<string, mixed>  $context
      */
-    public function component(string $bulkAction): ActionComponent
+    public function component(string $bulkAction, array $context = []): ActionComponent
     {
         $key = $this->registeredKeyFor($bulkAction);
 
         return $this->make($bulkAction)
+            ->withContext($context)
             ->definition(BulkActionComponent::make($key))
+            ->signedAs($key)
+            ->context($context)
             ->endpoint($this->endpointFor($key));
     }
 

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -46,11 +46,12 @@ class Action extends Component
 
     /**
      * @param  class-string<ActionDefinition>  $action
+     * @param  array<string, mixed>  $context
      */
-    public static function use(string $action): static
+    public static function use(string $action, array $context = []): static
     {
         /** @var static $registered */
-        $registered = app(ActionRegistry::class)->component($action);
+        $registered = app(ActionRegistry::class)->component($action, $context);
 
         return clone $registered;
     }

--- a/src/Actions/Components/BulkAction.php
+++ b/src/Actions/Components/BulkAction.php
@@ -12,12 +12,13 @@ class BulkAction extends Action
 {
     /**
      * @param  class-string<BulkActionDefinition>  $action
+     * @param  array<string, mixed>  $context
      */
     #[\Override]
-    public static function use(string $action): static
+    public static function use(string $action, array $context = []): static
     {
         /** @var static $registered */
-        $registered = app(BulkActionRegistry::class)->component($action);
+        $registered = app(BulkActionRegistry::class)->component($action, $context);
 
         return clone $registered;
     }

--- a/src/Core/Components/IsInteractive.php
+++ b/src/Core/Components/IsInteractive.php
@@ -11,6 +11,13 @@ trait IsInteractive
 {
     protected ?string $id = null;
 
+    /**
+     * The key the reference is sealed under (the registered definition slug).
+     * Defaults to the id, so the DOM id can vary freely per instance while the
+     * sealed key still matches the endpoint slug.
+     */
+    protected ?string $signatureKey = null;
+
     /** @var array<string, mixed> */
     protected array $context = [];
 
@@ -23,6 +30,16 @@ trait IsInteractive
     public function id(string $id): static
     {
         $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Set the key the reference is sealed under (the registered definition slug).
+     */
+    public function signedAs(string $signatureKey): static
+    {
+        $this->signatureKey = $signatureKey;
 
         return $this;
     }
@@ -66,7 +83,7 @@ trait IsInteractive
                 ));
             }
 
-            $props['ref'] = app(SignsComponentReferences::class)->seal($this->type(), $this->id, $this->context);
+            $props['ref'] = app(SignsComponentReferences::class)->seal($this->type(), $this->signatureKey ?? $this->id, $this->context);
         }
 
         return $props;

--- a/src/Core/Concerns/HasOptions.php
+++ b/src/Core/Concerns/HasOptions.php
@@ -43,4 +43,14 @@ trait HasOptions
     {
         return $this->options($enum);
     }
+
+    /**
+     * The configured option values.
+     *
+     * @return list<string>
+     */
+    public function optionValues(): array
+    {
+        return array_map(static fn (Option $option): string => $option->value, $this->options);
+    }
 }

--- a/src/Core/Concerns/InteractsWithComponents.php
+++ b/src/Core/Concerns/InteractsWithComponents.php
@@ -15,7 +15,7 @@ trait InteractsWithComponents
      * @template TDefinition of Definition
      *
      * @param  DefinitionRegistry<TDefinition>  $registry
-     * @return array{0: Request, 1: TDefinition}
+     * @return array{0: Request, 1: TDefinition, 2: array<string, mixed>}
      */
     protected function authorizeComponent(
         Request $request,
@@ -24,16 +24,16 @@ trait InteractsWithComponents
         string $type,
         string $key,
     ): array {
-        $request = $references->mergeTrustedContext($request, $type, $key);
+        $context = $references->trustedContext($request, $type, $key);
 
         try {
-            $definition = $registry->resolve($key);
+            $definition = $registry->resolve($key)->withContext($context);
         } catch (UnknownComponent) {
             abort(404);
         }
 
         abort_unless($definition->authorize($request), 403);
 
-        return [$request, $definition];
+        return [$request, $definition, $context];
     }
 }

--- a/src/Core/Contracts/SignsComponentReferences.php
+++ b/src/Core/Contracts/SignsComponentReferences.php
@@ -12,8 +12,6 @@ interface SignsComponentReferences
      */
     public function seal(string $type, string $key, array $context): string;
 
-    public function mergeTrustedContext(Request $request, string $type, string $key): Request;
-
     /**
      * @return array<string, mixed>
      */

--- a/src/Core/Definition.php
+++ b/src/Core/Definition.php
@@ -8,13 +8,31 @@ use Lattice\Lattice\Core\Contracts\Authorizable;
 
 abstract class Definition implements Authorizable
 {
+    /**
+     * The instance context, set identically on render (by the registry) and on
+     * the endpoint (by the controller, from the sealed reference).
+     *
+     * @var array<string, mixed>
+     */
+    protected array $context = [];
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function withContext(array $context): static
+    {
+        $this->context = $context;
+
+        return $this;
+    }
+
     public function authorize(Request $request): bool
     {
         return true;
     }
 
-    protected function context(Request $request, string $key, mixed $default = null): mixed
+    protected function context(string $key, mixed $default = null): mixed
     {
-        return data_get($request->input('context', []), $key, $default);
+        return data_get($this->context, $key, $default);
     }
 }

--- a/src/Core/Services/ComponentReferenceSigner.php
+++ b/src/Core/Services/ComponentReferenceSigner.php
@@ -74,15 +74,6 @@ final readonly class ComponentReferenceSigner implements SignsComponentReference
         return is_array($payload['context'] ?? null) ? $payload['context'] : [];
     }
 
-    public function mergeTrustedContext(Request $request, string $type, string $key): Request
-    {
-        $request->merge([
-            'context' => $this->trustedContext($request, $type, $key),
-        ]);
-
-        return $request;
-    }
-
     /**
      * @return array<string, mixed>
      */

--- a/src/Forms/Components/Choice.php
+++ b/src/Forms/Components/Choice.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Forms\Components;
 
+use Illuminate\Validation\Rule;
 use Lattice\Lattice\Core\Concerns\HasAutoFocus;
 use Lattice\Lattice\Core\Concerns\HasOptions;
 use Lattice\Lattice\Core\Concerns\HasTabIndex;
@@ -15,4 +16,21 @@ class Choice extends Field
     use HasAutoFocus;
     use HasOptions;
     use HasTabIndex;
+
+    /**
+     * A choice is always backed by a fixed set of options, so its submitted
+     * value is constrained to them automatically. `nullable` lets an optional
+     * choice stay unselected; `required()` still gates presence when set.
+     *
+     * @return array<int, mixed>
+     */
+    #[\Override]
+    protected function defaultRules(): array
+    {
+        if ($this->options === []) {
+            return [];
+        }
+
+        return ['nullable', Rule::in($this->optionValues())];
+    }
 }

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -195,6 +195,18 @@ abstract class Field extends Component
     }
 
     /**
+     * Rules the field contributes intrinsically, before any added via rules().
+     * Overridden by fields with a built-in constraint (e.g. a Choice limiting
+     * its value to the configured options).
+     *
+     * @return array<int, mixed>
+     */
+    protected function defaultRules(): array
+    {
+        return [];
+    }
+
+    /**
      * @internal
      *
      * @return array<int, mixed>
@@ -202,7 +214,7 @@ abstract class Field extends Component
     public function resolveRules(FormData $data, Request $request): array
     {
         $context = $this->evaluationContext($data, $request);
-        $resolved = [];
+        $resolved = $this->defaultRules();
 
         foreach ($this->rules as $rule) {
             if ($rule instanceof Closure) {

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -62,11 +62,12 @@ class Form extends ContainerComponent
 
     /**
      * @param  class-string<FormDefinition>  $form
+     * @param  array<string, mixed>  $context
      */
-    public static function use(string $form): static
+    public static function use(string $form, array $context = []): static
     {
         /** @var static $registered */
-        $registered = app(FormRegistry::class)->component($form);
+        $registered = app(FormRegistry::class)->component($form, $context);
 
         return clone $registered;
     }

--- a/src/Forms/FormRegistry.php
+++ b/src/Forms/FormRegistry.php
@@ -16,13 +16,17 @@ final class FormRegistry extends DefinitionRegistry
 {
     /**
      * @param  class-string<FormDefinition>  $form
+     * @param  array<string, mixed>  $context
      */
-    public function component(string $form): FormComponent
+    public function component(string $form, array $context = []): FormComponent
     {
         $key = $this->registeredKeyFor($form);
 
+        $component = FormComponent::make($key)->signedAs($key)->context($context);
+
         return $this->make($form)
-            ->definition(FormComponent::make($key), $this->container->make(Request::class))
+            ->withContext($context)
+            ->definition($component, $this->container->make(Request::class))
             ->action($this->endpointFor($key))
             ->errorBag($this->errorBagFor($key));
     }

--- a/src/Fragments/Components/Fragment.php
+++ b/src/Fragments/Components/Fragment.php
@@ -28,10 +28,11 @@ class Fragment extends ContainerComponent
 
     /**
      * @param  class-string<FragmentDefinition>  $fragment
+     * @param  array<string, mixed>  $context
      */
-    public static function lazy(string $fragment): self
+    public static function lazy(string $fragment, array $context = []): self
     {
-        return app(FragmentRegistry::class)->lazyComponent($fragment);
+        return app(FragmentRegistry::class)->lazyComponent($fragment, $context);
     }
 
     public function endpoint(string $endpoint): static

--- a/src/Fragments/FragmentRegistry.php
+++ b/src/Fragments/FragmentRegistry.php
@@ -17,12 +17,15 @@ final class FragmentRegistry extends DefinitionRegistry
 {
     /**
      * @param  class-string<FragmentDefinition>  $fragment
+     * @param  array<string, mixed>  $context
      */
-    public function lazyComponent(string $fragment): FragmentComponent
+    public function lazyComponent(string $fragment, array $context = []): FragmentComponent
     {
         $key = $this->registeredKeyFor($fragment);
 
         $component = FragmentComponent::make($key)
+            ->signedAs($key)
+            ->context($context)
             ->endpoint($this->endpointFor($key));
 
         $component->lazy = true;

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -32,7 +32,7 @@ final readonly class BulkActionController
     {
         $this->markPrecognitive($request);
 
-        [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->bulkActions, 'bulkAction', $bulkAction);
+        [$request, $definition, $context] = $this->authorizeComponent($request, $this->references, $this->bulkActions, 'bulkAction', $bulkAction);
 
         if (($response = $this->formSubRequest($request, $definition)) instanceof Response) {
             return $response;
@@ -42,8 +42,8 @@ final readonly class BulkActionController
             return $this->validatePrecognitive($request, fn () => $definition->validate($request));
         }
 
-        $tableKey = $this->trustedTableKey($request);
-        $table = $this->resolveTable($tableKey);
+        $tableKey = $this->trustedTableKey($context);
+        $table = $this->resolveTable($tableKey)->withContext($context);
 
         abort_unless($table->authorize($request), 403);
 
@@ -74,9 +74,12 @@ final readonly class BulkActionController
         return $source->resolveSelection($this->selectedKeys($request));
     }
 
-    private function trustedTableKey(Request $request): string
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function trustedTableKey(array $context): string
     {
-        $key = data_get($request->input('context', []), 'table');
+        $key = data_get($context, 'table');
 
         abort_unless(is_string($key), 422);
 

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -69,22 +69,24 @@ class Table extends Component
 
     /**
      * @param  class-string<TableDefinition>  $table
+     * @param  array<string, mixed>  $context
      */
-    public static function use(string $table): static
+    public static function use(string $table, array $context = []): static
     {
         /** @var static $registered */
-        $registered = app(TableRegistry::class)->component($table);
+        $registered = app(TableRegistry::class)->component($table, $context);
 
         return clone $registered;
     }
 
     /**
      * @param  class-string<TableDefinition>  $table
+     * @param  array<string, mixed>  $context
      */
-    public static function lazy(string $table): static
+    public static function lazy(string $table, array $context = []): static
     {
         /** @var static $registered */
-        $registered = app(TableRegistry::class)->lazyComponent($table);
+        $registered = app(TableRegistry::class)->lazyComponent($table, $context);
 
         return clone $registered;
     }

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -26,24 +26,28 @@ final class TableRegistry extends DefinitionRegistry
 
     /**
      * @param  class-string<TableDefinition>  $table
+     * @param  array<string, mixed>  $context
      */
-    public function component(string $table): TableComponent
+    public function component(string $table, array $context = []): TableComponent
     {
         return $this->buildComponent(
             $table,
             fn (TableDefinition $definition, TableQuery $query): TableResult => $definition->source()->query($query),
+            $context,
         );
     }
 
     /**
      * @param  class-string<TableDefinition>  $table
+     * @param  array<string, mixed>  $context
      */
-    public function lazyComponent(string $table): TableComponent
+    public function lazyComponent(string $table, array $context = []): TableComponent
     {
         return $this->buildComponent(
             $table,
             fn (TableDefinition $definition, TableQuery $query): TableResult => TableResult::make([])
                 ->pagination(TablePagination::pending($definition->paginationType())),
+            $context,
             lazy: true,
         );
     }
@@ -51,15 +55,18 @@ final class TableRegistry extends DefinitionRegistry
     /**
      * @param  class-string<TableDefinition>  $table
      * @param  callable(TableDefinition, TableQuery): TableResult  $result
+     * @param  array<string, mixed>  $context
      */
-    private function buildComponent(string $table, callable $result, bool $lazy = false): TableComponent
+    private function buildComponent(string $table, callable $result, array $context = [], bool $lazy = false): TableComponent
     {
         $key = $this->registeredKeyFor($table);
-        $definition = $this->make($table);
+        $definition = $this->make($table)->withContext($context);
         $columns = $definition->columns();
         $query = TableQuery::empty($definition->perPage());
 
         $component = TableComponent::make($key)
+            ->signedAs($key)
+            ->context($context)
             ->endpoint($this->endpointFor($key))
             ->columns($columns)
             ->filters($definition->filters())
@@ -68,7 +75,7 @@ final class TableRegistry extends DefinitionRegistry
             ->resizableColumns($definition->resizableColumns(), $definition->resizeIndicator())
             ->actionsLabel($definition->actionsLabel())
             ->emptyLabel($definition->emptyLabel())
-            ->bulkActions($this->bulkActions($definition, $key))
+            ->bulkActions($this->bulkActions($definition, $key, $context))
             ->result($this->decorateResult($definition, $result($definition, $query), $columns), $query);
 
         if ($lazy) {
@@ -118,12 +125,13 @@ final class TableRegistry extends DefinitionRegistry
     }
 
     /**
+     * @param  array<string, mixed>  $context
      * @return array<int, ActionComponent>
      */
-    private function bulkActions(TableDefinition $definition, string $key): array
+    private function bulkActions(TableDefinition $definition, string $key, array $context): array
     {
         return array_map(
-            fn (ActionComponent $action): ActionComponent => $action->context(['table' => $key]),
+            fn (ActionComponent $action): ActionComponent => $action->context([...$context, 'table' => $key]),
             $definition->bulkActions(),
         );
     }

--- a/tests/Feature/Actions/ActionFormTest.php
+++ b/tests/Feature/Actions/ActionFormTest.php
@@ -61,7 +61,7 @@ class EditActionFixture extends FormActionDefinition
     {
         return $form
             ->schema([TextInput::make('title', 'Title')->required()])
-            ->fill(['title' => $this->context($request, 'current_title')]);
+            ->fill(['title' => $this->context('current_title')]);
     }
 
     public function handle(Request $request): ActionResult

--- a/tests/Feature/Commerce/BusinessPartnerFormTest.php
+++ b/tests/Feature/Commerce/BusinessPartnerFormTest.php
@@ -105,10 +105,8 @@ test('the business partner edit page renders the effective prices panel', functi
     $product = Product::factory()->withoutDefaultPrice()->create(['name' => 'Widget Pro']);
     SalesPrice::factory()->create(['product_id' => $product->getKey(), 'group_id' => null, 'amount' => '99.00']);
 
-    $formDef = new BusinessPartnerForm;
-    $request = Request::create('/test', 'GET', [
-        'context' => ['business_partner_id' => $partner->getKey()],
-    ]);
+    $formDef = (new BusinessPartnerForm)->withContext(['business_partner_id' => $partner->getKey()]);
+    $request = Request::create('/test', 'GET');
 
     $schema = wire($formDef->definition(Form::make('workbench.business-partners.form'), $request))['schema'];
 

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -129,7 +129,7 @@ class WorkbenchProfileForm extends FormDefinition
     public function handle(Request $request): Response
     {
         $request->session()->put('handled-form', $request->string('name')->toString());
-        $request->session()->put('handled-form-team', $this->context($request, 'team'));
+        $request->session()->put('handled-form-team', $this->context('team'));
 
         return redirect('/submitted');
     }

--- a/tests/Feature/Forms/Validation/FieldRulesValidationTest.php
+++ b/tests/Feature/Forms/Validation/FieldRulesValidationTest.php
@@ -110,3 +110,47 @@ it('requires the field when its condition matches', function (): void {
     expect(fn (): array => conditionalDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
         ->toThrow(ValidationException::class);
 });
+
+function choiceDefinition(bool $required = false): FormDefinition
+{
+    return new class($required) extends FormDefinition
+    {
+        public function __construct(private readonly bool $required) {}
+
+        public function definition(Form $form, Request $request): Form
+        {
+            $role = Choice::make('role', 'Role')->options([
+                Choice::option('Member', 'member'),
+                Choice::option('Admin', 'admin'),
+            ]);
+
+            return $form->schema([$this->required ? $role->required() : $role]);
+        }
+
+        public function handle(Request $request): Response
+        {
+            return new Response('ok');
+        }
+    };
+}
+
+it('rejects a choice value outside its options', function (): void {
+    expect(fn (): array => choiceDefinition()->validate(Request::create('/', 'POST', ['role' => 'owner'])))
+        ->toThrow(ValidationException::class);
+});
+
+it('accepts a choice value within its options', function (): void {
+    $validated = choiceDefinition()->validate(Request::create('/', 'POST', ['role' => 'admin']));
+
+    expect($validated)->toMatchArray(['role' => 'admin']);
+});
+
+it('allows an optional choice to be omitted', function (): void {
+    expect(fn (): array => choiceDefinition()->validate(Request::create('/', 'POST', [])))
+        ->not->toThrow(ValidationException::class);
+});
+
+it('still requires a choice marked required', function (): void {
+    expect(fn (): array => choiceDefinition(required: true)->validate(Request::create('/', 'POST', [])))
+        ->toThrow(ValidationException::class);
+});

--- a/tests/Fixtures/Discovery/DiscoveredProfileForm.php
+++ b/tests/Fixtures/Discovery/DiscoveredProfileForm.php
@@ -21,7 +21,7 @@ class DiscoveredProfileForm extends FormDefinition
 
     public function handle(Request $request): Response|Responsable
     {
-        $request->session()->put('discovered-form-team', $this->context($request, 'team'));
+        $request->session()->put('discovered-form-team', $this->context('team'));
 
         return response()->noContent();
     }

--- a/tests/Fixtures/Discovery/DiscoveredUsersTable.php
+++ b/tests/Fixtures/Discovery/DiscoveredUsersTable.php
@@ -26,7 +26,7 @@ class DiscoveredUsersTable extends TableDefinition
         return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([
             [
                 'id' => 1,
-                'name' => $this->context(request(), 'team'),
+                'name' => $this->context('team'),
             ],
         ]));
     }

--- a/tests/Fixtures/Workbench/WorkbenchPingAction.php
+++ b/tests/Fixtures/Workbench/WorkbenchPingAction.php
@@ -27,7 +27,7 @@ class WorkbenchPingAction extends ActionDefinition
     {
         return ActionResult::success([
             'handled' => $request->string('name')->toString(),
-            'team' => data_get($request->input('context', []), 'team'),
+            'team' => $this->context('team'),
         ])
             ->toast(Variant::Info, 'Action handled.')
             ->reloadComponent('workbench.users');

--- a/workbench/app/Actions/ArchiveProductAction.php
+++ b/workbench/app/Actions/ArchiveProductAction.php
@@ -30,12 +30,12 @@ class ArchiveProductAction extends ActionDefinition
     #[\Override]
     public function authorize(Request $request): bool
     {
-        return $this->product($request)->status !== 'archived';
+        return $this->product()->status !== 'archived';
     }
 
     public function handle(Request $request): ActionResult
     {
-        $product = $this->product($request);
+        $product = $this->product();
         $product->update(['status' => 'archived']);
 
         return ActionResult::success(['id' => $product->getKey()])
@@ -47,7 +47,7 @@ class ArchiveProductAction extends ActionDefinition
             ->reloadComponent('workbench.products');
     }
 
-    private function product(Request $request): Product
+    private function product(): Product
     {
         return Product::query()->findOrFail($this->context('product_id'));
     }

--- a/workbench/app/Actions/ArchiveProductAction.php
+++ b/workbench/app/Actions/ArchiveProductAction.php
@@ -49,6 +49,6 @@ class ArchiveProductAction extends ActionDefinition
 
     private function product(Request $request): Product
     {
-        return Product::query()->findOrFail($this->context($request, 'product_id'));
+        return Product::query()->findOrFail($this->context('product_id'));
     }
 }

--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -30,7 +30,7 @@ class EditProductAction extends FormActionDefinition
 
     public function formSchema(Form $form, Request $request): Form
     {
-        $product = $this->product($request);
+        $product = $this->product();
         $productForm = app(ProductForm::class)->withContext(['product_id' => $product->getKey()]);
 
         return $productForm->definition($form, $request)->fill([
@@ -46,7 +46,7 @@ class EditProductAction extends FormActionDefinition
     public function handle(Request $request): ActionResult
     {
         $data = $this->validate($request);
-        $product = $this->product($request);
+        $product = $this->product();
 
         $relatedIds = $data['related_products'] ?? [];
         $priceRows = $data['sales_prices'] ?? [];
@@ -77,7 +77,7 @@ class EditProductAction extends FormActionDefinition
             ->reloadComponent('workbench.products');
     }
 
-    private function product(Request $request): Product
+    private function product(): Product
     {
         return Product::query()->findOrFail($this->context('product_id'));
     }

--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -31,7 +31,7 @@ class EditProductAction extends FormActionDefinition
     public function formSchema(Form $form, Request $request): Form
     {
         $product = $this->product($request);
-        $productForm = app(ProductForm::class);
+        $productForm = app(ProductForm::class)->withContext(['product_id' => $product->getKey()]);
 
         return $productForm->definition($form, $request)->fill([
             'name' => $product->name,
@@ -69,9 +69,8 @@ class EditProductAction extends FormActionDefinition
             ->toast(
                 ToastMessage::make(Variant::Success, __('workbench.actions.edit.toast'))
                     ->action(
-                        Action::use(RejectProductAction::class)
-                            ->label(__('workbench.actions.edit.reject-product'))
-                            ->context(['product_id' => $product->getKey()]),
+                        Action::use(RejectProductAction::class, ['product_id' => $product->getKey()])
+                            ->label(__('workbench.actions.edit.reject-product')),
                     )
                     ->persistent(),
             )
@@ -80,6 +79,6 @@ class EditProductAction extends FormActionDefinition
 
     private function product(Request $request): Product
     {
-        return Product::query()->findOrFail($this->context($request, 'product_id'));
+        return Product::query()->findOrFail($this->context('product_id'));
     }
 }

--- a/workbench/app/Actions/RejectProductAction.php
+++ b/workbench/app/Actions/RejectProductAction.php
@@ -44,14 +44,14 @@ class RejectProductAction extends ActionDefinition
     #[\Override]
     public function authorize(Request $request): bool
     {
-        return $this->product($request)->status !== 'archived';
+        return $this->product()->status !== 'archived';
     }
 
     public function handle(Request $request): ActionResult
     {
         $data = $this->validate($request);
 
-        $product = $this->product($request);
+        $product = $this->product();
         $product->update(['status' => 'archived']);
 
         return ActionResult::success(['id' => $product->getKey(), 'reason' => $data['reason']])
@@ -59,7 +59,7 @@ class RejectProductAction extends ActionDefinition
             ->reloadComponent('workbench.products');
     }
 
-    private function product(Request $request): Product
+    private function product(): Product
     {
         return Product::query()->findOrFail($this->context('product_id'));
     }

--- a/workbench/app/Actions/RejectProductAction.php
+++ b/workbench/app/Actions/RejectProductAction.php
@@ -61,6 +61,6 @@ class RejectProductAction extends ActionDefinition
 
     private function product(Request $request): Product
     {
-        return Product::query()->findOrFail($this->context($request, 'product_id'));
+        return Product::query()->findOrFail($this->context('product_id'));
     }
 }

--- a/workbench/app/Actions/SetLocaleAction.php
+++ b/workbench/app/Actions/SetLocaleAction.php
@@ -21,7 +21,7 @@ class SetLocaleAction extends ActionDefinition
 
     public function handle(Request $request): ActionResult
     {
-        $locale = $this->context($request, 'locale');
+        $locale = $this->context('locale');
         $configured = config('lattice.i18n.locales', []);
         $locales = is_array($configured)
             ? array_values(array_filter($configured, is_string(...)))

--- a/workbench/app/Forms/BusinessPartnerForm.php
+++ b/workbench/app/Forms/BusinessPartnerForm.php
@@ -26,7 +26,7 @@ class BusinessPartnerForm extends FormDefinition
 {
     public function definition(FormComponent $form, Request $request): FormComponent
     {
-        $partner = $this->partner($request);
+        $partner = $this->partner();
 
         $schema = [
             Card::make(__('workbench.commerce.business-partners.form.details-card'))->schema([
@@ -98,7 +98,7 @@ class BusinessPartnerForm extends FormDefinition
 
     public function handle(Request $request): Response
     {
-        $partner = $this->partner($request);
+        $partner = $this->partner();
         $validated = $this->validate($request);
 
         $groupIds = $validated['groups'] ?? [];
@@ -164,7 +164,7 @@ class BusinessPartnerForm extends FormDefinition
         return redirect('/business-partners');
     }
 
-    private function partner(Request $request): ?BusinessPartner
+    private function partner(): ?BusinessPartner
     {
         $id = $this->context('business_partner_id');
 

--- a/workbench/app/Forms/BusinessPartnerForm.php
+++ b/workbench/app/Forms/BusinessPartnerForm.php
@@ -166,7 +166,7 @@ class BusinessPartnerForm extends FormDefinition
 
     private function partner(Request $request): ?BusinessPartner
     {
-        $id = $this->context($request, 'business_partner_id');
+        $id = $this->context('business_partner_id');
 
         if ($id === null || $id === '') {
             return null;

--- a/workbench/app/Forms/GroupForm.php
+++ b/workbench/app/Forms/GroupForm.php
@@ -41,7 +41,7 @@ class GroupForm extends FormDefinition
 
     private function group(Request $request): ?Group
     {
-        $id = $this->context($request, 'group_id');
+        $id = $this->context('group_id');
 
         if ($id === null || $id === '') {
             return null;

--- a/workbench/app/Forms/GroupForm.php
+++ b/workbench/app/Forms/GroupForm.php
@@ -27,7 +27,7 @@ class GroupForm extends FormDefinition
 
     public function handle(Request $request): Response
     {
-        $group = $this->group($request);
+        $group = $this->group();
         $validated = $this->validate($request);
 
         if (! $group instanceof Group) {
@@ -39,7 +39,7 @@ class GroupForm extends FormDefinition
         return redirect('/groups');
     }
 
-    private function group(Request $request): ?Group
+    private function group(): ?Group
     {
         $id = $this->context('group_id');
 

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -280,7 +280,7 @@ class ProductForm extends FormDefinition
 
     private function product(Request $request): ?Product
     {
-        $id = $this->context($request, 'product_id');
+        $id = $this->context('product_id');
 
         if ($id === null || $id === '') {
             return null;

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -31,7 +31,7 @@ class ProductForm extends FormDefinition
 {
     public function definition(FormComponent $form, Request $request): FormComponent
     {
-        $product = $this->product($request);
+        $product = $this->product();
 
         return $form
             ->precognitive(2650)
@@ -78,7 +78,7 @@ class ProductForm extends FormDefinition
 
     public function handle(Request $request): Response
     {
-        $product = $this->product($request);
+        $product = $this->product();
         $validated = $this->validate($request);
 
         $relatedIds = $validated['related_products'] ?? [];
@@ -278,7 +278,7 @@ class ProductForm extends FormDefinition
             .($extension !== '' ? '.'.$extension : '');
     }
 
-    private function product(Request $request): ?Product
+    private function product(): ?Product
     {
         $id = $this->context('product_id');
 

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -47,7 +47,7 @@ class ProductForm extends FormDefinition
                             Choice::option(__('workbench.forms.product.status.active'), 'active'),
                             Choice::option(__('workbench.forms.product.status.archived'), 'archived'),
                         ])
-                        ->rules(['required', 'string', Rule::in(['draft', 'active', 'archived'])]),
+                        ->rules(['required', 'string']),
                     $this->imageUploadField(),
                     Select::make('related_products', __('workbench.forms.product.fields.related-products'))
                         ->multiple()

--- a/workbench/app/Forms/SalesOrderForm.php
+++ b/workbench/app/Forms/SalesOrderForm.php
@@ -205,7 +205,7 @@ class SalesOrderForm extends FormDefinition
 
     private function order(Request $request): ?SalesOrder
     {
-        $id = $this->context($request, 'sales_order_id');
+        $id = $this->context('sales_order_id');
 
         if ($id === null || $id === '') {
             return null;

--- a/workbench/app/Forms/SalesOrderForm.php
+++ b/workbench/app/Forms/SalesOrderForm.php
@@ -33,7 +33,7 @@ class SalesOrderForm extends FormDefinition
 
     public function definition(FormComponent $form, Request $request): FormComponent
     {
-        $order = $this->order($request);
+        $order = $this->order();
 
         $schema = [
             Card::make(__('workbench.commerce.sales-orders.form.details-card'))->schema([
@@ -97,7 +97,7 @@ class SalesOrderForm extends FormDefinition
 
     public function handle(Request $request): Response
     {
-        $order = $this->order($request);
+        $order = $this->order();
         $validated = $this->validate($request);
 
         $lineRows = $validated['lines'] ?? [];
@@ -203,7 +203,7 @@ class SalesOrderForm extends FormDefinition
         return 'SO-'.str_pad((string) $sequence, 4, '0', STR_PAD_LEFT);
     }
 
-    private function order(Request $request): ?SalesOrder
+    private function order(): ?SalesOrder
     {
         $id = $this->context('sales_order_id');
 

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -185,16 +185,14 @@ class AppLayout extends LayoutDefinition
                 ),
             ])
             ->items([
-                ActionComponent::use(SetLocaleAction::class)
+                ActionComponent::use(SetLocaleAction::class, ['locale' => 'en'])
                     ->key('locale-en')
                     ->label(__('workbench.language.en'))
-                    ->variant(ButtonVariant::Ghost)
-                    ->context(['locale' => 'en']),
-                ActionComponent::use(SetLocaleAction::class)
+                    ->variant(ButtonVariant::Ghost),
+                ActionComponent::use(SetLocaleAction::class, ['locale' => 'de'])
                     ->key('locale-de')
                     ->label(__('workbench.language.de'))
-                    ->variant(ButtonVariant::Ghost)
-                    ->context(['locale' => 'de']),
+                    ->variant(ButtonVariant::Ghost),
             ]);
     }
 

--- a/workbench/app/Pages/BusinessPartnerEditPage.php
+++ b/workbench/app/Pages/BusinessPartnerEditPage.php
@@ -41,7 +41,7 @@ class BusinessPartnerEditPage extends WorkbenchPage
                 ->gap(Gap::Large)
                 ->schema([
                     Heading::make(__('workbench.commerce.business-partners.pages.edit.heading')),
-                    Form::use(BusinessPartnerForm::class)
+                    Form::use(BusinessPartnerForm::class, ['business_partner_id' => $businessPartner->getKey()])
                         ->method(HttpMethod::Patch)
                         ->submitLabel(__('workbench.commerce.business-partners.pages.edit.submit'))
                         ->fill([
@@ -55,9 +55,6 @@ class BusinessPartnerEditPage extends WorkbenchPage
                             'default_billing_address_id' => $businessPartner->default_billing_address_id !== null
                                 ? (string) $businessPartner->default_billing_address_id
                                 : null,
-                        ])
-                        ->context([
-                            'business_partner_id' => $businessPartner->getKey(),
                         ]),
                 ]),
         ]);

--- a/workbench/app/Pages/GroupEditPage.php
+++ b/workbench/app/Pages/GroupEditPage.php
@@ -28,14 +28,11 @@ class GroupEditPage extends WorkbenchPage
                 ->gap(Gap::Large)
                 ->schema([
                     Heading::make(__('workbench.commerce.groups.pages.edit.heading')),
-                    Form::use(GroupForm::class)
+                    Form::use(GroupForm::class, ['group_id' => $group->getKey()])
                         ->method(HttpMethod::Patch)
                         ->submitLabel(__('workbench.commerce.groups.pages.edit.submit'))
                         ->fill([
                             'name' => $group->name,
-                        ])
-                        ->context([
-                            'group_id' => $group->getKey(),
                         ]),
                 ]),
         ]);

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -30,7 +30,7 @@ class ProductEditPage extends WorkbenchPage
                 ->gap(Gap::Large)
                 ->schema([
                     Heading::make(__('workbench.pages.product-edit.heading')),
-                    Form::use(ProductForm::class)
+                    Form::use(ProductForm::class, ['product_id' => $product->getKey()])
                         ->method(HttpMethod::Patch)
                         ->submitLabel(__('workbench.pages.product-edit.submit'))
                         ->fill([
@@ -40,9 +40,6 @@ class ProductEditPage extends WorkbenchPage
                             'related_products' => $product->relatedProducts()->pluck('products.id')->all(),
                             'images' => $productForm->imagePaths($product),
                             'sales_prices' => $productForm->salesPriceRows($product),
-                        ])
-                        ->context([
-                            'product_id' => $product->getKey(),
                         ]),
                 ]),
         ]);

--- a/workbench/app/Pages/SalesOrderEditPage.php
+++ b/workbench/app/Pages/SalesOrderEditPage.php
@@ -38,7 +38,7 @@ class SalesOrderEditPage extends WorkbenchPage
                 ->gap(Gap::Large)
                 ->schema([
                     Heading::make(__('workbench.commerce.sales-orders.pages.edit.heading')),
-                    Form::use(SalesOrderForm::class)
+                    Form::use(SalesOrderForm::class, ['sales_order_id' => $salesOrder->getKey()])
                         ->method(HttpMethod::Patch)
                         ->submitLabel(__('workbench.commerce.sales-orders.pages.edit.submit'))
                         ->fill([
@@ -51,9 +51,6 @@ class SalesOrderEditPage extends WorkbenchPage
                                 ? (string) $salesOrder->billing_address_id
                                 : null,
                             'lines' => $lines,
-                        ])
-                        ->context([
-                            'sales_order_id' => $salesOrder->getKey(),
                         ]),
                 ]),
         ]);

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -123,12 +123,9 @@ class ProductsTable extends EloquentTableDefinition
                 ->actions([
                     Link::make(__('workbench.tables.products.edit'), 'product-edit')
                         ->href('/products/'.$row['id'].'/edit'),
-                    Action::use(EditProductAction::class)
-                        ->context(['product_id' => $row['id']]),
-                    Action::use(ArchiveProductAction::class)
-                        ->context(['product_id' => $row['id']]),
-                    Action::use(RejectProductAction::class)
-                        ->context(['product_id' => $row['id']]),
+                    Action::use(EditProductAction::class, ['product_id' => $row['id']]),
+                    Action::use(ArchiveProductAction::class, ['product_id' => $row['id']]),
+                    Action::use(RejectProductAction::class, ['product_id' => $row['id']]),
                 ]),
         ];
     }


### PR DESCRIPTION
Makes component **context** flow identically on page render and on the HTTP endpoints, instead of being read off the request on submit but invisible on render.

## What changed
- Context is owned by the resolved definition: `Definition::withContext()` is set by each registry on render and by the controller (from the sealed reference) on the endpoint; everything reads it via `$this->context($key)`. The request no longer carries context (`mergeTrustedContext` removed).
- `use()` / `lazy()` take context as a second argument across forms, actions, bulk actions, tables and fragments — one consistent API.
- References are sealed under the registered slug (`signedAs`), decoupling the DOM `id` from the signature so the same definition can appear multiple times in one container.
- A `Choice` is now validated against its configured options automatically (`Rule::in`, nullable) — no manual `Rule::in`/`Rule::enum`.
- Dropped the unused `Request` param from workbench context resolvers now that context comes from the instance.

## Why
Forms/tables/fragments could not resolve their record while building a schema on render (context was only merged into the request on submit). This unifies the two paths, removes a footgun where reading the raw request body bypassed the trusted context, and makes tables/fragments first-class context citizens.

Breaking change to the definition/factory API (pre-1.0 alpha).

Gate: Pint, PHPStan, Pest all green (953+ tests; the symmetric model + new Choice constraint tests included).

Note: includes one unrelated commit (`test: drop brittle edge cases from column-resizing tests`) that was already on the branch.