### PR TITLE
fix(pages): resolve route arguments and bound models on directly-returned pages

### DIFF
--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -91,8 +91,12 @@ abstract class Page implements PageContract, Responsable
         abort_unless($this->authorize($request), 403);
 
         // schema is passed so the container resolves render()'s other
-        // dependencies but does not rebuild PageSchema itself.
-        $schema = app()->call([$this, 'render'], ['schema' => PageSchema::make()]);
+        // dependencies but does not rebuild PageSchema itself; the route's
+        // (already-bound) parameters are merged so route arguments and model
+        // binding resolve exactly as they do on the [Page, 'render'] path.
+        $parameters = ['schema' => PageSchema::make()] + ($request->route()?->parameters() ?? []);
+
+        $schema = app()->call([$this, 'render'], $parameters);
 
         return $this->pageResponse('render', $schema)->toResponse($request);
     }

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -214,6 +214,25 @@ test('a page can be returned directly and renders through the responsable contra
         );
 });
 
+test('directly returned pages resolve route arguments and bound models in render', function (): void {
+    $user = UserFactory::new()->create([
+        'name' => 'Route Bound User',
+    ]);
+
+    Route::get('responsable-injection/{user}/{label}', fn (User $user): Page => app(WorkbenchInjectedPage::class))
+        ->middleware('web')
+        ->name('responsable-injection.show');
+
+    withoutVite();
+
+    get("/responsable-injection/{$user->getKey()}/details")
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('lattice/page')
+            ->where('lattice.schema.0.props.text', 'Injected Route Bound User details details')
+        );
+});
+
 test('directly returned pages resolve render dependencies through the container, including form requests', function (): void {
     Route::get('responsable-form-request', fn (): Page => new WorkbenchFormRequestPage)
         ->middleware('web')


### PR DESCRIPTION
The Responsable path (`Page::toResponse`, used when a Page instance is returned from a route/controller) resolved `render()` purely through the container, so it could not resolve any route parameter — including scalars — and threw `Unable to resolve dependency`.

Merge the route's already-bound parameters into the call so route arguments and model binding resolve exactly as they do on the `[Page, 'render']` controller path. Adds a guard test covering a bound model + scalar arg.

Gate: Pint, PHPStan, Pest green.