### PR TITLE
test: simplify js test mocks

### DIFF
--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -8,32 +8,15 @@ beforeAll(() => {
 });
 afterAll(() => configure({ testIdAttribute: prev }));
 
-const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
-
 vi.mock("@lattice-php/lattice/core/renderer", async () => {
-  const { useFieldScope } = await import("../field-scope");
-  return {
-    RenderNode: ({ node }: { node: { props: { name: string } } }) => {
-      const scope = useFieldScope();
-      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
-      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
-      return (
-        <>
-          <span data-test="child">{key}</span>
-          <button
-            aria-label={`commit ${key}`}
-            data-test={`commit-${key}`}
-            type="button"
-            onClick={() => scope?.setValue(node.props.name, "x")}
-          />
-        </>
-      );
-    },
-  };
+  const { RenderNode } = await import("../../../test/form-renderer-probe");
+
+  return { RenderNode };
 });
 
 import { FormProvider } from "../context";
 import { FormValuesProvider } from "../values";
+import { renderCounts } from "../../../test/form-renderer-probe";
 import { BuilderComponent } from "./builder";
 
 const node = {

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -1,7 +1,6 @@
 import { expect, it, vi, beforeAll, afterAll } from "vitest";
 import { configure, getConfig, fireEvent, render, screen, within } from "@testing-library/react";
 
-// The form convention is data-test; scope the RTL testIdAttribute to this file only.
 let prevTestIdAttribute: string;
 beforeAll(() => {
   prevTestIdAttribute = getConfig().testIdAttribute;
@@ -11,36 +10,15 @@ afterAll(() => {
   configure({ testIdAttribute: prevTestIdAttribute });
 });
 
-// Per-scoped-key render counter, shared with the mock factory below.
-const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
-
-// Mock the child-node renderer so the test doesn't need the full registry.
-// The stub reads the FieldScope to prove each row scopes its children, counts
-// its own renders, and exposes a button that commits a value into its row.
 vi.mock("@lattice-php/lattice/core/renderer", async () => {
-  const { useFieldScope } = await import("../field-scope");
-  return {
-    RenderNode: ({ node }: { node: { props: { name: string } } }) => {
-      const scope = useFieldScope();
-      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
-      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
-      return (
-        <>
-          <span data-test="child">{key}</span>
-          <button
-            aria-label={`commit ${key}`}
-            data-test={`commit-${key}`}
-            type="button"
-            onClick={() => scope?.setValue(node.props.name, "x")}
-          />
-        </>
-      );
-    },
-  };
+  const { RenderNode } = await import("../../../test/form-renderer-probe");
+
+  return { RenderNode };
 });
 
 import { FormProvider } from "../context";
 import { FormValuesProvider } from "../values";
+import { renderCounts } from "../../../test/form-renderer-probe";
 import { RepeaterComponent } from "./repeater";
 
 const repeaterNode = {

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -12,32 +12,15 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const { renderCounts } = vi.hoisted(() => ({ renderCounts: new Map<string, number>() }));
-
 vi.mock("@lattice-php/lattice/core/renderer", async () => {
-  const { useFieldScope } = await import("../field-scope");
-  return {
-    RenderNode: ({ node }: { node: { props: { name: string } } }) => {
-      const scope = useFieldScope();
-      const key = scope ? scope.scopedName(node.props.name) : "no-scope";
-      renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
-      return (
-        <>
-          <span data-test="child">{key}</span>
-          <button
-            aria-label={`commit ${key}`}
-            data-test={`commit-${key}`}
-            type="button"
-            onClick={() => scope?.setValue(node.props.name, "x")}
-          />
-        </>
-      );
-    },
-  };
+  const { RenderNode } = await import("../../../test/form-renderer-probe");
+
+  return { RenderNode };
 });
 
 import { FormProvider } from "../context";
 import { FormValuesProvider } from "../values";
+import { renderCounts } from "../../../test/form-renderer-probe";
 import { RepeaterComponent } from "./repeater";
 import { TableRows, type TableColumn } from "./table-rows";
 

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -1,6 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";
+import type { EffectHandler } from "@lattice-php/lattice/effects/registry";
+import { createPlugin, createRegistry } from "@lattice-php/lattice/core/registry";
+import { Provider } from "@lattice-php/lattice/provider";
 import { BulkBar } from "./bulk-bar";
 import type { BulkAction } from "../bulk";
 
@@ -18,62 +21,17 @@ const http = vi.hoisted(() => ({
   })),
 }));
 
+const router = vi.hoisted(() => ({
+  on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(() =>
+    vi.fn<() => void>(),
+  ),
+  reload: vi.fn<() => void>(),
+  visit: vi.fn<(url: string) => void>(),
+}));
+
 vi.mock("@inertiajs/react", () => ({
+  router,
   useHttp: () => http,
-}));
-
-const runAction = vi.hoisted(() =>
-  vi.fn<(request: () => Promise<ActionResponse>, dispatch: unknown) => Promise<boolean>>(
-    async (request) => {
-      await request();
-
-      return true;
-    },
-  ),
-);
-
-vi.mock("@lattice-php/lattice/action/run-action", () => ({
-  runAction,
-}));
-
-const dispatch = vi.hoisted(() => vi.fn<(effects: unknown) => void>());
-
-vi.mock("@lattice-php/lattice/effects/use-effect-dispatcher", () => ({
-  useEffectDispatcher: () => dispatch,
-}));
-
-const getActionEffects = vi.hoisted(() =>
-  vi.fn<(effects: unknown) => unknown>((effects) => effects),
-);
-
-vi.mock("@lattice-php/lattice/effects/dispatch", () => ({
-  getActionEffects,
-}));
-
-type ConfirmProps = {
-  title: string;
-  description?: string;
-  confirmLabel: string;
-  cancelLabel?: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-};
-
-vi.mock("@lattice-php/lattice/core/components/confirm-dialog", () => ({
-  ConfirmDialog: (props: ConfirmProps) => (
-    <div data-test="confirm-dialog">
-      <span data-test="confirm-title">{props.title}</span>
-      <span data-test="confirm-description">{props.description ?? "(none)"}</span>
-      <span data-test="confirm-confirm-label">{props.confirmLabel}</span>
-      <span data-test="confirm-cancel-label">{props.cancelLabel}</span>
-      <button type="button" data-test="confirm-accept" onClick={props.onConfirm}>
-        accept
-      </button>
-      <button type="button" data-test="confirm-cancel" onClick={props.onCancel}>
-        cancel
-      </button>
-    </div>
-  ),
 }));
 
 type ActionFormProps = {
@@ -97,7 +55,7 @@ vi.mock("@lattice-php/lattice/action/components/action-form", () => ({
       <button
         type="button"
         data-test="form-success"
-        onClick={() => props.onSuccess({ effects: [{ type: "reloadPage" }] })}
+        onClick={() => props.onSuccess({ effects: [{ type: "test.bulk-success" } as never] })}
       >
         success
       </button>
@@ -121,21 +79,33 @@ function action(partial: Partial<BulkAction> & Pick<BulkAction, "id">): BulkActi
   };
 }
 
+const effectHandler = vi.fn<EffectHandler>();
+const registry = createRegistry(
+  createPlugin({
+    name: "bulk-bar-test",
+    effects: {
+      "test.bulk-success": effectHandler,
+    },
+  }),
+);
+
 function renderBar(props: Partial<Parameters<typeof BulkBar>[0]> = {}) {
   const onSelectAllMatching = vi.fn<() => void>();
   const onCompleted = vi.fn<() => void>();
 
   render(
-    <BulkBar
-      actions={[action({ id: "archive" })]}
-      selectedKeys={["1", "2"]}
-      allMatching={false}
-      query={{ filter: "status:eq:active" }}
-      canSelectAllMatching={false}
-      onSelectAllMatching={onSelectAllMatching}
-      onCompleted={onCompleted}
-      {...props}
-    />,
+    <Provider registry={registry} toaster={false}>
+      <BulkBar
+        actions={[action({ id: "archive" })]}
+        selectedKeys={["1", "2"]}
+        allMatching={false}
+        query={{ filter: "status:eq:active" }}
+        canSelectAllMatching={false}
+        onSelectAllMatching={onSelectAllMatching}
+        onCompleted={onCompleted}
+        {...props}
+      />
+    </Provider>,
   );
 
   return { onSelectAllMatching, onCompleted };
@@ -144,19 +114,16 @@ function renderBar(props: Partial<Parameters<typeof BulkBar>[0]> = {}) {
 describe("BulkBar", () => {
   beforeEach(() => {
     http.processing = false;
+    http.transformer = (data: Record<string, unknown>): Record<string, unknown> => data;
   });
 
   afterEach(() => {
     http.patch.mockClear();
     http.post.mockClear();
-    runAction.mockClear();
-    dispatch.mockClear();
-    getActionEffects.mockClear();
-    runAction.mockImplementation(async (request) => {
-      await request();
-
-      return true;
-    });
+    router.on.mockClear();
+    router.reload.mockClear();
+    router.visit.mockClear();
+    effectHandler.mockClear();
   });
 
   it("shows the selected count when not selecting all matching", () => {
@@ -244,12 +211,14 @@ describe("BulkBar", () => {
   });
 
   it("does not complete when the request fails", async () => {
-    runAction.mockImplementation(async () => false);
+    const actionError = vi.fn<(event: Event) => void>();
+    http.post.mockRejectedValueOnce(new Error("failed"));
+    window.addEventListener("lattice:action-error", actionError, { once: true });
     const { onCompleted } = renderBar({ actions: [action({ id: "archive" })] });
 
     fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
-    await waitFor(() => expect(runAction).toHaveBeenCalled());
+    await waitFor(() => expect(actionError).toHaveBeenCalledTimes(1));
     expect(onCompleted).not.toHaveBeenCalled();
   });
 
@@ -279,10 +248,10 @@ describe("BulkBar", () => {
 
       fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
-      expect(screen.getByTestId("confirm-title")).toHaveTextContent("Archive items?");
-      expect(screen.getByTestId("confirm-description")).toHaveTextContent("This cannot be undone.");
-      expect(screen.getByTestId("confirm-confirm-label")).toHaveTextContent("Yes archive");
-      expect(screen.getByTestId("confirm-cancel-label")).toHaveTextContent("No");
+      const dialog = screen.getByRole("dialog", { name: "Archive items?" });
+      expect(within(dialog).getByText("This cannot be undone.")).toBeVisible();
+      expect(within(dialog).getByRole("button", { name: "Yes archive" })).toBeVisible();
+      expect(within(dialog).getByRole("button", { name: "No" })).toBeVisible();
     });
 
     it("falls back to the action label and defaults when confirmation fields are missing", () => {
@@ -303,10 +272,10 @@ describe("BulkBar", () => {
 
       fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
-      expect(screen.getByTestId("confirm-title")).toHaveTextContent("Archive");
-      expect(screen.getByTestId("confirm-description")).toHaveTextContent("(none)");
-      expect(screen.getByTestId("confirm-confirm-label")).toHaveTextContent("Archive");
-      expect(screen.getByTestId("confirm-cancel-label")).toHaveTextContent("Cancel");
+      const dialog = screen.getByRole("dialog", { name: "Archive" });
+      expect(within(dialog).getByRole("button", { name: "Archive" })).toBeVisible();
+      expect(within(dialog).getByRole("button", { name: "Cancel" })).toBeVisible();
+      expect(within(dialog).queryByText("(none)")).toBeNull();
     });
 
     it("submits and closes when the confirmation is accepted", async () => {
@@ -328,7 +297,9 @@ describe("BulkBar", () => {
       fireEvent.click(screen.getByTestId("confirm-accept"));
 
       await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
-      await waitFor(() => expect(screen.queryByTestId("confirm-dialog")).toBeNull());
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog", { name: "Sure?" })).not.toBeInTheDocument(),
+      );
     });
 
     it("closes without submitting when the confirmation is cancelled", () => {
@@ -349,7 +320,7 @@ describe("BulkBar", () => {
       fireEvent.click(screen.getByTestId("bulk-action-archive"));
       fireEvent.click(screen.getByTestId("confirm-cancel"));
 
-      expect(screen.queryByTestId("confirm-dialog")).toBeNull();
+      expect(screen.queryByRole("dialog", { name: "Sure?" })).not.toBeInTheDocument();
       expect(onCompleted).not.toHaveBeenCalled();
     });
   });
@@ -408,8 +379,7 @@ describe("BulkBar", () => {
       fireEvent.click(screen.getByTestId("bulk-action-tag"));
       fireEvent.click(screen.getByTestId("form-success"));
 
-      expect(getActionEffects).toHaveBeenCalledWith([{ type: "reloadPage" }]);
-      expect(dispatch).toHaveBeenCalledWith([{ type: "reloadPage" }]);
+      expect(effectHandler).toHaveBeenCalledWith({ type: "test.bulk-success" });
       await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
       expect(screen.queryByTestId("action-form")).toBeNull();
     });

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { TableNode, TablePagination } from "../types";
+import type { TableNode, TablePagination, TableResponse, TableState } from "../types";
 import type { ColumnData } from "@lattice-php/lattice/types/generated";
 import TableComponent from "./table";
 
@@ -31,6 +31,51 @@ function pagination(overrides: Partial<TablePagination> = {}): TablePagination {
     hasMore: false,
     nextPage: null,
     ...overrides,
+  };
+}
+
+function tableState(overrides: Partial<TableState> = {}): Partial<TableState> {
+  return {
+    filters: [],
+    page: 1,
+    perPage: 25,
+    sorts: [],
+    ...overrides,
+  };
+}
+
+function tableResponse(overrides: TableResponse = {}): Response {
+  return Response.json({
+    data: [],
+    pagination: {},
+    ...overrides,
+    state: tableState(overrides.state),
+  });
+}
+
+function tableFetch(...responses: TableResponse[]) {
+  let calls = 0;
+  const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+    const response = responses[Math.min(calls, responses.length - 1)] ?? {};
+    calls += 1;
+
+    return tableResponse(response);
+  });
+
+  vi.stubGlobal("fetch", fetch);
+
+  return fetch;
+}
+
+function requestOptions(headers: Record<string, string> = {}) {
+  return {
+    credentials: "same-origin",
+    method: undefined,
+    headers: {
+      Accept: "application/json",
+      "Accept-Language": "en",
+      ...headers,
+    },
   };
 }
 
@@ -429,23 +474,14 @@ describe("Lattice table component", () => {
   });
 
   it("adds and clears individual sorts through the table endpoint", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [],
-        pagination: {},
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [
-            { key: "name", direction: "asc" },
-            { key: "email", direction: "asc" },
-          ],
-        },
+    const fetch = tableFetch({
+      state: tableState({
+        sorts: [
+          { key: "name", direction: "asc" },
+          { key: "email", direction: "asc" },
+        ],
       }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    });
 
     const node = {
       id: "workbench.users",
@@ -464,12 +500,7 @@ describe("Lattice table component", () => {
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.users",
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [{ key: "name", direction: "asc" }],
-        },
+        state: tableState({ sorts: [{ key: "name", direction: "asc" }] }),
       },
       type: "table",
     } satisfies TableNode;
@@ -481,13 +512,7 @@ describe("Lattice table component", () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         "/lattice/tables/workbench.users?sort=name%2Cemail&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: {
-            Accept: "application/json",
-            "Accept-Language": "en",
-          },
-        },
+        requestOptions(),
       );
     });
 
@@ -498,32 +523,15 @@ describe("Lattice table component", () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.users?sort=name&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: {
-            Accept: "application/json",
-            "Accept-Language": "en",
-          },
-        },
+        requestOptions(),
       );
     });
   });
 
   it("sends component refs with table state requests", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [],
-        pagination: {},
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [{ key: "name", direction: "asc" }],
-        },
-      }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    const fetch = tableFetch({
+      state: tableState({ sorts: [{ key: "name", direction: "asc" }] }),
+    });
 
     const node = {
       id: "teams.members",
@@ -538,12 +546,7 @@ describe("Lattice table component", () => {
         data: [],
         endpoint: "/lattice/tables/teams.members",
         ref: "sealed-reference",
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [],
-        },
+        state: tableState(),
       },
       type: "table",
     } satisfies TableNode;
@@ -555,35 +558,18 @@ describe("Lattice table component", () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         "/lattice/tables/teams.members?sort=name&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: {
-            Accept: "application/json",
-            "Accept-Language": "en",
-            "X-Lattice-Ref": "sealed-reference",
-          },
-        },
+        requestOptions({ "X-Lattice-Ref": "sealed-reference" }),
       );
     });
   });
 
   it("reloads itself when a matching reload component event is dispatched", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [{ id: 2, name: "Ada" }],
-        pagination: {
-          mode: "none",
-        },
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [],
-        },
+    const fetch = tableFetch({
+      data: [{ id: 2, name: "Ada" }],
+      pagination: pagination({
+        mode: "none",
       }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    });
 
     const node = {
       id: "settings.passkeys",
@@ -597,12 +583,7 @@ describe("Lattice table component", () => {
         data: [{ id: 1, name: "Taylor" }],
         endpoint: "/lattice/tables/settings.passkeys",
         pagination: pagination(),
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [],
-        },
+        state: tableState(),
       },
       type: "table",
     } satisfies TableNode;
@@ -620,57 +601,38 @@ describe("Lattice table component", () => {
 
     await screen.findByRole("cell", { name: "Ada" });
 
-    expect(fetch).toHaveBeenCalledWith("/lattice/tables/settings.passkeys?page=1&per_page=25", {
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-        "Accept-Language": "en",
-      },
-    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/lattice/tables/settings.passkeys?page=1&per_page=25",
+      requestOptions(),
+    );
     expect(screen.queryByRole("cell", { name: "Taylor" })).not.toBeInTheDocument();
   });
 
   it("appends infinite table rows and resets them when sorting", async () => {
-    const fetch = vi
-      .fn<typeof globalThis.fetch>()
-      .mockResolvedValueOnce(
-        Response.json({
-          data: [{ id: 2, name: "Ada" }],
-          pagination: {
-            currentPage: 2,
-            hasMore: false,
-            mode: "infinite",
-            nextPage: null,
-            perPage: 1,
-          },
-          state: {
-            filters: [],
-            page: 2,
-            perPage: 1,
-            sorts: [],
-          },
+    const fetch = tableFetch(
+      {
+        data: [{ id: 2, name: "Ada" }],
+        pagination: pagination({
+          currentPage: 2,
+          hasMore: false,
+          mode: "infinite",
+          nextPage: null,
+          perPage: 1,
         }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({
-          data: [{ id: 3, name: "Grace" }],
-          pagination: {
-            currentPage: 1,
-            hasMore: false,
-            mode: "infinite",
-            nextPage: null,
-            perPage: 1,
-          },
-          state: {
-            filters: [],
-            page: 1,
-            perPage: 1,
-            sorts: [{ key: "name", direction: "asc" }],
-          },
+        state: tableState({ page: 2, perPage: 1 }),
+      },
+      {
+        data: [{ id: 3, name: "Grace" }],
+        pagination: pagination({
+          currentPage: 1,
+          hasMore: false,
+          mode: "infinite",
+          nextPage: null,
+          perPage: 1,
         }),
-      );
-
-    vi.stubGlobal("fetch", fetch);
+        state: tableState({ perPage: 1, sorts: [{ key: "name", direction: "asc" }] }),
+      },
+    );
 
     const node = {
       id: "workbench.users",
@@ -691,12 +653,7 @@ describe("Lattice table component", () => {
           hasMore: true,
           nextPage: 2,
         }),
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 1,
-          sorts: [],
-        },
+        state: tableState({ perPage: 1 }),
       },
       type: "table",
     } satisfies TableNode;
@@ -708,13 +665,11 @@ describe("Lattice table component", () => {
     await screen.findByRole("cell", { name: "Ada" });
 
     expect(screen.getByRole("cell", { name: "Taylor" })).toBeVisible();
-    expect(fetch).toHaveBeenNthCalledWith(1, "/lattice/tables/workbench.users?page=2&per_page=1", {
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-        "Accept-Language": "en",
-      },
-    });
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "/lattice/tables/workbench.users?page=2&per_page=1",
+      requestOptions(),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Sort Name" }));
 
@@ -725,13 +680,7 @@ describe("Lattice table component", () => {
     expect(fetch).toHaveBeenNthCalledWith(
       2,
       "/lattice/tables/workbench.users?sort=name&page=1&per_page=1",
-      {
-        credentials: "same-origin",
-        headers: {
-          Accept: "application/json",
-          "Accept-Language": "en",
-        },
-      },
+      requestOptions(),
     );
   });
 
@@ -766,30 +715,21 @@ describe("Lattice table component", () => {
   });
 
   it("renders numbered controls for table pagination", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [{ id: 3, name: "Grace" }],
-        pagination: {
-          currentPage: 3,
-          hasMore: true,
-          lastPage: 4,
-          mode: "table",
-          nextPage: 4,
-          perPage: 1,
-          from: 3,
-          to: 3,
-          total: 4,
-        },
-        state: {
-          filters: [],
-          page: 3,
-          perPage: 1,
-          sorts: [],
-        },
-      }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    const fetch = tableFetch({
+      data: [{ id: 3, name: "Grace" }],
+      pagination: {
+        currentPage: 3,
+        hasMore: true,
+        lastPage: 4,
+        mode: "table",
+        nextPage: 4,
+        perPage: 1,
+        from: 3,
+        to: 3,
+        total: 4,
+      },
+      state: tableState({ page: 3, perPage: 1 }),
+    });
 
     const node = {
       id: "workbench.users",
@@ -813,12 +753,7 @@ describe("Lattice table component", () => {
           to: 2,
           total: 4,
         },
-        state: {
-          filters: [],
-          page: 2,
-          perPage: 1,
-          sorts: [],
-        },
+        state: tableState({ page: 2, perPage: 1 }),
       },
       type: "table",
     } satisfies TableNode;
@@ -832,37 +767,24 @@ describe("Lattice table component", () => {
 
     await screen.findByRole("cell", { name: "Grace" });
 
-    expect(fetch).toHaveBeenCalledWith("/lattice/tables/workbench.users?page=3&per_page=1", {
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-        "Accept-Language": "en",
-      },
-    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/lattice/tables/workbench.users?page=3&per_page=1",
+      requestOptions(),
+    );
   });
 
   it("loads lazy table data after the component mounts", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [{ id: 1, name: "Ada" }],
-        pagination: {
-          currentPage: 1,
-          hasMore: false,
-          mode: "none",
-          total: 1,
-          from: 1,
-          to: 1,
-        },
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [],
-        },
+    const fetch = tableFetch({
+      data: [{ id: 1, name: "Ada" }],
+      pagination: pagination({
+        currentPage: 1,
+        hasMore: false,
+        mode: "none",
+        total: 1,
+        from: 1,
+        to: 1,
       }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    });
 
     const node = {
       id: "workbench.users.none",
@@ -877,12 +799,7 @@ describe("Lattice table component", () => {
         endpoint: "/lattice/tables/workbench.users.none",
         lazy: true,
         pagination: pagination(),
-        state: {
-          filters: [],
-          page: 1,
-          perPage: 25,
-          sorts: [],
-        },
+        state: tableState(),
       },
       type: "table",
     } satisfies TableNode;
@@ -894,26 +811,15 @@ describe("Lattice table component", () => {
     await screen.findByRole("cell", { name: "Ada" });
 
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith("/lattice/tables/workbench.users.none?page=1&per_page=25", {
-      credentials: "same-origin",
-      headers: {
-        Accept: "application/json",
-        "Accept-Language": "en",
-      },
-    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/lattice/tables/workbench.users.none?page=1&per_page=25",
+      requestOptions(),
+    );
     expect(screen.getByText("Showing 1-1 of 1")).toBeVisible();
   });
 
   it("applies per-column header filters by type", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [],
-        pagination: {},
-        state: { filters: [], page: 1, perPage: 25, sorts: [] },
-      }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    const fetch = tableFetch();
 
     const node = {
       id: "workbench.products",
@@ -964,7 +870,7 @@ describe("Lattice table component", () => {
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.products",
-        state: { filters: [], page: 1, perPage: 25, sorts: [] },
+        state: tableState(),
       },
       type: "table",
     } satisfies TableNode;
@@ -977,10 +883,7 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=featured%3Aeq%3Atrue&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: { Accept: "application/json", "Accept-Language": "en" },
-        },
+        requestOptions(),
       ),
     );
 
@@ -990,10 +893,7 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=updated_at%3Aeq%3A2026-06-01&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: { Accept: "application/json", "Accept-Language": "en" },
-        },
+        requestOptions(),
       ),
     );
 
@@ -1003,10 +903,7 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=name%3Acontains%3ALamp&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: { Accept: "application/json", "Accept-Language": "en" },
-        },
+        requestOptions(),
       ),
     );
   });
@@ -1018,7 +915,7 @@ describe("Lattice table component", () => {
         columns: [col({ key: "name", label: "Name" })],
         data: [{ name: "Taylor" }],
         striped: true,
-        state: { filters: [], page: 1, perPage: 25, sorts: [] },
+        state: tableState(),
       },
       type: "table",
     } satisfies TableNode;
@@ -1031,15 +928,7 @@ describe("Lattice table component", () => {
   });
 
   it("adds a clause with a chosen operator from the column filter popover", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({
-        data: [],
-        pagination: {},
-        state: { filters: [], page: 1, perPage: 25, sorts: [] },
-      }),
-    );
-
-    vi.stubGlobal("fetch", fetch);
+    const fetch = tableFetch();
 
     const node = {
       id: "workbench.products",
@@ -1062,7 +951,7 @@ describe("Lattice table component", () => {
         ],
         data: [],
         endpoint: "/lattice/tables/workbench.products",
-        state: { filters: [], page: 1, perPage: 25, sorts: [] },
+        state: tableState(),
       },
       type: "table",
     } satisfies TableNode;
@@ -1082,10 +971,7 @@ describe("Lattice table component", () => {
     await waitFor(() =>
       expect(fetch).toHaveBeenLastCalledWith(
         "/lattice/tables/workbench.products?filter=name%3Aneq%3Abar&page=1&per_page=25",
-        {
-          credentials: "same-origin",
-          headers: { Accept: "application/json", "Accept-Language": "en" },
-        },
+        requestOptions(),
       ),
     );
   });

--- a/resources/js/table/registry.test.tsx
+++ b/resources/js/table/registry.test.tsx
@@ -1,13 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ColumnData } from "@lattice-php/lattice/types/generated";
 import { Provider } from "../provider";
 import { createPlugin, createRegistry } from "../core/registry";
 import { ColumnCell } from "./components/table-cell";
-
-vi.mock("@lattice-php/lattice/clipboard", () => ({
-  copyToClipboard: vi.fn<(value: string) => Promise<boolean>>(),
-}));
 
 function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): ColumnData {
   const type = partial.type ?? "column.text";
@@ -24,7 +20,28 @@ function col(partial: Partial<ColumnData> & Pick<ColumnData, "key" | "label">): 
   };
 }
 
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+function stubClipboard(writeText = vi.fn<Clipboard["writeText"]>(async () => undefined)) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+
+  return writeText;
+}
+
 describe("column registry", () => {
+  afterEach(() => {
+    if (clipboardDescriptor) {
+      Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+
+    vi.restoreAllMocks();
+  });
+
   it("dispatches a registered custom cell renderer", () => {
     const registry = createRegistry(
       createPlugin({
@@ -210,7 +227,9 @@ describe("column registry", () => {
     expect(screen.getByRole("button", { name: /Copy Token/ })).toBeVisible();
   });
 
-  it("copies the text cell value and shows the copied state", () => {
+  it("copies the text cell value and shows the copied state", async () => {
+    const writeText = stubClipboard();
+
     renderCell(
       col({ key: "token", label: "Token", type: "column.text", props: { copyable: true } }),
       {
@@ -220,7 +239,8 @@ describe("column registry", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Copy Token/ }));
 
-    expect(screen.getByRole("button", { name: /Copied Token/ })).toBeVisible();
+    expect(await screen.findByRole("button", { name: /Copied Token/ })).toBeVisible();
+    expect(writeText).toHaveBeenCalledWith("abc");
   });
 
   it("renders a badge cell with the gray fallback for an unmapped value", () => {

--- a/resources/js/test/form-renderer-probe.tsx
+++ b/resources/js/test/form-renderer-probe.tsx
@@ -1,0 +1,21 @@
+import { useFieldScope } from "../form/components/field-scope";
+
+export const renderCounts = new Map<string, number>();
+
+export function RenderNode({ node }: { node: { props: { name: string } } }) {
+  const scope = useFieldScope();
+  const key = scope ? scope.scopedName(node.props.name) : "no-scope";
+  renderCounts.set(key, (renderCounts.get(key) ?? 0) + 1);
+
+  return (
+    <>
+      <span data-test="child">{key}</span>
+      <button
+        aria-label={`commit ${key}`}
+        data-test={`commit-${key}`}
+        type="button"
+        onClick={() => scope?.setValue(node.props.name, "x")}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- remove internal BulkBar action/effect/dialog mocks while keeping HTTP and the heavy form boundary controlled
- share the field renderer probe helper from the test-only directory
- use the real clipboard wrapper in registry tests and trim repeated table endpoint setup

## Verification
- npm run check