### PR TITLE
feat(testing): first-class endpoint testing helpers

### DIFF
--- a/docs/content/docs/testing/overview.md
+++ b/docs/content/docs/testing/overview.md
@@ -1,35 +1,54 @@
 ---
 title: Testing
-description: Assert against the components a Lattice page renders — forms, fields, tables, filters, and actions — with the AssertsLatticeComponents trait.
+description: Why testing matters for a server-driven UI, and the Lattice traits for asserting what a page renders and exercising its endpoints.
 ---
 
-Lattice ships a testing trait, `AssertsLatticeComponents`, that lets you make readable
-assertions about the components your pages render: which forms, tables, and actions are
-visible, whether a field is shown or hidden, what initial value it carries, and which
-filters a table exposes. It asserts against the serialized wire tree — the exact payload
-that reaches the browser — so a passing test reflects what a user with the current request
-and authorization actually sees.
+Testing matters more, not less, for a server-driven UI. Your interface is described in PHP
+and serialized to the browser, so a test can assert against the _exact_ payload a user
+receives — what renders, what is hidden, what a field is seeded with — without a browser or
+a duplicated UI contract. Correctness becomes cheap to pin down, so treat tests as a
+first-class part of building with Lattice, not an afterthought.
 
-It is inspired by Filament's test helpers, adapted to Lattice's stateless Inertia output.
+Lattice holds itself to the same bar: the package is covered by an extensive Pest and Vitest
+suite, and it ships — and dogfoods — the very helpers documented here.
+
+[![Pest coverage](https://img.shields.io/codecov/c/github/lattice-php/lattice/main?flag=pest&label=pest&style=flat-square)](https://app.codecov.io/gh/lattice-php/lattice) [![Vitest coverage](https://img.shields.io/codecov/c/github/lattice-php/lattice/main?flag=vitest&label=vitest&style=flat-square)](https://app.codecov.io/gh/lattice-php/lattice)
+
+Two traits cover the ground. `AssertsLatticeComponents` makes readable assertions about the
+components your pages render — which forms, tables, and actions are visible, whether a field
+is shown or hidden, what value it carries, which filters a table exposes — all against the
+serialized wire tree, the exact payload that reaches the browser. `InteractsWithLatticeComponents`
+adds the other half: it submits to a component's own endpoint with a signed ref sealed from the
+class and context, so you can exercise forms, actions, tables, and fragments end to end. It
+bundles `AssertsLatticeComponents`, so a single trait gives you both.
+
+The assertion helpers are inspired by Filament's, adapted to Lattice's stateless Inertia output.
 
 ## Setup
 
-The trait adds methods to your test case. Apply it once in your base `TestCase`:
+Apply `InteractsWithLatticeComponents` once in your base `TestCase`. It bundles
+`AssertsLatticeComponents`, so a single trait provides both the assertions and the endpoint
+helpers:
 
 ```php
-use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
+use Lattice\Lattice\Support\Testing\InteractsWithLatticeComponents;
 
 abstract class TestCase extends \Tests\TestCase
 {
-    use AssertsLatticeComponents;
+    use InteractsWithLatticeComponents;
 }
 ```
 
 …or per file in Pest:
 
 ```php
-uses(Lattice\Lattice\Support\Testing\AssertsLatticeComponents::class);
+uses(Lattice\Lattice\Support\Testing\InteractsWithLatticeComponents::class);
 ```
+
+:::note
+If you only assert against rendered components and never submit to an endpoint, the
+`AssertsLatticeComponents` trait on its own is enough.
+:::
 
 ## Entry points
 
@@ -215,6 +234,42 @@ $this->assertLatticeComponent($action)
         ->assertConfirmationTitle('Archive product?')
         ->assertHasForm());
 ```
+
+## Submitting to a component endpoint
+
+The assertions above check what a page _renders_. To exercise the other half — what happens
+when a form is submitted, an action is invoked, or a table is queried — `InteractsWithLatticeComponents`
+seals a signed ref from the component class and context and posts to the generic endpoint for
+you, returning the `TestResponse` to assert on with the usual Laravel helpers:
+
+```php
+$this->submitForm(ProductForm::class, ['name' => 'Desk Lamp'])
+    ->assertRedirect('/products');
+
+$this->callAction(ArchiveProduct::class, ['id' => 7], context: ['team' => $team])
+    ->assertJsonPath('ok', true);
+
+$this->callBulkAction(ArchiveProducts::class, ['selected' => [1, 2]], context: ['table' => 'products'])
+    ->assertOk();
+
+$this->loadTable(ProductsTable::class, ['filter' => ['name' => 'lamp'], 'page' => 2])
+    ->assertJsonPath('data.0.name', 'Desk Lamp');
+
+$this->loadFragment(SalesChart::class)
+    ->assertOk();
+```
+
+Each helper builds the component exactly as a render would — same class, same context — extracts
+the signed ref, and issues the request with the component's declared HTTP method and the
+`X-Lattice-Ref` header. The request payload is the second argument; context (the active team or
+tenant, and the bound table slug for a bulk action) is the third.
+
+:::caution
+These helpers issue **JSON** requests, so a form whose validation fails returns a `422` JSON
+response rather than the redirect-back-with-errors path of a non-JSON post. Assert with
+`assertJsonValidationErrors()` (not `assertSessionHasErrors()`), and for multi-step flows that
+reuse a single sealed ref, build the request by hand instead.
+:::
 
 ## Test selectors
 

--- a/src/Support/Testing/InteractsWithLatticeComponents.php
+++ b/src/Support/Testing/InteractsWithLatticeComponents.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing;
+
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Testing\TestResponse;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Components\BulkAction;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Fragments\Components\Fragment;
+use Lattice\Lattice\Fragments\FragmentDefinition;
+use Lattice\Lattice\Tables\Components\Table;
+use Lattice\Lattice\Tables\TableDefinition;
+use RuntimeException;
+
+/**
+ * Submit to the generic Lattice endpoints with a ref sealed from a component
+ * class plus its context, exactly like a rendered component would. Mix into a
+ * test case to drive forms, actions, tables, bulk actions and fragments without
+ * hand-building the signed ref and headers.
+ *
+ * @mixin TestCase
+ */
+trait InteractsWithLatticeComponents
+{
+    use AssertsLatticeComponents;
+
+    /**
+     * @param  class-string<FormDefinition>  $form
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $context
+     * @return TestResponse<JsonResponse>
+     */
+    public function submitForm(string $form, array $data = [], array $context = []): TestResponse
+    {
+        $component = $this->sealLatticeComponent(Form::use($form, $context));
+
+        return $this->latticeRequest(
+            $component['props']['method'] ?? 'post',
+            $component['props']['action'],
+            $data,
+            $this->latticeRef($component),
+        );
+    }
+
+    /**
+     * @param  class-string<ActionDefinition>  $action
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $context
+     * @return TestResponse<JsonResponse>
+     */
+    public function callAction(string $action, array $data = [], array $context = []): TestResponse
+    {
+        $component = $this->sealLatticeComponent(Action::use($action, $context));
+
+        return $this->latticeRequest(
+            $component['props']['method'] ?? 'post',
+            $component['props']['endpoint'],
+            $data,
+            $this->latticeRef($component),
+        );
+    }
+
+    /**
+     * Bulk actions are pinned to their table, so pass the table slug via
+     * context, e.g. `['table' => 'team.members']`.
+     *
+     * @param  class-string<BulkActionDefinition>  $bulkAction
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $context
+     * @return TestResponse<JsonResponse>
+     */
+    public function callBulkAction(string $bulkAction, array $data = [], array $context = []): TestResponse
+    {
+        $component = $this->sealLatticeComponent(BulkAction::use($bulkAction, $context));
+
+        return $this->latticeRequest(
+            $component['props']['method'] ?? 'post',
+            $component['props']['endpoint'],
+            $data,
+            $this->latticeRef($component),
+        );
+    }
+
+    /**
+     * @param  class-string<TableDefinition>  $table
+     * @param  array<string, mixed>  $query
+     * @param  array<string, mixed>  $context
+     * @return TestResponse<JsonResponse>
+     */
+    public function loadTable(string $table, array $query = [], array $context = []): TestResponse
+    {
+        $component = $this->sealLatticeComponent(Table::use($table, $context));
+        $url = $component['props']['endpoint'];
+
+        if ($query !== []) {
+            $url .= '?'.http_build_query($query);
+        }
+
+        return $this->getJson($url, $this->latticeHeaders($this->latticeRef($component)));
+    }
+
+    /**
+     * @param  class-string<FragmentDefinition>  $fragment
+     * @param  array<string, mixed>  $context
+     * @return TestResponse<JsonResponse>
+     */
+    public function loadFragment(string $fragment, array $context = []): TestResponse
+    {
+        $component = $this->sealLatticeComponent(Fragment::lazy($fragment, $context));
+
+        return $this->getJson(
+            $component['props']['endpoint'],
+            $this->latticeHeaders($this->latticeRef($component)),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sealLatticeComponent(mixed $component): array
+    {
+        return json_decode(json_encode($component, JSON_THROW_ON_ERROR), true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $component
+     */
+    private function latticeRef(array $component): string
+    {
+        $props = $component['props'] ?? [];
+        $ref = is_array($props) ? ($props['ref'] ?? null) : null;
+
+        if (! is_string($ref) || $ref === '') {
+            throw new RuntimeException('Lattice component ref is missing.');
+        }
+
+        return $ref;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function latticeHeaders(string $ref): array
+    {
+        return ['X-Lattice-Ref' => $ref];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return TestResponse<JsonResponse>
+     */
+    private function latticeRequest(string $method, string $url, array $data, string $ref): TestResponse
+    {
+        $headers = $this->latticeHeaders($ref);
+
+        return match (strtolower($method)) {
+            'put' => $this->putJson($url, $data, $headers),
+            'patch' => $this->patchJson($url, $data, $headers),
+            'delete' => $this->deleteJson($url, $data, $headers),
+            default => $this->postJson($url, $data, $headers),
+        };
+    }
+}

--- a/tests/Feature/Actions/ActionEndpointTest.php
+++ b/tests/Feature/Actions/ActionEndpointTest.php
@@ -39,15 +39,12 @@ test('registered actions serialize their configured endpoint method and label', 
 test('registered actions can be handled through the package endpoint', function (): void {
     Lattice::actions([WorkbenchPingAction::class]);
 
-    $ref = componentRef(wire(ActionComponent::use(WorkbenchPingAction::class)
-        ->context(['team' => 'trusted-team'])));
-
-    postJson('/lattice/actions/workbench.ping', [
+    $this->callAction(WorkbenchPingAction::class, [
         'name' => 'Taylor',
         'context' => [
             'team' => 'tampered-team',
         ],
-    ], latticeHeaders($ref))
+    ], ['team' => 'trusted-team'])
         ->assertOk()
         ->assertJsonPath('ok', true)
         ->assertJsonPath('data.handled', 'Taylor')

--- a/tests/Feature/Actions/ActionFormTest.php
+++ b/tests/Feature/Actions/ActionFormTest.php
@@ -28,9 +28,8 @@ it('marks a form-action component as lazy without inlining the schema', function
 
 it('returns a prefilled schema for a lazy form action', function (): void {
     Lattice::actions([EditActionFixture::class]);
-    $ref = componentRef(wire(ActionComponent::use(EditActionFixture::class)->context(['current_title' => 'Existing'])));
 
-    postJson('/lattice/actions/test.edit', ['_form' => true], latticeHeaders($ref))
+    $this->callAction(EditActionFixture::class, ['_form' => true], ['current_title' => 'Existing'])
         ->assertOk()
         ->assertJsonPath('type', 'form')
         ->assertJsonPath('props.state.title', 'Existing');
@@ -72,9 +71,8 @@ class EditActionFixture extends FormActionDefinition
 
 it('validates the embedded form and hands the data to handle', function (): void {
     Lattice::actions([RejectActionFixture::class]);
-    $ref = componentRef(wire(ActionComponent::use(RejectActionFixture::class)));
 
-    postJson('/lattice/actions/test.reject', ['reason' => 'spam'], latticeHeaders($ref))
+    $this->callAction(RejectActionFixture::class, ['reason' => 'spam'])
         ->assertOk()
         ->assertJsonPath('ok', true)
         ->assertJsonPath('data.reason', 'spam');
@@ -82,18 +80,16 @@ it('validates the embedded form and hands the data to handle', function (): void
 
 it('rejects an invalid embedded form with a 422', function (): void {
     Lattice::actions([RejectActionFixture::class]);
-    $ref = componentRef(wire(ActionComponent::use(RejectActionFixture::class)));
 
-    postJson('/lattice/actions/test.reject', ['reason' => ''], latticeHeaders($ref))
+    $this->callAction(RejectActionFixture::class, ['reason' => ''])
         ->assertStatus(422)
         ->assertJsonValidationErrors('reason');
 });
 
 it('validates final embedded form submissions before handle is called', function (): void {
     Lattice::actions([UnvalidatedRejectActionFixture::class]);
-    $ref = componentRef(wire(ActionComponent::use(UnvalidatedRejectActionFixture::class)));
 
-    postJson('/lattice/actions/test.unvalidated-reject', ['reason' => ''], latticeHeaders($ref))
+    $this->callAction(UnvalidatedRejectActionFixture::class, ['reason' => ''])
         ->assertStatus(422)
         ->assertJsonValidationErrors('reason');
 
@@ -119,9 +115,8 @@ it('validates the embedded form precognitively without running handle', function
 
 it('resolves searchable options for an embedded select', function (): void {
     Lattice::actions([AssignActionFixture::class]);
-    $ref = componentRef(wire(ActionComponent::use(AssignActionFixture::class)));
 
-    postJson('/lattice/actions/test.assign', ['_search' => 'owner', 'q' => 'taylor'], latticeHeaders($ref))
+    $this->callAction(AssignActionFixture::class, ['_search' => 'owner', 'q' => 'taylor'])
         ->assertOk()
         ->assertJsonPath('options.0.label', 'Match: taylor')
         ->assertJsonPath('options.0.value', '7');
@@ -129,9 +124,8 @@ it('resolves searchable options for an embedded select', function (): void {
 
 it('resolves computed fields for an embedded form', function (): void {
     Lattice::actions([AssignActionFixture::class]);
-    $ref = componentRef(wire(ActionComponent::use(AssignActionFixture::class)));
 
-    postJson('/lattice/actions/test.assign', ['_resolve' => true, 'qty' => '5'], latticeHeaders($ref))
+    $this->callAction(AssignActionFixture::class, ['_resolve' => true, 'qty' => '5'])
         ->assertOk()
         ->assertJsonPath('values.total', 7.5);
 });

--- a/tests/Feature/Actions/ProductActionsTest.php
+++ b/tests/Feature/Actions/ProductActionsTest.php
@@ -1,8 +1,6 @@
 <?php
 declare(strict_types=1);
 
-use Lattice\Lattice\Actions\Components\Action;
-use Lattice\Lattice\Actions\Components\BulkAction;
 use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
 use Lattice\Lattice\Facades\Lattice;
 use Workbench\App\Actions\ArchiveProductAction;
@@ -19,15 +17,10 @@ test('the product archive row action is pinned to its sealed product', function 
     $target = Product::factory()->create(['status' => 'active']);
     $other = Product::factory()->create(['status' => 'active']);
 
-    $ref = componentRef(
-        wire(Action::use(ArchiveProductAction::class)
-            ->context(['product_id' => $target->getKey()])),
-    );
-
-    patch('/lattice/actions/workbench.products.archive', [
+    $this->callAction(ArchiveProductAction::class, [
         'context' => ['product_id' => $other->getKey()],
         'product_id' => $other->getKey(),
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['product_id' => $target->getKey()])
         ->assertOk()
         ->assertJsonPath('data.id', $target->getKey());
 
@@ -40,12 +33,7 @@ test('the product archive row action authorizes per row', function (): void {
 
     $archived = Product::factory()->create(['status' => 'archived']);
 
-    $ref = componentRef(
-        wire(Action::use(ArchiveProductAction::class)
-            ->context(['product_id' => $archived->getKey()])),
-    );
-
-    patch('/lattice/actions/workbench.products.archive', [], ['X-Lattice-Ref' => $ref])
+    $this->callAction(ArchiveProductAction::class, [], ['product_id' => $archived->getKey()])
         ->assertForbidden();
 });
 
@@ -57,15 +45,9 @@ test('bulk actions resolve the selection through the table and archive only thos
     $b = Product::factory()->create(['status' => 'active']);
     $c = Product::factory()->create(['status' => 'active']);
 
-    $ref = app(ComponentReferenceSigner::class)->seal(
-        'bulkAction',
-        'workbench.products.archive-selected',
-        ['table' => 'workbench.products'],
-    );
-
-    patch('/lattice/bulk-actions/workbench.products.archive-selected', [
+    $this->callBulkAction(ArchiveSelectedProductsAction::class, [
         'selected' => [$a->getKey(), $b->getKey()],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['table' => 'workbench.products'])
         ->assertOk()
         ->assertJsonPath('data.archived', 2);
 
@@ -80,15 +62,9 @@ test('bulk actions ignore selected ids that are not in the table result', functi
 
     $a = Product::factory()->create(['status' => 'active']);
 
-    $ref = app(ComponentReferenceSigner::class)->seal(
-        'bulkAction',
-        'workbench.products.archive-selected',
-        ['table' => 'workbench.products'],
-    );
-
-    patch('/lattice/bulk-actions/workbench.products.archive-selected', [
+    $this->callBulkAction(ArchiveSelectedProductsAction::class, [
         'selected' => [$a->getKey(), 999999],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['table' => 'workbench.products'])
         ->assertOk()
         ->assertJsonPath('data.archived', 1);
 
@@ -103,18 +79,12 @@ test('bulk actions resolve all matching rows with dedicated table filters', func
     $notFeatured = Product::factory()->create(['featured' => false, 'status' => 'active']);
     $draft = Product::factory()->create(['featured' => true, 'status' => 'draft']);
 
-    $ref = app(ComponentReferenceSigner::class)->seal(
-        'bulkAction',
-        'workbench.products.archive-selected',
-        ['table' => 'workbench.products'],
-    );
-
-    patch('/lattice/bulk-actions/workbench.products.archive-selected', [
+    $this->callBulkAction(ArchiveSelectedProductsAction::class, [
         'allMatching' => true,
         'tf' => [
             'featured' => 'true',
         ],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['table' => 'workbench.products'])
         ->assertOk()
         ->assertJsonPath('data.archived', 2);
 
@@ -137,15 +107,9 @@ test('bulk actions execute through their serialized component reference', functi
 
     $product = Product::factory()->create(['status' => 'active']);
 
-    $ref = data_get(
-        wire(BulkAction::use(ArchiveSelectedProductsAction::class)
-            ->context(['table' => 'workbench.products'])),
-        'props.ref',
-    );
-
-    patch('/lattice/bulk-actions/workbench.products.archive-selected', [
+    $this->callBulkAction(ArchiveSelectedProductsAction::class, [
         'selected' => [$product->getKey()],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['table' => 'workbench.products'])
         ->assertOk()
         ->assertJsonPath('data.archived', 1);
 

--- a/tests/Feature/Commerce/BusinessPartnerFormTest.php
+++ b/tests/Feature/Commerce/BusinessPartnerFormTest.php
@@ -12,8 +12,6 @@ use Workbench\App\Models\Product;
 use Workbench\App\Models\SalesPrice;
 
 use function Pest\Laravel\get;
-use function Pest\Laravel\patch;
-use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
 
 test('the business partner create page renders', function (): void {
@@ -27,9 +25,8 @@ test('the business partner form creates a partner with groups and addresses', fu
     Lattice::forms([BusinessPartnerForm::class]);
 
     $group = Group::factory()->create();
-    $form = wire(Form::use(BusinessPartnerForm::class));
 
-    post('/lattice/forms/workbench.business-partners.form', [
+    $this->submitForm(BusinessPartnerForm::class, [
         'name' => 'Acme Corp',
         'email' => 'acme@example.com',
         'groups' => [(string) $group->getKey()],
@@ -44,7 +41,7 @@ test('the business partner form creates a partner with groups and addresses', fu
                 'country' => 'DE',
             ],
         ],
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ])
         ->assertRedirect('/business-partners');
 
     $partner = BusinessPartner::query()->where('name', 'Acme Corp')->firstOrFail();
@@ -61,10 +58,7 @@ test('the business partner form updates default address FKs', function (): void 
     $shipping = Address::factory()->create(['business_partner_id' => $partner->getKey()]);
     $billing = Address::factory()->create(['business_partner_id' => $partner->getKey()]);
 
-    $form = wire(Form::use(BusinessPartnerForm::class)
-        ->context(['business_partner_id' => $partner->getKey()]));
-
-    patch('/lattice/forms/workbench.business-partners.form', [
+    $this->submitForm(BusinessPartnerForm::class, [
         'name' => $partner->name,
         'email' => $partner->email,
         'groups' => [],
@@ -90,7 +84,7 @@ test('the business partner form updates default address FKs', function (): void 
         ],
         'default_shipping_address_id' => (string) $shipping->getKey(),
         'default_billing_address_id' => (string) $billing->getKey(),
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ], ['business_partner_id' => $partner->getKey()])
         ->assertRedirect('/business-partners');
 
     $partner->refresh();
@@ -121,10 +115,7 @@ test('the business partner form deletes removed addresses', function (): void {
     $keep = Address::factory()->create(['business_partner_id' => $partner->getKey()]);
     $remove = Address::factory()->create(['business_partner_id' => $partner->getKey()]);
 
-    $form = wire(Form::use(BusinessPartnerForm::class)
-        ->context(['business_partner_id' => $partner->getKey()]));
-
-    patch('/lattice/forms/workbench.business-partners.form', [
+    $this->submitForm(BusinessPartnerForm::class, [
         'name' => $partner->name,
         'email' => $partner->email,
         'groups' => [],
@@ -139,7 +130,7 @@ test('the business partner form deletes removed addresses', function (): void {
                 'country' => $keep->country,
             ],
         ],
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ], ['business_partner_id' => $partner->getKey()])
         ->assertRedirect('/business-partners');
 
     expect($partner->addresses()->count())->toBe(1);
@@ -155,10 +146,7 @@ test('removing the default shipping address nulls the FK on the partner', functi
 
     $partner->update(['default_shipping_address_id' => $shipping->getKey()]);
 
-    $form = wire(Form::use(BusinessPartnerForm::class)
-        ->context(['business_partner_id' => $partner->getKey()]));
-
-    patch('/lattice/forms/workbench.business-partners.form', [
+    $this->submitForm(BusinessPartnerForm::class, [
         'name' => $partner->name,
         'email' => $partner->email,
         'groups' => [],
@@ -173,7 +161,7 @@ test('removing the default shipping address nulls the FK on the partner', functi
                 'country' => $other->country,
             ],
         ],
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ], ['business_partner_id' => $partner->getKey()])
         ->assertRedirect('/business-partners');
 
     $partner->refresh();

--- a/tests/Feature/Commerce/GroupFormTest.php
+++ b/tests/Feature/Commerce/GroupFormTest.php
@@ -2,13 +2,10 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Facades\Lattice;
-use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Forms\GroupForm;
 use Workbench\App\Models\Group;
 
 use function Pest\Laravel\get;
-use function Pest\Laravel\patch;
-use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
 
 test('the group create page renders', function (): void {
@@ -21,11 +18,9 @@ test('the group create page renders', function (): void {
 test('the group form creates a group and redirects', function (): void {
     Lattice::forms([GroupForm::class]);
 
-    $form = wire(Form::use(GroupForm::class));
-
-    post('/lattice/forms/workbench.groups.form', [
+    $this->submitForm(GroupForm::class, [
         'name' => 'Premium Customers',
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ])
         ->assertRedirect('/groups');
 
     expect(Group::query()->where('name', 'Premium Customers')->exists())->toBeTrue();
@@ -47,12 +42,9 @@ test('the group form updates an existing group', function (): void {
 
     $group = Group::factory()->create(['name' => 'Old Name']);
 
-    $form = wire(Form::use(GroupForm::class)
-        ->context(['group_id' => $group->getKey()]));
-
-    patch('/lattice/forms/workbench.groups.form', [
+    $this->submitForm(GroupForm::class, [
         'name' => 'New Name',
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ], ['group_id' => $group->getKey()])
         ->assertRedirect('/groups');
 
     expect($group->fresh()->name)->toBe('New Name');

--- a/tests/Feature/Commerce/SalesOrderFormTest.php
+++ b/tests/Feature/Commerce/SalesOrderFormTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Facades\Lattice;
-use Lattice\Lattice\Forms\Components\Form;
 use Workbench\App\Enums\SalesOrderStatus;
 use Workbench\App\Forms\SalesOrderForm;
 use Workbench\App\Models\Address;
@@ -14,7 +13,6 @@ use Workbench\App\Models\SalesPrice;
 use Workbench\App\Pricing\PriceResolver;
 
 use function Pest\Laravel\get;
-use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
 
 test('the sales order create page renders', function (): void {
@@ -44,16 +42,14 @@ test('the sales order form creates an order with snapshotted lines and partner d
     $chair = Product::factory()->withoutDefaultPrice()->create(['name' => 'Office Chair']);
     SalesPrice::factory()->create(['product_id' => $chair->getKey(), 'group_id' => null, 'amount' => '250.00']);
 
-    $form = wire(Form::use(SalesOrderForm::class));
-
-    post('/lattice/forms/workbench.sales-orders.form', [
+    $this->submitForm(SalesOrderForm::class, [
         'business_partner_id' => (string) $partner->getKey(),
         'status' => SalesOrderStatus::Placed->value,
         'lines' => [
             ['id' => '', 'product_id' => (string) $deskLamp->getKey(), 'quantity' => '2', 'unit_price' => '100.00'],
             ['id' => '', 'product_id' => (string) $chair->getKey(), 'quantity' => '1', 'unit_price' => '250.00'],
         ],
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ])
         ->assertRedirect('/sales-orders');
 
     $order = SalesOrder::query()->where('business_partner_id', $partner->getKey())->firstOrFail();

--- a/tests/Feature/Forms/FileUploadFieldTest.php
+++ b/tests/Feature/Forms/FileUploadFieldTest.php
@@ -15,16 +15,6 @@ use Workbench\App\Forms\UploadForm;
 
 use function Pest\Laravel\post;
 
-/**
- * @param  array<string, mixed>  $component
- * @param  array<string, string>  $extra
- * @return array<string, string>
- */
-function uploadHeaders(array $component, array $extra = []): array
-{
-    return ['X-Lattice-Ref' => componentRef($component), ...$extra];
-}
-
 it('signs an upload through the form endpoint', function (): void {
     Storage::fake('s3');
     Storage::disk('s3')->buildTemporaryUploadUrlsUsing(
@@ -33,9 +23,7 @@ it('signs an upload through the form endpoint', function (): void {
 
     Lattice::forms([UploadForm::class]);
 
-    $form = wire(Form::use(UploadForm::class));
-
-    post('/lattice/forms/workbench.upload.form', ['_upload' => 'document', 'filename' => 'invoice.pdf'], uploadHeaders($form))
+    $this->submitForm(UploadForm::class, ['_upload' => 'document', 'filename' => 'invoice.pdf'])
         ->assertOk()
         ->assertJsonStructure(['key', 'url', 'headers', 'method']);
 });
@@ -48,15 +36,13 @@ it('signs an upload for a file field inside a repeater row', function (): void {
 
     Lattice::forms([UploadForm::class]);
 
-    $form = wire(Form::use(UploadForm::class));
-
-    post('/lattice/forms/workbench.upload.form', [
+    $this->submitForm(UploadForm::class, [
         '_upload' => 'documents.0.file',
         'filename' => 'invoice.pdf',
         'documents' => [
             ['file' => null],
         ],
-    ], uploadHeaders($form))
+    ])
         ->assertOk()
         ->assertJsonStructure(['key', 'url', 'headers', 'method']);
 });
@@ -104,9 +90,7 @@ it('returns 422 when the field does not use signed uploads', function (): void {
 
     Lattice::forms([UploadForm::class]);
 
-    $form = wire(Form::use(UploadForm::class));
-
-    post('/lattice/forms/workbench.upload.form', ['_upload' => 'avatar', 'filename' => 'photo.jpg'], uploadHeaders($form))
+    $this->submitForm(UploadForm::class, ['_upload' => 'avatar', 'filename' => 'photo.jpg'])
         ->assertStatus(422);
 });
 
@@ -115,9 +99,7 @@ it('returns 404 when the upload field does not exist', function (): void {
 
     Lattice::forms([UploadForm::class]);
 
-    $form = wire(Form::use(UploadForm::class));
-
-    post('/lattice/forms/workbench.upload.form', ['_upload' => 'nonexistent', 'filename' => 'file.pdf'], uploadHeaders($form))
+    $this->submitForm(UploadForm::class, ['_upload' => 'nonexistent', 'filename' => 'file.pdf'])
         ->assertNotFound();
 });
 
@@ -126,11 +108,9 @@ it('stores a multipart upload through the form', function (): void {
 
     Lattice::forms([UploadForm::class]);
 
-    $form = wire(Form::use(UploadForm::class));
-
-    post('/lattice/forms/workbench.upload.form', [
+    $this->submitForm(UploadForm::class, [
         'avatar' => UploadedFile::fake()->image('me.jpg'),
-    ], uploadHeaders($form))
+    ])
         ->assertRedirect('/uploads');
 
     $stored = session('upload')['avatar'];
@@ -149,7 +129,7 @@ it('rejects a multipart image upload that exceeds maxSize', function (): void {
 
     post('/lattice/forms/workbench.upload.form', [
         'avatar' => UploadedFile::fake()->create('huge.jpg', 5000, 'image/jpeg'),
-    ], uploadHeaders($form))
+    ], ['X-Lattice-Ref' => componentRef($form)])
         ->assertSessionHasErrors(['avatar']);
 });
 
@@ -162,10 +142,10 @@ it('accepts a signed tmp key that exists and rejects an out-of-prefix key', func
 
     $form = wire(Form::use(UploadForm::class));
 
-    post('/lattice/forms/workbench.upload.form', ['document' => 'tmp/real.pdf'], uploadHeaders($form))
+    post('/lattice/forms/workbench.upload.form', ['document' => 'tmp/real.pdf'], ['X-Lattice-Ref' => componentRef($form)])
         ->assertRedirect('/uploads');
 
-    post('/lattice/forms/workbench.upload.form', ['document' => 'uploads/secret.pdf'], uploadHeaders($form))
+    post('/lattice/forms/workbench.upload.form', ['document' => 'uploads/secret.pdf'], ['X-Lattice-Ref' => componentRef($form)])
         ->assertSessionHasErrors(['document']);
 });
 
@@ -176,9 +156,8 @@ it('deletes an existing file when its removal token is submitted', function (): 
     $token = $signer->seal('file', 'avatar', ['disk' => 'public', 'path' => 'uploads/old.jpg']);
 
     Lattice::forms([UploadForm::class]);
-    $form = wire(Form::use(UploadForm::class));
 
-    post('/lattice/forms/workbench.upload.form', ['avatar__removed' => [$token]], uploadHeaders($form))
+    $this->submitForm(UploadForm::class, ['avatar__removed' => [$token]])
         ->assertRedirect('/uploads');
 
     Storage::disk('public')->assertMissing('uploads/old.jpg');
@@ -189,9 +168,8 @@ it('ignores a forged removal token (no deletion)', function (): void {
     Storage::disk('public')->put('uploads/keep.jpg', 'data');
 
     Lattice::forms([UploadForm::class]);
-    $form = wire(Form::use(UploadForm::class));
 
-    post('/lattice/forms/workbench.upload.form', ['avatar__removed' => ['forged']], uploadHeaders($form))
+    $this->submitForm(UploadForm::class, ['avatar__removed' => ['forged']])
         ->assertRedirect('/uploads');
 
     Storage::disk('public')->assertExists('uploads/keep.jpg');

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -59,15 +59,12 @@ test('registered forms serialize their configured endpoint and isolated error ba
 test('registered forms can be submitted through the package endpoint', function (): void {
     Lattice::forms([WorkbenchProfileForm::class]);
 
-    $ref = componentRef(wire(Form::use(WorkbenchProfileForm::class)
-        ->context(['team' => 'lattice-core'])));
-
-    patch('/lattice/forms/settings.profile', [
+    $this->submitForm(WorkbenchProfileForm::class, [
         'name' => 'Taylor',
         'context' => [
             'team' => 'tampered-team',
         ],
-    ], latticeHeaders($ref))
+    ], ['team' => 'lattice-core'])
         ->assertRedirect('/submitted');
 
     expect(session('handled-form'))->toBe('Taylor');

--- a/tests/Feature/Forms/ProductFormTest.php
+++ b/tests/Feature/Forms/ProductFormTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Testing\AssertableInertia;
-use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Form;
@@ -19,7 +18,6 @@ use Workbench\App\Models\Product;
 
 use function Pest\Laravel\get;
 use function Pest\Laravel\patch;
-use function Pest\Laravel\patchJson;
 use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
 
@@ -86,16 +84,14 @@ test('the product index page lists products and links to creation', function ():
 test('the product form creates products', function (): void {
     Lattice::forms([ProductForm::class]);
 
-    $form = wire(Form::use(ProductForm::class));
-
-    post('/lattice/forms/workbench.products.form', [
+    $this->submitForm(ProductForm::class, [
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
         'sales_prices' => [
             ['group_id' => '', 'amount' => '49.99'],
         ],
-    ], productHeaders($form))
+    ])
         ->assertRedirect('/products');
 
     $product = Product::query()->where('sku', 'LAMP-001')->first();
@@ -111,14 +107,12 @@ test('the product form creates product images from signed uploads', function ():
     Storage::disk('s3')->put('tmp/lamp.jpg', 'image-data');
     Lattice::forms([ProductForm::class]);
 
-    $form = wire(Form::use(ProductForm::class));
-
-    post('/lattice/forms/workbench.products.form', [
+    $this->submitForm(ProductForm::class, [
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
         'images' => ['tmp/lamp.jpg'],
-    ], productHeaders($form))
+    ])
         ->assertRedirect('/products');
 
     $product = Product::query()->where('sku', 'LAMP-001')->firstOrFail();
@@ -194,10 +188,7 @@ test('the product form updates the trusted product from sealed context', functio
         'status' => 'active',
     ]);
 
-    $form = wire(Form::use(ProductForm::class)
-        ->context(['product_id' => $trustedProduct->getKey()]));
-
-    patch('/lattice/forms/workbench.products.form', [
+    $this->submitForm(ProductForm::class, [
         'product_id' => $tamperedProduct->getKey(),
         'name' => 'Updated Lamp',
         'sku' => 'LAMP-002',
@@ -205,7 +196,7 @@ test('the product form updates the trusted product from sealed context', functio
         'sales_prices' => [
             ['group_id' => '', 'amount' => '59.99'],
         ],
-    ], productHeaders($form))
+    ], ['product_id' => $trustedProduct->getKey()])
         ->assertRedirect('/products');
 
     $trustedProduct->refresh();
@@ -254,16 +245,14 @@ test('the product form updates product images from signed uploads and removals',
 
     $removedToken = app(SignsComponentReferences::class)
         ->seal('file', 'images', ['disk' => 's3', 'path' => 'workbench/products/old.jpg']);
-    $form = wire(Form::use(ProductForm::class)
-        ->context(['product_id' => $product->getKey()]));
 
-    patch('/lattice/forms/workbench.products.form', [
+    $this->submitForm(ProductForm::class, [
         'name' => 'Updated Lamp',
         'sku' => 'LAMP-002',
         'status' => 'active',
         'images' => ['tmp/new.jpg'],
         'images__removed' => [$removedToken],
-    ], productHeaders($form))
+    ], ['product_id' => $product->getKey()])
         ->assertRedirect('/products');
 
     $product->refresh();
@@ -460,12 +449,7 @@ test('the edit product action syncs sales prices', function (): void {
         'status' => 'active',
     ]);
 
-    $ref = componentRef(
-        wire(Action::use(EditProductAction::class)
-            ->context(['product_id' => $product->getKey()])),
-    );
-
-    patchJson('/lattice/actions/workbench.products.edit-modal', [
+    $this->callAction(EditProductAction::class, [
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
@@ -473,7 +457,7 @@ test('the edit product action syncs sales prices', function (): void {
         'sales_prices' => [
             ['group_id' => '', 'amount' => '79.99'],
         ],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['product_id' => $product->getKey()])
         ->assertOk();
 
     expect($product->salesPrices()->whereNull('group_id')->count())->toBe(1)
@@ -491,12 +475,7 @@ test('the edit product action syncs images', function (): void {
         'status' => 'active',
     ]);
 
-    $ref = componentRef(
-        wire(Action::use(EditProductAction::class)
-            ->context(['product_id' => $product->getKey()])),
-    );
-
-    patchJson('/lattice/actions/workbench.products.edit-modal', [
+    $this->callAction(EditProductAction::class, [
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
@@ -505,7 +484,7 @@ test('the edit product action syncs images', function (): void {
         'sales_prices' => [
             ['group_id' => '', 'amount' => '79.99'],
         ],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['product_id' => $product->getKey()])
         ->assertOk();
 
     $image = $product->images()->firstOrFail();
@@ -539,12 +518,8 @@ test('the edit product action removes existing images without new uploads', func
 
     $removedToken = app(SignsComponentReferences::class)
         ->seal('file', 'images', ['disk' => 's3', 'path' => 'workbench/products/lamp.jpg']);
-    $ref = componentRef(
-        wire(Action::use(EditProductAction::class)
-            ->context(['product_id' => $product->getKey()])),
-    );
 
-    patchJson('/lattice/actions/workbench.products.edit-modal', [
+    $this->callAction(EditProductAction::class, [
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
@@ -554,7 +529,7 @@ test('the edit product action removes existing images without new uploads', func
         'sales_prices' => [
             ['group_id' => '', 'amount' => '79.99'],
         ],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['product_id' => $product->getKey()])
         ->assertOk();
 
     expect($product->images()->count())->toBe(0)
@@ -573,12 +548,7 @@ test('the edit product action rejects two default sales prices with a 422', func
     ]);
     $product->salesPrices()->create(['group_id' => null, 'amount' => '49.99']);
 
-    $ref = componentRef(
-        wire(Action::use(EditProductAction::class)
-            ->context(['product_id' => $product->getKey()])),
-    );
-
-    patchJson('/lattice/actions/workbench.products.edit-modal', [
+    $this->callAction(EditProductAction::class, [
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
@@ -587,7 +557,7 @@ test('the edit product action rejects two default sales prices with a 422', func
             ['group_id' => '', 'amount' => '49.99'],
             ['group_id' => '', 'amount' => '59.99'],
         ],
-    ], ['X-Lattice-Ref' => $ref])
+    ], ['product_id' => $product->getKey()])
         ->assertStatus(422)
         ->assertJsonValidationErrors(['sales_prices']);
 

--- a/tests/Feature/LocalePreferenceTest.php
+++ b/tests/Feature/LocalePreferenceTest.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
-use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Workbench\App\Actions\SetLocaleAction;
 use Workbench\App\Models\User;
 
 use function Pest\Laravel\getJson;
-use function Pest\Laravel\postJson;
 
 beforeEach(function (): void {
     config(['lattice.i18n.locales' => ['en', 'de']]);
@@ -45,10 +43,7 @@ test('locale action persists the authenticated user locale preference', function
     $user = createWorkbenchLocaleUser('en');
     $this->actingAs($user);
 
-    $ref = componentRef(wire(ActionComponent::use(SetLocaleAction::class)
-        ->context(['locale' => 'de'])));
-
-    postJson('/lattice/actions/workbench.locale.set', [], latticeHeaders($ref))
+    $this->callAction(SetLocaleAction::class, [], ['locale' => 'de'])
         ->assertOk()
         ->assertJsonPath('ok', true)
         ->assertJsonPath('effects.0.type', 'localeChange')

--- a/tests/Feature/Support/EndpointTestingHelpersTest.php
+++ b/tests/Feature/Support/EndpointTestingHelpersTest.php
@@ -1,0 +1,166 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Attributes\AsBulkAction;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Attributes\AsFragment;
+use Lattice\Lattice\Attributes\AsTable;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Fragments\FragmentDefinition;
+use Lattice\Lattice\Tables\CallbackTableSource;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Contracts\TableSource;
+use Lattice\Lattice\Tables\TableDefinition;
+use Lattice\Lattice\Tables\TableQuery;
+use Lattice\Lattice\Tables\TableResult;
+use Symfony\Component\HttpFoundation\Response;
+
+test('submitForm seals the ref and submits to the form endpoint with the declared method', function (): void {
+    Lattice::forms([HelperDemoForm::class]);
+
+    $this->submitForm(HelperDemoForm::class, ['name' => 'Taylor'], ['team' => 'lattice-core'])
+        ->assertRedirect('/submitted');
+
+    expect(session('helper-demo-form'))->toBe('Taylor')
+        ->and(session('helper-demo-team'))->toBe('lattice-core');
+});
+
+test('callAction seals the ref and posts to the action endpoint', function (): void {
+    Lattice::actions([HelperDemoAction::class]);
+
+    $this->callAction(HelperDemoAction::class, ['name' => 'Taylor'], ['team' => 'trusted-team'])
+        ->assertOk()
+        ->assertJsonPath('ok', true)
+        ->assertJsonPath('data.handled', 'Taylor')
+        ->assertJsonPath('data.team', 'trusted-team');
+});
+
+test('callBulkAction seals the ref against the bound table and patches the endpoint', function (): void {
+    Lattice::tables([HelperDemoTable::class]);
+    Lattice::bulkActions([HelperDemoBulkAction::class]);
+
+    $this->callBulkAction(
+        HelperDemoBulkAction::class,
+        ['selected' => [1, 2]],
+        ['table' => 'helper.demo'],
+    )
+        ->assertOk()
+        ->assertJsonPath('data.count', 2);
+});
+
+test('loadTable seals the ref and gets the table endpoint with query parameters', function (): void {
+    Lattice::tables([HelperDemoTable::class]);
+
+    $this->loadTable(HelperDemoTable::class, ['per_page' => 10])
+        ->assertOk()
+        ->assertJsonPath('data.0.name', 'Ada')
+        ->assertJsonPath('state.perPage', 10);
+});
+
+test('loadFragment seals the ref and gets the lazy fragment endpoint', function (): void {
+    Lattice::fragments([HelperDemoFragment::class]);
+
+    $this->loadFragment(HelperDemoFragment::class)
+        ->assertOk()
+        ->assertJsonPath('schema.0.type', 'text')
+        ->assertJsonPath('schema.0.props.text', 'Fragment loaded.');
+});
+
+// ---------------------------------------------------------------------------
+// Inline fixture classes required only by this file
+// ---------------------------------------------------------------------------
+
+#[AsForm('helper.demo')]
+class HelperDemoForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form
+            ->method(HttpMethod::Patch)
+            ->schema([Text::make('Helper demo form')])
+            ->withoutSubmitButton();
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->session()->put('helper-demo-form', $request->string('name')->toString());
+        $request->session()->put('helper-demo-team', $this->context('team'));
+
+        return redirect('/submitted');
+    }
+}
+
+#[AsAction('helper.demo')]
+class HelperDemoAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Helper demo')->method(HttpMethod::Post);
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success([
+            'handled' => $request->string('name')->toString(),
+            'team' => $this->context('team'),
+        ]);
+    }
+}
+
+#[AsBulkAction('helper.demo')]
+class HelperDemoBulkAction extends BulkActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Archive selected')->method(HttpMethod::Patch);
+    }
+
+    /**
+     * @param  Collection<int, mixed>  $records
+     */
+    public function handle(Collection $records, Request $request): ActionResult
+    {
+        return ActionResult::success(['count' => $records->count()]);
+    }
+}
+
+#[AsTable('helper.demo')]
+class HelperDemoTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [TextColumn::make('name')->label('Name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(
+            query: fn (TableQuery $query): TableResult => TableResult::make([
+                ['id' => 1, 'name' => 'Ada'],
+                ['id' => 2, 'name' => 'Grace'],
+            ]),
+            selection: fn (array $keys): Collection => collect($keys),
+        );
+    }
+}
+
+#[AsFragment('helper.demo')]
+final class HelperDemoFragment extends FragmentDefinition
+{
+    public function schema(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Fragment loaded.'));
+    }
+}

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -251,9 +251,12 @@ test('registered tables serialize grid layout stack columns and row actions', fu
 test('registered tables parse clause filters sorts and pagination through the endpoint', function (): void {
     Lattice::tables([WorkbenchUsersTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchUsersTable::class)));
-
-    latticeGet('/lattice/tables/workbench.users?filter=name:contains:tay,status:eq:active&sort=-name,email&page=2&per_page=50', $ref)
+    $this->loadTable(WorkbenchUsersTable::class, [
+        'filter' => 'name:contains:tay,status:eq:active',
+        'sort' => '-name,email',
+        'page' => 2,
+        'per_page' => 50,
+    ])
         ->assertOk()
         ->assertJsonPath('data.0.name', 'Taylor')
         ->assertJsonPath('state.filters.0.field', 'name')

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -49,9 +49,7 @@ test('a table applies a dedicated select filter from the request', function (): 
     Product::factory()->create(['name' => 'Active One', 'status' => 'active']);
     Product::factory()->create(['name' => 'Draft One', 'status' => 'draft']);
 
-    $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
-
-    $response = latticeGet('/lattice/tables/workbench.filtered-products?tf[status]=active', $ref)
+    $response = $this->loadTable(WorkbenchFilteredProductsTable::class, ['tf' => ['status' => 'active']])
         ->assertOk()
         ->assertJsonPath('data.0.name', 'Active One')
         ->assertJsonPath('state.tableFilters.status', 'active');
@@ -62,9 +60,7 @@ test('a table applies a dedicated select filter from the request', function (): 
 test('a table rejects a filter key that is not declared', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
-
-    latticeGet('/lattice/tables/workbench.filtered-products?tf[unknown]=x', $ref)
+    $this->loadTable(WorkbenchFilteredProductsTable::class, ['tf' => ['unknown' => 'x']])
         ->assertUnprocessable()
         ->assertJsonPath('message', 'Filter [unknown] is not allowed for table [workbench.filtered-products].');
 });
@@ -72,9 +68,7 @@ test('a table rejects a filter key that is not declared', function (): void {
 test('a table searches a searchable filter\'s options through the endpoint', function (): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchSearchableFilterTable::class)));
-
-    latticeGet('/lattice/tables/workbench.searchable-filter?_search=author&q=ad', $ref)
+    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => 'author', 'q' => 'ad'])
         ->assertOk()
         ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
 });
@@ -82,9 +76,7 @@ test('a table searches a searchable filter\'s options through the endpoint', fun
 test('a table searches a searchable column filter through the endpoint', function (): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchSearchableFilterTable::class)));
-
-    latticeGet('/lattice/tables/workbench.searchable-filter?_search=owner&q=ad', $ref)
+    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => 'owner', 'q' => 'ad'])
         ->assertOk()
         ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
 });
@@ -92,18 +84,14 @@ test('a table searches a searchable column filter through the endpoint', functio
 test('a table 404s searching an unknown filter key', function (): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchSearchableFilterTable::class)));
-
-    latticeGet('/lattice/tables/workbench.searchable-filter?_search=nope&q=a', $ref)
+    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => 'nope', 'q' => 'a'])
         ->assertNotFound();
 });
 
 test('a table rejects searching a filter that is not searchable', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchFilteredProductsTable::class)));
-
-    latticeGet('/lattice/tables/workbench.filtered-products?_search=status&q=a', $ref)
+    $this->loadTable(WorkbenchFilteredProductsTable::class, ['_search' => 'status', 'q' => 'a'])
         ->assertStatus(422);
 });
 
@@ -113,9 +101,9 @@ test('a table accepts column filter clause option operators', function (): void 
     Product::factory()->create(['name' => 'June One', 'updated_at' => '2026-06-12 12:00:00']);
     Product::factory()->create(['name' => 'July One', 'updated_at' => '2026-07-01 12:00:00']);
 
-    $ref = componentRef(wire(Table::use(WorkbenchClauseOptionProductsTable::class)));
-
-    $response = latticeGet('/lattice/tables/workbench.clause-option-products?filter=updated_at:gte:2026-06-01,updated_at:lte:2026-06-30', $ref)
+    $response = $this->loadTable(WorkbenchClauseOptionProductsTable::class, [
+        'filter' => 'updated_at:gte:2026-06-01,updated_at:lte:2026-06-30',
+    ])
         ->assertOk()
         ->assertJsonPath('data.0.name', 'June One');
 

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -69,9 +69,7 @@ test('eloquent tables use table pagination with totals by default', function ():
 
     Lattice::tables([WorkbenchDefaultUsersTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchDefaultUsersTable::class)));
-
-    latticeGet('/lattice/tables/workbench.default-users?per_page=2', $ref)
+    $this->loadTable(WorkbenchDefaultUsersTable::class, ['per_page' => 2])
         ->assertOk()
         ->assertJsonCount(2, 'data')
         ->assertJsonPath('pagination.mode', 'table')
@@ -93,9 +91,7 @@ test('eloquent tables can use simple pagination without totals', function (): vo
 
     Lattice::tables([WorkbenchSimpleUsersTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchSimpleUsersTable::class)));
-
-    latticeGet('/lattice/tables/workbench.simple-users?per_page=2', $ref)
+    $this->loadTable(WorkbenchSimpleUsersTable::class, ['per_page' => 2])
         ->assertOk()
         ->assertJsonCount(2, 'data')
         ->assertJsonPath('pagination.mode', 'simple')
@@ -116,9 +112,7 @@ test('eloquent tables can disable pagination for small datasets', function (): v
 
     Lattice::tables([WorkbenchSmallUsersTable::class]);
 
-    $ref = componentRef(wire(Table::use(WorkbenchSmallUsersTable::class)));
-
-    latticeGet('/lattice/tables/workbench.small-users?per_page=1', $ref)
+    $this->loadTable(WorkbenchSmallUsersTable::class, ['per_page' => 1])
         ->assertOk()
         ->assertJsonCount(3, 'data')
         ->assertJsonPath('pagination.mode', 'none')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,8 @@ use Illuminate\Testing\TestResponse;
 use Lattice\Lattice\Core\Contracts\OptionSource;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Option;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tests\BrowserTestCase;
 use Lattice\Lattice\Tests\TestCase;
 use Orchestra\Testbench\Factories\UserFactory;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\ParallelTesting;
 use Inertia\ServiceProvider as InertiaServiceProvider;
 use Lattice\Lattice\LatticeServiceProvider;
-use Lattice\Lattice\Support\Testing\AssertsLatticeComponents;
+use Lattice\Lattice\Support\Testing\InteractsWithLatticeComponents;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -16,7 +16,7 @@ use Workbench\App\Providers\WorkbenchServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
-    use AssertsLatticeComponents;
+    use InteractsWithLatticeComponents;
     use WithLaravelMigrations;
     use WithWorkbench;
 


### PR DESCRIPTION
## What
Adds `InteractsWithLatticeComponents` — a shipped test trait under `src/Support/Testing` — that drives the generic Lattice endpoints straight from a component class + context, sealing the signed ref and headers internally:

- `submitForm`, `callAction`, `callBulkAction`, `loadTable`, `loadFragment`

It composes `AssertsLatticeComponents`, so a single `use` gives consumers both the endpoint helpers and the schema assertions. It dispatches via `$this->postJson/getJson/...`, so it works for any Pest **or** PHPUnit consumer (no Pest-only `expect()`).

## Why
Previously every endpoint test hand-built `wire(Form::use(Class, $ctx))->componentRef()->latticeHeaders()`. The trait removes that boilerplate and ships the ergonomics to package consumers, not just the internal suite.

## Dogfooding
Migrated 45 call sites across 10 test files to the new helpers. Left hand-built where the helper model doesn't fit: ref-security tests (tampered/missing refs), multi-request-on-one-ref flows (session rotation), schema-only assertions via `wire()`, the custom remote-source token endpoint, and form-validation tests that assert the non-JSON redirect-back path.

## Gate
`composer check` green — Pint, PHPStan (0 errors), Rector, Pest (883 passed).