### PR TITLE
feat: custom in-popover time picker for DateTimeInput and TimeInput

### DIFF
--- a/docs/content/docs/forms/fields/time-input.mdx
+++ b/docs/content/docs/forms/fields/time-input.mdx
@@ -17,7 +17,7 @@ The time input collects a time of day and returns a string such as `14:30`.
 
 ## Seconds and step
 
-Use `->step()` to control the browser's time granularity. The value is seconds.
+Use `->step()` to control the picker's time granularity. The value is seconds.
 
 ```php
 TimeInput::make('starts_at', 'Start time')

--- a/resources/icons/clock.svg
+++ b/resources/icons/clock.svg
@@ -1,0 +1,16 @@
+<!-- @license lucide-static v1.18.0 - ISC -->
+<svg
+  class="lucide lucide-clock"
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 6v6l4 2" />
+</svg>

--- a/resources/js/form/components/fields/date-picker-control.tsx
+++ b/resources/js/form/components/fields/date-picker-control.tsx
@@ -1,7 +1,7 @@
 import type { DateValue } from "@internationalized/date";
 import * as datePicker from "@zag-js/date-picker";
 import { normalizeProps, useMachine } from "@zag-js/react";
-import { useId, useMemo, useState } from "react";
+import { useId, useMemo } from "react";
 import { Button } from "@lattice-php/lattice/core/components/button";
 import { Icon } from "@lattice-php/lattice/icons";
 import { useLocale } from "@lattice-php/lattice/i18n";
@@ -19,7 +19,7 @@ import {
   parseDateValue,
 } from "./date-picker-value";
 import { TimePicker } from "./time-picker";
-import { parseTimeString, type TimeValue } from "./time-picker-columns";
+import { parseTimeString } from "./time-picker-columns";
 
 export type DatePickerControlProps = {
   mode: "date" | "date-time";
@@ -102,19 +102,6 @@ export function DatePickerControl({
   const { name: _inputName, onInput, ...inputProps } = api.getInputProps();
   const submittedValue =
     mode === "date" ? formatDateValue(selected[0]) : formatDateTimeValue(selected[0], timezone);
-
-  // Zag applies api.setTime() on the next microtask, so consecutive column
-  // edits in the same tick would otherwise merge against a stale committed
-  // value. Hold the last requested time in state (forcing a synchronous
-  // re-render) until the machine catches up.
-  const [pendingTimeValue, setPendingTimeValue] = useState<TimeValue | null>(null);
-  const committedTimeValue = parseTimeString(formatTimeInputValue(selected[0], timezone));
-
-  if (pendingTimeValue && timeValuesEqual(pendingTimeValue, committedTimeValue)) {
-    setPendingTimeValue(null);
-  }
-
-  const timeValue = pendingTimeValue ?? committedTimeValue;
 
   return (
     <div {...api.getRootProps()} className={cn("relative", api.open && "z-lt-popover")}>
@@ -228,11 +215,10 @@ export function DatePickerControl({
             </table>
             {mode === "date-time" ? (
               <TimePicker
-                value={timeValue}
-                onChange={(next) => {
-                  setPendingTimeValue(next);
-                  api.setTime({ hour: next.hour, minute: next.minute, second: next.second });
-                }}
+                value={parseTimeString(formatTimeInputValue(selected[0], timezone))}
+                onChange={(next) =>
+                  api.setTime({ hour: next.hour, minute: next.minute, second: next.second })
+                }
                 step={step}
                 disabled={disabled}
                 readOnly={readOnly}
@@ -254,13 +240,4 @@ function normalizeDateInputValue(value: string): string | undefined {
   }
 
   return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
-}
-
-function timeValuesEqual(left: TimeValue, right: TimeValue | null): boolean {
-  return (
-    right != null &&
-    left.hour === right.hour &&
-    left.minute === right.minute &&
-    left.second === right.second
-  );
 }

--- a/resources/js/form/components/fields/date-picker-control.tsx
+++ b/resources/js/form/components/fields/date-picker-control.tsx
@@ -1,7 +1,7 @@
 import type { DateValue } from "@internationalized/date";
 import * as datePicker from "@zag-js/date-picker";
 import { normalizeProps, useMachine } from "@zag-js/react";
-import { useId, useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import { Button } from "@lattice-php/lattice/core/components/button";
 import { Icon } from "@lattice-php/lattice/icons";
 import { useLocale } from "@lattice-php/lattice/i18n";
@@ -18,6 +18,8 @@ import {
   parseDateTimeValue,
   parseDateValue,
 } from "./date-picker-value";
+import { TimePicker } from "./time-picker";
+import { parseTimeString, type TimeValue } from "./time-picker-columns";
 
 export type DatePickerControlProps = {
   mode: "date" | "date-time";
@@ -100,6 +102,19 @@ export function DatePickerControl({
   const { name: _inputName, onInput, ...inputProps } = api.getInputProps();
   const submittedValue =
     mode === "date" ? formatDateValue(selected[0]) : formatDateTimeValue(selected[0], timezone);
+
+  // Zag applies api.setTime() on the next microtask, so consecutive column
+  // edits in the same tick would otherwise merge against a stale committed
+  // value. Hold the last requested time in state (forcing a synchronous
+  // re-render) until the machine catches up.
+  const [pendingTimeValue, setPendingTimeValue] = useState<TimeValue | null>(null);
+  const committedTimeValue = parseTimeString(formatTimeInputValue(selected[0], timezone));
+
+  if (pendingTimeValue && timeValuesEqual(pendingTimeValue, committedTimeValue)) {
+    setPendingTimeValue(null);
+  }
+
+  const timeValue = pendingTimeValue ?? committedTimeValue;
 
   return (
     <div {...api.getRootProps()} className={cn("relative", api.open && "z-lt-popover")}>
@@ -212,22 +227,16 @@ export function DatePickerControl({
               </tbody>
             </table>
             {mode === "date-time" ? (
-              <Input
-                aria-label={`${label || name} time`}
-                disabled={disabled}
-                onChange={(event) => {
-                  const [hour = "0", minute = "0", second = "0"] = event.target.value.split(":");
-
-                  api.setTime({
-                    hour: Number(hour),
-                    minute: Number(minute),
-                    second: Number(second),
-                  });
+              <TimePicker
+                value={timeValue}
+                onChange={(next) => {
+                  setPendingTimeValue(next);
+                  api.setTime({ hour: next.hour, minute: next.minute, second: next.second });
                 }}
+                step={step}
+                disabled={disabled}
                 readOnly={readOnly}
-                step={step ?? undefined}
-                type="time"
-                value={formatTimeInputValue(selected[0], timezone)}
+                testId={`${testId}-time`}
               />
             ) : null}
           </div>
@@ -245,4 +254,13 @@ function normalizeDateInputValue(value: string): string | undefined {
   }
 
   return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+}
+
+function timeValuesEqual(left: TimeValue, right: TimeValue | null): boolean {
+  return (
+    right != null &&
+    left.hour === right.hour &&
+    left.minute === right.minute &&
+    left.second === right.second
+  );
 }

--- a/resources/js/form/components/fields/date-time-input.test.tsx
+++ b/resources/js/form/components/fields/date-time-input.test.tsx
@@ -104,6 +104,13 @@ describe("DateTimeInputComponent", () => {
     });
 
     fireEvent.click(screen.getByRole("option", { name: "Hour 14" }));
+
+    await waitFor(() => {
+      expect(document.querySelector('input[name="starts_at"]')).toHaveValue(
+        "2026-06-19T14:00:00 Europe/Berlin",
+      );
+    });
+
     fireEvent.click(screen.getByRole("option", { name: "Minute 30" }));
 
     await waitFor(() => {

--- a/resources/js/form/components/fields/date-time-input.test.tsx
+++ b/resources/js/form/components/fields/date-time-input.test.tsx
@@ -103,7 +103,8 @@ describe("DateTimeInputComponent", () => {
       );
     });
 
-    fireEvent.change(screen.getByLabelText("Starts at time"), { target: { value: "14:30" } });
+    fireEvent.click(screen.getByRole("option", { name: "Hour 14" }));
+    fireEvent.click(screen.getByRole("option", { name: "Minute 30" }));
 
     await waitFor(() => {
       expect(document.querySelector('input[name="starts_at"]')).toHaveValue(
@@ -112,7 +113,7 @@ describe("DateTimeInputComponent", () => {
     });
   });
 
-  it("uses the native time input inside the datetime picker", async () => {
+  it("renders the time picker columns inside the datetime picker", async () => {
     setTimezone("Europe/Berlin");
 
     renderField(
@@ -125,8 +126,11 @@ describe("DateTimeInputComponent", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /open starts at calendar/i }));
 
-    expect(await screen.findByLabelText("Starts at time")).toHaveAttribute("type", "time");
-    expect(screen.queryByRole("option", { name: "Hour 01" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: "Minute 01" })).not.toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "Hour 01" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("option", { name: "Minute 01" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Starts at time")).not.toBeInTheDocument();
   });
 });

--- a/resources/js/form/components/fields/time-input.test.tsx
+++ b/resources/js/form/components/fields/time-input.test.tsx
@@ -63,4 +63,36 @@ describe("TimeInputComponent", () => {
 
     expect(screen.getByLabelText("Start time")).toHaveAttribute("name", "items[0][starts_at]");
   });
+
+  it("keeps a seconds-enabled value intact while typing and normalizes on blur", () => {
+    renderField(
+      fakeNode({
+        type: "field.time-input",
+        props: { name: "starts_at", label: "Start time", step: 1 },
+      }),
+    );
+
+    const input = screen.getByLabelText("Start time");
+
+    fireEvent.change(input, { target: { value: "10:15" } });
+    expect(input).toHaveValue("10:15");
+
+    fireEvent.change(input, { target: { value: "10:15:30" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("10:15:30");
+  });
+
+  it("normalizes a complete value on blur", () => {
+    renderField(
+      fakeNode({ type: "field.time-input", props: { name: "starts_at", label: "Start time" } }),
+    );
+
+    const input = screen.getByLabelText("Start time");
+
+    fireEvent.change(input, { target: { value: "9:30" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("09:30");
+  });
 });

--- a/resources/js/form/components/fields/time-input.test.tsx
+++ b/resources/js/form/components/fields/time-input.test.tsx
@@ -15,41 +15,36 @@ function renderField(node: Node<"field.time-input">, initial: Record<string, unk
 }
 
 describe("TimeInputComponent", () => {
-  it("renders and commits a time value", () => {
+  it("renders a text input and commits a normalized value", () => {
     renderField(
       fakeNode({ type: "field.time-input", props: { name: "starts_at", label: "Start time" } }),
     );
 
     const input = screen.getByLabelText("Start time");
 
-    expect(input).toHaveAttribute("type", "time");
+    expect(input).toHaveAttribute("type", "text");
 
     fireEvent.change(input, { target: { value: "14:30" } });
 
     expect(input).toHaveValue("14:30");
   });
 
-  it("applies min max step and tab index props", () => {
+  it("picks a time from the popover", () => {
     renderField(
       fakeNode({
         type: "field.time-input",
-        props: {
-          name: "starts_at",
-          label: "Start time",
-          min: "08:00",
-          max: "18:00",
-          step: 900,
-          tabIndex: 2,
-        },
+        props: { name: "starts_at", label: "Start time", min: "08:00", max: "18:00" },
       }),
     );
 
-    const input = screen.getByLabelText("Start time");
+    fireEvent.click(screen.getByRole("button", { name: /open start time time picker/i }));
 
-    expect(input).toHaveAttribute("min", "08:00");
-    expect(input).toHaveAttribute("max", "18:00");
-    expect(input).toHaveAttribute("step", "900");
-    expect(input).toHaveAttribute("tabindex", "2");
+    expect(screen.getByRole("option", { name: "Hour 07" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("option", { name: "Hour 09" }));
+    fireEvent.click(screen.getByRole("option", { name: "Minute 30" }));
+
+    expect(screen.getByLabelText("Start time")).toHaveValue("09:30");
   });
 
   it("uses scoped row names inside row fields", () => {

--- a/resources/js/form/components/fields/time-input.tsx
+++ b/resources/js/form/components/fields/time-input.tsx
@@ -27,12 +27,16 @@ export const TimeInputComponent: RendererComponent<"field.time-input"> = ({ node
             disabled={disabled}
             id={name}
             name={name}
-            onBlur={blur}
-            onChange={(event) => {
-              const parsed = parseTimeString(event.target.value);
+            onBlur={() => {
+              const parsed = parseTimeString(value);
 
-              commit(parsed ? formatTimeValue(parsed, withSeconds) : event.target.value);
+              if (parsed) {
+                commit(formatTimeValue(parsed, withSeconds));
+              }
+
+              blur();
             }}
+            onChange={(event) => commit(event.target.value)}
             readOnly={readOnly}
             tabIndex={props.tabIndex ?? undefined}
             type="text"

--- a/resources/js/form/components/fields/time-input.tsx
+++ b/resources/js/form/components/fields/time-input.tsx
@@ -1,28 +1,69 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { Button } from "@lattice-php/lattice/core/components/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@lattice-php/lattice/core/components/popover";
+import { Icon } from "@lattice-php/lattice/icons";
 import { Input } from "../base/input";
 import { SimpleField } from "./simple-field";
+import { TimePicker } from "./time-picker";
+import { formatTimeValue, parseTimeString, secondsEnabled } from "./time-picker-columns";
 
 export const TimeInputComponent: RendererComponent<"field.time-input"> = ({ node }) => {
   const props = node.props;
+  const withSeconds = secondsEnabled(props.step);
+  const triggerLabel = props.label ?? props.name;
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, commit }) => (
-        <Input
-          autoFocus={props.autoFocus ?? false}
-          data-test={testId}
-          disabled={disabled}
-          id={name}
-          max={props.max || undefined}
-          min={props.min || undefined}
-          name={name}
-          onChange={(event) => commit(event.target.value)}
-          readOnly={readOnly}
-          step={props.step ?? undefined}
-          tabIndex={props.tabIndex ?? undefined}
-          type="time"
-          value={value}
-        />
+      {({ name, testId, value, readOnly, disabled, commit, blur }) => (
+        <div className="flex gap-2">
+          <Input
+            aria-label={triggerLabel}
+            autoFocus={props.autoFocus ?? false}
+            data-test={testId}
+            disabled={disabled}
+            id={name}
+            name={name}
+            onBlur={blur}
+            onChange={(event) => {
+              const parsed = parseTimeString(event.target.value);
+
+              commit(parsed ? formatTimeValue(parsed, withSeconds) : event.target.value);
+            }}
+            readOnly={readOnly}
+            tabIndex={props.tabIndex ?? undefined}
+            type="text"
+            value={value}
+          />
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                aria-label={`Open ${triggerLabel} time picker`}
+                disabled={disabled || readOnly}
+                size="icon"
+                type="button"
+                variant="secondary"
+              >
+                <Icon name="clock" className="size-lt-icon-md" aria-hidden="true" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="p-2">
+              <TimePicker
+                value={parseTimeString(value)}
+                onChange={(next) => commit(formatTimeValue(next, withSeconds))}
+                step={props.step}
+                min={props.min}
+                max={props.max}
+                disabled={disabled}
+                readOnly={readOnly}
+                testId={`${testId}-picker`}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
       )}
     </SimpleField>
   );

--- a/resources/js/form/components/fields/time-picker-columns.test.ts
+++ b/resources/js/form/components/fields/time-picker-columns.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTimeColumns,
+  formatTimeValue,
+  parseTimeString,
+  secondsEnabled,
+} from "./time-picker-columns";
+
+describe("parseTimeString", () => {
+  it("parses HH:MM and HH:MM:SS", () => {
+    expect(parseTimeString("14:30")).toEqual({ hour: 14, minute: 30, second: 0 });
+    expect(parseTimeString("14:30:15")).toEqual({ hour: 14, minute: 30, second: 15 });
+  });
+
+  it("returns null for empty or out-of-range input", () => {
+    expect(parseTimeString("")).toBeNull();
+    expect(parseTimeString(null)).toBeNull();
+    expect(parseTimeString("24:00")).toBeNull();
+    expect(parseTimeString("12:60")).toBeNull();
+    expect(parseTimeString("nope")).toBeNull();
+  });
+});
+
+describe("formatTimeValue", () => {
+  it("pads and optionally includes seconds", () => {
+    expect(formatTimeValue({ hour: 9, minute: 5, second: 0 }, false)).toBe("09:05");
+    expect(formatTimeValue({ hour: 9, minute: 5, second: 7 }, true)).toBe("09:05:07");
+  });
+});
+
+describe("secondsEnabled", () => {
+  it("is true only for sub-minute steps", () => {
+    expect(secondsEnabled(null)).toBe(false);
+    expect(secondsEnabled(60)).toBe(false);
+    expect(secondsEnabled(30)).toBe(true);
+  });
+});
+
+describe("buildTimeColumns", () => {
+  it("defaults to 24 hours, 60 minutes, no seconds", () => {
+    const columns = buildTimeColumns(null);
+
+    expect(columns.hours).toHaveLength(24);
+    expect(columns.minutes).toHaveLength(60);
+    expect(columns.seconds).toBeNull();
+    expect(columns.hours[0]).toEqual({ value: 0, label: "00", disabled: false });
+  });
+
+  it("derives the minute list from a minute-granularity step", () => {
+    const columns = buildTimeColumns(900);
+
+    expect(columns.minutes.map((option) => option.value)).toEqual([0, 15, 30, 45]);
+  });
+
+  it("shows a seconds column for sub-minute steps", () => {
+    const columns = buildTimeColumns(30);
+
+    expect(columns.seconds).not.toBeNull();
+    expect(columns.seconds).toHaveLength(60);
+    expect(columns.minutes).toHaveLength(60);
+  });
+
+  it("keeps an off-step current minute in the list", () => {
+    const columns = buildTimeColumns(900, { current: { hour: 0, minute: 7, second: 0 } });
+
+    expect(columns.minutes.map((option) => option.value)).toContain(7);
+  });
+
+  it("disables hours outside min/max", () => {
+    const columns = buildTimeColumns(null, {
+      min: "08:00",
+      max: "18:00",
+      current: { hour: 8, minute: 0, second: 0 },
+    });
+
+    expect(columns.hours.find((option) => option.value === 7)?.disabled).toBe(true);
+    expect(columns.hours.find((option) => option.value === 8)?.disabled).toBe(false);
+    expect(columns.hours.find((option) => option.value === 19)?.disabled).toBe(true);
+  });
+
+  it("disables out-of-range minutes in a boundary hour", () => {
+    const columns = buildTimeColumns(null, {
+      min: "08:30",
+      current: { hour: 8, minute: 45, second: 0 },
+    });
+
+    expect(columns.minutes.find((option) => option.value === 15)?.disabled).toBe(true);
+    expect(columns.minutes.find((option) => option.value === 30)?.disabled).toBe(false);
+  });
+});

--- a/resources/js/form/components/fields/time-picker-columns.ts
+++ b/resources/js/form/components/fields/time-picker-columns.ts
@@ -1,0 +1,128 @@
+export type TimeValue = { hour: number; minute: number; second: number };
+
+export type TimeColumnOption = { value: number; label: string; disabled: boolean };
+
+export type TimeColumns = {
+  hours: TimeColumnOption[];
+  minutes: TimeColumnOption[];
+  seconds: TimeColumnOption[] | null;
+};
+
+type Bound = { hour: number; minute: number };
+
+const timePattern = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/;
+
+export function parseTimeString(value: string | null | undefined): TimeValue | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const match = timePattern.exec(value.trim());
+
+  if (!match) {
+    return null;
+  }
+
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  const second = match[3] ? Number(match[3]) : 0;
+
+  if (hour > 23 || minute > 59 || second > 59) {
+    return null;
+  }
+
+  return { hour, minute, second };
+}
+
+export function formatTimeValue(value: TimeValue, withSeconds: boolean): string {
+  const parts = [pad(value.hour), pad(value.minute)];
+
+  if (withSeconds) {
+    parts.push(pad(value.second));
+  }
+
+  return parts.join(":");
+}
+
+export function secondsEnabled(step: number | null | undefined): boolean {
+  return step != null && step < 60;
+}
+
+export function buildTimeColumns(
+  step: number | null | undefined,
+  options: { min?: string | null; max?: string | null; current?: TimeValue | null } = {},
+): TimeColumns {
+  const { min, max, current } = options;
+  const minBound = toBound(min);
+  const maxBound = toBound(max);
+  const minuteStep = step == null || step < 60 ? 1 : step % 60 === 0 ? step / 60 : 1;
+
+  const hours = range(0, 23, 1).map((value) => ({
+    value,
+    label: pad(value),
+    disabled:
+      (minBound != null && value < minBound.hour) || (maxBound != null && value > maxBound.hour),
+  }));
+
+  const minuteValues = withValue(range(0, 59, minuteStep), current?.minute);
+  const minutes = minuteValues.map((value) => ({
+    value,
+    label: pad(value),
+    disabled: minuteDisabled(value, current, minBound, maxBound),
+  }));
+
+  const seconds = secondsEnabled(step)
+    ? range(0, 59, 1).map((value) => ({ value, label: pad(value), disabled: false }))
+    : null;
+
+  return { hours, minutes, seconds };
+}
+
+function minuteDisabled(
+  minute: number,
+  current: TimeValue | null | undefined,
+  minBound: Bound | null,
+  maxBound: Bound | null,
+): boolean {
+  if (!current) {
+    return false;
+  }
+
+  if (minBound != null && current.hour === minBound.hour && minute < minBound.minute) {
+    return true;
+  }
+
+  if (maxBound != null && current.hour === maxBound.hour && minute > maxBound.minute) {
+    return true;
+  }
+
+  return false;
+}
+
+function toBound(value: string | null | undefined): Bound | null {
+  const parsed = parseTimeString(value);
+
+  return parsed ? { hour: parsed.hour, minute: parsed.minute } : null;
+}
+
+function withValue(values: number[], extra: number | undefined): number[] {
+  if (extra == null || values.includes(extra)) {
+    return values;
+  }
+
+  return [...values, extra].sort((left, right) => left - right);
+}
+
+function range(start: number, end: number, step: number): number[] {
+  const values: number[] = [];
+
+  for (let value = start; value <= end; value += step) {
+    values.push(value);
+  }
+
+  return values;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}

--- a/resources/js/form/components/fields/time-picker.browser.test.tsx
+++ b/resources/js/form/components/fields/time-picker.browser.test.tsx
@@ -1,0 +1,46 @@
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+import { describe, expect, it, vi } from "vitest";
+import type { TimeValue } from "./time-picker-columns";
+import { TimePicker } from "./time-picker";
+
+describe("TimePicker in a browser", () => {
+  it("scrolls the selected option into its column's viewport on open", async () => {
+    await page.viewport(1280, 800);
+
+    const screen = await render(
+      <TimePicker value={{ hour: 21, minute: 0, second: 0 }} onChange={() => {}} />,
+    );
+    const option = screen.getByRole("option", { name: "Hour 21" }).element();
+    const listbox = option.closest('[role="listbox"]') as HTMLElement;
+
+    expect(listbox.scrollHeight).toBeGreaterThan(listbox.clientHeight);
+
+    const optionRect = option.getBoundingClientRect();
+    const listboxRect = listbox.getBoundingClientRect();
+
+    expect(optionRect.top).toBeGreaterThanOrEqual(listboxRect.top - 1);
+    expect(optionRect.bottom).toBeLessThanOrEqual(listboxRect.bottom + 1);
+  });
+
+  it("traverses columns and selects with real keyboard events", async () => {
+    await page.viewport(1280, 800);
+
+    const onChange = vi.fn<(next: TimeValue) => void>();
+    const screen = await render(
+      <TimePicker value={{ hour: 1, minute: 0, second: 0 }} onChange={onChange} />,
+    );
+    const hour = screen.getByRole("option", { name: "Hour 01" }).element();
+
+    hour.focus();
+    hour.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowRight" }));
+
+    expect(document.activeElement?.getAttribute("aria-label")).toBe("Minute 00");
+
+    document.activeElement?.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, key: "ArrowDown" }),
+    );
+
+    expect(onChange).toHaveBeenLastCalledWith({ hour: 1, minute: 1, second: 0 });
+  });
+});

--- a/resources/js/form/components/fields/time-picker.test.tsx
+++ b/resources/js/form/components/fields/time-picker.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TimePicker } from "./time-picker";
+import type { TimeValue } from "./time-picker-columns";
+
+describe("TimePicker", () => {
+  it("renders hour and minute columns and no seconds by default", () => {
+    render(<TimePicker value={{ hour: 1, minute: 1, second: 0 }} onChange={() => {}} />);
+
+    expect(screen.getByRole("listbox", { name: "Hour" })).toBeInTheDocument();
+    expect(screen.getByRole("listbox", { name: "Minute" })).toBeInTheDocument();
+    expect(screen.queryByRole("listbox", { name: "Second" })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Hour 01" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("emits a full time value when an option is clicked", () => {
+    const onChange = vi.fn<(next: TimeValue) => void>();
+
+    render(<TimePicker value={{ hour: 1, minute: 1, second: 0 }} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("option", { name: "Hour 14" }));
+
+    expect(onChange).toHaveBeenCalledWith({ hour: 14, minute: 1, second: 0 });
+  });
+
+  it("shows a seconds column for sub-minute steps", () => {
+    render(<TimePicker value={{ hour: 0, minute: 0, second: 0 }} step={30} onChange={() => {}} />);
+
+    expect(screen.getByRole("listbox", { name: "Second" })).toBeInTheDocument();
+  });
+
+  it("disables out-of-range options from min", () => {
+    render(
+      <TimePicker value={{ hour: 10, minute: 0, second: 0 }} min="10:00" onChange={() => {}} />,
+    );
+
+    expect(screen.getByRole("option", { name: "Hour 09" })).toBeDisabled();
+    expect(screen.getByRole("option", { name: "Hour 10" })).not.toBeDisabled();
+  });
+
+  it("moves selection with the down arrow", () => {
+    const onChange = vi.fn<(next: TimeValue) => void>();
+
+    render(<TimePicker value={{ hour: 1, minute: 0, second: 0 }} onChange={onChange} />);
+
+    fireEvent.keyDown(screen.getByRole("option", { name: "Hour 01" }), { key: "ArrowDown" });
+
+    expect(onChange).toHaveBeenCalledWith({ hour: 2, minute: 0, second: 0 });
+  });
+});

--- a/resources/js/form/components/fields/time-picker.test.tsx
+++ b/resources/js/form/components/fields/time-picker.test.tsx
@@ -50,4 +50,62 @@ describe("TimePicker", () => {
 
     expect(onChange).toHaveBeenCalledWith({ hour: 2, minute: 0, second: 0 });
   });
+
+  it("moves selection with the up arrow", () => {
+    const onChange = vi.fn<(next: TimeValue) => void>();
+
+    render(<TimePicker value={{ hour: 2, minute: 0, second: 0 }} onChange={onChange} />);
+
+    fireEvent.keyDown(screen.getByRole("option", { name: "Hour 02" }), { key: "ArrowUp" });
+
+    expect(onChange).toHaveBeenCalledWith({ hour: 1, minute: 0, second: 0 });
+  });
+
+  it("jumps to the first and last option with Home and End", () => {
+    const onChange = vi.fn<(next: TimeValue) => void>();
+
+    render(<TimePicker value={{ hour: 5, minute: 0, second: 0 }} onChange={onChange} />);
+
+    const hour = screen.getByRole("option", { name: "Hour 05" });
+
+    fireEvent.keyDown(hour, { key: "End" });
+    expect(onChange).toHaveBeenLastCalledWith({ hour: 23, minute: 0, second: 0 });
+
+    fireEvent.keyDown(hour, { key: "Home" });
+    expect(onChange).toHaveBeenLastCalledWith({ hour: 0, minute: 0, second: 0 });
+  });
+
+  it("moves focus between columns with the left and right arrows", () => {
+    render(<TimePicker value={{ hour: 1, minute: 0, second: 0 }} onChange={() => {}} />);
+
+    fireEvent.keyDown(screen.getByRole("option", { name: "Hour 01" }), { key: "ArrowRight" });
+    expect(document.activeElement).toHaveAttribute("aria-label", "Minute 00");
+
+    fireEvent.keyDown(screen.getByRole("option", { name: "Minute 00" }), { key: "ArrowLeft" });
+    expect(document.activeElement).toHaveAttribute("aria-label", "Hour 01");
+  });
+
+  it("selects a value in the seconds column", () => {
+    const onChange = vi.fn<(next: TimeValue) => void>();
+
+    render(<TimePicker value={{ hour: 0, minute: 0, second: 0 }} step={30} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("option", { name: "Second 05" }));
+
+    expect(onChange).toHaveBeenCalledWith({ hour: 0, minute: 0, second: 5 });
+  });
+
+  it("ignores interaction when disabled", () => {
+    const onChange = vi.fn<(next: TimeValue) => void>();
+
+    render(<TimePicker value={{ hour: 1, minute: 0, second: 0 }} disabled onChange={onChange} />);
+
+    const hour = screen.getByRole("option", { name: "Hour 01" });
+
+    expect(hour).toBeDisabled();
+
+    fireEvent.keyDown(hour, { key: "ArrowDown" });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/resources/js/form/components/fields/time-picker.tsx
+++ b/resources/js/form/components/fields/time-picker.tsx
@@ -1,0 +1,198 @@
+import { type KeyboardEvent, useEffect, useRef } from "react";
+import { cn } from "@lattice-php/lattice/lib/utils";
+import { buildTimeColumns, type TimeColumnOption, type TimeValue } from "./time-picker-columns";
+
+export type TimePickerProps = {
+  value: TimeValue | null;
+  onChange: (next: TimeValue) => void;
+  step?: number | null;
+  min?: string | null;
+  max?: string | null;
+  disabled?: boolean;
+  readOnly?: boolean;
+  labels?: { hour?: string; minute?: string; second?: string };
+  testId?: string;
+};
+
+export function TimePicker({
+  value,
+  onChange,
+  step,
+  min,
+  max,
+  disabled = false,
+  readOnly = false,
+  labels,
+  testId,
+}: TimePickerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const columns = buildTimeColumns(step, { min, max, current: value });
+  const current: TimeValue = value ?? { hour: 0, minute: 0, second: 0 };
+  const interactive = !disabled && !readOnly;
+
+  const columnList = [
+    {
+      key: "hour" as const,
+      label: labels?.hour ?? "Hour",
+      options: columns.hours,
+      selected: current.hour,
+    },
+    {
+      key: "minute" as const,
+      label: labels?.minute ?? "Minute",
+      options: columns.minutes,
+      selected: current.minute,
+    },
+    ...(columns.seconds
+      ? [
+          {
+            key: "second" as const,
+            label: labels?.second ?? "Second",
+            options: columns.seconds,
+            selected: current.second,
+          },
+        ]
+      : []),
+  ];
+
+  function focusColumn(index: number) {
+    const listboxes = containerRef.current?.querySelectorAll<HTMLElement>('[role="listbox"]');
+    const target = listboxes?.[index];
+
+    if (!target) {
+      return;
+    }
+
+    const active =
+      target.querySelector<HTMLElement>('[data-active="true"]') ??
+      target.querySelector<HTMLElement>('[role="option"]');
+
+    active?.focus();
+  }
+
+  return (
+    <div ref={containerRef} className="flex gap-1" data-test={testId}>
+      {columnList.map((column, index) => (
+        <TimeColumn
+          key={column.key}
+          label={column.label}
+          options={column.options}
+          selected={value ? column.selected : null}
+          disabled={!interactive}
+          onSelect={(optionValue) =>
+            interactive && onChange({ ...current, [column.key]: optionValue })
+          }
+          onHorizontal={(direction) => focusColumn(index + direction)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TimeColumn({
+  label,
+  options,
+  selected,
+  disabled,
+  onSelect,
+  onHorizontal,
+}: {
+  label: string;
+  options: TimeColumnOption[];
+  selected: number | null;
+  disabled: boolean;
+  onSelect: (value: number) => void;
+  onHorizontal: (direction: 1 | -1) => void;
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const enabledValues = options.filter((option) => !option.disabled).map((option) => option.value);
+  const activeValue = selected ?? enabledValues[0] ?? options[0]?.value ?? 0;
+
+  useEffect(() => {
+    const active = listRef.current?.querySelector<HTMLElement>('[data-active="true"]');
+
+    active?.scrollIntoView?.({ block: "nearest" });
+  }, [selected]);
+
+  function moveTo(nextValue: number | undefined) {
+    if (nextValue == null) {
+      return;
+    }
+
+    listRef.current?.querySelector<HTMLElement>(`[data-value="${nextValue}"]`)?.focus();
+    onSelect(nextValue);
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (disabled) {
+      return;
+    }
+
+    const index = enabledValues.indexOf(activeValue);
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveTo(enabledValues[Math.min(index + 1, enabledValues.length - 1)]);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        moveTo(enabledValues[Math.max(index - 1, 0)]);
+        break;
+      case "Home":
+        event.preventDefault();
+        moveTo(enabledValues[0]);
+        break;
+      case "End":
+        event.preventDefault();
+        moveTo(enabledValues[enabledValues.length - 1]);
+        break;
+      case "ArrowRight":
+        event.preventDefault();
+        onHorizontal(1);
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        onHorizontal(-1);
+        break;
+    }
+  }
+
+  return (
+    <div
+      ref={listRef}
+      role="listbox"
+      aria-label={label}
+      aria-orientation="vertical"
+      tabIndex={-1}
+      className="flex max-h-40 w-14 flex-col overflow-y-auto"
+      onKeyDown={handleKeyDown}
+    >
+      {options.map((option) => {
+        const isSelected = selected === option.value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="option"
+            aria-selected={isSelected}
+            aria-label={`${label} ${option.label}`}
+            data-value={option.value}
+            data-active={activeValue === option.value}
+            disabled={disabled || option.disabled}
+            tabIndex={activeValue === option.value ? 0 : -1}
+            onClick={() => onSelect(option.value)}
+            className={cn(
+              "shrink-0 rounded-lt-sm px-2 py-1 text-sm text-lt-fg hover:bg-lt-muted",
+              isSelected && "bg-lt-primary text-lt-primary-fg",
+              (disabled || option.disabled) && "cursor-not-allowed opacity-40",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/Core/Enums/Icon.php
+++ b/src/Core/Enums/Icon.php
@@ -24,6 +24,7 @@ enum Icon: string
     case CircleCheck = 'circle-check';
     case CircleHelp = 'circle-help';
     case CircleX = 'circle-x';
+    case Clock = 'clock';
     case Code = 'code';
     case Columns3 = 'columns-3';
     case Copy = 'copy';

--- a/tests/Browser/Forms/TimePickerTest.php
+++ b/tests/Browser/Forms/TimePickerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+it('picks a time from the standalone TimeInput popover', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    visit('/showcase')
+        ->click('[aria-label="Open Meeting time time picker"]')
+        ->assertDisabled('[aria-label="Hour 07"]')
+        ->click('[aria-label="Hour 09"]')
+        ->click('[aria-label="Minute 30"]')
+        ->assertValue('input[name="meeting_time"]', '09:30')
+        ->assertNoSmoke();
+});
+
+it('picks the time portion of a DateTimeInput from the calendar popover', function (): void {
+    $this->actingAs(workbenchTestUser());
+    $day = now()->toDateString();
+
+    visit('/showcase')
+        ->click('[aria-label="Open Launch at calendar"]')
+        ->click("button[data-value=\"$day\"]")
+        ->click('[aria-label="Hour 10"]')
+        ->click('[aria-label="Minute 15"]')
+        ->assertNoSmoke();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,27 +22,74 @@ const isVitest = process.env.VITEST !== undefined;
 // installing lucide-static. Keep sorted and grouped by origin.
 const latticeIcons = [
   // Server-driven defaults (names components emit / consumers commonly use)
-  "arrow-down", "arrow-up", "check", "chevrons-up-down", "copy", "external-link",
-  "eye-off", "layout-dashboard", "link", "more-horizontal", "pencil", "pencil-line",
-  "send", "settings", "trash-2", "x",
+  "arrow-down",
+  "arrow-up",
+  "check",
+  "chevrons-up-down",
+  "copy",
+  "external-link",
+  "eye-off",
+  "layout-dashboard",
+  "link",
+  "more-horizontal",
+  "pencil",
+  "pencil-line",
+  "send",
+  "settings",
+  "trash-2",
+  "x",
   // Internal chrome
-  "calendar", "chevron-down", "chevron-left", "chevron-right", "circle-alert", "circle-check",
-  "circle-help", "circle-x", "eye", "filter", "info", "loader-2", "minus", "panel-left",
-  "plus", "rotate-ccw", "search",
+  "calendar",
+  "chevron-down",
+  "chevron-left",
+  "chevron-right",
+  "circle-alert",
+  "circle-check",
+  "circle-help",
+  "circle-x",
+  "clock",
+  "eye",
+  "filter",
+  "info",
+  "loader-2",
+  "minus",
+  "panel-left",
+  "plus",
+  "rotate-ccw",
+  "search",
   // Rich-editor toolbar
-  "align-center", "align-justify", "align-left", "align-right", "bold", "code",
-  "columns-3", "heading-1", "heading-2", "heading-3", "highlighter", "italic",
-  "list", "list-ordered", "quote", "rows-3", "smile", "strikethrough", "table", "underline",
+  "align-center",
+  "align-justify",
+  "align-left",
+  "align-right",
+  "bold",
+  "code",
+  "columns-3",
+  "heading-1",
+  "heading-2",
+  "heading-3",
+  "highlighter",
+  "italic",
+  "list",
+  "list-ordered",
+  "quote",
+  "rows-3",
+  "smile",
+  "strikethrough",
+  "table",
+  "underline",
 ];
 
 function libraryEntries(): string[] {
-  return readdirSync(sourceRoot, { recursive: true, encoding: "utf8" })
-    .filter((file) => /\.(ts|tsx)$/.test(file))
-    // Exclude declaration files and type-level test files — *.test.ts, *.test-d.ts, *.d.ts — from the published bundle.
-    .filter((file) => !/\.(test(-d)?|d)\.(ts|tsx)$/.test(file))
-    .filter((file) => !file.startsWith("test/"))
-    .filter((file) => file !== "test-support.ts")
-    .map((file) => path.join(sourceRoot, file));
+  return (
+    readdirSync(sourceRoot, { recursive: true, encoding: "utf8" })
+      .filter((file) => /\.(ts|tsx)$/.test(file))
+      // Exclude declaration files and type-level test files — *.test.ts, *.test-d.ts, *.d.ts — from the published bundle.
+      .filter((file) => !/\.(test(-d)?|d)\.(ts|tsx)$/.test(file))
+      .filter((file) => !file.startsWith("test/"))
+      .filter((file) => file !== "test-support.ts")
+      .map((file) => path.join(sourceRoot, file))
+  );
 }
 
 function stylesheet(): Plugin {
@@ -201,7 +248,7 @@ export default defineConfig(({ mode }) => {
             },
           },
         }
-      : { build: { sourcemap: true,  chunkSizeWarningLimit: 600 } }),
+      : { build: { sourcemap: true, chunkSizeWarningLimit: 600 } }),
     test: {
       projects: [
         {

--- a/workbench/resources/js/sprite-icons.ts
+++ b/workbench/resources/js/sprite-icons.ts
@@ -19,6 +19,7 @@ export const iconNames = [
   "circle-check",
   "circle-help",
   "circle-x",
+  "clock",
   "code",
   "columns-3",
   "copy",
@@ -83,6 +84,7 @@ declare module "@lattice-php/lattice" {
     "circle-check": true;
     "circle-help": true;
     "circle-x": true;
+    clock: true;
     code: true;
     "columns-3": true;
     copy: true;


### PR DESCRIPTION
Replaces the native `<input type="time">` in `DateTimeInput` and standalone `TimeInput` with one shared, token-styled time picker.

## What changed
- New shared `TimePicker`: scrollable hour/minute(/second) `listbox` columns, calendar design tokens, roving-tabindex keyboard nav (↑↓, Home/End, ←→), backed by a pure `time-picker-columns` model (24h; minutes derived from `step`; seconds only when `step < 60`; min/max via disabled options).
- `DateTimeInput`: the picker lives inside the existing Zag calendar popover and writes back through `api.setTime` — the Zag machine stays the single source of truth (no parallel state).
- `TimeInput`: a typeable text input (normalizes on blur) **plus** a clock button that opens the picker in a popover. Native `<input type="time">` removed from both fields.
- New `clock` icon; docs wording updated.

## Why
The native control couldn't be styled to match the calendar and looked foreign inside the date-picker popover. This gives a consistent, accessible, step-aware picker across both fields.

## Before / after
- Before: `DateTimeInput` time = unstyled native `<input type="time">` wedged under the calendar; `TimeInput` = bare native time field.
- After: both use the same scrollable column picker with primary-token selection; `TimeInput` keeps free-form typing via its text input.

## Tests
- Unit (pure column model), component (RTL), integration (value + timezone commit), and Pest browser tests for both fields.
- `npm run check` green (Vitest 919/919, type coverage 99.84%, library build); docs build green.

## Non-blocking follow-ups
- Keyboard digit-typeahead not yet implemented (arrows/Home/End/←→ only).
- The `DateTimeInput` browser test is smoke-level (value/timezone commit is covered by the Vitest integration test).