### PR TITLE
feat: add semantic data-slot hooks to structural components

### DIFF
--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -229,6 +229,30 @@
   --text-7xl--line-height: 1;
 }
 
+/*
+ * Layering utilities backed by the --lt-z-* scale. Tailwind v4 does not expose
+ * z-index as a themeable namespace, so these are defined as named utilities
+ * (the scale itself stays the single source of truth in the :root block above).
+ */
+@utility z-lt-dropdown {
+  z-index: var(--lt-z-dropdown);
+}
+@utility z-lt-sticky {
+  z-index: var(--lt-z-sticky);
+}
+@utility z-lt-overlay {
+  z-index: var(--lt-z-overlay);
+}
+@utility z-lt-modal {
+  z-index: var(--lt-z-modal);
+}
+@utility z-lt-popover {
+  z-index: var(--lt-z-popover);
+}
+@utility z-lt-toast {
+  z-index: var(--lt-z-toast);
+}
+
 @keyframes lt-toast-in {
   from {
     opacity: 0;

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -59,15 +59,6 @@
   --lt-control-h-md: 2.25rem;
   --lt-control-h-lg: 2.5rem;
 
-  --lt-font-weight-normal: 400;
-  --lt-font-weight-medium: 500;
-  --lt-font-weight-semibold: 600;
-  --lt-font-weight-bold: 700;
-
-  /* Focus-ring size (colour: --lt-ring) */
-  --lt-ring-width: 0.125rem;
-  --lt-ring-offset: 0.125rem;
-
   /* Elevation */
   --lt-shadow-xs: 0 1px 1px 0 oklch(0 0 0 / 0.04);
   --lt-shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.05);
@@ -87,13 +78,14 @@
   /* Motion */
   --lt-duration-fast: 120ms;
   --lt-duration-base: 160ms;
-  --lt-duration-slow: 240ms;
-  --lt-ease: cubic-bezier(0.2, 0, 0, 1);
 
   /* Layout dimensions */
   --lt-sidebar-w: 16rem;
   --lt-sidebar-w-collapsed: 4rem;
   --lt-container-max: 80rem;
+
+  /* Card / section content inset — the gutter apps can break out of */
+  --lt-gutter: calc(var(--spacing) * 6); /* 1.5rem */
 
   color-scheme: light;
 }
@@ -199,6 +191,7 @@
   --spacing-lt-control-sm: var(--lt-control-h-sm);
   --spacing-lt-control-md: var(--lt-control-h-md);
   --spacing-lt-control-lg: var(--lt-control-h-lg);
+  --spacing-lt-gutter: var(--lt-gutter);
   --animate-lt-toast-in: lt-toast-in var(--lt-duration-base) ease-out;
   --animate-lt-toast-out: lt-toast-out var(--lt-duration-fast) ease-in;
 }

--- a/resources/js/core/components/card.tsx
+++ b/resources/js/core/components/card.tsx
@@ -9,7 +9,7 @@ function Card({ className, ...props }: React.ComponentProps<"article">) {
     <article
       data-slot="card"
       className={cn(
-        "flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-lt-sm",
+        "flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-lt-gutter text-lt-surface-fg shadow-lt-sm",
         className,
       )}
       {...props}
@@ -21,7 +21,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
-      className={cn("flex flex-col gap-1.5 px-6", className)}
+      className={cn("flex flex-col gap-1.5 px-lt-gutter", className)}
       {...props}
     />
   );
@@ -48,12 +48,16 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="card-content" className={cn("px-6", className)} {...props} />;
+  return <div data-slot="card-content" className={cn("px-lt-gutter", className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div data-slot="card-footer" className={cn("flex items-center px-6", className)} {...props} />
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-lt-gutter", className)}
+      {...props}
+    />
   );
 }
 

--- a/resources/js/core/components/collapsible.tsx
+++ b/resources/js/core/components/collapsible.tsx
@@ -41,7 +41,7 @@ const CollapsibleComponent: RendererComponent<"collapsible"> = ({ children, node
   }
 
   return (
-    <div data-lattice-component={identity}>
+    <div data-slot="collapsible" data-lattice-component={identity}>
       <div
         aria-controls={contentId}
         aria-expanded={open}

--- a/resources/js/core/components/dialog.tsx
+++ b/resources/js/core/components/dialog.tsx
@@ -5,7 +5,7 @@ import { Button } from "@lattice-php/lattice/core/components/button";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
 export const DIALOG_SURFACE =
-  "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lt-lg";
+  "fixed left-1/2 top-1/2 z-lt-modal -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border bg-lt-bg p-6 shadow-lt-lg";
 
 function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -46,7 +46,7 @@ function DialogContent({
   return (
     <DialogPrimitive.Portal>
       <DialogPrimitive.Overlay
-        className="fixed inset-0 z-50 bg-lt-overlay"
+        className="fixed inset-0 z-lt-overlay bg-lt-overlay"
         data-slot="dialog-overlay"
       />
       <DialogPrimitive.Content

--- a/resources/js/core/components/floating-panel.tsx
+++ b/resources/js/core/components/floating-panel.tsx
@@ -32,7 +32,7 @@ const FloatingPanelComponent: RendererComponent<"floating-panel"> = ({ children,
     return (
       <div
         aria-label={label}
-        className="fixed z-50 max-w-[calc(100vw-2rem)] rounded-lt border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-lt-md"
+        className="fixed z-lt-popover max-w-[calc(100vw-2rem)] rounded-lt border border-lt-border bg-lt-popover p-1 text-lt-popover-fg shadow-lt-md"
         data-lattice-component={nodeIdentity(node)}
         role={label ? "group" : undefined}
         style={placementStyle(placement, offset)}
@@ -48,7 +48,7 @@ const FloatingPanelComponent: RendererComponent<"floating-panel"> = ({ children,
   return (
     <div
       aria-label={label}
-      className="fixed z-50 max-w-[calc(100vw-2rem)]"
+      className="fixed z-lt-popover max-w-[calc(100vw-2rem)]"
       data-lattice-component={nodeIdentity(node)}
       role={label ? "group" : undefined}
       style={placementStyle(placement, offset)}

--- a/resources/js/core/components/grid.tsx
+++ b/resources/js/core/components/grid.tsx
@@ -7,6 +7,7 @@ const GridComponent: RendererComponent<"grid"> = ({ children, node }) => {
 
   return (
     <div
+      data-slot="grid"
       data-lattice-component={nodeIdentity(node)}
       className={cn(
         "grid gap-x-4 gap-y-6",

--- a/resources/js/core/components/popover.tsx
+++ b/resources/js/core/components/popover.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
 export const POPOVER_SURFACE =
-  "z-50 rounded-lt-sm border border-lt-border bg-lt-popover text-lt-popover-fg shadow-lt-md";
+  "z-lt-popover rounded-lt-sm border border-lt-border bg-lt-popover text-lt-popover-fg shadow-lt-md";
 
 function Popover(props: React.ComponentProps<typeof PopoverPrimitive.Root>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -46,6 +46,7 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
 
   return (
     <section
+      data-slot="section"
       className="flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-lt-sm"
       data-lattice-component={identity}
     >

--- a/resources/js/core/components/section.tsx
+++ b/resources/js/core/components/section.tsx
@@ -47,11 +47,11 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
   return (
     <section
       data-slot="section"
-      className="flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-6 text-lt-surface-fg shadow-lt-sm"
+      className="flex flex-col gap-6 rounded-lt border border-lt-border bg-lt-surface py-lt-gutter text-lt-surface-fg shadow-lt-sm"
       data-lattice-component={identity}
     >
       {hasHeader && (
-        <div className="flex items-start justify-between gap-4 px-6">
+        <div className="flex items-start justify-between gap-4 px-lt-gutter">
           <div className="flex min-w-0 items-start gap-2">
             {collapsible && (
               <button
@@ -95,7 +95,9 @@ const SectionComponent: RendererComponent<"section"> = ({ children, node }) => {
         </div>
       )}
 
-      {!isCollapsed && children && <div className="flex flex-col gap-6 px-6">{children}</div>}
+      {!isCollapsed && children && (
+        <div className="flex flex-col gap-6 px-lt-gutter">{children}</div>
+      )}
     </section>
   );
 };

--- a/resources/js/core/components/stack.tsx
+++ b/resources/js/core/components/stack.tsx
@@ -63,6 +63,7 @@ const StackComponent: RendererComponent<"stack"> = ({ children, node }) => {
 
   return (
     <div
+      data-slot="stack"
       data-lattice-component={nodeIdentity(node)}
       className={cn(
         isFlex ? cn("flex", direction === "row" ? "flex-wrap" : "flex-col") : "grid content-start",

--- a/resources/js/core/components/theming.test.tsx
+++ b/resources/js/core/components/theming.test.tsx
@@ -68,6 +68,6 @@ describe("Lattice component theming", () => {
 
     expect(getByText("Recovery codes")).toHaveClass("font-semibold");
     expect(getByText("Keep these somewhere safe.")).toHaveClass("text-lt-muted-fg");
-    expect(getByText("Codes")).toHaveClass("px-6");
+    expect(getByText("Codes")).toHaveClass("px-lt-gutter");
   });
 });

--- a/resources/js/form/components/base/submit-button.tsx
+++ b/resources/js/form/components/base/submit-button.tsx
@@ -34,7 +34,7 @@ export function FormSubmitButton({
 
       {hasErrors && (
         <div
-          className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 w-max max-w-xs -translate-x-1/2 rounded-lt border border-lt-border bg-lt-surface p-3 text-left text-sm opacity-0 shadow-lt-md transition-opacity group-hover:opacity-100"
+          className="pointer-events-none absolute bottom-full left-1/2 z-lt-popover mb-2 w-max max-w-xs -translate-x-1/2 rounded-lt border border-lt-border bg-lt-surface p-3 text-left text-sm opacity-0 shadow-lt-md transition-opacity group-hover:opacity-100"
           role="tooltip"
         >
           <p className="mb-1 font-medium text-lt-fg">{summaryLabel}</p>

--- a/resources/js/form/components/fields/date-picker-control.tsx
+++ b/resources/js/form/components/fields/date-picker-control.tsx
@@ -102,7 +102,7 @@ export function DatePickerControl({
     mode === "date" ? formatDateValue(selected[0]) : formatDateTimeValue(selected[0], timezone);
 
   return (
-    <div {...api.getRootProps()} className={cn("relative", api.open && "z-[var(--lt-z-popover)]")}>
+    <div {...api.getRootProps()} className={cn("relative", api.open && "z-lt-popover")}>
       <input type="hidden" name={name} value={submittedValue} data-test={`${testId}-value`} />
       <div {...api.getControlProps()} className="flex gap-2">
         <Input
@@ -153,7 +153,7 @@ export function DatePickerControl({
       {api.open ? (
         <div
           {...api.getPositionerProps()}
-          className="absolute z-[var(--lt-z-popover)] mt-2 rounded-lt-sm border border-lt-border bg-lt-popover p-3 text-lt-popover-fg shadow-lt-md"
+          className="absolute z-lt-popover mt-2 rounded-lt-sm border border-lt-border bg-lt-popover p-3 text-lt-popover-fg shadow-lt-md"
         >
           <div {...api.getContentProps()} className="grid gap-3">
             <div className="flex items-center justify-between gap-2">

--- a/resources/js/form/components/fields/rich-editor.tsx
+++ b/resources/js/form/components/fields/rich-editor.tsx
@@ -252,7 +252,7 @@ function EmojiPicker({ editor }: { editor: Editor }) {
         <Icon name="smile" />
       </button>
       {open && (
-        <div className="absolute z-10 mt-1 grid grid-cols-8 gap-0.5 rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-lt-md">
+        <div className="absolute z-lt-dropdown mt-1 grid grid-cols-8 gap-0.5 rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-lt-md">
           {emojis.map((emoji) => (
             <button
               className="inline-flex size-7 items-center justify-center rounded-lt-sm text-base hover:bg-lt-accent"

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -117,6 +117,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
   return (
     <InertiaForm
       action={action}
+      data-slot="form"
       data-lattice-component={node.id}
       errorBag={errorBag}
       method={method}

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -84,7 +84,7 @@ function FormBody({
           {children}
 
           {shouldRenderSubmitButton && (
-            <div className="flex justify-end rounded-lt border border-lt-border bg-lt-surface px-6 py-4 shadow-lt-sm">
+            <div className="flex justify-end rounded-lt border border-lt-border bg-lt-surface px-lt-gutter py-4 shadow-lt-sm">
               <FormSubmitButton label={submitLabel} summaryLabel={summaryLabel} />
             </div>
           )}

--- a/resources/js/layout/menu-item.tsx
+++ b/resources/js/layout/menu-item.tsx
@@ -46,7 +46,7 @@ const MenuItemComponent: RendererComponent<"menu-item"> = ({ children, node }) =
       {prefix ? <MenuAffix affix={prefix} /> : null}
       {collapsed ? (
         <span
-          className="pointer-events-none absolute top-1/2 left-full z-50 ml-2 hidden -translate-y-1/2 rounded-lt-sm border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lt-md group-hover:block"
+          className="pointer-events-none absolute top-1/2 left-full z-lt-popover ml-2 hidden -translate-y-1/2 rounded-lt-sm border border-lt-border bg-lt-popover px-2 py-1 text-sm whitespace-nowrap text-lt-popover-fg shadow-lt-md group-hover:block"
           role="tooltip"
         >
           {label}

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -112,14 +112,14 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
       {mobileOpen ? (
         <div
           aria-hidden="true"
-          className="fixed inset-0 z-30 bg-lt-overlay md:hidden"
+          className="fixed inset-0 z-lt-overlay bg-lt-overlay md:hidden"
           data-test="sidebar-backdrop"
           onClick={() => setMobileOpen(false)}
         />
       ) : null}
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-40 flex h-svh w-72 max-w-[80vw] shrink-0 flex-col gap-4 border-r border-lt-border bg-lt-bg p-4 transition-transform",
+          "fixed inset-y-0 left-0 z-lt-modal flex h-svh w-72 max-w-[80vw] shrink-0 flex-col gap-4 border-r border-lt-border bg-lt-bg p-4 transition-transform",
           "md:sticky md:top-0 md:z-auto md:max-w-none md:translate-x-0 md:transition-[width]",
           mobileOpen ? "translate-x-0" : "-translate-x-full",
           isCollapsed

--- a/resources/js/layout/sidebar.tsx
+++ b/resources/js/layout/sidebar.tsx
@@ -112,7 +112,7 @@ const SidebarComponent: RendererComponent<"sidebar"> = ({ children, node }) => {
       {mobileOpen ? (
         <div
           aria-hidden="true"
-          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          className="fixed inset-0 z-30 bg-lt-overlay md:hidden"
           data-test="sidebar-backdrop"
           onClick={() => setMobileOpen(false)}
         />

--- a/resources/js/layout/topbar.test.tsx
+++ b/resources/js/layout/topbar.test.tsx
@@ -20,6 +20,6 @@ describe("Lattice topbar component", () => {
 
     render(<TopbarComponent node={node}>Content</TopbarComponent>);
 
-    expect(screen.getByText("Content")).toHaveClass("sticky", "top-0", "z-30");
+    expect(screen.getByText("Content")).toHaveClass("sticky", "top-0", "z-lt-sticky");
   });
 });

--- a/resources/js/layout/topbar.tsx
+++ b/resources/js/layout/topbar.tsx
@@ -10,7 +10,7 @@ const TopbarComponent: RendererComponent<"topbar"> = ({ children, node }) => {
       data-lattice-component={nodeIdentity(node)}
       className={cn(
         "flex h-14 w-full items-center gap-2 border-b border-lt-border bg-lt-bg px-4 text-lt-fg",
-        sticky && "sticky top-0 z-30",
+        sticky && "sticky top-0 z-lt-sticky",
       )}
     >
       {children}

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -152,7 +152,7 @@ function MultiSelectControl({
         <Icon name="chevron-down" aria-hidden="true" className="size-lt-icon-sm shrink-0" />
       </button>
       {open && (
-        <div className="absolute z-10 mt-1 min-w-full rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-lt-md">
+        <div className="absolute z-lt-dropdown mt-1 min-w-full rounded-lt-sm border border-lt-border bg-lt-bg p-1 shadow-lt-md">
           {filterOptions(filter).map((option) => (
             <label
               key={option.value}

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -27,7 +27,10 @@ export function TablePagination({
   const { t } = useT("lattice");
 
   return (
-    <div className="flex items-center justify-between gap-3 border-t border-lt-border p-4 text-sm">
+    <div
+      data-slot="table-pagination"
+      className="flex items-center justify-between gap-3 border-t border-lt-border p-4 text-sm"
+    >
       <span>
         {pagination.total == null
           ? t("table.pagination.page", "Page {{page}}", { page: currentPage })

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -122,7 +122,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
     });
 
   return (
-    <div data-lattice-component={node.id} className="relative">
+    <div data-slot="table" data-lattice-component={node.id} className="relative">
       {hasOverrides && (
         <button
           aria-label={t("table.resetColumnWidths", "Reset column widths")}
@@ -135,7 +135,10 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
           <Icon name="rotate-ccw" className="size-lt-icon-sm" />
         </button>
       )}
-      <div className="overflow-x-auto rounded-lt-sm border border-lt-border">
+      <div
+        data-slot="table-scroll"
+        className="overflow-x-auto rounded-lt-sm border border-lt-border"
+      >
         {hasDedicatedFilters && hasActiveFilters && (
           <FilterBar
             filters={filterDefinitions}
@@ -180,7 +183,11 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
           />
         )}
         <div className="min-w-full text-base" role="table">
-          <div className="border-b border-lt-border bg-lt-muted/50" role="rowgroup">
+          <div
+            data-slot="table-header"
+            className="border-b border-lt-border bg-lt-muted/50"
+            role="rowgroup"
+          >
             <div
               className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
               role="row"
@@ -270,7 +277,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                 <div role="cell">{t("table.loading", "Loading rows...")}</div>
               </div>
             ) : rowEntries.length === 0 ? (
-              <div className="p-8 text-center text-lt-muted-fg" role="row">
+              <div data-slot="table-empty" className="p-8 text-center text-lt-muted-fg" role="row">
                 <div role="cell">{node.props?.emptyLabel}</div>
               </div>
             ) : (
@@ -278,6 +285,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                 return (
                   <div
                     key={key}
+                    data-slot="table-row"
                     className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
                       striped ? "odd:bg-lt-muted/30" : ""
                     }`}
@@ -297,6 +305,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                     {visibleColumns.map((column) => (
                       <div
                         key={column.key}
+                        data-slot="table-cell"
                         className={cn(
                           "grid min-w-0 gap-1 overflow-hidden p-4 align-middle",
                           alignText(column.align),

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -72,7 +72,7 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
           ) : null}
         </Toast.Root>
       ))}
-      <Toast.Viewport className="fixed inset-x-0 bottom-0 z-[100] mx-auto flex w-full max-w-sm flex-col gap-2 p-4 outline-none" />
+      <Toast.Viewport className="fixed inset-x-0 bottom-0 z-lt-toast mx-auto flex w-full max-w-sm flex-col gap-2 p-4 outline-none" />
     </Toast.Provider>
   );
 }


### PR DESCRIPTION
Makes app-level theming robust by giving structural components stable, type-level styling hooks — instead of forcing consumers to key off Tailwind utility classes or the instance-level `data-lattice-component` id.

## What changed
- **Type slot on container roots**: `stack`, `grid`, `section`, `collapsible`, `form` now emit `data-slot="<type>"` alongside the existing `data-lattice-component` (which stays for instance/JS targeting). `card` already did this.
- **Structural part slots on the table**: `table` (root), `table-scroll` (the bordered scroll wrapper), `table-header`, `table-row`, `table-cell`, `table-empty`, `table-pagination` (complements the existing `table-cell-content`).

Purely additive attributes — no markup restructuring, no prop or wire-format changes.

## Why
Consumers currently have to write selectors like `[data-slot='card-content'] [data-lattice-component] > .overflow-x-auto` to theme a table inside a card, which breaks if an internal utility class or wrapper changes. With these hooks that becomes `[data-slot='card-content'] [data-slot='table-scroll']`, and things like `[data-slot='form'] [data-slot='button']` become expressible.

These `data-slot` values are intended as the stable, public theming contract (distinct from `data-test`).

## Verification
`oxlint`, `tsc --noEmit`, and the full non-browser suite (883 tests) pass; `build:lib` succeeds with all slots present in the output.