### PR TITLE
refactor: adopt density tokens (control heights, cell padding, prose) + weight token

### DIFF
--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -59,6 +59,15 @@
   --lt-control-h-md: 2.25rem;
   --lt-control-h-lg: 2.5rem;
 
+  /* Table cell padding — table density lever */
+  --lt-table-cell-x: calc(var(--spacing) * 4); /* 1rem */
+  --lt-table-cell-y: calc(var(--spacing) * 4); /* 1rem */
+
+  --lt-font-weight-normal: 400;
+  --lt-font-weight-medium: 500;
+  --lt-font-weight-semibold: 600;
+  --lt-font-weight-bold: 700;
+
   /* Elevation */
   --lt-shadow-xs: 0 1px 1px 0 oklch(0 0 0 / 0.04);
   --lt-shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.05);
@@ -192,6 +201,12 @@
   --spacing-lt-control-md: var(--lt-control-h-md);
   --spacing-lt-control-lg: var(--lt-control-h-lg);
   --spacing-lt-gutter: var(--lt-gutter);
+  --spacing-lt-cell-x: var(--lt-table-cell-x);
+  --spacing-lt-cell-y: var(--lt-table-cell-y);
+  --font-weight-lt-normal: var(--lt-font-weight-normal);
+  --font-weight-lt-medium: var(--lt-font-weight-medium);
+  --font-weight-lt-semibold: var(--lt-font-weight-semibold);
+  --font-weight-lt-bold: var(--lt-font-weight-bold);
   --animate-lt-toast-in: lt-toast-in var(--lt-duration-base) ease-out;
   --animate-lt-toast-out: lt-toast-out var(--lt-duration-fast) ease-in;
 }
@@ -361,44 +376,44 @@
  * `:where()` keeps specificity low so consumers can override freely.
  */
 .lattice-prose :where(h1) {
-  font-size: 1.5rem;
+  font-size: var(--text-4xl);
   line-height: 2rem;
-  font-weight: 700;
-  margin: 1rem 0 0.5rem;
+  font-weight: var(--lt-font-weight-bold);
+  margin: calc(var(--spacing) * 4) 0 calc(var(--spacing) * 2);
 }
 
 .lattice-prose :where(h2) {
-  font-size: 1.25rem;
+  font-size: var(--text-3xl);
   line-height: 1.75rem;
-  font-weight: 700;
-  margin: 1rem 0 0.5rem;
+  font-weight: var(--lt-font-weight-bold);
+  margin: calc(var(--spacing) * 4) 0 calc(var(--spacing) * 2);
 }
 
 .lattice-prose :where(h3) {
-  font-size: 1.125rem;
+  font-size: var(--text-2xl);
   line-height: 1.5rem;
-  font-weight: 600;
-  margin: 0.75rem 0 0.5rem;
+  font-weight: var(--lt-font-weight-semibold);
+  margin: calc(var(--spacing) * 3) 0 calc(var(--spacing) * 2);
 }
 
 .lattice-prose :where(p) {
-  margin: 0.5rem 0;
+  margin: calc(var(--spacing) * 2) 0;
 }
 
 .lattice-prose :where(ul) {
   list-style: disc;
-  padding-left: 1.5rem;
-  margin: 0.5rem 0;
+  padding-left: calc(var(--spacing) * 6);
+  margin: calc(var(--spacing) * 2) 0;
 }
 
 .lattice-prose :where(ol) {
   list-style: decimal;
-  padding-left: 1.5rem;
-  margin: 0.5rem 0;
+  padding-left: calc(var(--spacing) * 6);
+  margin: calc(var(--spacing) * 2) 0;
 }
 
 .lattice-prose :where(li) {
-  margin: 0.25rem 0;
+  margin: var(--spacing) 0;
 }
 
 .lattice-prose :where(li p) {
@@ -407,14 +422,14 @@
 
 .lattice-prose :where(blockquote) {
   border-left: 3px solid var(--lt-border);
-  padding-left: 1rem;
-  margin: 0.75rem 0;
+  padding-left: calc(var(--spacing) * 4);
+  margin: calc(var(--spacing) * 3) 0;
   color: var(--lt-muted-fg);
   font-style: italic;
 }
 
 .lattice-prose :where(strong) {
-  font-weight: 700;
+  font-weight: var(--lt-font-weight-bold);
 }
 
 .lattice-prose :where(em) {
@@ -431,7 +446,7 @@
 }
 
 .lattice-prose :where(mark) {
-  background: var(--lt-warning, #fef08a);
+  background: var(--lt-warning);
   color: inherit;
   border-radius: var(--lt-radius-sm);
   padding: 0.05em 0.15em;
@@ -446,7 +461,7 @@
 .lattice-prose :where(code) {
   background: var(--lt-muted);
   border-radius: var(--lt-radius-sm);
-  padding: 0.125rem 0.25rem;
+  padding: calc(var(--spacing) * 0.5) var(--spacing);
   font-family: ui-monospace, "SFMono-Regular", "Menlo", monospace;
   font-size: 0.875em;
 }
@@ -454,11 +469,11 @@
 .lattice-prose :where(pre) {
   background: var(--lt-muted);
   border-radius: var(--lt-radius-sm);
-  padding: 0.75rem 1rem;
-  margin: 0.75rem 0;
+  padding: calc(var(--spacing) * 3) calc(var(--spacing) * 4);
+  margin: calc(var(--spacing) * 3) 0;
   overflow-x: auto;
   font-family: ui-monospace, "SFMono-Regular", "Menlo", monospace;
-  font-size: 0.875rem;
+  font-size: var(--text-lg);
 }
 
 .lattice-prose :where(pre code) {
@@ -470,27 +485,27 @@
 .lattice-prose :where(hr) {
   border: none;
   border-top: 1px solid var(--lt-border);
-  margin: 1rem 0;
+  margin: calc(var(--spacing) * 4) 0;
 }
 
 .lattice-prose :where(table) {
   border-collapse: collapse;
   width: 100%;
-  margin: 0.75rem 0;
+  margin: calc(var(--spacing) * 3) 0;
   table-layout: fixed;
   overflow: hidden;
 }
 
 .lattice-prose :where(th, td) {
   border: 1px solid var(--lt-border);
-  padding: 0.375rem 0.5rem;
+  padding: calc(var(--spacing) * 1.5) calc(var(--spacing) * 2);
   text-align: left;
   vertical-align: top;
 }
 
 .lattice-prose :where(th) {
   background: var(--lt-muted);
-  font-weight: 600;
+  font-weight: var(--lt-font-weight-semibold);
 }
 
 .lattice-prose :where(.selectedCell) {
@@ -500,13 +515,13 @@
 .lattice-prose :where(details) {
   border: 1px solid var(--lt-border);
   border-radius: var(--lt-radius-sm);
-  padding: 0.5rem 0.75rem;
-  margin: 0.75rem 0;
+  padding: calc(var(--spacing) * 2) calc(var(--spacing) * 3);
+  margin: calc(var(--spacing) * 3) 0;
 }
 
 .lattice-prose :where(summary) {
   cursor: pointer;
-  font-weight: 600;
+  font-weight: var(--lt-font-weight-semibold);
 }
 
 .lattice-prose :where(:first-child) {

--- a/resources/js/action/components/action-group.tsx
+++ b/resources/js/action/components/action-group.tsx
@@ -36,7 +36,7 @@ const ActionGroupComponent: RendererComponent<"action.group"> = ({ children, nod
         <DropdownMenuTrigger asChild>
           <Button
             aria-label={label}
-            className="size-8 text-lt-muted-fg shadow-none hover:text-lt-fg"
+            className="size-lt-control-sm text-lt-muted-fg shadow-none hover:text-lt-fg"
             data-test={nodeIdentity(node)}
             size="icon"
             type="button"

--- a/resources/js/action/components/action-menu-context.tsx
+++ b/resources/js/action/components/action-menu-context.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, type ReactNode } from "react";
 const ActionMenuContext = createContext(false);
 
 export const actionMenuItemClassName =
-  "flex h-8 w-full items-center justify-start gap-2 rounded-lt-sm px-2.5 text-left text-sm font-normal text-lt-popover-fg no-underline decoration-transparent shadow-none transition-colors hover:bg-lt-accent/70 hover:text-lt-popover-fg focus-visible:bg-lt-accent/70 focus-visible:text-lt-popover-fg focus-visible:ring-0 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-lt-icon-sm [&_svg]:text-lt-muted-fg";
+  "flex h-lt-control-sm w-full items-center justify-start gap-2 rounded-lt-sm px-2.5 text-left text-sm font-normal text-lt-popover-fg no-underline decoration-transparent shadow-none transition-colors hover:bg-lt-accent/70 hover:text-lt-popover-fg focus-visible:bg-lt-accent/70 focus-visible:text-lt-popover-fg focus-visible:ring-0 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-lt-icon-sm [&_svg]:text-lt-muted-fg";
 
 export function ActionMenuProvider({ children }: { children: ReactNode }) {
   return <ActionMenuContext.Provider value={true}>{children}</ActionMenuContext.Provider>;

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -181,7 +181,7 @@ describe("Lattice action component", () => {
     );
 
     expect(screen.getByRole("button", { name: "custom.sparkEdit" })).toHaveClass(
-      "h-8",
+      "h-lt-control-sm",
       "w-full",
       "text-lt-popover-fg",
     );

--- a/resources/js/core/components/link.test.tsx
+++ b/resources/js/core/components/link.test.tsx
@@ -35,7 +35,7 @@ describe("Lattice link component", () => {
       </ActionMenuProvider>,
     );
 
-    expect(screen.getByRole("link", { name: "Edit" })).toHaveClass("h-8", "w-full", "no-underline");
+    expect(screen.getByRole("link", { name: "Edit" })).toHaveClass("h-lt-control-sm", "w-full", "no-underline");
   });
 
   it("renders prefix and suffix affixes around the label", () => {

--- a/resources/js/core/components/link.test.tsx
+++ b/resources/js/core/components/link.test.tsx
@@ -35,7 +35,11 @@ describe("Lattice link component", () => {
       </ActionMenuProvider>,
     );
 
-    expect(screen.getByRole("link", { name: "Edit" })).toHaveClass("h-lt-control-sm", "w-full", "no-underline");
+    expect(screen.getByRole("link", { name: "Edit" })).toHaveClass(
+      "h-lt-control-sm",
+      "w-full",
+      "no-underline",
+    );
   });
 
   it("renders prefix and suffix affixes around the label", () => {

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -102,7 +102,7 @@ export function ColumnFilterControl({
               label: column.label,
             })}
             data-test={`filter-${column.key}`}
-            className="relative -ml-px inline-flex size-9 shrink-0 items-center justify-center rounded-r-lt-sm border border-lt-input disabled:opacity-50 data-[state=open]:z-10 data-[state=open]:border-lt-primary"
+            className="relative -ml-px inline-flex size-lt-control-md shrink-0 items-center justify-center rounded-r-lt-sm border border-lt-input disabled:opacity-50 data-[state=open]:z-10 data-[state=open]:border-lt-primary"
             disabled={processing}
           >
             <Icon name="filter" aria-hidden="true" className="size-lt-icon-md" />
@@ -371,7 +371,7 @@ function FilterClauseRow({
           type="button"
           aria-label={t("table.filter.remove", "Remove {{label}} filter", { label: column.label })}
           data-test={`filter-${column.key}-remove`}
-          className="inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border hover:bg-lt-muted disabled:opacity-50"
+          className="inline-flex size-lt-control-md items-center justify-center rounded-lt-sm border border-lt-border hover:bg-lt-muted disabled:opacity-50"
           disabled={processing}
           onClick={onRemove}
         >

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -349,7 +349,7 @@ function ToggleControl({
   const checked = value === "1" || value === true || value === "true";
 
   return (
-    <label className="flex h-9 cursor-pointer items-center gap-2 text-sm">
+    <label className="flex h-lt-control-md cursor-pointer items-center gap-2 text-sm">
       <Checkbox
         aria-label={filter.label}
         data-test={`table-filter-${filter.key}`}

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -46,7 +46,7 @@ export function TablePagination({
             <button
               type="button"
               data-test="pagination-load-more"
-              className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
+              className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
               disabled={processing}
               onClick={onLoadMore}
             >
@@ -65,7 +65,7 @@ export function TablePagination({
           <button
             type="button"
             data-test="pagination-previous"
-            className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
+            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || currentPage <= 1}
             onClick={() => onPage(currentPage - 1)}
           >
@@ -74,7 +74,7 @@ export function TablePagination({
           <button
             type="button"
             data-test="pagination-next"
-            className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
+            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || !hasNextPage}
             onClick={() => onPage(currentPage + 1)}
           >
@@ -86,7 +86,7 @@ export function TablePagination({
           <button
             type="button"
             data-test="pagination-previous"
-            className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
+            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || currentPage <= 1}
             onClick={() => onPage(currentPage - 1)}
           >
@@ -97,7 +97,7 @@ export function TablePagination({
               key={pageNumber}
               type="button"
               data-test={`pagination-page-${pageNumber}`}
-              className="inline-flex size-9 items-center justify-center rounded-lt-sm border border-lt-border font-medium disabled:opacity-50"
+              className="inline-flex size-lt-control-md items-center justify-center rounded-lt-sm border border-lt-border font-medium disabled:opacity-50"
               disabled={processing || pageNumber === currentPage}
               aria-current={pageNumber === currentPage ? "page" : undefined}
               aria-label={t("table.pagination.page", "Page {{page}}", { page: pageNumber })}
@@ -109,7 +109,7 @@ export function TablePagination({
           <button
             type="button"
             data-test="pagination-next"
-            className="h-9 rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
+            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || !hasNextPage}
             onClick={() => onPage(currentPage + 1)}
           >

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -469,10 +469,10 @@ describe("Lattice table component", () => {
     const link = screen.getByRole("link", { name: "Edit" });
 
     expect(action).toBeVisible();
-    expect(action).toHaveClass("h-8", "font-normal", "text-lt-popover-fg");
+    expect(action).toHaveClass("h-lt-control-sm", "font-normal", "text-lt-popover-fg");
     expect(action).not.toHaveClass("bg-lt-secondary");
     expect(link).toHaveAttribute("href", "/products/2/edit");
-    expect(link).toHaveClass("h-8", "font-normal", "text-lt-popover-fg", "no-underline");
+    expect(link).toHaveClass("h-lt-control-sm", "font-normal", "text-lt-popover-fg", "no-underline");
   });
 
   it("adds and clears individual sorts through the table endpoint", async () => {

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -472,7 +472,12 @@ describe("Lattice table component", () => {
     expect(action).toHaveClass("h-lt-control-sm", "font-normal", "text-lt-popover-fg");
     expect(action).not.toHaveClass("bg-lt-secondary");
     expect(link).toHaveAttribute("href", "/products/2/edit");
-    expect(link).toHaveClass("h-lt-control-sm", "font-normal", "text-lt-popover-fg", "no-underline");
+    expect(link).toHaveClass(
+      "h-lt-control-sm",
+      "font-normal",
+      "text-lt-popover-fg",
+      "no-underline",
+    );
   });
 
   it("adds and clears individual sorts through the table endpoint", async () => {

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -293,7 +293,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                     style={{ "--lattice-table-columns": gridTemplateColumns } as never}
                   >
                     {hasBulkActions && (
-                      <div className="flex items-center p-4" role="cell">
+                      <div className="flex items-center px-lt-cell-x py-lt-cell-y" role="cell">
                         <Checkbox
                           aria-label={t("table.selectRow", "Select row {{key}}", { key })}
                           data-test={`select-row-${key}`}
@@ -307,7 +307,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                         key={column.key}
                         data-slot="table-cell"
                         className={cn(
-                          "grid min-w-0 gap-1 overflow-hidden p-4 align-middle",
+                          "grid min-w-0 gap-1 overflow-hidden px-lt-cell-x py-lt-cell-y align-middle",
                           alignText(column.align),
                           alignJustifyItems(column.align),
                         )}
@@ -330,7 +330,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                     {hasTrailingUtility && (
                       <div
                         className={cn(
-                          "items-center justify-start gap-2 p-4 md:justify-end",
+                          "items-center justify-start gap-2 px-lt-cell-x py-lt-cell-y md:justify-end",
                           actions.length > 0 ? "flex" : "hidden md:flex",
                         )}
                         role="cell"


### PR DESCRIPTION
Follow-up to the semantic-slots/token work (#212). Adopts existing tokens and adds a couple of density levers. **All changes are value-identical — no visual change**; the point is the levers now actually move things.

## What changed
1. **Control-height adoption** — pagination buttons, filter-column triggers, the action-group menu button + menu items, and the boolean-filter row hardcoded `h-8/h-9/size-9`, bypassing the `--lt-control-h-*` lever the core inputs already use. Now on `h-lt-control-*`/`size-lt-control-*` (11 sites). Calendar-grid cells intentionally kept raw.
2. **Table cell-padding tokens** — new `--lt-table-cell-x/y` (→ `px-lt-cell-x`/`py-lt-cell-y`), adopted on the body cells: a table compact/comfortable density lever that previously required editing the component.
3. **`.lattice-prose` tokenized** — ~30 raw rems → `--text-*` / `--spacing`; weights → the weight token; dropped the dead `#fef08a` fallback. Line-heights kept explicit to avoid retuning headings.
4. **Weight token** — reintroduced `--lt-font-weight-*` (pruned earlier as dead), now **wired** to Tailwind as `font-weight-lt-*` and actually **used** by prose.

## Verification
`oxlint`, `tsc`, and the full non-browser suite (883) pass; `build:lib` succeeds with all new tokens present. Verified end-to-end in a consuming app: tokens compile and tables render pixel-identical.