### PR TITLE
ci: resolve the two intermittent CI flakes (peststan + column-popover browser test)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,3 +11,13 @@ parameters:
     excludePaths:
         # Pest's arch() DSL is a runtime fluent API PHPStan cannot statically model.
         - tests/ArchTest.php
+    # peststan (0.2.10) memoizes expectation analysis keyed by spl_object_id() of
+    # short-lived AST nodes and Type objects; PHP recycles those ids after GC, so
+    # within a parallel worker a later file collides with a stale cache entry and
+    # these two rules fire nondeterministically — including on non-expect() calls
+    # (e.g. a Laravel Http ->json()). CI-only, different file each run. Suppress
+    # the two affected rules; the rest of peststan is unaffected.
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - identifier: pest.expectation.requiresString
+        - identifier: pest.expectation.impossible

--- a/tests/Browser/Tables/FilterTest.php
+++ b/tests/Browser/Tables/FilterTest.php
@@ -22,6 +22,7 @@ it('adds a filter through the column popover', function (): void {
     seedNamedWorkbenchUsers();
 
     visit('/')
+        ->assertSee('Ada Lovelace')
         ->click('@filter-name')
         ->fill('[aria-label="Name filter value"]', 'Grace')
         ->keys('[aria-label="Name filter value"]', 'Enter')

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -5,10 +5,21 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tests;
 
 use Lattice\Lattice\Tests\Browser\Support\ReverbServer;
+use Pest\Browser\Playwright\Playwright;
 
 class BrowserTestCase extends TestCase
 {
     private static ?ReverbServer $reverb = null;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // CI runners are slower than Playwright's tight 5s default, which
+        // intermittently trips browser actions/assertions under load.
+        Playwright::setTimeout(15_000);
+    }
 
     protected function bootReverb(): void
     {


### PR DESCRIPTION
Two unrelated flakes were randomly failing CI on unrelated PRs. Both root-caused.

## 1. PHPStan / peststan false positives (nondeterministic, CI-only)
Failed a different, often untouched file each run — e.g. `pest.expectation.requiresString` on a plain Laravel `Http::...->json()` (no `expect()` at all), or an `expect()->and()` chain mis-typed as `array`.

**Root cause:** `mrpunyapal/peststan` (0.2.10) memoizes expectation analysis in its rule singletons keyed by `spl_object_id()` of short-lived AST nodes and PHPStan `Type` objects. PHP recycles those ids after GC, so within a parallel worker (which analyses dozens of files sequentially) a later file collides with a stale cache entry and the rule fires with zero re-validation. GC + file-to-job scheduling vary with runner core count, so it only surfaces on CI, on a different file each run. `0.2.11` doesn't touch the affected files, so upgrading doesn't help.

**Fix:** ignore the two affected rule identifiers (`pest.expectation.requiresString`, `pest.expectation.impossible`) with `reportUnmatchedIgnoredErrors: false` (they fire only sometimes, so a plain ignore would fail CI the other way). All other peststan rules stay active. Verified: both rules fire on a scratch trigger without the ignore and are suppressed with it.

## 2. Flaky `FilterTest > adds a filter through the column popover`
`Timeout 5000ms exceeded` on CI, never reproducible locally (40+ runs). It's the only browser test that opens a Radix popover and then fills an input inside it; the reliable sibling tests interact with always-visible inputs.

**Fix (two mitigations):** wait for the seeded table to render (`assertSee`) before the stateful popover click so it can't land before the app is interactive, and raise the browser action/assertion timeout from Playwright's tight 5s default to 15s for all browser tests (`BrowserTestCase::setUp`) to absorb CI-load latency spikes.

## Notes
- The peststan bug has no upstream issue; worth filing one against `mrpunyapal/peststan` (exact lines: `ExpectationChainStateResolver::resolve()` and `ExpectationTypeNarrower::cacheKey()`, both keyed on raw `spl_object_id`).
- `BrowserTestCase` now references peststan-adjacent `@internal` `Pest\Browser\Playwright\Playwright` to set the timeout — the only public-ish knob the plugin exposes.