### PR TITLE
feat: support link icons and affixes

### DIFF
--- a/resources/js/core/components/link.test.tsx
+++ b/resources/js/core/components/link.test.tsx
@@ -38,6 +38,43 @@ describe("Lattice link component", () => {
     expect(screen.getByRole("link", { name: "Edit" })).toHaveClass("h-8", "w-full", "no-underline");
   });
 
+  it("renders prefix and suffix affixes around the label", () => {
+    const node = fakeNode({
+      props: {
+        href: "/docs",
+        label: "Docs",
+        prefix: { icon: "book-open", text: null },
+        suffix: { icon: null, text: "new" },
+      },
+      type: "link",
+    });
+
+    render(<LinkComponent node={node}>{null}</LinkComponent>);
+
+    const link = screen.getByRole("link", { name: "Docs new" });
+    expect(link).toHaveAttribute("href", "/docs");
+    expect(link.querySelector("svg")).not.toBeNull();
+    expect(screen.getByText("new")).toBeVisible();
+  });
+
+  it("renders icon-only links with the label as their accessible name", () => {
+    const node = fakeNode({
+      props: {
+        href: "/settings",
+        icon: "settings",
+        label: "Settings",
+      },
+      type: "link",
+    });
+
+    render(<LinkComponent node={node}>{null}</LinkComponent>);
+
+    const link = screen.getByRole("link", { name: "Settings" });
+    expect(link).toHaveAttribute("aria-label", "Settings");
+    expect(link.querySelector("svg")).not.toBeNull();
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+
   it("merges custom classes on direct text links", () => {
     render(
       <TextLink className="custom-class" href="/docs">

--- a/resources/js/core/components/link.tsx
+++ b/resources/js/core/components/link.tsx
@@ -4,6 +4,8 @@ import { useAction } from "@lattice-php/lattice/action/use-action";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
+import { IconRenderer } from "@lattice-php/lattice/icons";
+import type { Affix } from "@lattice-php/lattice/types/generated";
 import {
   actionMenuItemClassName,
   useActionMenu,
@@ -22,11 +24,13 @@ function TextLink({ className = "", children, ...props }: ComponentProps<typeof 
 
 function ActionLink({
   action,
+  ariaLabel,
   className,
   children,
   testId,
 }: {
   action: Node<"action">;
+  ariaLabel?: string;
   className?: string;
   children: ReactNode;
   testId?: string;
@@ -36,6 +40,7 @@ function ActionLink({
   return (
     <>
       <button
+        aria-label={ariaLabel}
         className={cn(textLinkClassName, className)}
         data-test={testId}
         disabled={processing}
@@ -49,31 +54,106 @@ function ActionLink({
   );
 }
 
+function LinkAffix({ affix, className }: { affix: Affix; className?: string }) {
+  if (affix.icon) {
+    return <IconRenderer className={cn("size-lt-icon-md shrink-0", className)} icon={affix.icon} />;
+  }
+
+  return <span className={cn("shrink-0 text-sm text-lt-muted-fg", className)}>{affix.text}</span>;
+}
+
+function LinkContent({
+  icon,
+  isMenuItem,
+  label,
+  prefix,
+  suffix,
+}: {
+  icon?: string | null;
+  isMenuItem: boolean;
+  label: string;
+  prefix?: Affix | null;
+  suffix?: Affix | null;
+}) {
+  if (icon) {
+    return <IconRenderer className="size-lt-icon-md shrink-0" icon={icon} />;
+  }
+
+  if (isMenuItem) {
+    return (
+      <>
+        {prefix ? <LinkAffix affix={prefix} /> : null}
+        <span>{label}</span>
+        {suffix ? <LinkAffix affix={suffix} className="ml-auto" /> : null}
+      </>
+    );
+  }
+
+  if (prefix || suffix) {
+    return (
+      <span className="inline-flex items-center gap-1.5 align-baseline">
+        {prefix ? <LinkAffix affix={prefix} /> : null}
+        <span>{label}</span>
+        {suffix ? <LinkAffix affix={suffix} /> : null}
+      </span>
+    );
+  }
+
+  return label;
+}
+
+function labelWithTextAffixes(label: string, prefix?: Affix | null, suffix?: Affix | null) {
+  if (!prefix?.text && !suffix?.text) {
+    return undefined;
+  }
+
+  return [prefix?.text, label, suffix?.text]
+    .filter((part): part is string => Boolean(part))
+    .join(" ");
+}
+
 const LinkComponent: RendererComponent<"link"> = ({ node }) => {
   const isMenuItem = useActionMenu();
   const action = node.props.action;
+  const icon = node.props.icon;
+  const label = node.props.label;
+  const prefix = node.props.prefix;
+  const suffix = node.props.suffix;
+  const iconOnly = Boolean(icon);
+  const content = (
+    <LinkContent
+      icon={icon}
+      isMenuItem={isMenuItem}
+      label={label}
+      prefix={prefix}
+      suffix={suffix}
+    />
+  );
+  const ariaLabel = iconOnly ? label : labelWithTextAffixes(label, prefix, suffix);
 
   if (action) {
     return (
       <ActionLink
         action={action as Node<"action">}
+        ariaLabel={ariaLabel}
         className={isMenuItem ? actionMenuItemClassName : undefined}
         testId={nodeIdentity(node)}
       >
-        {node.props.label}
+        {content}
       </ActionLink>
     );
   }
 
   return (
     <TextLink
+      aria-label={ariaLabel}
       className={isMenuItem ? actionMenuItemClassName : undefined}
       data-test={nodeIdentity(node)}
       href={node.props.href ?? "#"}
       method={node.props.method ?? "get"}
       tabIndex={node.props.tabIndex ?? undefined}
     >
-      {node.props.label}
+      {content}
     </TextLink>
   );
 };

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -830,8 +830,11 @@ export type LayoutNode =
 export type Link = {
   action: Node | null;
   href: string | null;
+  icon: string | null;
   label: string;
   method: HttpMethod | null;
+  prefix: Affix | null;
+  suffix: Affix | null;
   tabIndex: number | null;
 };
 export type ListenerPayload = {

--- a/src/Core/Components/Link.php
+++ b/src/Core/Components/Link.php
@@ -3,17 +3,22 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core\Components;
 
+use BackedEnum;
 use Lattice\Lattice\Actions\Concerns\TriggersAction;
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Concerns\HasAffixes;
 use Lattice\Lattice\Core\Concerns\HasTabIndex;
 use Lattice\Lattice\Core\Concerns\Navigable;
 
 #[AsComponent('link')]
 class Link extends Component
 {
+    use HasAffixes;
     use HasTabIndex;
     use Navigable;
     use TriggersAction;
+
+    public ?string $icon = null;
 
     public static function make(string $label, ?string $key = null): static
     {
@@ -21,5 +26,12 @@ class Link extends Component
         $link->label = $label;
 
         return $link;
+    }
+
+    public function icon(BackedEnum|string $icon): static
+    {
+        $this->icon = $this->enumValue($icon);
+
+        return $this;
     }
 }

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -23,6 +23,7 @@ use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\FloatingPlacement;
 use Lattice\Lattice\Core\Enums\Gap;
 use Lattice\Lattice\Core\Enums\HttpMethod;
+use Lattice\Lattice\Core\Enums\Icon;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Choice;
@@ -30,6 +31,7 @@ use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Fragments\Components\Fragment as FragmentComponent;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\LatticeRegistry;
+use Lattice\Lattice\Support\Affix;
 use Lattice\Lattice\Tables\Components\Table;
 
 test('lattice component factories stay open for extension', function (): void {
@@ -367,10 +369,31 @@ test('links and horizontal stacks serialize as separate composable primitives', 
                         'method' => null,
                         'tabIndex' => null,
                         'action' => null,
+                        'icon' => null,
+                        'prefix' => null,
+                        'suffix' => null,
                     ],
                 ],
             ],
         ]);
+});
+
+test('links serialize their icon and affixes', function (): void {
+    $wire = wire(
+        Link::make('Docs')
+            ->href('/docs')
+            ->icon(Icon::ExternalLink)
+            ->prefix(Affix::icon('book-open'))
+            ->suffix('new'),
+    );
+
+    expect($wire['props'])->toMatchArray([
+        'href' => '/docs',
+        'icon' => 'external-link',
+        'label' => 'Docs',
+        'prefix' => ['icon' => 'book-open', 'text' => null],
+        'suffix' => ['icon' => null, 'text' => 'new'],
+    ]);
 });
 
 test('tabs ignore hidden tab children when resolving their active value', function (): void {


### PR DESCRIPTION
## What changed
- Added `icon()`, `prefix()`, and `suffix()` support to the core `Link` component.
- Rendered icon-only links with an accessible label and affix links with visible prefix/suffix content.
- Regenerated TypeScript wire types and added PHP/React coverage.

## Validation
- `composer check`
- `npm run check`