### PR TITLE
chore: add git hooks for the verification gate

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -13,15 +13,17 @@
 
 ## Verification
 
-- Before pushing or opening a PR, run `composer check` (Pint, PHPStan, Pest) — it mirrors the CI PHP job. Never push on
-  red. `composer test` alone is not enough; PHPStan and Pint run in CI too. For frontend changes run `npm run check` —
-  it fixes lint/format, then runs the type check, the Vitest suite, and the library build. CI additionally verifies that
-  generated TypeScript types (`composer types`) and docs fixtures are up to date.
-- After any change to TypeScript/TSX files (`resources/js/**`, `workbench/resources/js/**`), always run `npm run check`
-  before finalizing. It fixes lint and formatting (`oxlint --fix`, `oxfmt`), then runs the type check (`tsc`), the
-  Vitest suite, and the library build (`build:lib`).
+- Git hooks enforce the gate automatically. `composer install` points `core.hooksPath` at `.githooks/`; if the hooks are
+  not active, run `composer install` (or `git config core.hooksPath .githooks`) once.
+  - **pre-commit** auto-formats staged PHP/JS (Pint, oxfmt, oxlint) and blocks on lint errors.
+  - **pre-push** runs the full CI-equivalent gate: `composer check` (Pint, PHPStan, Rector, Pest) and `npm run check`
+    (lint, format, type check, type coverage, Vitest, library build).
+- Never push on red. Use `git commit`/`git push --no-verify` only in emergencies.
 - The library build is part of the gate on purpose: it is the artifact consumers receive, and it catches bundling
   regressions (e.g. dependencies that must stay external) that the type check and tests do not.
+- CI additionally verifies that generated TypeScript types (`composer types`) and docs fixtures are up to date. These are
+  left out of the local hooks because a local run reorders `resources/js/types/generated.ts` spuriously; regenerate and
+  commit them deliberately only when you change a `#[TypeScript]`/component shape.
 
 ## Comments
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Fast pre-commit gate: auto-format staged PHP/JS and block on lint errors.
+# The full CI-equivalent gate runs on pre-push. Bypass with `git commit --no-verify`.
+set -e
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+staged_php=$(git diff --cached --name-only --diff-filter=ACMR -- '*.php')
+staged_js=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx')
+
+if [ -n "$staged_php" ]; then
+    echo "▶ pint (staged PHP)"
+    echo "$staged_php" | xargs ./vendor/bin/pint
+    echo "$staged_php" | xargs git add
+fi
+
+if [ -n "$staged_js" ]; then
+    echo "▶ oxfmt + oxlint (staged JS)"
+    echo "$staged_js" | xargs ./node_modules/.bin/oxfmt --write
+    echo "$staged_js" | xargs ./node_modules/.bin/oxlint --fix
+    echo "$staged_js" | xargs git add
+    echo "$staged_js" | xargs ./node_modules/.bin/oxlint
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Full CI-equivalent gate. Mirrors the local Verification routine in .ai/guidelines/development.md.
+# Bypass with `git push --no-verify` (emergencies only — never push on red).
+#
+# The generated-types and docs-fixtures diffs are intentionally left to CI: a local run
+# regenerates resources/js/types/generated.ts with a different property ordering than main,
+# so a local diff check would fail spuriously.
+set -e
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+echo "▶ pre-push: composer check (pint, phpstan, rector, pest)"
+composer check
+
+echo "▶ pre-push: npm run check (lint, format, typecheck, type-coverage, vitest, build:lib)"
+npm run check
+
+echo "✓ pre-push gate passed"

--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,15 @@
             "@clear",
             "@prepare"
         ],
-        "post-install-cmd": "@boost:refresh",
-        "post-update-cmd": "@boost:refresh",
+        "post-install-cmd": [
+            "@boost:refresh",
+            "@hooks:install"
+        ],
+        "post-update-cmd": [
+            "@boost:refresh",
+            "@hooks:install"
+        ],
+        "hooks:install": "git config core.hooksPath .githooks 2>/dev/null || true",
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
         "boost:refresh": "@php vendor/bin/testbench boost:update --no-interaction",


### PR DESCRIPTION
Automates the pre-push/pre-PR verification routine as versioned git hooks so it always runs, and trims the guideline that used to describe it by hand.

## What
- **`.githooks/pre-commit`** — fast: formats staged PHP/JS (Pint, oxfmt, oxlint `--fix`), re-stages fixes, blocks on remaining lint errors.
- **`.githooks/pre-push`** — full CI-equivalent gate: `composer check` (Pint, PHPStan, Rector, Pest) + `npm run check` (lint, format, typecheck, type-coverage, Vitest, `build:lib`).
- **Auto-wire** — `composer install`/`update` runs `@hooks:install` to point `core.hooksPath` at `.githooks/`. No new dependency; safe no-op outside a git repo.
- **Guideline** — trims `## Verification` in `.ai/guidelines/development.md` to point at the hooks.

## Notes
- The generated-types and docs-fixtures diffs are intentionally left to CI: a local run reorders `resources/js/types/generated.ts` spuriously and would false-fail.
- Both hooks honor `--no-verify` for emergencies.
- Existing clones activate the hooks on their next `composer install` (or `git config core.hooksPath .githooks` once).