### PR TITLE
fix(icon): let an explicit size override the sprite baseline, add 2xl–4xl

### DIFF
--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -494,6 +494,18 @@
             {
                 "name": "Xl",
                 "value": "xl"
+            },
+            {
+                "name": "Xl2",
+                "value": "2xl"
+            },
+            {
+                "name": "Xl3",
+                "value": "3xl"
+            },
+            {
+                "name": "Xl4",
+                "value": "4xl"
             }
         ]
     },

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -49,6 +49,9 @@
   --lt-icon-md: 1rem;
   --lt-icon-lg: 1.25rem;
   --lt-icon-xl: 1.5rem;
+  --lt-icon-2xl: 2rem;
+  --lt-icon-3xl: 2.5rem;
+  --lt-icon-4xl: 3rem;
   --lt-icon-stroke: 1.5;
 
   /* Control heights — density lever */
@@ -190,6 +193,9 @@
   --spacing-lt-icon-md: var(--lt-icon-md);
   --spacing-lt-icon-lg: var(--lt-icon-lg);
   --spacing-lt-icon-xl: var(--lt-icon-xl);
+  --spacing-lt-icon-2xl: var(--lt-icon-2xl);
+  --spacing-lt-icon-3xl: var(--lt-icon-3xl);
+  --spacing-lt-icon-4xl: var(--lt-icon-4xl);
   --spacing-lt-control-sm: var(--lt-control-h-sm);
   --spacing-lt-control-md: var(--lt-control-h-md);
   --spacing-lt-control-lg: var(--lt-control-h-lg);

--- a/resources/js/core/components/fragment.tsx
+++ b/resources/js/core/components/fragment.tsx
@@ -16,6 +16,9 @@ const fragmentSizeHeights = {
   sm: 40,
   xl: 384,
   xs: 32,
+  "2xl": 448,
+  "3xl": 512,
+  "4xl": 576,
 } as const;
 
 const FragmentComponent: RendererComponent<"fragment"> = ({ node }) => {

--- a/resources/js/core/components/icon.test.tsx
+++ b/resources/js/core/components/icon.test.tsx
@@ -27,11 +27,20 @@ describe("Lattice icon component", () => {
       class: "opacity-80",
     });
 
-    expect(container.querySelector("svg")).toHaveClass(
-      "size-lt-icon-lg",
-      "text-lt-danger",
-      "opacity-80",
-    );
+    const svg = container.querySelector("svg");
+
+    expect(svg).toHaveClass("size-lt-icon-lg", "text-lt-danger", "opacity-80");
+    // The sprite renderer applies size-lt-icon-md as a baseline; an explicit
+    // size must override it rather than coexist with it.
+    expect(svg).not.toHaveClass("size-lt-icon-md");
+  });
+
+  it.each(["2xl", "3xl", "4xl"] as const)("supports the %s display size", (size) => {
+    const { container } = renderIcon({ name: "house", size, color: null, class: null });
+    const svg = container.querySelector("svg");
+
+    expect(svg).toHaveClass(`size-lt-icon-${size}`);
+    expect(svg).not.toHaveClass("size-lt-icon-md");
   });
 
   it("renders the md token and omits colour when unset", () => {

--- a/resources/js/core/components/icon.tsx
+++ b/resources/js/core/components/icon.tsx
@@ -9,6 +9,9 @@ const sizeClass: Record<Size, string> = {
   md: "size-lt-icon-md",
   lg: "size-lt-icon-lg",
   xl: "size-lt-icon-xl",
+  "2xl": "size-lt-icon-2xl",
+  "3xl": "size-lt-icon-3xl",
+  "4xl": "size-lt-icon-4xl",
 };
 
 const colorClass: Record<Color, string> = {

--- a/resources/js/core/components/text.tsx
+++ b/resources/js/core/components/text.tsx
@@ -23,6 +23,9 @@ const textSizes: Record<Size, string> = {
   md: "text-base leading-7",
   lg: "text-lg leading-8",
   xl: "text-xl leading-8",
+  "2xl": "text-2xl leading-9",
+  "3xl": "text-3xl leading-10",
+  "4xl": "text-4xl leading-none",
 };
 
 const TextComponent: RendererComponent<"text"> = ({ node }) => {

--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -1,6 +1,20 @@
 import { clsx } from "clsx";
 import type { ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// The sprite renderer always applies `size-lt-icon-md` as a baseline, and these
+// custom utilities are invisible to tailwind-merge's stock config, so an explicit
+// `size-lt-icon-*` would otherwise be left to fight the baseline on source order.
+// Registering them as one conflicting group lets the explicit size always win.
+const twMerge = extendTailwindMerge<"lt-icon-size">({
+  extend: {
+    classGroups: {
+      "lt-icon-size": [
+        { size: [{ lt: [{ icon: ["xs", "sm", "md", "lg", "xl", "2xl", "3xl", "4xl"] }] }] },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1105,7 +1105,7 @@ export type Sidebar = {
   collapsible: boolean;
   rememberState: boolean;
 };
-export type Size = "xs" | "sm" | "md" | "lg" | "xl";
+export type Size = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
 export type SortDirection = "asc" | "desc";
 export type Stack = {
   align: Align | null;

--- a/src/Core/Enums/Size.php
+++ b/src/Core/Enums/Size.php
@@ -13,4 +13,7 @@ enum Size: string
     case Md = 'md';
     case Lg = 'lg';
     case Xl = 'xl';
+    case Xl2 = '2xl';
+    case Xl3 = '3xl';
+    case Xl4 = '4xl';
 }


### PR DESCRIPTION
## What

Two related icon-sizing fixes.

**1. An explicit icon size now actually wins.** The sprite renderer always applies `size-lt-icon-md` as a baseline, and the custom `size-lt-icon-*` utilities are invisible to tailwind-merge's stock config — so `Icon::make(...)->size(Size::Xl)` only beat the baseline on CSS source-order luck, and `->class('size-N')` lost outright. `cn` now registers `size-lt-icon-*` as one conflicting group via `extendTailwindMerge`, so the chosen size always overrides the baseline.

**2. New display sizes `2xl`, `3xl`, `4xl`** (32 / 40 / 48px). The scale previously topped out at `xl` = 24px — fine for inline UI icons but too small for display use such as an auth-screen logo.

## Why

Surfaced while sizing the auth logo in the starter kit: `->size(Size::Xl)` rendered at 24px and couldn't go bigger, and `->class()` couldn't override it (measured 16px — the baseline `md` won).

## Changes

- `Size` enum: add `Xl2` / `Xl3` / `Xl4` (`2xl` / `3xl` / `4xl`).
- `cn` (`lib/utils.ts`): `extendTailwindMerge` group so `size-lt-icon-*` conflict and the last one wins.
- CSS tokens `--lt-icon-2xl/3xl/4xl` + `--spacing-*` registrations.
- Wire the new cases through the icon and text size maps and fragment skeleton heights (all `Record<Size>`-keyed, so required by `tsc`).
- Regenerated `generated.ts` + `docs/fixtures/enums.json`.
- Test: an explicit size drops the baseline `md`, and the new display sizes render.

## Verification

`composer check` (Pint, PHPStan, Pest — 899 passed) and `npm run check` (lint, format, tsc, type-coverage, Vitest, build) both green. The tailwind-merge dedup was also verified directly (`cn("size-lt-icon-md size-lt-icon-4xl") === "size-lt-icon-4xl"`).