### PR TITLE
feat: extend tooltips to Card, Section, Heading, Collapsible + standalone Tooltip

### DIFF
--- a/docs/content/docs/core/components.mdx
+++ b/docs/content/docs/core/components.mdx
@@ -31,7 +31,8 @@ Layout components arrange their children. They are containers — pass children 
   optional `->align()` and `->width()`. Pass `->direction('row')` to lay children out horizontally.
 - **`Grid`** lays children out in columns via `->columns(n)`.
 - **`Card`** wraps children in a bordered panel with an optional title and description —
-  `Card::make('Title', 'Description')`.
+  `Card::make('Title', 'Description')`. Call `->tooltip('…')` to attach an ⓘ info popover next
+  to the title; the content may include links.
 - **`Section`** is a titled panel like `Card`, but it can collapse and carry actions in its header —
   see [below](#section).
 - **`Collapsible`** is an untitled disclosure: a clickable trigger row that folds a body of children
@@ -50,9 +51,10 @@ Layout components arrange their children. They are containers — pass children 
 
 ### Section
 
-`Section::make('Title', 'Description')` groups content under a heading. Call `->collapsible()` to let
-it fold (pass `collapsed: true` to start folded; `rememberState: false` to not persist the state), and
-`->headerActions([...])` to place buttons or actions in the header.
+`Section::make('Title', 'Description')` groups content under a heading. Call `->tooltip('…')` to
+attach an ⓘ info popover next to the title; the content may include links. Call `->collapsible()` to
+let it fold (pass `collapsed: true` to start folded; `rememberState: false` to not persist the
+state), and `->headerActions([...])` to place buttons or actions in the header.
 
 <ComponentExample
   php={`Section::make('Members', 'People with access to this team.')
@@ -74,12 +76,27 @@ it fold (pass `collapsed: true` to start folded; `rememberState: false` to not p
 starts folded; call `->collapsed(false)` to start open, and `->rememberState()` to persist the open
 state across reloads. Unlike `Section`, the whole trigger row is clickable and there is no built-in
 title — you supply it, which makes it a good fit for settings rows that reveal an inline edit form.
+Call `->tooltip('…')` to attach an ⓘ info popover in the trigger row; the content may include links.
 
 <ComponentExample
   php={`Collapsible::make('account-name')
     ->trigger([Text::make('Name')])
     ->content([Text::make('Update the name shown on your account.')]);`}
   fixture="components.collapsible"
+/>
+
+### Tooltip
+
+`Tooltip::make()->content('…')` renders an ⓘ info popover you can place anywhere. The content is
+trusted HTML (links are supported). Pass `->trigger([...])` to use your own non-interactive trigger
+(text, a badge, an icon) instead of the default ⓘ icon — clicking it opens the popover.
+
+<ComponentExample
+  php={`Stack::make()->direction('row')->gap(Gap::Small)->schema([
+    Badge::make('Plan: Pro'),
+    Tooltip::make()->content('Includes unlimited seats and priority support.'),
+]);`}
+  fixture="components.tooltip"
 />
 
 ## Display

--- a/docs/content/docs/core/components.mdx
+++ b/docs/content/docs/core/components.mdx
@@ -89,7 +89,9 @@ Call `->tooltip('…')` to attach an ⓘ info popover in the trigger row; the co
 
 `Tooltip::make()->content('…')` renders an ⓘ info popover you can place anywhere. The content is
 trusted HTML (links are supported). Pass `->trigger([...])` to use your own non-interactive trigger
-(text, a badge, an icon) instead of the default ⓘ icon — clicking it opens the popover.
+(text, a badge, an icon) instead of the default ⓘ icon — clicking it opens the popover. Keep the
+trigger non-interactive: it becomes the popover's clickable button, so a button or link inside it
+would nest one interactive element in another.
 
 <ComponentExample
   php={`Stack::make()->direction('row')->gap(Gap::Small)->schema([

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -2,7 +2,8 @@
     {
         "props": {
             "description": "Manage how your team appears.",
-            "title": "Team settings"
+            "title": "Team settings",
+            "tooltip": "These settings affect everyone on the team."
         },
         "schema": [
             {

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -20,7 +20,8 @@
                     {
                         "props": {
                             "level": 2,
-                            "text": "Members"
+                            "text": "Members",
+                            "tooltip": null
                         },
                         "type": "heading"
                     },

--- a/docs/fixtures/components.collapsible.json
+++ b/docs/fixtures/components.collapsible.json
@@ -4,6 +4,7 @@
         "props": {
             "collapsed": true,
             "rememberState": false,
+            "tooltip": "Shown on invoices and receipts.",
             "trigger": [
                 {
                     "props": {

--- a/docs/fixtures/components.section.json
+++ b/docs/fixtures/components.section.json
@@ -18,7 +18,8 @@
                 }
             ],
             "rememberState": true,
-            "title": "Members"
+            "title": "Members",
+            "tooltip": "Only admins can change who has access."
         },
         "schema": [
             {

--- a/docs/fixtures/components.tooltip.json
+++ b/docs/fixtures/components.tooltip.json
@@ -1,0 +1,29 @@
+[
+    {
+        "props": {
+            "align": null,
+            "direction": "row",
+            "float": null,
+            "gap": "sm",
+            "height": null,
+            "justify": null,
+            "width": null
+        },
+        "schema": [
+            {
+                "props": {
+                    "label": "Plan: Pro"
+                },
+                "type": "badge"
+            },
+            {
+                "props": {
+                    "content": "Includes unlimited seats and priority support.",
+                    "trigger": []
+                },
+                "type": "tooltip"
+            }
+        ],
+        "type": "stack"
+    }
+]

--- a/resources/js/core/components/card.test.tsx
+++ b/resources/js/core/components/card.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import CardComponent from "./card";
+
+function renderCard(props: Node<"card">["props"]) {
+  const node = { type: "card", props } as Node<"card">;
+  return render(<CardComponent node={node}>{null}</CardComponent>);
+}
+
+describe("CardComponent tooltip", () => {
+  it("renders no info trigger when there is no tooltip", () => {
+    renderCard({ title: "Plan", description: null, tooltip: null });
+
+    expect(screen.getByText("Plan")).toBeVisible();
+    expect(screen.queryByRole("button", { name: "More information" })).not.toBeInTheDocument();
+  });
+
+  it("reveals the tooltip content next to the title on click", () => {
+    renderCard({ title: "Plan", description: null, tooltip: "Billed monthly." });
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+    expect(screen.getByText("Billed monthly.")).toBeVisible();
+  });
+
+  it("anchors the tooltip to the description when there is no title", () => {
+    renderCard({ title: null, description: "Some detail", tooltip: "Extra." });
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+    expect(screen.getByText("Extra.")).toBeVisible();
+  });
+});

--- a/resources/js/core/components/card.tsx
+++ b/resources/js/core/components/card.tsx
@@ -64,18 +64,18 @@ const CardComponent: RendererComponent<"card"> = ({ children, node }) => {
     <Card data-lattice-component={nodeIdentity(node)}>
       {(title || description) && (
         <CardHeader>
-          {title ? (
+          {title && (
             <div className="flex items-center">
               <CardTitle>{title}</CardTitle>
               <InfoTooltip content={tooltip} />
             </div>
-          ) : (
+          )}
+          {description && (
             <div className="flex items-center">
               <CardDescription>{description}</CardDescription>
-              <InfoTooltip content={tooltip} />
+              {!title && <InfoTooltip content={tooltip} />}
             </div>
           )}
-          {title && description && <CardDescription>{description}</CardDescription>}
         </CardHeader>
       )}
       {children && <CardContent className="flex flex-col gap-6">{children}</CardContent>}

--- a/resources/js/core/components/card.tsx
+++ b/resources/js/core/components/card.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { InfoTooltip } from "./info-tooltip";
 
 function Card({ className, ...props }: React.ComponentProps<"article">) {
   return (
@@ -57,14 +58,24 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const CardComponent: RendererComponent<"card"> = ({ children, node }) => {
-  const { title, description } = node.props;
+  const { title, description, tooltip } = node.props;
 
   return (
     <Card data-lattice-component={nodeIdentity(node)}>
       {(title || description) && (
         <CardHeader>
-          {title && <CardTitle>{title}</CardTitle>}
-          {description && <CardDescription>{description}</CardDescription>}
+          {title ? (
+            <div className="flex items-center">
+              <CardTitle>{title}</CardTitle>
+              <InfoTooltip content={tooltip} />
+            </div>
+          ) : (
+            <div className="flex items-center">
+              <CardDescription>{description}</CardDescription>
+              <InfoTooltip content={tooltip} />
+            </div>
+          )}
+          {title && description && <CardDescription>{description}</CardDescription>}
         </CardHeader>
       )}
       {children && <CardContent className="flex flex-col gap-6">{children}</CardContent>}

--- a/resources/js/core/components/collapsible.test.tsx
+++ b/resources/js/core/components/collapsible.test.tsx
@@ -109,4 +109,25 @@ describe("Collapsible component", () => {
     expect(screen.getByText("Hidden body")).toBeVisible();
     window.localStorage.clear();
   });
+
+  it("opens the tooltip without toggling the collapse", () => {
+    renderCollapsible({
+      id: "name",
+      type: "collapsible",
+      props: {
+        tooltip: "Reveals the edit form.",
+        trigger: [{ type: "text", props: { text: "Name" } }],
+      },
+      schema: [{ type: "text", props: { text: "Hidden body" } }],
+    });
+
+    const toggle = screen.getByRole("button", { name: /Name/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Hidden body")).not.toBeInTheDocument();
+    expect(screen.getByText("Reveals the edit form.")).toBeVisible();
+  });
 });

--- a/resources/js/core/components/collapsible.tsx
+++ b/resources/js/core/components/collapsible.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Icon } from "@lattice-php/lattice/icons";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { InfoTooltip } from "./info-tooltip";
 import { nodeIdentity, prefixedTestId } from "@lattice-php/lattice/core/test-id";
 import { toNodes } from "@lattice-php/lattice/core/nodes";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
@@ -58,6 +59,14 @@ const CollapsibleComponent: RendererComponent<"collapsible"> = ({ children, node
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <Renderer nodes={trigger} />
+          {node.props.tooltip && (
+            <span
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+            >
+              <InfoTooltip content={node.props.tooltip} />
+            </span>
+          )}
         </div>
         <Icon
           name="chevron-down"

--- a/resources/js/core/components/collapsible.tsx
+++ b/resources/js/core/components/collapsible.tsx
@@ -61,6 +61,7 @@ const CollapsibleComponent: RendererComponent<"collapsible"> = ({ children, node
           <Renderer nodes={trigger} />
           {node.props.tooltip && (
             <span
+              role="presentation"
               onClick={(event) => event.stopPropagation()}
               onKeyDown={(event) => event.stopPropagation()}
             >

--- a/resources/js/core/components/eager.ts
+++ b/resources/js/core/components/eager.ts
@@ -17,6 +17,7 @@ import SegmentedControlComponent from "./segmented-control";
 import StackComponent from "./stack";
 import TabComponent, { TabsComponent } from "./tabs";
 import TextComponent from "./text";
+import TooltipComponent from "./tooltip";
 
 export const eagerCoreComponents = createPlugin({
   components: {
@@ -39,6 +40,7 @@ export const eagerCoreComponents = createPlugin({
     tab: eagerComponent(TabComponent),
     tabs: eagerComponent(TabsComponent),
     text: eagerComponent(TextComponent),
+    tooltip: eagerComponent(TooltipComponent),
   },
   name: "lattice/core",
 });

--- a/resources/js/core/components/heading.test.tsx
+++ b/resources/js/core/components/heading.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import HeadingComponent from "./heading";
@@ -39,5 +39,16 @@ describe("HeadingComponent", () => {
     renderHeading(2);
 
     expect(screen.getByRole("heading", { level: 2 })).toHaveClass("text-xl");
+  });
+
+  it("reveals a tooltip after the heading text on click", () => {
+    const node = {
+      type: "heading",
+      props: { level: 2, text: "Billing", tooltip: "Invoices go out monthly." },
+    } as Node<"heading">;
+    render(<HeadingComponent node={node}>{null}</HeadingComponent>);
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+    expect(screen.getByText("Invoices go out monthly.")).toBeVisible();
   });
 });

--- a/resources/js/core/components/heading.test.tsx
+++ b/resources/js/core/components/heading.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import HeadingComponent from "./heading";
 
-function renderHeading(level: number, text = "Title") {
-  const node = { type: "heading", props: { level, text } } as Node<"heading">;
+function renderHeading(level: number, text = "Title", tooltip: string | null = null) {
+  const node = { type: "heading", props: { level, text, tooltip } } as Node<"heading">;
   return render(<HeadingComponent node={node}>{null}</HeadingComponent>);
 }
 

--- a/resources/js/core/components/heading.tsx
+++ b/resources/js/core/components/heading.tsx
@@ -1,8 +1,9 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { InfoTooltip } from "./info-tooltip";
 
 const HeadingComponent: RendererComponent<"heading"> = ({ node }) => {
-  const { text } = node.props;
+  const { text, tooltip } = node.props;
   const level = Math.min(Math.max(node.props.level, 1), 6);
   const className = cn(
     "max-w-3xl font-semibold tracking-normal text-balance text-lt-fg",
@@ -11,19 +12,26 @@ const HeadingComponent: RendererComponent<"heading"> = ({ node }) => {
     level > 2 && "text-base",
   );
 
+  const content = (
+    <>
+      {text}
+      <InfoTooltip content={tooltip} />
+    </>
+  );
+
   switch (level) {
     case 1:
-      return <h1 className={className}>{text}</h1>;
+      return <h1 className={className}>{content}</h1>;
     case 2:
-      return <h2 className={className}>{text}</h2>;
+      return <h2 className={className}>{content}</h2>;
     case 3:
-      return <h3 className={className}>{text}</h3>;
+      return <h3 className={className}>{content}</h3>;
     case 4:
-      return <h4 className={className}>{text}</h4>;
+      return <h4 className={className}>{content}</h4>;
     case 5:
-      return <h5 className={className}>{text}</h5>;
+      return <h5 className={className}>{content}</h5>;
     default:
-      return <h6 className={className}>{text}</h6>;
+      return <h6 className={className}>{content}</h6>;
   }
 };
 

--- a/resources/js/core/components/index.ts
+++ b/resources/js/core/components/index.ts
@@ -17,6 +17,7 @@ import SegmentedControlComponent from "./segmented-control";
 import StackComponent from "./stack";
 import TabComponent, { TabsComponent } from "./tabs";
 import TextComponent from "./text";
+import TooltipComponent from "./tooltip";
 
 export const coreComponents = createPlugin({
   components: {
@@ -41,6 +42,7 @@ export const coreComponents = createPlugin({
     tab: eagerComponent(TabComponent),
     tabs: eagerComponent(TabsComponent),
     text: eagerComponent(TextComponent),
+    tooltip: eagerComponent(TooltipComponent),
   },
   name: "lattice/core",
 });

--- a/resources/js/core/components/section.test.tsx
+++ b/resources/js/core/components/section.test.tsx
@@ -52,6 +52,18 @@ describe("Section component", () => {
     expect(screen.getByText("People with access.")).toBeVisible();
   });
 
+  it("anchors the tooltip to the description when there is no title", () => {
+    renderSection({
+      id: "members",
+      type: "section",
+      props: { description: "People with access.", tooltip: "Only admins can change this." },
+      schema: [],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+    expect(screen.getByText("Only admins can change this.")).toBeVisible();
+  });
+
   it("toggles its content when collapsible", () => {
     renderSection({
       id: "advanced",

--- a/resources/js/core/components/section.test.tsx
+++ b/resources/js/core/components/section.test.tsx
@@ -40,6 +40,18 @@ describe("Section component", () => {
     expect(screen.getByRole("button", { name: "Invite" })).toBeVisible();
   });
 
+  it("reveals a tooltip next to the title on click", () => {
+    renderSection({
+      id: "members",
+      type: "section",
+      props: { title: "Members", tooltip: "People with access." },
+      schema: [],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+    expect(screen.getByText("People with access.")).toBeVisible();
+  });
+
   it("toggles its content when collapsible", () => {
     renderSection({
       id: "advanced",

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -5,6 +5,7 @@ import { nodeIdentity, prefixedTestId } from "@lattice-php/lattice/core/test-id"
 import { toNodes } from "@lattice-php/lattice/core/nodes";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { InfoTooltip } from "./info-tooltip";
 
 function readStored(key: string, remember: boolean, fallback: boolean): boolean {
   if (!remember || typeof window === "undefined") {
@@ -17,7 +18,7 @@ function readStored(key: string, remember: boolean, fallback: boolean): boolean 
 }
 
 const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
-  const { title, description } = node.props;
+  const { title, description, tooltip } = node.props;
   const collapsible = node.props.collapsible === true;
   const rememberState = node.props.rememberState !== false;
   const headerActions = toNodes(node.props.headerActions);
@@ -70,8 +71,18 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
               </button>
             )}
             <div className="flex min-w-0 flex-col gap-1.5">
-              {title && <div className="font-semibold leading-none">{title}</div>}
-              {description && <div className="text-sm text-lt-muted-fg">{description}</div>}
+              {title && (
+                <div className="flex items-center">
+                  <div className="font-semibold leading-none">{title}</div>
+                  <InfoTooltip content={tooltip} />
+                </div>
+              )}
+              {description && (
+                <div className="flex items-center">
+                  <div className="text-sm text-lt-muted-fg">{description}</div>
+                  {!title && <InfoTooltip content={tooltip} />}
+                </div>
+              )}
             </div>
           </div>
 

--- a/resources/js/core/components/tooltip.test.tsx
+++ b/resources/js/core/components/tooltip.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import type { Node } from "@lattice-php/lattice/core/types";
+import BadgeComponent from "./badge";
+import TooltipComponent from "./tooltip";
+
+const registry = createRegistry({
+  components: {
+    badge: eagerComponent(BadgeComponent),
+    tooltip: eagerComponent(TooltipComponent),
+  },
+  name: "test/tooltip",
+});
+
+function renderTooltip(node: Node) {
+  return renderWithRegistry(<Renderer nodes={[node]} />, registry);
+}
+
+describe("TooltipComponent", () => {
+  it("renders nothing when content is empty", () => {
+    const { container } = renderTooltip({ type: "tooltip", props: { content: null, trigger: [] } });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the content from a bare info icon when no trigger is given", () => {
+    renderTooltip({ type: "tooltip", props: { content: "Hello there.", trigger: [] } });
+
+    expect(screen.queryByText("Hello there.")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "More information" }));
+    expect(screen.getByText("Hello there.")).toBeVisible();
+  });
+
+  it("uses a custom trigger to reveal the content", () => {
+    renderTooltip({
+      type: "tooltip",
+      props: { content: "Still in beta.", trigger: [{ type: "badge", props: { label: "Beta" } }] },
+    });
+
+    fireEvent.click(screen.getByText("Beta"));
+    expect(screen.getByText("Still in beta.")).toBeVisible();
+  });
+});

--- a/resources/js/core/components/tooltip.tsx
+++ b/resources/js/core/components/tooltip.tsx
@@ -1,0 +1,36 @@
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { toNodes } from "@lattice-php/lattice/core/nodes";
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { InfoTooltip } from "./info-tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+const TooltipComponent: RendererComponent<"tooltip"> = ({ node }) => {
+  const content = node.props.content;
+  const trigger = toNodes(node.props.trigger);
+
+  if (!content) {
+    return null;
+  }
+
+  if (trigger.length === 0) {
+    return <InfoTooltip content={content} />;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        type="button"
+        className="inline-flex items-center rounded-lt-sm outline-none focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]"
+      >
+        <Renderer nodes={trigger} />
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="max-w-xs p-3 text-sm [&_a]:underline"
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    </Popover>
+  );
+};
+
+export default TooltipComponent;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -414,6 +414,11 @@ export type CoreNode =
       type: "text";
       key?: string;
       props: Text;
+    }
+  | {
+      type: "tooltip";
+      key?: string;
+      props: Tooltip;
     };
 export type DataList = {
   dataEndpoint: string | null;
@@ -1386,6 +1391,10 @@ export type ToggleSidebarEffect = {
 export type ToolCallPart = {
   args: Record<string, unknown>;
   name: string;
+};
+export type Tooltip = {
+  content: string | null;
+  trigger: Node[];
 };
 export type Topbar = {
   sticky: boolean;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1117,6 +1117,7 @@ export type Section = {
   headerActions: Node[];
   rememberState: boolean;
   title: string | null;
+  tooltip: string | null;
 };
 export type SegmentedControl = {
   emits: string | null;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -134,6 +134,7 @@ export type Callouts = Record<string, never>;
 export type Card = {
   description: string | null;
   title: string | null;
+  tooltip: string | null;
 };
 export type ChannelVisibility = "public" | "private" | "presence";
 export type Chart = {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -246,6 +246,7 @@ export type CloseModalEffect = {
 export type Collapsible = {
   collapsed: boolean;
   rememberState: boolean;
+  tooltip: string | null;
   trigger: Node[];
 };
 export type Color = "default" | "muted" | "primary" | "success" | "info" | "warning" | "danger";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -725,6 +725,7 @@ export type Grid = {
 export type Heading = {
   level: number;
   text: string;
+  tooltip: string | null;
 };
 export type Height = "full" | "screen";
 export type HiddenInput = {

--- a/src/Core/Components/Card.php
+++ b/src/Core/Components/Card.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Concerns\HasTooltip;
 
 #[AsComponent('card')]
 class Card extends ContainerComponent
 {
+    use HasTooltip;
+
     public ?string $title = null;
 
     public ?string $description = null;

--- a/src/Core/Components/Collapsible.php
+++ b/src/Core/Components/Collapsible.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Concerns\HasTooltip;
 
 #[AsComponent('collapsible')]
 class Collapsible extends ContainerComponent
 {
+    use HasTooltip;
+
     public bool $collapsed = true;
 
     public bool $rememberState = false;

--- a/src/Core/Components/Heading.php
+++ b/src/Core/Components/Heading.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Concerns\HasTooltip;
 
 #[AsComponent('heading')]
 class Heading extends Component
 {
+    use HasTooltip;
+
     public string $text = '';
 
     public int $level = 1;

--- a/src/Core/Components/Section.php
+++ b/src/Core/Components/Section.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Concerns\HasTooltip;
 
 #[AsComponent('section')]
 class Section extends ContainerComponent
 {
+    use HasTooltip;
+
     public ?string $title = null;
 
     public ?string $description = null;

--- a/src/Core/Components/Tooltip.php
+++ b/src/Core/Components/Tooltip.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Components;
+
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Concerns\FiltersRenderableComponents;
+
+#[AsComponent('tooltip')]
+class Tooltip extends Component
+{
+    use FiltersRenderableComponents;
+
+    public ?string $content = null;
+
+    /**
+     * @var array<int, Component>
+     */
+    public array $trigger = [];
+
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+
+    public function content(string $content): static
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, Component>  $components
+     */
+    public function trigger(array $components): static
+    {
+        $this->trigger = $components;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $props
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function decorateProps(array $props): array
+    {
+        return [
+            ...parent::decorateProps($props),
+            'trigger' => $this->renderableComponents($this->trigger),
+        ];
+    }
+}

--- a/tests/Unit/Core/Components/CollapsibleTest.php
+++ b/tests/Unit/Core/Components/CollapsibleTest.php
@@ -30,6 +30,12 @@ it('serializes the open and remember-state flags', function (): void {
     ]);
 });
 
+it('serializes a collapsible tooltip', function (): void {
+    $node = wire(Collapsible::make('details')->tooltip('Reveals the edit form.'));
+
+    expect($node['props']['tooltip'])->toBe('Reveals the edit form.');
+});
+
 it('omits trigger components hidden by a condition', function (): void {
     $node = wire(
         Collapsible::make()->trigger([
@@ -47,6 +53,7 @@ describe('docs fixtures', function (): void {
         dumpFixture('components.collapsible', [
             Collapsible::make('account-name')
                 ->trigger([Text::make('Name')])
+                ->tooltip('Shown on invoices and receipts.')
                 ->content([Text::make('Update the name shown on your account.')]),
         ]);
 

--- a/tests/Unit/Core/Components/HeadingTest.php
+++ b/tests/Unit/Core/Components/HeadingTest.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Components\Heading;
+
+it('serializes a heading tooltip', function (): void {
+    $node = wire(Heading::make('Billing', 2)->tooltip('Invoices go out monthly.'));
+
+    expect($node['props']['tooltip'])->toBe('Invoices go out monthly.');
+});
+
+it('serializes a null heading tooltip when unset', function (): void {
+    $node = wire(Heading::make('Billing', 2));
+
+    expect($node['props']['tooltip'])->toBeNull();
+});

--- a/tests/Unit/Core/Components/SectionTest.php
+++ b/tests/Unit/Core/Components/SectionTest.php
@@ -34,3 +34,9 @@ it('serializes the collapsible flags', function (): void {
         'rememberState' => false,
     ]);
 });
+
+it('serializes a section tooltip', function (): void {
+    $node = wire(Section::make('Members')->tooltip('People with access.'));
+
+    expect($node['props']['tooltip'])->toBe('People with access.');
+});

--- a/tests/Unit/Core/Components/TooltipTest.php
+++ b/tests/Unit/Core/Components/TooltipTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Components\Badge;
+use Lattice\Lattice\Core\Components\Tooltip;
+
+it('serializes content and an empty trigger by default', function (): void {
+    $node = wire(Tooltip::make()->content('More about this metric.'));
+
+    expect($node['type'])->toBe('tooltip')
+        ->and($node['props']['content'])->toBe('More about this metric.')
+        ->and($node['props']['trigger'])->toBe([]);
+});
+
+it('serializes a custom trigger slot', function (): void {
+    $node = wire(
+        Tooltip::make()->content('Still in beta.')->trigger([Badge::make('Beta')]),
+    );
+
+    expect($node['props']['trigger'])->toHaveCount(1)
+        ->and($node['props']['trigger'][0]['type'])->toBe('badge');
+});
+
+it('omits trigger components hidden by a condition', function (): void {
+    $node = wire(
+        Tooltip::make()->content('x')->trigger([
+            Badge::make('Visible'),
+            Badge::make('Hidden')->when(false),
+        ]),
+    );
+
+    expect($node['props']['trigger'])->toHaveCount(1);
+});

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Core\Components\Heading;
 use Lattice\Lattice\Core\Components\Section;
 use Lattice\Lattice\Core\Components\Stack;
 use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Components\Tooltip;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
 
@@ -67,6 +68,17 @@ describe('docs fixtures', function (): void {
         ]);
 
         expect('docs/fixtures/components.section.json')->toBeReadableFile();
+    });
+
+    it('dumps the tooltip example', function (): void {
+        dumpFixture('components.tooltip', [
+            Stack::make()->direction('row')->gap(Gap::Small)->schema([
+                Badge::make('Plan: Pro'),
+                Tooltip::make()->content('Includes unlimited seats and priority support.'),
+            ]),
+        ]);
+
+        expect('docs/fixtures/components.tooltip.json')->toBeReadableFile();
     });
 
     it('dumps the button variants example', function (): void {

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -58,6 +58,7 @@ describe('docs fixtures', function (): void {
         dumpFixture('components.section', [
             Section::make('Members', 'People with access to this team.')
                 ->collapsible()
+                ->tooltip('Only admins can change who has access.')
                 ->headerActions([Button::make('Invite member')->variant(ButtonVariant::Outline)])
                 ->schema([
                     Text::make('Three people have access to this team.'),

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -12,17 +12,31 @@ use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
 
+it('serializes a card tooltip', function (): void {
+    $node = wire(Card::make('Plan')->tooltip('Billed monthly.'));
+
+    expect($node['props']['tooltip'])->toBe('Billed monthly.');
+});
+
+it('serializes a null card tooltip when unset', function (): void {
+    $node = wire(Card::make('Plan'));
+
+    expect($node['props']['tooltip'])->toBeNull();
+});
+
 describe('docs fixtures', function (): void {
     it('dumps the card example', function (): void {
         dumpFixture('components.card', [
-            Card::make('Team settings', 'Manage how your team appears.')->schema([
-                Stack::make()->gap(Gap::Small)->schema([
-                    Heading::make('Members', 2),
-                    Text::make('Three people have access to this team.'),
-                    Badge::make('3 active'),
+            Card::make('Team settings', 'Manage how your team appears.')
+                ->tooltip('These settings affect everyone on the team.')
+                ->schema([
+                    Stack::make()->gap(Gap::Small)->schema([
+                        Heading::make('Members', 2),
+                        Text::make('Three people have access to this team.'),
+                        Badge::make('3 active'),
+                    ]),
+                    Button::make('Invite member')->variant(ButtonVariant::Default),
                 ]),
-                Button::make('Invite member')->variant(ButtonVariant::Default),
-            ]),
         ]);
 
         expect('docs/fixtures/components.card.json')->toBeReadableFile();


### PR DESCRIPTION
## What & why

Tooltips previously existed only on form fields. This extends the same ⓘ click-popover (the existing `InfoTooltip` atom, backed by Radix Popover — no new dependency) to more of the component vocabulary, plus a standalone composable node.

## Changes

- **`->tooltip('…')` adornment** on `Card`, `Section`, `Heading`, and `Collapsible` via the existing `HasTooltip` trait. The ⓘ renders next to the title (or description when there's no title); a tooltip with no title/description is a no-op.
- **Collapsible**: the ⓘ lives inside the clickable trigger row, wrapped in a `role="presentation"` span that stops click/keydown propagation so opening the popover doesn't toggle the collapse.
- **New standalone `Tooltip` node** (`#[AsComponent('tooltip')]`): `Tooltip::make()->content('…')` renders a bare ⓘ; `->trigger([...])` swaps in custom (non-interactive) trigger content. Mirrors `Collapsible`'s slot pattern (`extends Component` + `FiltersRenderableComponents` + `decorateProps`).
- Docs prose + a standalone example; generated TS types and docs fixtures refreshed.

## Usage

```php
Card::make('Plan')->tooltip('Billed monthly. See <a href="/docs">docs</a>.');
Heading::make('Billing', 2)->tooltip('Invoices go out monthly.');

// Standalone, composable anywhere:
Tooltip::make()->content('Includes unlimited seats and priority support.');
Tooltip::make()->content('Still in beta.')->trigger([Badge::make('Beta')]);
```

## Verification

- `composer check` — Pint, PHPStan, Rector, Pest (932 passing).
- `npm run check` — oxlint, oxfmt, tsc, type-coverage, Vitest (886 passing), library build.

Tooltip content is trusted HTML (rendered via `dangerouslySetInnerHTML`), consistent with the existing field-tooltip and raw-block trust boundary.