### PR TITLE
feat: add Collapsible disclosure component

### DIFF
--- a/docs/content/docs/core/components.mdx
+++ b/docs/content/docs/core/components.mdx
@@ -34,6 +34,8 @@ Layout components arrange their children. They are containers — pass children 
   `Card::make('Title', 'Description')`.
 - **`Section`** is a titled panel like `Card`, but it can collapse and carry actions in its header —
   see [below](#section).
+- **`Collapsible`** is an untitled disclosure: a clickable trigger row that folds a body of children
+  open and closed — see [below](#collapsible).
 - **`FloatingPanel`** fixes children to a viewport corner, useful for compact persistent controls
   such as language or appearance switchers. Set the corner with `->placement(FloatingPlacement::TopEnd)`.
 
@@ -63,6 +65,21 @@ it fold (pass `collapsed: true` to start folded; `rememberState: false` to not p
         Badge::make('3 active'),
     ]);`}
   fixture="components.section"
+/>
+
+### Collapsible
+
+`Collapsible::make()` folds a body of children behind a clickable trigger. Pass the header content to
+`->trigger([...])` (any components — a label, a value, a badge) and the body to `->content([...])`. It
+starts folded; call `->collapsed(false)` to start open, and `->rememberState()` to persist the open
+state across reloads. Unlike `Section`, the whole trigger row is clickable and there is no built-in
+title — you supply it, which makes it a good fit for settings rows that reveal an inline edit form.
+
+<ComponentExample
+  php={`Collapsible::make('account-name')
+    ->trigger([Text::make('Name')])
+    ->content([Text::make('Update the name shown on your account.')]);`}
+  fixture="components.collapsible"
 />
 
 ## Display

--- a/docs/fixtures/components.collapsible.json
+++ b/docs/fixtures/components.collapsible.json
@@ -1,0 +1,34 @@
+[
+    {
+        "key": "account-name",
+        "props": {
+            "collapsed": true,
+            "rememberState": false,
+            "trigger": [
+                {
+                    "props": {
+                        "align": null,
+                        "color": "muted",
+                        "copyable": false,
+                        "size": "md",
+                        "text": "Name"
+                    },
+                    "type": "text"
+                }
+            ]
+        },
+        "schema": [
+            {
+                "props": {
+                    "align": null,
+                    "color": "muted",
+                    "copyable": false,
+                    "size": "md",
+                    "text": "Update the name shown on your account."
+                },
+                "type": "text"
+            }
+        ],
+        "type": "collapsible"
+    }
+]

--- a/resources/js/core/components/collapsible.test.tsx
+++ b/resources/js/core/components/collapsible.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import type { Node } from "@lattice-php/lattice/core/types";
+import CollapsibleComponent from "./collapsible";
+import TextComponent from "./text";
+
+const registry = createRegistry({
+  components: {
+    collapsible: eagerComponent(CollapsibleComponent),
+    text: eagerComponent(TextComponent),
+  },
+  name: "test/collapsible",
+});
+
+function renderCollapsible(node: Node) {
+  return renderWithRegistry(<Renderer nodes={[node]} />, registry);
+}
+
+describe("Collapsible component", () => {
+  it("renders the trigger and hides the content until opened", () => {
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: { trigger: [{ type: "text", props: { text: "Name" } }] },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    expect(screen.getByText("Name")).toBeVisible();
+    expect(screen.queryByText("Hidden body")).not.toBeInTheDocument();
+  });
+
+  it("toggles its content on click", () => {
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: { trigger: [{ type: "text", props: { text: "Name" } }] },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    const toggle = screen.getByRole("button", { name: "Name" });
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+    expect(screen.getByText("Hidden body")).toBeVisible();
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(toggle);
+    expect(screen.queryByText("Hidden body")).not.toBeInTheDocument();
+  });
+
+  it("starts open when collapsed is false", () => {
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: { collapsed: false, trigger: [{ type: "text", props: { text: "Name" } }] },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    expect(screen.getByText("Hidden body")).toBeVisible();
+  });
+
+  it("toggles with the Enter and Space keys", () => {
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: { trigger: [{ type: "text", props: { text: "Name" } }] },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    const toggle = screen.getByRole("button", { name: "Name" });
+
+    fireEvent.keyDown(toggle, { key: "Enter" });
+    expect(screen.getByText("Hidden body")).toBeVisible();
+
+    fireEvent.keyDown(toggle, { key: " " });
+    expect(screen.queryByText("Hidden body")).not.toBeInTheDocument();
+  });
+
+  it("persists the open state when rememberState is set", () => {
+    window.localStorage.clear();
+
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: { rememberState: true, trigger: [{ type: "text", props: { text: "Name" } }] },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Name" }));
+
+    expect(window.localStorage.getItem("lattice:collapsible:name")).toBe("true");
+    window.localStorage.clear();
+  });
+
+  it("restores the persisted open state", () => {
+    window.localStorage.setItem("lattice:collapsible:name", "true");
+
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: { rememberState: true, trigger: [{ type: "text", props: { text: "Name" } }] },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    expect(screen.getByText("Hidden body")).toBeVisible();
+    window.localStorage.clear();
+  });
+});

--- a/resources/js/core/components/collapsible.tsx
+++ b/resources/js/core/components/collapsible.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Icon } from "@lattice-php/lattice/icons";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { nodeIdentity, prefixedTestId } from "@lattice-php/lattice/core/test-id";
+import { toNodes } from "@lattice-php/lattice/core/nodes";
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { cn } from "@lattice-php/lattice/lib/utils";
+
+function readStored(key: string, remember: boolean, fallback: boolean): boolean {
+  if (!remember || typeof window === "undefined") {
+    return fallback;
+  }
+
+  const stored = window.localStorage.getItem(key);
+
+  return stored === null ? fallback : stored === "true";
+}
+
+const CollapsibleComponent: RendererComponent<"collapsible"> = ({ children, node }) => {
+  const rememberState = node.props.rememberState === true;
+  const trigger = toNodes(node.props.trigger);
+  const identity = nodeIdentity(node);
+  const storageKey = `lattice:collapsible:${identity ?? "default"}`;
+  const contentId = `${identity ?? "collapsible"}-content`;
+
+  const [open, setOpen] = useState(() =>
+    readStored(storageKey, rememberState, node.props.collapsed === false),
+  );
+
+  function toggle(): void {
+    setOpen((value) => {
+      const next = !value;
+
+      if (rememberState && typeof window !== "undefined") {
+        window.localStorage.setItem(storageKey, String(next));
+      }
+
+      return next;
+    });
+  }
+
+  return (
+    <div data-lattice-component={identity}>
+      <div
+        aria-controls={contentId}
+        aria-expanded={open}
+        data-test={prefixedTestId("collapsible-toggle", identity) ?? "collapsible-toggle-default"}
+        className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-lt-sm py-2 text-left text-lt-fg transition-colors hover:bg-lt-muted"
+        onClick={toggle}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            toggle();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Renderer nodes={trigger} />
+        </div>
+        <Icon
+          name="chevron-down"
+          className={cn(
+            "size-lt-icon-md shrink-0 text-lt-muted-fg transition-transform",
+            !open && "-rotate-90",
+          )}
+        />
+      </div>
+
+      {open && children && (
+        <div id={contentId} className="flex flex-col gap-4 pt-2">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CollapsibleComponent;

--- a/resources/js/core/components/index.ts
+++ b/resources/js/core/components/index.ts
@@ -3,6 +3,7 @@ import type { RendererComponentModule } from "@lattice-php/lattice/core/types";
 import BadgeComponent from "./badge";
 import ButtonComponent from "./button";
 import CardComponent from "./card";
+import CollapsibleComponent from "./collapsible";
 import FloatingPanelComponent from "./floating-panel";
 import FragmentComponent from "./fragment";
 import GridComponent from "./grid";
@@ -25,6 +26,7 @@ export const coreComponents = createPlugin({
     chart: lazyComponent(
       () => import("./chart") as unknown as Promise<RendererComponentModule<"chart">>,
     ),
+    collapsible: eagerComponent(CollapsibleComponent),
     "floating-panel": eagerComponent(FloatingPanelComponent),
     fragment: eagerComponent(FragmentComponent),
     grid: eagerComponent(GridComponent),

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -242,6 +242,11 @@ export type Choice = {
 export type CloseModalEffect = {
   readonly modal: string | null;
 };
+export type Collapsible = {
+  collapsed: boolean;
+  rememberState: boolean;
+  trigger: Node[];
+};
 export type Color = "default" | "muted" | "primary" | "success" | "info" | "warning" | "danger";
 export type ColumnAlign = "start" | "center" | "end";
 export type ColumnData = {
@@ -326,6 +331,12 @@ export type CoreNode =
       type: "chart";
       key?: string;
       props: Chart;
+    }
+  | {
+      type: "collapsible";
+      key?: string;
+      props: Collapsible;
+      schema?: Node[];
     }
   | {
       type: "floating-panel";

--- a/src/Core/Components/Collapsible.php
+++ b/src/Core/Components/Collapsible.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Components;
+
+use Lattice\Lattice\Attributes\AsComponent;
+
+#[AsComponent('collapsible')]
+class Collapsible extends ContainerComponent
+{
+    public bool $collapsed = true;
+
+    public bool $rememberState = false;
+
+    /**
+     * @var array<int, Component>
+     */
+    public array $trigger = [];
+
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+
+    public function collapsed(bool $collapsed = true): static
+    {
+        $this->collapsed = $collapsed;
+
+        return $this;
+    }
+
+    public function rememberState(bool $rememberState = true): static
+    {
+        $this->rememberState = $rememberState;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, Component>  $components
+     */
+    public function trigger(array $components): static
+    {
+        $this->trigger = $components;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, Component>  $components
+     */
+    public function content(array $components): static
+    {
+        return $this->schema($components);
+    }
+
+    /**
+     * @param  array<string, mixed>  $props
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function decorateProps(array $props): array
+    {
+        return [
+            ...parent::decorateProps($props),
+            'trigger' => $this->renderableComponents($this->trigger),
+        ];
+    }
+}

--- a/tests/Unit/Core/Components/CollapsibleTest.php
+++ b/tests/Unit/Core/Components/CollapsibleTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Components\Collapsible;
+use Lattice\Lattice\Core\Components\Text;
+
+it('serializes its trigger, content, and default flags', function (): void {
+    $node = wire(
+        Collapsible::make('details')
+            ->trigger([Text::make('Name')])
+            ->content([Text::make('Hidden body')]),
+    );
+
+    expect($node['type'])->toBe('collapsible')
+        ->and($node['props'])->toMatchArray([
+            'collapsed' => true,
+            'rememberState' => false,
+        ])
+        ->and($node['props']['trigger'])->toHaveCount(1)
+        ->and($node['props']['trigger'][0]['type'])->toBe('text')
+        ->and($node['schema'][0]['type'])->toBe('text');
+});
+
+it('serializes the open and remember-state flags', function (): void {
+    $node = wire(Collapsible::make()->collapsed(false)->rememberState());
+
+    expect($node['props'])->toMatchArray([
+        'collapsed' => false,
+        'rememberState' => true,
+    ]);
+});
+
+it('omits trigger components hidden by a condition', function (): void {
+    $node = wire(
+        Collapsible::make()->trigger([
+            Text::make('Visible'),
+            Text::make('Hidden')->when(false),
+        ]),
+    );
+
+    expect($node['props']['trigger'])->toHaveCount(1)
+        ->and($node['props']['trigger'][0]['props']['text'])->toBe('Visible');
+});
+
+describe('docs fixtures', function (): void {
+    it('dumps the collapsible example', function (): void {
+        dumpFixture('components.collapsible', [
+            Collapsible::make('account-name')
+                ->trigger([Text::make('Name')])
+                ->content([Text::make('Update the name shown on your account.')]),
+        ]);
+
+        expect('docs/fixtures/components.collapsible.json')->toBeReadableFile();
+    });
+});


### PR DESCRIPTION
Adds a core `Collapsible` component: a clickable trigger row that folds a body of child components open and closed.

Unlike `Section`, it has no built-in title and the **whole trigger row is clickable**, so consumers compose their own header (a label, a value, a badge) that reveals a body — the pattern settings pages need (e.g. a profile row that expands into an inline edit form).

```php
Collapsible::make('account-name')
    ->trigger([Text::make('Name'), Badge::make('Manuel Christlieb')])
    ->content([/* an inline edit form */]);
```

- `->trigger([...])` — header content (respects `->when()`, mirroring `Dropdown`).
- `->content([...])` — body (alias for `schema()`).
- Starts collapsed; `->collapsed(false)` starts open, `->rememberState()` persists across reloads.
- Trigger is a `role="button"` row (keyboard + `aria-expanded`/`aria-controls`) so it can hold rich flow content, not just phrasing.

Docs: new `### Collapsible` example on the Core Components page, backed by a test-generated fixture.

Gates: `composer check`, `npm run check`, and `npm run docs:build` all green.