### PR TITLE
chore: clean up redundant comments

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -28,6 +28,12 @@
 - Code must be self-explanatory: reach for clear names, small functions, and types before a comment.
 - Do not add comments. A comment is a last resort and explains only *why* something is done, never *what* the code does.
 - When you encounter an obsolete, redundant, or "what" comment, delete it.
+- Delete section banners and navigation comments unless they explain a non-obvious boundary.
+- Delete comments that narrate the next line, assertion, or obvious test setup; prefer clearer test names and variable names.
+- Keep PHPDoc/JSDoc only when it carries type information, public API intent, static-analysis value, generated-file context,
+  or a non-obvious constraint.
+- Keep comments that explain framework quirks, ordering requirements, browser/test timing, cache/build behavior, performance
+  traps, or other constraints that are hard to infer from the code alone.
 
 ## Testing
 

--- a/resources/js/core/components/combobox.test.tsx
+++ b/resources/js/core/components/combobox.test.tsx
@@ -103,7 +103,6 @@ describe("Combobox", () => {
     act(() => vi.advanceTimersByTime(250));
 
     expect(onSearch).toHaveBeenCalledWith("x");
-    // Remote mode shows options as given (no local filtering).
     expect(screen.getByRole("option", { name: "Red" })).toBeVisible();
   });
 });

--- a/resources/js/core/components/control.ts
+++ b/resources/js/core/components/control.ts
@@ -1,6 +1,5 @@
 import { cva, type VariantProps } from "class-variance-authority";
 
-/** The focus-visible ring shared by every interactive control surface. */
 export const FOCUS_RING =
   "focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]";
 

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -16,12 +16,10 @@ function nodeKey(node: Node, index: number): string {
   return node.key ?? node.id ?? `${node.type}-${index}`;
 }
 
-/** Renders a schema (list of nodes) against the active component registry. */
 export function Renderer({ nodes }: { nodes: Node[] }): ReactNode {
   return nodes.map((node, index) => <NodeRenderer key={nodeKey(node, index)} node={node} />);
 }
 
-/** Renders a single node against the active component registry. */
 export function RenderNode({ node }: { node: Node }): ReactNode {
   return <NodeRenderer node={node} />;
 }

--- a/resources/js/core/types.test-d.ts
+++ b/resources/js/core/types.test-d.ts
@@ -20,7 +20,6 @@ const _customBad: PropsOf<"custom.thing"> = { foo: "no" };
 // 3. Unaugmented unknown type falls back to the loose NodeProps bag
 const _loose: PropsOf<"totally.unknown"> = { anything: true } satisfies NodeProps;
 
-// Silence unused-variable warnings
 void _okBadge;
 void _badBadge;
 void _customOk;

--- a/resources/js/effects/dispatch.ts
+++ b/resources/js/effects/dispatch.ts
@@ -5,7 +5,6 @@ import type { EffectHandlerRegistry } from "./registry";
 
 export type ActionEffect = Effect;
 
-/** The server's action response. Fields are optional: a handler may omit any of them. */
 export type ActionResponse = Partial<ActionResult>;
 
 /**

--- a/resources/js/effects/registry.test.ts
+++ b/resources/js/effects/registry.test.ts
@@ -20,8 +20,6 @@ afterEach(() => {
 });
 
 describe("builtinEffectHandlers", () => {
-  // ── Imperative handlers ─────────────────────────────────────────────────
-
   it("reloadPage calls router.reload()", () => {
     builtinEffectHandlers.reloadPage({ type: "reloadPage" } as never);
     expect(router.reload).toHaveBeenCalledOnce();
@@ -47,7 +45,6 @@ describe("builtinEffectHandlers", () => {
 
     expect(click).toHaveBeenCalledOnce();
     expect(hrefs[0]).toContain("/exports/report.csv");
-    // anchor must be removed from the DOM after the click
     expect(document.querySelector("a")).toBeNull();
   });
 
@@ -82,8 +79,6 @@ describe("builtinEffectHandlers", () => {
 
     expect(fired).toEqual([]);
   });
-
-  // ── Bridged handlers (lattice:* DOM events) ─────────────────────────────
 
   it("toast bridges to the lattice:toast DOM event", () => {
     const listener = vi.fn<(event: Event) => void>();

--- a/resources/js/effects/registry.ts
+++ b/resources/js/effects/registry.ts
@@ -12,7 +12,6 @@ import { setLocale } from "@lattice-php/lattice/i18n/locale";
  */
 export interface EffectProps {}
 
-// The generated built-in effect payloads, keyed by `type` (the discriminant stripped).
 type EffectPayloads = { [TEffect in Effect as TEffect["type"]]: Omit<TEffect, "type"> };
 
 type EffectPayloadOf<TType extends string> = ResolveProps<
@@ -56,7 +55,6 @@ function triggerDownload(url: string): void {
   link.remove();
 }
 
-/** Re-broadcast an effect as its `lattice:*` DOM event for feature components. */
 function bridge(event: string): EffectHandler {
   return (effect) => window.dispatchEvent(new CustomEvent(event, { detail: effect }));
 }

--- a/resources/js/form/components/base/field.test.tsx
+++ b/resources/js/form/components/base/field.test.tsx
@@ -22,11 +22,8 @@ it("keeps a visually-hidden accessible label inside a table cell", () => {
       </FormFieldFrame>
     </TableCellProvider>,
   );
-  // input is accessibly labeled via the sr-only <label for="qty">
   expect(screen.getByLabelText("Qty")).toBeInTheDocument();
-  // the error still renders
   expect(screen.getByText("bad")).toBeInTheDocument();
-  // the label is visually hidden
   expect(screen.getByText("Qty")).toHaveClass("sr-only");
 });
 

--- a/resources/js/form/components/base/input-otp.tsx
+++ b/resources/js/form/components/base/input-otp.tsx
@@ -27,7 +27,6 @@ export type InputOTPProps = Omit<
   length: number;
 };
 
-/** A segmented one-time-code input styled to match Lattice's control surfaces. */
 export function InputOTP({
   length,
   containerClassName,

--- a/resources/js/form/components/field-props.ts
+++ b/resources/js/form/components/field-props.ts
@@ -29,7 +29,6 @@ export function fieldProps(node: Node): FieldProps {
   return node.props as FieldProps;
 }
 
-/** The single schema traversal shared by the label/value and dependency-watch collectors. */
 export function walkFields(
   nodes: Node[] | undefined,
   visit: (props: FieldProps, node: Node) => void,

--- a/resources/js/form/components/fields/repeater-rows.ts
+++ b/resources/js/form/components/fields/repeater-rows.ts
@@ -4,7 +4,6 @@ export const ROW_ID_KEY = "__rowId";
 
 let rowIdCounter = 0;
 
-/** Stamp a stable client-only id on a row (no-op if it already has one). */
 export function withRowId(row: RepeaterRow): RepeaterRow {
   return row[ROW_ID_KEY] ? row : { ...row, [ROW_ID_KEY]: `r${rowIdCounter++}` };
 }
@@ -17,7 +16,6 @@ export function ensureRowIds(rows: RepeaterRow[]): RepeaterRow[] {
   return rows.map(withRowId);
 }
 
-/** Seed the row list from a stored value, falling back to `defaultItems` blank rows. */
 export function seedRows(value: unknown, defaultItems: number): RepeaterRow[] {
   if (Array.isArray(value) && value.length > 0) {
     return value.map((row) => (row && typeof row === "object" ? { ...(row as RepeaterRow) } : {}));

--- a/resources/js/form/components/fields/simple-field.tsx
+++ b/resources/js/form/components/fields/simple-field.tsx
@@ -4,7 +4,6 @@ import { FormFieldFrame } from "../base/field";
 import { fieldProps } from "../field-props";
 import { type ControlledField, useControlledField } from "../use-controlled-field";
 
-/** The shared shell for single-input fields; the control is a render prop receiving the resolved field state. */
 export function SimpleField({
   node,
   label,

--- a/resources/js/form/components/use-controlled-field.ts
+++ b/resources/js/form/components/use-controlled-field.ts
@@ -17,7 +17,6 @@ export type ControlledField = FieldState & {
   commit: (value: unknown) => void;
 };
 
-/** Shared wiring read by every store-controlled, condition-aware field. */
 export function useControlledField(node: Node): ControlledField {
   const { errors } = useFormContext();
   const scope = useFieldScope();

--- a/resources/js/form/skeleton.test.tsx
+++ b/resources/js/form/skeleton.test.tsx
@@ -21,7 +21,6 @@ describe("FormSkeletonComponent", () => {
 
     const { container } = render(<FormSkeletonComponent node={node}>{null}</FormSkeletonComponent>);
 
-    // 2 visible fields × (label + input) + 1 submit placeholder.
     expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(5);
   });
 });

--- a/resources/js/table/components/cells/boolean-cell.tsx
+++ b/resources/js/table/components/cells/boolean-cell.tsx
@@ -6,7 +6,6 @@ function isTruthy(value: unknown): boolean {
   return value === true || value === 1 || value === "1" || value === "true";
 }
 
-/** Renders a boolean column as a check (truthy) or cross (falsy) icon. */
 export const BooleanCell: ColumnCellComponent<"column.boolean"> = ({ value }) => {
   const truthy = isTruthy(value);
 

--- a/resources/js/table/components/cells/numeric.ts
+++ b/resources/js/table/components/cells/numeric.ts
@@ -1,4 +1,3 @@
-/** Parses a cell value to a finite number, or null when it isn't numeric. */
 export function numericValue(value: unknown): number | null {
   const number = typeof value === "number" ? value : Number(value);
 

--- a/resources/js/table/components/cells/stack-cell.tsx
+++ b/resources/js/table/components/cells/stack-cell.tsx
@@ -2,7 +2,6 @@ import type { ColumnCellComponent } from "../../registry";
 import type { ColumnPropsOf } from "../../types";
 import { TextCell } from "./text-cell";
 
-/** Renders a stack column's nested columns as stacked text rows. */
 export const StackCell: ColumnCellComponent<"column.stack"> = ({ column, row }) => (
   <div className="grid gap-1">
     {(column.columns ?? []).map((stackedColumn) => (

--- a/resources/js/table/registry.ts
+++ b/resources/js/table/registry.ts
@@ -2,9 +2,7 @@ import type { ReactNode } from "react";
 import type { ColumnPropsOf, TableColumn, TableRow } from "./types";
 
 export type ColumnCellArgs<TType extends string = string> = {
-  /** The full wire column (key, label, type, nested columns). */
   column: TableColumn;
-  /** The column's `props`, resolved to the type's shape. */
   props: ColumnPropsOf<TType>;
   row: TableRow;
   value: unknown;

--- a/resources/js/table/types.test-d.ts
+++ b/resources/js/table/types.test-d.ts
@@ -15,12 +15,10 @@ const _bad: ColumnPropsOf<"column.rating"> = { max: "five" };
 // 2. Unaugmented type falls back to the loose bag.
 const _loose: ColumnPropsOf<"totally.unknown"> = { anything: true };
 
-// Silence unused-variable warnings
 void _ok;
 void _bad;
 void _loose;
 
-// Silence unused import warning
 type _ColumnProps = ColumnProps;
 
 // 3. Built-in column type resolves from the generated map.

--- a/resources/js/toast/callout.ts
+++ b/resources/js/toast/callout.ts
@@ -4,7 +4,6 @@ import { isVariant } from "@lattice-php/lattice/toast/toast";
 
 export type { Callout };
 
-/** Coerce a raw callout value (effect detail `{ callout: {...} }`) into a Callout. */
 export function normalizeCallout(detail: unknown): Callout | null {
   if (typeof detail !== "object" || detail === null) {
     return null;
@@ -31,7 +30,6 @@ export function normalizeCallout(detail: unknown): Callout | null {
   };
 }
 
-/** Subscribe to the `lattice:callout` bus. Returns an unsubscribe function. */
 export function onCallout(callback: (callout: Callout) => void): () => void {
   const listener = (event: Event): void => {
     const callout = normalizeCallout((event as CustomEvent).detail);

--- a/resources/js/toast/toast.ts
+++ b/resources/js/toast/toast.ts
@@ -39,7 +39,6 @@ export function normalizeToastMessage(value: unknown): ToastMessage | null {
   };
 }
 
-/** Coerce a `lattice:toast` event detail (`{ toast: {...} }`) into a ToastMessage. */
 export function normalizeToast(detail: unknown): ToastMessage | null {
   if (typeof detail !== "object" || detail === null) {
     return null;
@@ -48,7 +47,6 @@ export function normalizeToast(detail: unknown): ToastMessage | null {
   return normalizeToastMessage((detail as { toast?: unknown }).toast);
 }
 
-/** Emit a toast onto the shared `lattice:toast` bus. */
 export function showToast(toast: ToastMessage): void {
   if (typeof window === "undefined") {
     return;
@@ -57,7 +55,6 @@ export function showToast(toast: ToastMessage): void {
   window.dispatchEvent(new CustomEvent(LATTICE_EVENT.toast, { detail: { toast } }));
 }
 
-/** Subscribe to the shared toast bus. Returns an unsubscribe function. */
 export function onToast(callback: (toast: ToastMessage) => void): () => void {
   const listener = (event: Event): void => {
     const toast = normalizeToast((event as CustomEvent).detail);

--- a/src/Console/Commands/MakeDefinitionCommand.php
+++ b/src/Console/Commands/MakeDefinitionCommand.php
@@ -15,13 +15,10 @@ use Illuminate\Support\Str;
  */
 abstract class MakeDefinitionCommand extends Command
 {
-    /** Human label, e.g. "Page". */
     protected string $type;
 
-    /** Target directory under app/, e.g. "Pages". */
     protected string $directory;
 
-    /** Stub filename, e.g. "page.php.stub". */
     protected string $stub;
 
     public function handle(): int

--- a/tests/Feature/Core/RegistryTest.php
+++ b/tests/Feature/Core/RegistryTest.php
@@ -132,10 +132,6 @@ test('interaction endpoints re-run authorization for every interaction', functio
         ->assertForbidden();
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture classes required only by this file
-// ---------------------------------------------------------------------------
-
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Attributes\AsAction;

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -106,10 +106,6 @@ test('registered forms receive the current request while serializing definitions
         ->assertJsonPath('schema.0.props.text', 'Request aware');
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture classes required only by this file
-// ---------------------------------------------------------------------------
-
 #[AsForm('settings.profile')]
 class WorkbenchProfileForm extends FormDefinition
 {

--- a/tests/Feature/Fragments/FragmentEndpointTest.php
+++ b/tests/Feature/Fragments/FragmentEndpointTest.php
@@ -40,10 +40,6 @@ test('registered fragments serialize lazy endpoints and return component schemas
         ->assertJsonPath('schema.0.props.text', 'Authenticator setup loaded.');
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture class required only by this file
-// ---------------------------------------------------------------------------
-
 #[AsFragment('workbench.two-factor-setup')]
 final class WorkbenchTwoFactorSetupFragment extends FragmentDefinition
 {

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -253,10 +253,6 @@ test('directly returned pages resolve render dependencies through the container,
         ->assertStatus(302);
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture classes required only by this file
-// ---------------------------------------------------------------------------
-
 final class WorkbenchTabsPage extends Page
 {
     public function render(PageSchema $schema): PageSchema

--- a/tests/Feature/Support/EndpointTestingHelpersTest.php
+++ b/tests/Feature/Support/EndpointTestingHelpersTest.php
@@ -78,10 +78,6 @@ test('loadFragment seals the ref and gets the lazy fragment endpoint', function 
         ->assertJsonPath('schema.0.props.text', 'Fragment loaded.');
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture classes required only by this file
-// ---------------------------------------------------------------------------
-
 #[AsForm('helper.demo')]
 class HelperDemoForm extends FormDefinition
 {

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -384,10 +384,6 @@ test('workbench users table exposes timestamp columns for each row', function ()
         ]);
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture classes required only by this file
-// ---------------------------------------------------------------------------
-
 #[AsTable('workbench.users')]
 class WorkbenchUsersTable extends TableDefinition
 {

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -120,10 +120,6 @@ test('eloquent tables can disable pagination for small datasets', function (): v
         ->assertJsonPath('pagination.hasMore', false);
 });
 
-// ---------------------------------------------------------------------------
-// Inline fixture classes required only by this file
-// ---------------------------------------------------------------------------
-
 /**
  * @extends EloquentTableDefinition<User>
  *

--- a/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
+++ b/tests/Feature/TypeScript/GeneratedTypesSnapshotTest.php
@@ -12,12 +12,14 @@ it('keeps the committed generated.ts in sync with the transformer', function ():
     $before = file_get_contents($path);
     $manifestBefore = file_exists($manifest) ? file_get_contents($manifest) : null;
 
-    artisan('lattice:typescript')->assertSuccessful();
+    try {
+        artisan('lattice:typescript')->assertSuccessful();
 
-    $after = file_get_contents($path);
+        $after = file_get_contents($path);
 
-    file_put_contents($path, $before); // restore regardless of outcome
-    $manifestBefore === null ? @unlink($manifest) : file_put_contents($manifest, $manifestBefore);
-
-    expect($after)->toBe($before);
+        expect($after)->toBe($before);
+    } finally {
+        file_put_contents($path, $before);
+        $manifestBefore === null ? @unlink($manifest) : file_put_contents($manifest, $manifestBefore);
+    }
 });

--- a/tests/Unit/Core/PageMetadataTest.php
+++ b/tests/Unit/Core/PageMetadataTest.php
@@ -87,13 +87,11 @@ test('for() prefers a manifest descriptor and falls back to reflection', functio
     $manifest->cache();
 
     try {
-        // DiscoveredDemoPage is in the cached manifest.
-        $fromManifest = PageMetadata::for(DiscoveredDemoPage::class);
-        expect($fromManifest->name)->toBe('discovered.demo');
+        $fromCachedManifest = PageMetadata::for(DiscoveredDemoPage::class);
+        expect($fromCachedManifest->name)->toBe('discovered.demo');
 
-        // FixtureEditPage is NOT discovered (it lives in this test file) -> reflection fallback.
-        $fromReflection = PageMetadata::for(FixtureEditPage::class);
-        expect($fromReflection->name)->toBe('products.edit');
+        $fromReflectionFallback = PageMetadata::for(FixtureEditPage::class);
+        expect($fromReflectionFallback->name)->toBe('products.edit');
     } finally {
         $manifest->clear();
     }


### PR DESCRIPTION
## Summary
- Remove redundant comment banners, assertion narration, and self-describing docblocks.
- Tighten `.ai` comment guidelines with concrete cleanup rules.
- Keep type/tooling and non-obvious constraint comments intact.

## Verification
- `npm run check`
- `composer check`
