### PR TITLE
feat: only show the select search box when the field is searchable

### DIFF
--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -58,6 +58,10 @@ Select::make('status', 'Status')->enum(OrderStatus::class);
 
 ## Searchable
 
+A static `->options()` select has no search box — the dropdown shows the full list. Call
+`->searchable()` to add a search box and resolve options on the server (`->searchPlaceholder()` then
+sets its placeholder). For a static list long enough to need filtering, prefer `->searchable()`.
+
 `->searchable()` turns the select into a server-driven search. The resolver receives `$search` (the
 query string) and returns the matching options; it may also inject `$get`/`$state`/`$component` and
 any container type such as `Request` through [closure evaluation](/core/closure-evaluation/). The

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -192,6 +192,20 @@ describe("SelectComponent options", () => {
     expect(screen.getByTestId("select-color")).toHaveTextContent("Blue");
   });
 
+  it("omits the search box when not searchable", () => {
+    renderStaticSelect({
+      options: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+      ],
+    });
+
+    fireEvent.click(screen.getByTestId("select-color"));
+
+    expect(screen.queryByTestId("select-color-search")).not.toBeInTheDocument();
+    expect(screen.getByTestId("select-color-option-red")).toBeVisible();
+  });
+
   it("shows chips and removes a value in a multiple select", () => {
     renderStaticSelect(
       {

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -187,6 +187,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
           }}
           options={options}
           searchPlaceholder={props.searchPlaceholder ?? undefined}
+          showSearch={Boolean(searchable)}
           selected={selected}
           testId={`select-${name}`}
           trigger={


### PR DESCRIPTION
A static `->options()` select renders through the same `Combobox` as a searchable one, and the combobox's `showSearch` defaulted to `true` while the field never set it — so **every** select showed a search input (filtering client-side), even short static lists.

This passes `showSearch={Boolean(searchable)}` from the select field, so:
- a plain `->options()` select shows its full list with **no search box**;
- `->searchable()` adds the search box back (server-driven search, unchanged).

```php
Select::make('locale', 'Language')->options([...]);   // no search box
Select::make('author_id', 'Author')->searchable(/* … */);  // search box
```

Docs note added under Forms → Select → Searchable. New vitest case asserts a non-searchable select omits the search box; existing searchable tests cover the inverse.

Gates: `npm run check` and `npm run docs:build` green.