### PR TITLE
feat: add toggle form field

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -94,6 +94,7 @@ export default defineConfig({
                 { label: "Select", link: "/forms/fields/select/" },
                 { label: "Choice", link: "/forms/fields/choice/" },
                 { label: "Checkbox", link: "/forms/fields/checkbox/" },
+                { label: "Toggle", link: "/forms/fields/toggle/" },
                 { label: "Date input", link: "/forms/fields/date-input/" },
                 { label: "Number input", link: "/forms/fields/number-input/" },
                 { label: "Password input", link: "/forms/fields/password-input/" },

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -8,7 +8,7 @@ import ComponentExample from "@components/ComponentExample.astro";
 Fields are the building blocks of a form. Lattice ships
 [Text input](/forms/fields/text-input/), [Textarea](/forms/fields/textarea/),
 [Select](/forms/fields/select/), [Choice](/forms/fields/choice/),
-[Checkbox](/forms/fields/checkbox/), [Date input](/forms/fields/date-input/),
+[Checkbox](/forms/fields/checkbox/), [Toggle](/forms/fields/toggle/), [Date input](/forms/fields/date-input/),
 [Number input](/forms/fields/number-input/), [Password input](/forms/fields/password-input/),
 [Hidden input](/forms/fields/hidden-input/), [File upload](/forms/fields/file-upload/),
 [Rich editor](/forms/fields/rich-editor/), [Repeater](/forms/fields/repeater/), and

--- a/docs/content/docs/forms/fields/toggle.mdx
+++ b/docs/content/docs/forms/fields/toggle.mdx
@@ -1,0 +1,27 @@
+---
+title: Toggle
+description: A switch-style boolean input for enabling or disabling a setting.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+The toggle captures a single boolean with a switch-style control. Use it for settings where the on
+or off state is the important thing. Create one with `Toggle::make()`.
+
+<ComponentExample
+  php={`Toggle::make('published', 'Published')
+    ->helperText('Show this item publicly.')`}
+  fixture="toggle.basic"
+  values={{ published: false }}
+/>
+
+## Checkbox or toggle
+
+Use a [Checkbox](/forms/fields/checkbox/) when the label is consent or agreement text. Use a toggle
+when the field enables or disables a setting.
+
+## Common options
+
+`Toggle` shares label, default value, required, disabled, read-only, and visibility options with
+every field — see [Fields](/forms/fields/overview/). For validation and conditional behavior, see
+[Validation](/forms/validation/) and [Conditional fields](/forms/conditional-fields/).

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -630,6 +630,10 @@
             {
                 "name": "TextInput",
                 "value": "field.text-input"
+            },
+            {
+                "name": "Toggle",
+                "value": "field.toggle"
             }
         ]
     },

--- a/docs/fixtures/toggle.basic.json
+++ b/docs/fixtures/toggle.basic.json
@@ -1,0 +1,25 @@
+[
+    {
+        "props": {
+            "autoFocus": false,
+            "columnWidth": "md",
+            "conditions": null,
+            "dependsOnAny": false,
+            "dependsOnKeys": null,
+            "disabled": false,
+            "editablePrefill": false,
+            "helperText": "Show this item publicly.",
+            "hidden": false,
+            "label": "Published",
+            "name": "published",
+            "prefillRefreshOn": null,
+            "prefillResetOn": null,
+            "readOnly": false,
+            "required": false,
+            "tabIndex": null,
+            "tooltip": null,
+            "value": null
+        },
+        "type": "field.toggle"
+    }
+]

--- a/resources/js/form/components/fields/toggle.test.tsx
+++ b/resources/js/form/components/fields/toggle.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import { FormValuesProvider } from "../values";
+import { ToggleComponent } from "./toggle";
+
+function renderField(node: Node<"field.toggle">, initial: Record<string, unknown> = {}) {
+  return render(
+    <FormValuesProvider initial={initial}>
+      <ToggleComponent node={node}>{null}</ToggleComponent>
+    </FormValuesProvider>,
+  );
+}
+
+describe("ToggleComponent", () => {
+  it("renders helper text and toggles a boolean value", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: {
+          helperText: "Show this item publicly.",
+          label: "Published",
+          name: "published",
+          value: false,
+        },
+      }),
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Published" });
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByText("Show this item publicly.")).toBeVisible();
+    expect(document.querySelector('input[type="hidden"][name="published"]')).toHaveValue("0");
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(document.querySelector('input[type="hidden"][name="published"]')).toHaveValue("1");
+  });
+
+  it("uses form state before the field default", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: { label: "Featured", name: "featured", value: false },
+      }),
+      { featured: true },
+    );
+
+    expect(screen.getByRole("switch", { name: "Featured" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+
+  it("does not toggle while read-only", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: { label: "Locked", name: "locked", readOnly: true, value: true },
+      }),
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Locked" });
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toBeDisabled();
+  });
+});

--- a/resources/js/form/components/fields/toggle.test.tsx
+++ b/resources/js/form/components/fields/toggle.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fakeNode } from "@lattice-php/lattice/test-support";
+import { FieldScopeProvider } from "../field-scope";
 import { FormValuesProvider } from "../values";
 import { ToggleComponent } from "./toggle";
 
@@ -68,5 +69,80 @@ describe("ToggleComponent", () => {
 
     expect(toggle).toHaveAttribute("aria-checked", "true");
     expect(toggle).toBeDisabled();
+  });
+
+  it("hides when its visible condition fails", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: {
+          label: "Published",
+          name: "published",
+          conditions: { visible: [{ field: "status", operator: "eq", value: "live" }] },
+        },
+      }),
+      { status: "draft" },
+    );
+
+    expect(screen.queryByRole("switch", { name: "Published" })).not.toBeInTheDocument();
+  });
+
+  it("uses scoped row values and names inside row fields", () => {
+    const node = fakeNode({
+      type: "field.toggle",
+      props: { label: "Approved", name: "approved", value: false },
+    });
+
+    render(
+      <FormValuesProvider initial={{ approved: false }}>
+        <FieldScopeProvider base="items" index={0} row={{ approved: true }} onChange={() => {}}>
+          <ToggleComponent node={node}>{null}</ToggleComponent>
+        </FieldScopeProvider>
+      </FormValuesProvider>,
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Approved" });
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toHaveAttribute("name", "items[0][approved]");
+    expect(document.querySelector('input[type="hidden"][name="items[0][approved]"]')).toHaveValue(
+      "1",
+    );
+  });
+
+  it("uses the field name as its accessible label when no label is set", () => {
+    renderField(fakeNode({ type: "field.toggle", props: { name: "notifications" } }));
+
+    expect(screen.getByRole("switch", { name: "notifications" })).toBeVisible();
+  });
+
+  it("does not toggle while disabled", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: { disabled: true, label: "Notifications", name: "notifications", value: false },
+      }),
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Notifications" });
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("applies autofocus and tab index props", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: { autoFocus: true, label: "Notifications", name: "notifications", tabIndex: 2 },
+      }),
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Notifications" });
+
+    expect(toggle).toHaveAttribute("tabindex", "2");
+    expect(toggle).toHaveFocus();
   });
 });

--- a/resources/js/form/components/fields/toggle.tsx
+++ b/resources/js/form/components/fields/toggle.tsx
@@ -1,0 +1,68 @@
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { testIdentity } from "@lattice-php/lattice/core/test-id";
+import { cn } from "@lattice-php/lattice/lib/utils";
+import { FormFieldFrame } from "../base/field";
+import { toBoolean } from "../conditions";
+import { useFormContext } from "../context";
+import { useFieldScope } from "../field-scope";
+import { useDependentField } from "../use-dependent-field";
+import { useFieldCommit } from "../use-field-commit";
+import { useSeedDefault } from "../use-seed-default";
+import { useFormValue } from "../values";
+
+export const ToggleComponent: RendererComponent<"field.toggle"> = ({ node }) => {
+  const { hidden, required, readOnly, disabled } = useDependentField(node);
+  const props = node.props;
+  const localName = props.name;
+  const scope = useFieldScope();
+  const name = scope ? scope.scopedName(localName) : localName;
+  const errorKey = scope ? scope.errorKey(localName) : localName;
+  const globalValue = useFormValue(localName);
+  const storedValue = scope ? scope.getValue(localName) : globalValue;
+  const defaultChecked = toBoolean(props.value);
+  const checked = storedValue !== undefined ? toBoolean(storedValue) : defaultChecked;
+  const locked = readOnly || disabled;
+  const { errors } = useFormContext();
+  const { commit } = useFieldCommit();
+
+  useSeedDefault(localName, defaultChecked);
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <FormFieldFrame
+      error={errors[errorKey]}
+      helperText={props.helperText ?? undefined}
+      tooltip={props.tooltip ?? undefined}
+      label={props.label ?? ""}
+      name={name}
+      required={required}
+    >
+      <input disabled={locked} name={name} type="hidden" value={checked ? "1" : "0"} />
+      <button
+        aria-checked={checked}
+        aria-label={props.label ?? localName}
+        autoFocus={props.autoFocus ?? false}
+        className={cn(
+          "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-lt-muted p-0.5 shadow-lt-xs transition-colors outline-none focus-visible:border-lt-ring focus-visible:ring-[3px] focus-visible:ring-lt-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-lt-primary",
+        )}
+        data-state={checked ? "checked" : "unchecked"}
+        data-test={testIdentity(localName)}
+        disabled={locked}
+        id={name}
+        name={name}
+        onClick={() => commit(localName, !checked)}
+        role="switch"
+        tabIndex={props.tabIndex ?? undefined}
+        type="button"
+      >
+        <span
+          className="size-5 rounded-full bg-lt-bg shadow-lt-sm transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+          data-state={checked ? "checked" : "unchecked"}
+        />
+      </button>
+    </FormFieldFrame>
+  );
+};

--- a/resources/js/form/components/index.ts
+++ b/resources/js/form/components/index.ts
@@ -12,3 +12,4 @@ export { RepeaterComponent } from "./fields/repeater";
 export { SelectComponent } from "./fields/select";
 export { TextareaComponent } from "./fields/textarea";
 export { TextInputComponent } from "./fields/text-input";
+export { ToggleComponent } from "./fields/toggle";

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -16,7 +16,8 @@ type FormComponentName =
   | "RepeaterComponent"
   | "SelectComponent"
   | "TextareaComponent"
-  | "TextInputComponent";
+  | "TextInputComponent"
+  | "ToggleComponent";
 
 const loadFormComponents = () => import("./components");
 
@@ -57,6 +58,7 @@ export const formComponents = createPlugin({
     "field.select": lazyComponent(loadFormComponent("SelectComponent")),
     "field.textarea": lazyComponent(loadFormComponent("TextareaComponent")),
     "field.text-input": lazyComponent(loadFormComponent("TextInputComponent")),
+    "field.toggle": lazyComponent(loadFormComponent("ToggleComponent")),
   },
   name: "lattice/form",
 });

--- a/resources/js/registry.test.ts
+++ b/resources/js/registry.test.ts
@@ -29,6 +29,7 @@ describe("lattice component registry", () => {
     expect(registry.components["field.hidden-input"]?.mode).toBe("lazy");
     expect(registry.components["field.password-input"]?.mode).toBe("lazy");
     expect(registry.components["field.text-input"]?.mode).toBe("lazy");
+    expect(registry.components["field.toggle"]?.mode).toBe("lazy");
     expect(registry.components.table?.mode).toBe("lazy");
   });
 

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -488,7 +488,8 @@ export type FieldType =
   | "field.rich-editor"
   | "field.select"
   | "field.textarea"
-  | "field.text-input";
+  | "field.text-input"
+  | "field.toggle";
 export type FileUpload = {
   accept: string | null;
   columnWidth: ColumnWidth;
@@ -632,6 +633,11 @@ export type FormFieldNode =
       type: "field.textarea";
       key?: string;
       props: Textarea;
+    }
+  | {
+      type: "field.toggle";
+      key?: string;
+      props: Toggle;
     };
 export type FormNode =
   | FormFieldNode
@@ -1260,6 +1266,31 @@ export type ToastMessage = {
   action: Node | null;
   variant: Variant;
   message: Translatable | string;
+};
+export type Toggle = {
+  autoFocus: boolean;
+  columnWidth: ColumnWidth;
+  conditions: {
+    visible?: Condition[];
+    required?: Condition[];
+    readOnly?: Condition[];
+    disabled?: Condition[];
+  } | null;
+  dependsOnAny: boolean;
+  dependsOnKeys: string[] | null;
+  disabled: boolean;
+  editablePrefill: boolean;
+  helperText: string | null;
+  hidden: boolean;
+  label: string | null;
+  name: string;
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean;
+  required: boolean;
+  tabIndex: number | null;
+  tooltip: string | null;
+  value: unknown;
 };
 export type ToggleSidebarEffect = {
   readonly target: string | null;

--- a/src/Forms/Components/Toggle.php
+++ b/src/Forms/Components/Toggle.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Lattice\Lattice\Core\Concerns\HasAutoFocus;
+use Lattice\Lattice\Core\Concerns\HasTabIndex;
+use Lattice\Lattice\Forms\Attributes\AsField;
+use Lattice\Lattice\Forms\Enums\FieldType;
+
+#[AsField(FieldType::Toggle)]
+class Toggle extends Field
+{
+    use HasAutoFocus;
+    use HasTabIndex;
+}

--- a/src/Forms/Enums/FieldType.php
+++ b/src/Forms/Enums/FieldType.php
@@ -24,6 +24,7 @@ enum FieldType: string
     case Select = 'field.select';
     case Textarea = 'field.textarea';
     case TextInput = 'field.text-input';
+    case Toggle = 'field.toggle';
 
     public static function wireType(self|string $type): string
     {

--- a/tests/Browser/Forms/ShowcaseTest.php
+++ b/tests/Browser/Forms/ShowcaseTest.php
@@ -20,7 +20,9 @@ it('renders the form showcase with every field type', function (): void {
         ->assertSee('Quantity')
         ->assertSee('Total')
         ->assertSee('Article')
+        ->assertSee('Marketing updates')
         ->assertSee('Subscribe to the newsletter')
+        ->assertPresent('[role="switch"][aria-label="Marketing updates"]')
         ->assertPresent('[aria-label="Bold"]')
         ->assertPresent('.lattice-prose')
         ->assertPresent('input[type="hidden"][name="source"]');

--- a/tests/Unit/Forms/Components/ToggleTest.php
+++ b/tests/Unit/Forms/Components/ToggleTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\Toggle;
+
+it('serializes the shared focus options', function (): void {
+    $node = wire(Toggle::make('published', 'Published')->autoFocus()->tabIndex(3));
+
+    expect($node['type'])->toBe('field.toggle')
+        ->and($node['props'])->toMatchArray(['autoFocus' => true, 'tabIndex' => 3]);
+});
+
+it('serializes a default boolean value', function (): void {
+    $node = wire(Toggle::make('published', 'Published')->value(true));
+
+    expect($node['props'])->toMatchArray([
+        'name' => 'published',
+        'label' => 'Published',
+        'value' => true,
+    ]);
+});
+
+describe('docs fixtures', function (): void {
+    it('dumps the toggle example', function (): void {
+        dumpFixture('toggle.basic', [
+            Toggle::make('published', 'Published')->helperText('Show this item publicly.'),
+        ]);
+
+        expect('docs/fixtures/toggle.basic.json')->toBeReadableFile();
+    });
+});

--- a/workbench/app/Forms/ShowcaseForm.php
+++ b/workbench/app/Forms/ShowcaseForm.php
@@ -21,6 +21,7 @@ use Lattice\Lattice\Forms\Components\RichEditor;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\Components\Toggle;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
@@ -144,6 +145,8 @@ class ShowcaseForm extends FormDefinition
                 ]),
 
                 Card::make(__('workbench.forms.showcase.consent'))->schema([
+                    Toggle::make('marketing_opt_in', __('workbench.forms.showcase.marketing-opt-in.label'))
+                        ->helperText(__('workbench.forms.showcase.marketing-opt-in.help-text')),
                     Checkbox::make('newsletter', __('workbench.forms.showcase.newsletter')),
                     Checkbox::make('terms', __('workbench.forms.showcase.terms'))
                         ->rules(['accepted']),

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -278,6 +278,10 @@ return [
             'full-name' => 'Vollständiger Name',
             'germany' => 'Deutschland',
             'italy' => 'Italien',
+            'marketing-opt-in' => [
+                'help-text' => 'Erhalte Produktneuigkeiten und Versionshinweise.',
+                'label' => 'Marketing-Updates',
+            ],
             'newsletter' => 'Newsletter abonnieren',
             'order-total' => 'Bestellsumme',
             'order-total-description' => 'Die Summe wird auf dem Server berechnet.',

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -278,6 +278,10 @@ return [
             'full-name' => 'Full name',
             'germany' => 'Germany',
             'italy' => 'Italy',
+            'marketing-opt-in' => [
+                'help-text' => 'Receive product news and release notes.',
+                'label' => 'Marketing updates',
+            ],
             'newsletter' => 'Subscribe to the newsletter',
             'order-total' => 'Order total',
             'order-total-description' => 'The total is computed on the server.',


### PR DESCRIPTION
## Summary
- add a built-in Toggle form field with PHP serialization, generated types, and React registry support
- document Toggle with generated docs fixtures and add it to the workbench showcase

## Tests
- npm run check
- composer check
- npm run docs:build
- composer test:browser
