### PR TITLE
Add eager registry entrypoints

### DIFF
--- a/docs/content/docs/advanced/bundle-size.mdx
+++ b/docs/content/docs/advanced/bundle-size.mdx
@@ -29,6 +29,20 @@ so a page only pays for what it actually renders:
 Everything else — the renderer, registry, layout shell, toasts, and core components — sits in the eager
 entry chunk that every page loads.
 
+If you prefer a single eager Lattice component graph, pass the eager registry when bootstrapping the app:
+
+```ts
+import { createLatticeApp } from "@lattice-php/lattice";
+import { eagerRegistry } from "@lattice-php/lattice/registry/eager";
+
+createLatticeApp({
+  registry: eagerRegistry,
+});
+```
+
+The default `registry` export remains lazy. Use the eager registry when your deployment favors fewer
+runtime chunk requests over a smaller initial component bundle.
+
 :::note
 React, React-DOM, and Inertia are **peer dependencies**: your app already ships them, so they are not
 Lattice's marginal cost even though they show up in the entry chunk below.

--- a/docs/content/docs/extending/registry-and-types.md
+++ b/docs/content/docs/extending/registry-and-types.md
@@ -71,6 +71,19 @@ export const registry = extendRegistry(
 `packageRegistry` is Lattice's built-in registry. Pass the extended `registry` to `Provider`. Call
 `extendRegistry` again yourself only if you keep additional plugins in their own files.
 
+The package-level `registry` export is the default lazy registry. To eager-load Lattice's built-in
+components, extend the eager registry instead:
+
+```ts
+import { createPlugin, extendRegistry } from "@lattice-php/lattice";
+import { eagerRegistry } from "@lattice-php/lattice/registry/eager";
+
+export const registry = extendRegistry(
+  eagerRegistry,
+  createPlugin({ name: "app", components: {}, columns: {} }),
+);
+```
+
 ### createRegistry
 
 Creates a registry from scratch (no built-ins). Only use this if you want to replace the entire built-in component set:

--- a/package.json
+++ b/package.json
@@ -135,6 +135,14 @@
       "types": "./dist/registry.d.ts",
       "import": "./dist/registry.js"
     },
+    "./registry/eager": {
+      "types": "./dist/registry/eager.d.ts",
+      "import": "./dist/registry/eager.js"
+    },
+    "./registry/lazy": {
+      "types": "./dist/registry/lazy.d.ts",
+      "import": "./dist/registry/lazy.js"
+    },
     "./remote": {
       "types": "./dist/remote/index.d.ts",
       "import": "./dist/remote/index.js"

--- a/resources/js/core/components/eager.ts
+++ b/resources/js/core/components/eager.ts
@@ -1,0 +1,44 @@
+import { createPlugin, eagerComponent } from "@lattice-php/lattice/core/registry";
+import BadgeComponent from "./badge";
+import ButtonComponent from "./button";
+import CardComponent from "./card";
+import ChartComponent from "./chart";
+import CollapsibleComponent from "./collapsible";
+import FloatingPanelComponent from "./floating-panel";
+import FragmentComponent from "./fragment";
+import GridComponent from "./grid";
+import HeadingComponent from "./heading";
+import IconComponent from "./icon";
+import LinkComponent from "./link";
+import ModalComponent from "./modal";
+import RawBlockComponent from "./raw-block";
+import SectionComponent from "./section";
+import SegmentedControlComponent from "./segmented-control";
+import StackComponent from "./stack";
+import TabComponent, { TabsComponent } from "./tabs";
+import TextComponent from "./text";
+
+export const eagerCoreComponents = createPlugin({
+  components: {
+    badge: eagerComponent(BadgeComponent),
+    button: eagerComponent(ButtonComponent),
+    card: eagerComponent(CardComponent),
+    chart: eagerComponent(ChartComponent),
+    collapsible: eagerComponent(CollapsibleComponent),
+    "floating-panel": eagerComponent(FloatingPanelComponent),
+    fragment: eagerComponent(FragmentComponent),
+    grid: eagerComponent(GridComponent),
+    heading: eagerComponent(HeadingComponent),
+    icon: eagerComponent(IconComponent),
+    link: eagerComponent(LinkComponent),
+    modal: eagerComponent(ModalComponent),
+    "raw-block": eagerComponent(RawBlockComponent),
+    section: eagerComponent(SectionComponent),
+    "segmented-control": eagerComponent(SegmentedControlComponent),
+    stack: eagerComponent(StackComponent),
+    tab: eagerComponent(TabComponent),
+    tabs: eagerComponent(TabsComponent),
+    text: eagerComponent(TextComponent),
+  },
+  name: "lattice/core",
+});

--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -9,7 +9,7 @@ vi.mock("@inertiajs/react", () => ({ createInertiaApp }));
 import { createLatticeApp } from "./create-app";
 import { pageComponentName } from "./inertia";
 import Page from "./page";
-import { Provider } from "./provider";
+import { ProviderBase } from "./provider-base";
 
 type CapturedOptions = {
   resolve: (name: string) => unknown;
@@ -62,12 +62,14 @@ describe("createLatticeApp", () => {
 
   it("wraps the app in the Provider so toasts use Lattice's own Toaster", () => {
     const sprite = { href: "/sprite.svg" };
+    const registry = { columns: {}, components: {}, effects: {} };
 
-    createLatticeApp({ sprite });
+    createLatticeApp({ registry, sprite });
 
     const wrapped = captureOptions().withApp(<div />);
 
-    expect(wrapped.type).toBe(Provider);
+    expect(wrapped.type).toBe(ProviderBase);
+    expect((wrapped.props as { registry: unknown }).registry).toBe(registry);
     expect((wrapped.props as { sprite: unknown }).sprite).toBe(sprite);
   });
 

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -2,6 +2,7 @@ import { createInertiaApp } from "@inertiajs/react";
 import type { ReactElement } from "react";
 import { initializeTheme } from "./appearance";
 import type { Registry } from "./core/registry";
+import { setDefaultRegistry } from "./core/registry-context";
 import type { SpriteValue } from "./icons/sprite";
 import {
   createLayoutResolver,
@@ -9,7 +10,8 @@ import {
   type CreateLayoutResolverOptions,
   type PageModules,
 } from "./inertia";
-import { Provider } from "./provider";
+import { ProviderBase } from "./provider-base";
+import { registry as defaultRegistry } from "./registry";
 
 type InertiaAppOptions = NonNullable<Parameters<typeof createInertiaApp>[0]>;
 
@@ -38,15 +40,19 @@ export function createLatticeApp({
   strictMode = true,
   ...inertiaOptions
 }: CreateLatticeAppOptions = {}) {
+  const activeRegistry = registry ?? defaultRegistry;
+
+  setDefaultRegistry(activeRegistry);
+
   const app = createInertiaApp({
     ...inertiaOptions,
     strictMode,
     resolve: createPageResolver(pages),
     layout: createLayoutResolver({ defaultLayout }),
     withApp: (node: ReactElement): ReactElement => (
-      <Provider registry={registry} sprite={sprite}>
+      <ProviderBase registry={activeRegistry} sprite={sprite}>
         {node}
-      </Provider>
+      </ProviderBase>
     ),
   });
 

--- a/resources/js/form/eager.ts
+++ b/resources/js/form/eager.ts
@@ -1,0 +1,45 @@
+import { createPlugin, eagerComponent } from "@lattice-php/lattice/core/registry";
+import {
+  BuilderComponent,
+  CheckboxComponent,
+  ChoiceComponent,
+  DateInputComponent,
+  DateTimeInputComponent,
+  FileUploadComponent,
+  FormComponent,
+  HiddenInputComponent,
+  NumberInputComponent,
+  OtpInputComponent,
+  PasswordInputComponent,
+  RepeaterComponent,
+  SelectComponent,
+  TextareaComponent,
+  TextInputComponent,
+  TimeInputComponent,
+  ToggleComponent,
+} from "./components";
+import { RichEditorComponent } from "./components/fields/rich-editor";
+
+export const eagerFormComponents = createPlugin({
+  components: {
+    form: eagerComponent(FormComponent),
+    "field.builder": eagerComponent(BuilderComponent),
+    "field.checkbox": eagerComponent(CheckboxComponent),
+    "field.choice": eagerComponent(ChoiceComponent),
+    "field.date-input": eagerComponent(DateInputComponent),
+    "field.date-time-input": eagerComponent(DateTimeInputComponent),
+    "field.file-upload": eagerComponent(FileUploadComponent),
+    "field.hidden-input": eagerComponent(HiddenInputComponent),
+    "field.number-input": eagerComponent(NumberInputComponent),
+    "field.otp": eagerComponent(OtpInputComponent),
+    "field.password-input": eagerComponent(PasswordInputComponent),
+    "field.repeater": eagerComponent(RepeaterComponent),
+    "field.rich-editor": eagerComponent(RichEditorComponent),
+    "field.select": eagerComponent(SelectComponent),
+    "field.textarea": eagerComponent(TextareaComponent),
+    "field.text-input": eagerComponent(TextInputComponent),
+    "field.time-input": eagerComponent(TimeInputComponent),
+    "field.toggle": eagerComponent(ToggleComponent),
+  },
+  name: "lattice/form",
+});

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -1,4 +1,4 @@
-export { registry } from "./registry";
+export { lazyRegistry, registry } from "./registry";
 export { useChat } from "./chat/use-chat";
 export { chatPlugin } from "./chat";
 export {

--- a/resources/js/provider-base.tsx
+++ b/resources/js/provider-base.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import type { Registry } from "./core/registry";
+import { RegistryContext } from "./core/registry-context";
+import { useFlashEffects } from "./effects/use-flash-effects";
+import { EventBridge } from "./events/event-bridge";
+import type { SpriteValue } from "./icons/sprite";
+import { SpriteProvider } from "./icons/sprite";
+import { Toaster } from "./toast";
+import { updateAppearance } from "./appearance";
+
+const defaultSprite: SpriteValue = { href: "" };
+
+export type ProviderBaseProps = {
+  children: ReactNode;
+  registry: Registry;
+  sprite?: SpriteValue;
+  toaster?: boolean;
+};
+
+export function ProviderBase({
+  children,
+  registry,
+  sprite = defaultSprite,
+  toaster = true,
+}: ProviderBaseProps) {
+  useFlashEffects();
+
+  return (
+    <RegistryContext.Provider value={registry}>
+      <SpriteProvider sprite={sprite}>
+        {children}
+        <EventBridge onAppearanceChange={updateAppearance} />
+        {toaster ? <Toaster /> : null}
+      </SpriteProvider>
+    </RegistryContext.Provider>
+  );
+}

--- a/resources/js/provider.tsx
+++ b/resources/js/provider.tsx
@@ -1,43 +1,19 @@
-import type { ReactNode } from "react";
-import type { SpriteValue } from "./icons/sprite";
-import { SpriteProvider } from "./icons/sprite";
 import { registry as defaultRegistry } from "./registry";
 import type { Registry } from "./core/registry";
-import { RegistryContext, setDefaultRegistry } from "./core/registry-context";
-import { Toaster } from "./toast";
-import { updateAppearance } from "./appearance";
-import { EventBridge } from "./events/event-bridge";
-import { useFlashEffects } from "./effects/use-flash-effects";
+import { setDefaultRegistry } from "./core/registry-context";
+import { ProviderBase, type ProviderBaseProps } from "./provider-base";
 
 // Register the default registry so selectors work outside <Provider>.
 // This module is always loaded after registry.ts finishes, so defaultRegistry
 // is guaranteed to be defined here.
 setDefaultRegistry(defaultRegistry);
 
-const defaultSprite: SpriteValue = { href: "" };
-
-export function Provider({
-  children,
-  registry = defaultRegistry,
-  sprite = defaultSprite,
-  toaster = true,
-}: {
-  children: ReactNode;
+type ProviderProps = Omit<ProviderBaseProps, "registry"> & {
   registry?: Registry;
-  sprite?: SpriteValue;
-  toaster?: boolean;
-}) {
-  useFlashEffects();
+};
 
-  return (
-    <RegistryContext.Provider value={registry}>
-      <SpriteProvider sprite={sprite}>
-        {children}
-        <EventBridge onAppearanceChange={updateAppearance} />
-        {toaster ? <Toaster /> : null}
-      </SpriteProvider>
-    </RegistryContext.Provider>
-  );
+export function Provider({ registry = defaultRegistry, ...props }: ProviderProps) {
+  return <ProviderBase {...props} registry={registry} />;
 }
 
 export {

--- a/resources/js/registry.test.ts
+++ b/resources/js/registry.test.ts
@@ -3,8 +3,14 @@ import { actionComponents } from "./action";
 import { formComponents } from "./form";
 import { tableComponents } from "./table";
 import { registry } from "./index";
+import { eagerRegistry } from "./registry/eager";
+import { lazyRegistry } from "./registry/lazy";
 
 describe("lattice component registry", () => {
+  it("keeps the package registry export as the lazy registry", () => {
+    expect(registry).toBe(lazyRegistry);
+  });
+
   it("keeps visual primitives eager to avoid suspense flicker", () => {
     expect(registry.components.action?.mode).toBe("eager");
     expect(registry.components["action.group"]?.mode).toBe("eager");
@@ -28,9 +34,22 @@ describe("lattice component registry", () => {
     expect(registry.components["field.checkbox"]?.mode).toBe("lazy");
     expect(registry.components["field.hidden-input"]?.mode).toBe("lazy");
     expect(registry.components["field.password-input"]?.mode).toBe("lazy");
+    expect(registry.components["field.rich-editor"]?.mode).toBe("lazy");
     expect(registry.components["field.text-input"]?.mode).toBe("lazy");
     expect(registry.components["field.toggle"]?.mode).toBe("lazy");
+    expect(registry.components.chart?.mode).toBe("lazy");
     expect(registry.components.table?.mode).toBe("lazy");
+  });
+
+  it("can opt into an eager registry for build-time bundling", () => {
+    expect(eagerRegistry.components.form?.mode).toBe("eager");
+    expect(eagerRegistry.components["field.builder"]?.mode).toBe("eager");
+    expect(eagerRegistry.components["field.checkbox"]?.mode).toBe("eager");
+    expect(eagerRegistry.components["field.rich-editor"]?.mode).toBe("eager");
+    expect(eagerRegistry.components["field.text-input"]?.mode).toBe("eager");
+    expect(eagerRegistry.components["field.toggle"]?.mode).toBe("eager");
+    expect(eagerRegistry.components.chart?.mode).toBe("eager");
+    expect(eagerRegistry.components.table?.mode).toBe("eager");
   });
 
   it("keeps action form and table components in separate registries", () => {

--- a/resources/js/registry.ts
+++ b/resources/js/registry.ts
@@ -1,18 +1,1 @@
-import { createRegistry } from "@lattice-php/lattice/core/registry";
-import { actionComponents } from "./action";
-import { chatPlugin } from "./chat";
-import { coreComponents } from "./core/components";
-import { formComponents } from "./form";
-import { remoteComponents } from "./remote";
-import { layoutComponents } from "./layout/components";
-import { tableComponents } from "./table";
-
-export const registry = createRegistry(
-  coreComponents,
-  actionComponents,
-  formComponents,
-  layoutComponents,
-  tableComponents,
-  chatPlugin,
-  remoteComponents,
-);
+export { lazyRegistry, lazyRegistry as registry } from "./registry/lazy";

--- a/resources/js/registry/eager.ts
+++ b/resources/js/registry/eager.ts
@@ -1,0 +1,18 @@
+import { createRegistry } from "@lattice-php/lattice/core/registry";
+import { actionComponents } from "../action";
+import { chatPlugin } from "../chat";
+import { eagerCoreComponents } from "../core/components/eager";
+import { eagerFormComponents } from "../form/eager";
+import { layoutComponents } from "../layout/components";
+import { remoteComponents } from "../remote";
+import { eagerTableComponents } from "../table/eager";
+
+export const eagerRegistry = createRegistry(
+  eagerCoreComponents,
+  actionComponents,
+  eagerFormComponents,
+  layoutComponents,
+  eagerTableComponents,
+  chatPlugin,
+  remoteComponents,
+);

--- a/resources/js/registry/lazy.ts
+++ b/resources/js/registry/lazy.ts
@@ -1,0 +1,18 @@
+import { createRegistry } from "@lattice-php/lattice/core/registry";
+import { actionComponents } from "../action";
+import { chatPlugin } from "../chat";
+import { coreComponents } from "../core/components";
+import { formComponents } from "../form";
+import { layoutComponents } from "../layout/components";
+import { remoteComponents } from "../remote";
+import { tableComponents } from "../table";
+
+export const lazyRegistry = createRegistry(
+  coreComponents,
+  actionComponents,
+  formComponents,
+  layoutComponents,
+  tableComponents,
+  chatPlugin,
+  remoteComponents,
+);

--- a/resources/js/table/eager.ts
+++ b/resources/js/table/eager.ts
@@ -1,0 +1,10 @@
+import { createPlugin, eagerComponent } from "@lattice-php/lattice/core/registry";
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import TableComponent from "./components/table";
+
+export const eagerTableComponents = createPlugin({
+  components: {
+    table: eagerComponent(TableComponent as unknown as RendererComponent<"table">),
+  },
+  name: "lattice/table",
+});


### PR DESCRIPTION
## Summary
- Add lazy and eager registry entrypoints while keeping the default `registry` export lazy.
- Wire `createLatticeApp` through the selected registry and a registry-neutral provider base.
- Document the eager registry opt-in and how to extend it for custom registries.

## Validation
- `npm run check`
- `npm run docs:build`
