### PR TITLE
feat: composer-only custom component packages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -146,6 +146,7 @@ export default defineConfig({
             { label: "Custom fields", link: "/extending/custom-fields/" },
             { label: "Custom columns", link: "/extending/custom-columns/" },
             { label: "Registry and types", link: "/extending/registry-and-types/" },
+            { label: "Component packages", link: "/extending/component-packages/" },
           ],
         },
         {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,15 @@
             "email": "manuel@christlieb.eu"
         }
     ],
+    "repositories": [
+        {
+            "type": "path",
+            "url": "packages/*",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
     "require": {
         "php": "^8.4",
         "illuminate/http": "^11.0 || ^12.0 || ^13.0",
@@ -39,6 +48,7 @@
         "barryvdh/laravel-ide-helper": "^3.7",
         "fruitcake/laravel-debugbar": "^4.3",
         "larastan/larastan": "^3.0",
+        "lattice-php/signature-example": "@dev",
         "laravel/boost": "^2.4",
         "laravel/pint": "^1.16",
         "laravel/reverb": "^1.10",

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -1,0 +1,121 @@
+---
+title: Component packages
+description: Ship a custom component — PHP and its React renderer — as a Composer package, with no npm publish.
+---
+
+import Info from "@components/Info.astro";
+import Warning from "@components/Warning.astro";
+
+The [extension points](/extending/overview/) assume a component lives in your own app. To _distribute_ one — a signature pad, a chart widget, a domain-specific field — you would normally also publish an npm package for its React renderer, and keep it in lockstep with the PHP side. Lattice avoids that second release pipeline: because a consuming app already pulls Lattice itself from `vendor/` through the `lattice()` Vite plugin, a component package ships its renderer as source in `vendor/` too. A plain `composer require` is enough.
+
+## What a package ships
+
+Four things — or scaffold them with `php artisan lattice:component Signature --package=.`:
+
+**1. A `composer.json` declaring the two Lattice entry points:**
+
+```json
+{
+  "name": "acme/lattice-signature",
+  "autoload": { "psr-4": { "Acme\\Signature\\": "src/" } },
+  "extra": {
+    "lattice": {
+      "plugin": "resources/js/plugin.ts",
+      "discover": ["src"]
+    }
+  }
+}
+```
+
+**2. The PHP component, carrying its wire `type`:**
+
+```php
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Components\Component;
+
+#[AsComponent('signature')]
+final class Signature extends Component
+{
+    public string $label = 'Sign here';
+}
+```
+
+**3. The React renderer for that type:**
+
+```tsx
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+
+const Signature: RendererComponent<"signature"> = ({ node }) => (
+  <div className="rounded-lt-sm border border-lt-border p-4 text-lt-fg">
+    {String(node.props?.label ?? "Sign here")}
+  </div>
+);
+
+export default Signature;
+```
+
+**4. The plugin entry that registers it:**
+
+```ts
+import { createPlugin, lazyComponent } from "@lattice-php/lattice";
+
+export default createPlugin({
+  name: "acme-signature",
+  components: {
+    signature: lazyComponent(() => import("./signature")),
+  },
+});
+```
+
+## How it reaches the app
+
+The two `extra.lattice` keys are each read by one side of the stack:
+
+- **`plugin`** — the `lattice()` Vite plugin scans `vendor/composer/installed.json`, and for every package that declares it, grants Vite filesystem access to the package directory and exposes its plugin under the virtual module `virtual:lattice/plugins`. The package's TSX compiles straight into the consumer's bundle: no separate build step, one shared React instance, full tree-shaking.
+- **`discover`** — Lattice's PHP discovery merges these roots into `lattice.discover`, so the package's `#[AsComponent]` classes are picked up by `php artisan lattice:typescript` (which types `node.props` for the package's components) and by definition discovery for any forms, tables, or pages the package also ships.
+
+## Installing one
+
+For the consumer, it is a single dependency:
+
+```bash
+composer require acme/lattice-signature
+```
+
+Register the discovered plugins where the app is created:
+
+```ts
+import latticePlugins from "virtual:lattice/plugins";
+
+createLatticeApp({ plugins: latticePlugins });
+```
+
+Or merge them onto the registry yourself with `extendRegistry(registry, ...latticePlugins)`. Then use the component like any built-in:
+
+```php
+Signature::make('signature')->label('Sign the contract');
+```
+
+<Info>
+  Run `php artisan lattice:typescript` after installing a package to refresh the `ComponentProps`
+  augmentation, so `node.props` is typed for its components.
+</Info>
+
+<Warning title="Requires the Vite plugin">
+  Build-time discovery only runs when the consuming app uses Lattice's `lattice()` Vite plugin —
+  that plugin reads `installed.json`, provides `virtual:lattice/plugins`, and grants filesystem
+  access to the vendor package so its source can compile. Apps scaffolded from the Lattice starter
+  kit already have it.
+</Warning>
+
+## Styling
+
+<Warning title="Style with Lattice tokens">
+  Use Lattice's `lt-` design tokens — `bg-lt-surface`, `text-lt-fg`, `border-lt-border`,
+  `rounded-lt-sm` — in a package component. They ship pre-compiled in `@lattice-php/lattice/css`, so
+  the component is themed correctly with no extra Tailwind configuration in the consuming app.
+  Arbitrary utility classes would instead require every consumer to add the vendor path to their
+  Tailwind content sources.
+</Warning>
+
+See [Registry and types](/extending/registry-and-types/) for how the `type` string couples the two sides, and how generated types keep `node.props` sound.

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -10,7 +10,11 @@ The [extension points](/extending/overview/) assume a component lives in your ow
 
 ## What a package ships
 
-Four things — or scaffold them with `php artisan lattice:component Signature --package=.`:
+Four things — or let the generator write them. Point `--package` at a directory that has no `composer.json` yet and Lattice scaffolds the whole package on first use (the name and PSR-4 namespace are derived from the folder — `packages/acme-signature` → `acme/signature`, `Acme\Signature\`), then creates the component inside it:
+
+```bash
+php artisan lattice:component Signature --package=packages/acme-signature
+```
 
 **1. A `composer.json` declaring the two Lattice entry points:**
 

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -6,7 +6,7 @@ description: Ship a custom component — PHP and its React renderer — as a Com
 import Info from "@components/Info.astro";
 import Warning from "@components/Warning.astro";
 
-The [extension points](/extending/overview/) assume a component lives in your own app. To _distribute_ one — a signature pad, a chart widget, a domain-specific field — you would normally also publish an npm package for its React renderer, and keep it in lockstep with the PHP side. Lattice avoids that second release pipeline: because a consuming app already pulls Lattice itself from `vendor/` through the `lattice()` Vite plugin, a component package ships its renderer as source in `vendor/` too. A plain `composer require` is enough.
+The [extension points](/extending/overview/) assume a component lives in your own app. To _distribute_ one — a signature pad, a chart widget, a domain-specific field — you would normally also publish an npm package for its React renderer, and keep it in lockstep with the PHP side. Lattice removes that second release pipeline: a component package ships its React renderer as source inside its Composer package, and the `lattice()` Vite plugin compiles it straight into your app's existing build — resolving `@lattice-php/lattice` against the copy you already installed. A plain `composer require` is enough.
 
 ## What a package ships
 
@@ -86,7 +86,7 @@ For the consumer, it is a single dependency:
 composer require acme/lattice-signature
 ```
 
-Register the discovered plugins where the app is created:
+If you followed the [installation guide](/introduction/installation/), the discovered plugins are already registered — the standard bootstrap passes `virtual:lattice/plugins` to `createLatticeApp`, so an installed package registers itself with no further wiring:
 
 ```ts
 import latticePlugins from "virtual:lattice/plugins";
@@ -94,7 +94,7 @@ import latticePlugins from "virtual:lattice/plugins";
 createLatticeApp({ plugins: latticePlugins });
 ```
 
-Or merge them onto the registry yourself with `extendRegistry(registry, ...latticePlugins)`. Then use the component like any built-in:
+(Or merge them onto the registry yourself with `extendRegistry(registry, ...latticePlugins)`.) Then use the component like any built-in:
 
 ```php
 Signature::make('signature')->label('Sign the contract');

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -134,17 +134,22 @@ Every Lattice route resolves to the same Inertia page component, `lattice/page`,
 ```tsx
 // resources/js/app.tsx
 /// <reference types="@lattice-php/lattice/svg-sprite-client" />
+/// <reference types="@lattice-php/lattice/vite-client" />
 import "../css/app.css";
 import { createLatticeApp } from "@lattice-php/lattice";
+import latticePlugins from "virtual:lattice/plugins";
 import sprite from "virtual:svg-sprite";
 
 createLatticeApp({
+  plugins: latticePlugins,
   sprite,
   pages: import.meta.glob("./Pages/**/*.tsx"),
 });
 ```
 
 It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`.
+
+`plugins: latticePlugins` registers the renderers of any [component packages](/extending/component-packages/) you install via Composer. The `virtual:lattice/plugins` module is provided by the `lattice()` Vite plugin and resolves to an empty list until you install one, so it is safe to keep here from the start.
 
 #### Manual wiring
 
@@ -153,21 +158,24 @@ If you need full control of the Inertia bootstrap, wire the pieces yourself: use
 ```tsx
 // resources/js/app.tsx
 /// <reference types="@lattice-php/lattice/svg-sprite-client" />
+/// <reference types="@lattice-php/lattice/vite-client" />
 import "../css/app.css";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/react";
-import { createPageResolver, Provider, registry } from "@lattice-php/lattice";
+import { createPageResolver, extendRegistry, Provider, registry } from "@lattice-php/lattice";
 import { createRoot } from "react-dom/client";
+import latticePlugins from "virtual:lattice/plugins";
 import sprite from "virtual:svg-sprite";
 
 const pages = import.meta.glob<ResolvedComponent>("./Pages/**/*.tsx");
 const resolve = createPageResolver(pages);
+const appRegistry = extendRegistry(registry, ...latticePlugins);
 
 createInertiaApp({
   resolve,
   setup({ el, App, props }) {
     if (el) {
       createRoot(el).render(
-        <Provider registry={registry} sprite={sprite}>
+        <Provider registry={appRegistry} sprite={sprite}>
           <App {...props} />
         </Provider>,
       );
@@ -176,7 +184,7 @@ createInertiaApp({
 });
 ```
 
-Keep your existing Inertia options such as `title`, `progress`, layouts, and SSR setup. The important pieces are `createPageResolver(...)` and the single `Provider` around the app.
+Keep your existing Inertia options such as `title`, `progress`, layouts, and SSR setup. The important pieces are `createPageResolver(...)` and the single `Provider` around the app. `extendRegistry(registry, ...latticePlugins)` folds in any installed [component packages](/extending/component-packages/); drop it if you don't use them.
 
 ### Customizing the registry
 

--- a/package.json
+++ b/package.json
@@ -187,6 +187,9 @@
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
     },
+    "./vite-client": {
+      "types": "./dist/vite-client.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/signature-example/composer.json
+++ b/packages/signature-example/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "lattice-php/signature-example",
+    "description": "Example third-party package contributing a custom Lattice component via Composer only.",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Lattice\\SignatureExample\\": "src/"
+        }
+    },
+    "extra": {
+        "lattice": {
+            "plugin": "resources/js/plugin.ts",
+            "discover": ["src"]
+        }
+    }
+}

--- a/packages/signature-example/resources/js/plugin.ts
+++ b/packages/signature-example/resources/js/plugin.ts
@@ -1,0 +1,8 @@
+import { createPlugin, lazyComponent } from "@lattice-php/lattice";
+
+export default createPlugin({
+  name: "signature-example",
+  components: {
+    signature: lazyComponent(() => import("./signature")),
+  },
+});

--- a/packages/signature-example/resources/js/signature.tsx
+++ b/packages/signature-example/resources/js/signature.tsx
@@ -1,0 +1,16 @@
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+
+const Signature: RendererComponent<"signature"> = ({ node }) => {
+  const label = typeof node.props?.label === "string" ? node.props.label : "Sign here";
+
+  return (
+    <div
+      data-test="signature-pad"
+      className="rounded-lt-sm border border-lt-border bg-lt-surface p-4 text-sm text-lt-fg"
+    >
+      {label}
+    </div>
+  );
+};
+
+export default Signature;

--- a/packages/signature-example/src/Components/Signature.php
+++ b/packages/signature-example/src/Components/Signature.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\SignatureExample\Components;
+
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Components\Component;
+
+#[AsComponent('signature')]
+final class Signature extends Component
+{
+    public string $label = 'Sign here';
+
+    public static function make(?string $key = null): static
+    {
+        return new self($key);
+    }
+
+    public function label(string $label): static
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+}

--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -73,6 +73,22 @@ describe("createLatticeApp", () => {
     expect((wrapped.props as { sprite: unknown }).sprite).toBe(sprite);
   });
 
+  it("merges component-package plugins onto the registry", () => {
+    const Widget = (): null => null;
+
+    createLatticeApp({
+      plugins: [
+        { name: "acme", components: { "acme.widget": { component: Widget, mode: "eager" } } },
+      ],
+    });
+
+    const wrapped = captureOptions().withApp(<div />);
+    const registry = (wrapped.props as { registry: { components: Record<string, unknown> } })
+      .registry;
+
+    expect(registry.components["acme.widget"]).toBeDefined();
+  });
+
   it("defaults strictMode on and forwards other inertia options", () => {
     const title = (value: string): string => value;
 

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -1,7 +1,7 @@
 import { createInertiaApp } from "@inertiajs/react";
 import type { ReactElement } from "react";
 import { initializeTheme } from "./appearance";
-import type { Registry } from "./core/registry";
+import { extendRegistry, type Plugin, type Registry } from "./core/registry";
 import { setDefaultRegistry } from "./core/registry-context";
 import type { SpriteValue } from "./icons/sprite";
 import {
@@ -20,6 +20,12 @@ export type CreateLatticeAppOptions = Omit<
   "resolve" | "layout" | "setup" | "withApp" | "pages"
 > & {
   registry?: Registry;
+  /**
+   * Component-package plugins to merge onto the registry — pass the
+   * Composer-discovered `virtual:lattice/plugins` here to register vendor
+   * components with no manual `extendRegistry` call.
+   */
+  plugins?: Plugin[];
   sprite?: SpriteValue;
   /** Normal Inertia page modules, e.g. `import.meta.glob('./pages/**\/*.tsx')`. */
   pages?: PageModules;
@@ -34,13 +40,16 @@ export type CreateLatticeAppOptions = Omit<
  */
 export function createLatticeApp({
   registry,
+  plugins,
   sprite,
   pages = {},
   defaultLayout,
   strictMode = true,
   ...inertiaOptions
 }: CreateLatticeAppOptions = {}) {
-  const activeRegistry = registry ?? defaultRegistry;
+  const baseRegistry = registry ?? defaultRegistry;
+  const activeRegistry =
+    plugins && plugins.length > 0 ? extendRegistry(baseRegistry, ...plugins) : baseRegistry;
 
   setDefaultRegistry(activeRegistry);
 

--- a/resources/js/vite-client.d.ts
+++ b/resources/js/vite-client.d.ts
@@ -1,0 +1,8 @@
+declare module "virtual:lattice/plugins" {
+  import type { Plugin } from "@lattice-php/lattice";
+
+  /** Plugins for the Composer-installed Lattice component packages the `lattice()` Vite plugin discovered. */
+  const plugins: Plugin[];
+
+  export default plugins;
+}

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -3,7 +3,13 @@ import path from "node:path";
 import { searchForWorkspaceRoot } from "vite";
 import type { Plugin } from "vite";
 import { describe, expect, it } from "vitest";
-import { lattice, latticeConfig } from "./vite";
+import {
+  collectComponentPackages,
+  componentPackagesPlugin,
+  discoverComponentPackages,
+  lattice,
+  latticeConfig,
+} from "./vite";
 
 type PackageJson = {
   exports: Record<string, unknown>;
@@ -105,6 +111,66 @@ describe("lattice Vite helper", () => {
     expect(resolved).toBeNull();
     expect(await resolveId.call({ resolve: async () => null }, "react")).toBeNull();
     expect(load("react")).toBeNull();
+  });
+
+  it("resolves plugin entries only for packages that declare extra.lattice.plugin", () => {
+    const composerDir = path.resolve("/tmp/app/vendor/composer");
+
+    const packages = collectComponentPackages(
+      {
+        packages: [
+          {
+            name: "acme/signature",
+            "install-path": "../acme/signature",
+            extra: { lattice: { plugin: "resources/js/plugin.ts" } },
+          },
+          { name: "acme/plain", "install-path": "../acme/plain" },
+        ],
+      },
+      composerDir,
+    );
+
+    expect(packages).toEqual([
+      {
+        name: "acme/signature",
+        dir: path.resolve("/tmp/app/vendor/acme/signature"),
+        plugin: path.resolve("/tmp/app/vendor/acme/signature/resources/js/plugin.ts"),
+      },
+    ]);
+  });
+
+  it("exposes the discovered plugins as the virtual:lattice/plugins module", () => {
+    const plugin = componentPackagesPlugin([
+      {
+        name: "acme/signature",
+        dir: "/app/vendor/acme/signature",
+        plugin: "/app/vendor/acme/signature/resources/js/plugin.ts",
+      },
+    ]);
+    const resolveId = plugin.resolveId as unknown as (id: string) => string | null;
+    const load = plugin.load as unknown as (id: string) => string | null;
+    const config = plugin.config as unknown as () => unknown;
+
+    const resolved = resolveId("virtual:lattice/plugins");
+
+    expect(resolved).toBe("\0virtual:lattice/plugins");
+
+    const code = load(resolved as string) ?? "";
+
+    expect(code).toContain('import p0 from "/app/vendor/acme/signature/resources/js/plugin.ts";');
+    expect(code).toContain("export default [p0];");
+    expect(config()).toMatchObject({ server: { fs: { allow: ["/app/vendor/acme/signature"] } } });
+  });
+
+  it("degrades to an empty plugin list when nothing is discoverable", () => {
+    expect(discoverComponentPackages(path.resolve("/tmp/lattice-missing"))).toEqual([]);
+
+    const plugin = componentPackagesPlugin([]);
+    const load = plugin.load as unknown as (id: string) => string | null;
+    const config = plugin.config as unknown as () => unknown;
+
+    expect(load("\0virtual:lattice/plugins")).toContain("export default [];");
+    expect(config()).toEqual({});
   });
 
   it("keeps package exports explicit and internal test helpers private", () => {

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { svgSprite } from "@lattice-php/vite-svg-sprite";
 import type { SvgSpriteOptions } from "@lattice-php/vite-svg-sprite";
@@ -34,7 +35,12 @@ type Roots = {
 };
 
 export function lattice(options: LatticeViteOptions = {}): PluginOption[] {
-  const plugins: PluginOption[] = [corePlugin(options), optionalPeersPlugin()];
+  const { appRoot } = resolveRoots(options);
+  const plugins: PluginOption[] = [
+    corePlugin(options),
+    optionalPeersPlugin(),
+    componentPackagesPlugin(discoverComponentPackages(appRoot)),
+  ];
   const iconOptions = resolveIconOptions(options);
 
   if (iconOptions) {
@@ -42,6 +48,97 @@ export function lattice(options: LatticeViteOptions = {}): PluginOption[] {
   }
 
   return plugins;
+}
+
+/** A Composer package that contributes a Lattice component plugin. */
+export type LatticeComponentPackage = {
+  name: string;
+  /** Absolute path to the package's installed directory. */
+  dir: string;
+  /** Absolute path to the package's JS plugin entry (its `createPlugin(...)`). */
+  plugin: string;
+};
+
+type InstalledPackage = {
+  name: string;
+  "install-path"?: string;
+  extra?: { lattice?: { plugin?: string } };
+};
+
+/**
+ * Resolve every Composer package that declares `extra.lattice.plugin` into an
+ * absolute plugin-entry path. `installPathsRelativeTo` is `vendor/composer` (the
+ * dir `installed.json` records its `install-path`s against).
+ */
+export function collectComponentPackages(
+  installed: { packages?: InstalledPackage[] } | InstalledPackage[],
+  installPathsRelativeTo: string,
+): LatticeComponentPackage[] {
+  const packages = Array.isArray(installed) ? installed : (installed.packages ?? []);
+
+  return packages.flatMap((pkg) => {
+    const entry = pkg.extra?.lattice?.plugin;
+
+    if (typeof entry !== "string") {
+      return [];
+    }
+
+    const dir = path.resolve(installPathsRelativeTo, pkg["install-path"] ?? `../${pkg.name}`);
+
+    return [{ name: pkg.name, dir, plugin: path.resolve(dir, entry) }];
+  });
+}
+
+/** Read `<appRoot>/vendor/composer/installed.json` and collect component packages. */
+export function discoverComponentPackages(appRoot: string): LatticeComponentPackage[] {
+  const composerDir = path.resolve(appRoot, "vendor/composer");
+
+  let raw: string;
+
+  try {
+    raw = readFileSync(path.join(composerDir, "installed.json"), "utf8");
+  } catch {
+    return [];
+  }
+
+  return collectComponentPackages(JSON.parse(raw), composerDir);
+}
+
+const VIRTUAL_PLUGINS_ID = "virtual:lattice/plugins";
+const RESOLVED_VIRTUAL_PLUGINS_ID = `\0${VIRTUAL_PLUGINS_ID}`;
+
+/**
+ * Exposes the discovered component packages as `virtual:lattice/plugins` — a
+ * module whose default export is the array of their `createPlugin(...)` results,
+ * ready for `extendRegistry(registry, ...plugins)`. Also grants Vite filesystem
+ * access to each package dir so its source compiles from `vendor/` (or a symlink).
+ */
+export function componentPackagesPlugin(packages: LatticeComponentPackage[]): Plugin {
+  return {
+    name: "lattice:component-packages",
+    config() {
+      if (packages.length === 0) {
+        return {};
+      }
+
+      return { server: { fs: { allow: packages.map((pkg) => pkg.dir) } } };
+    },
+    resolveId(id) {
+      return id === VIRTUAL_PLUGINS_ID ? RESOLVED_VIRTUAL_PLUGINS_ID : null;
+    },
+    load(id) {
+      if (id !== RESOLVED_VIRTUAL_PLUGINS_ID) {
+        return null;
+      }
+
+      const imports = packages
+        .map((pkg, index) => `import p${index} from ${JSON.stringify(pkg.plugin)};`)
+        .join("\n");
+      const list = packages.map((_, index) => `p${index}`).join(", ");
+
+      return `${imports}\nexport default [${list}];\n`;
+    },
+  };
 }
 
 export function latticeConfig(options: LatticeViteOptions = {}): ConfigWithTest {

--- a/src/Console/Commands/Concerns/GeneratesComponentPair.php
+++ b/src/Console/Commands/Concerns/GeneratesComponentPair.php
@@ -14,6 +14,85 @@ trait GeneratesComponentPair
     }
 
     /**
+     * Resolve where to scaffold the pair — the app by default, or a Composer
+     * package when `--package=<dir>` is passed. In package mode the PHP
+     * namespace comes from the package's composer.json psr-4 map, files land in
+     * the package's own `src/` and `resources/js/`, and registration targets its
+     * `plugin.ts` (created if absent) instead of the app's `registry.ts`.
+     *
+     * @return array{php: string, namespace: string, tsx: string, plugin: string, import: string, refresh: bool}
+     */
+    protected function scaffoldTarget(
+        string $name,
+        string $kebab,
+        string $phpSubdir,
+        string $tsxSubdir,
+        string $appNamespace,
+    ): array {
+        $package = $this->option('package');
+
+        if (! is_string($package) || trim($package) === '') {
+            return [
+                'php' => app_path($phpSubdir.'/'.$name.'.php'),
+                'namespace' => $appNamespace,
+                'tsx' => resource_path('js/'.$tsxSubdir.'/'.$kebab.'.tsx'),
+                'plugin' => resource_path('js/registry.ts'),
+                'import' => './'.$tsxSubdir.'/'.$kebab,
+                'refresh' => true,
+            ];
+        }
+
+        $dir = rtrim(trim($package), '/');
+        $plugin = $dir.'/resources/js/plugin.ts';
+        $this->ensurePluginFile($plugin, $dir);
+
+        return [
+            'php' => $dir.'/src/'.$phpSubdir.'/'.$name.'.php',
+            'namespace' => $this->packageNamespace($dir).'\\'.str_replace('/', '\\', $phpSubdir),
+            'tsx' => $dir.'/resources/js/'.$kebab.'.tsx',
+            'plugin' => $plugin,
+            'import' => './'.$kebab,
+            'refresh' => false,
+        ];
+    }
+
+    private function packageNamespace(string $packageDir): string
+    {
+        $composer = json_decode((string) File::get($packageDir.'/composer.json'), true);
+        $psr4 = is_array($composer['autoload']['psr-4'] ?? null) ? $composer['autoload']['psr-4'] : [];
+
+        foreach ($psr4 as $namespace => $path) {
+            if (is_string($path) && rtrim($path, '/') === 'src') {
+                return rtrim($namespace, '\\');
+            }
+        }
+
+        $first = array_key_first($psr4);
+
+        return is_string($first) ? rtrim($first, '\\') : 'App';
+    }
+
+    private function ensurePluginFile(string $pluginPath, string $packageDir): void
+    {
+        if (File::exists($pluginPath)) {
+            return;
+        }
+
+        $composer = json_decode((string) File::get($packageDir.'/composer.json'), true);
+        $name = is_string($composer['name'] ?? null) ? $composer['name'] : basename($packageDir);
+
+        File::ensureDirectoryExists(dirname($pluginPath));
+        File::put(
+            $pluginPath,
+            'import { createPlugin } from "@lattice-php/lattice";'."\n\n"
+            .'export default createPlugin({'."\n"
+            .'  name: "'.$name.'",'."\n"
+            .'  components: {},'."\n"
+            .'});'."\n",
+        );
+    }
+
+    /**
      * @param  array<string, string>  $replacements
      */
     protected function writeStub(string $stub, string $targetPath, array $replacements, bool $force = false): void

--- a/src/Console/Commands/Concerns/GeneratesComponentPair.php
+++ b/src/Console/Commands/Concerns/GeneratesComponentPair.php
@@ -43,6 +43,7 @@ trait GeneratesComponentPair
         }
 
         $dir = rtrim(trim($package), '/');
+        $this->ensurePackageComposer($dir);
         $plugin = $dir.'/resources/js/plugin.ts';
         $this->ensurePluginFile($plugin, $dir);
 
@@ -54,6 +55,37 @@ trait GeneratesComponentPair
             'import' => './'.$kebab,
             'refresh' => false,
         ];
+    }
+
+    /**
+     * Scaffold a Composer package on first use: when the target dir has no
+     * composer.json, derive a vendor/name and PSR-4 namespace from its basename
+     * (`acme-signature` → `acme/signature`, `Acme\Signature\`) and write a
+     * skeleton already wired with the `extra.lattice` entry points.
+     */
+    private function ensurePackageComposer(string $packageDir): void
+    {
+        $composerPath = $packageDir.'/composer.json';
+
+        if (File::exists($composerPath)) {
+            return;
+        }
+
+        $slug = Str::kebab(basename($packageDir));
+        [$vendor, $package] = str_contains($slug, '-')
+            ? explode('-', $slug, 2)
+            : [$slug, $slug];
+        $namespace = Str::studly($vendor).'\\'.Str::studly($package);
+
+        File::ensureDirectoryExists($packageDir);
+        File::put($composerPath, json_encode([
+            'name' => $vendor.'/'.$package,
+            'type' => 'library',
+            'autoload' => ['psr-4' => [$namespace.'\\' => 'src/']],
+            'extra' => ['lattice' => ['plugin' => 'resources/js/plugin.ts', 'discover' => ['src']]],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        $this->components->info('Scaffolded package: '.$composerPath);
     }
 
     private function packageNamespace(string $packageDir): string

--- a/src/Console/Commands/Concerns/GeneratesComponentPair.php
+++ b/src/Console/Commands/Concerns/GeneratesComponentPair.php
@@ -58,12 +58,12 @@ trait GeneratesComponentPair
 
     private function packageNamespace(string $packageDir): string
     {
-        $composer = json_decode((string) File::get($packageDir.'/composer.json'), true);
+        $composer = json_decode(File::get($packageDir.'/composer.json'), true);
         $psr4 = is_array($composer['autoload']['psr-4'] ?? null) ? $composer['autoload']['psr-4'] : [];
 
         foreach ($psr4 as $namespace => $path) {
             if (is_string($path) && rtrim($path, '/') === 'src') {
-                return rtrim($namespace, '\\');
+                return rtrim((string) $namespace, '\\');
             }
         }
 
@@ -78,7 +78,7 @@ trait GeneratesComponentPair
             return;
         }
 
-        $composer = json_decode((string) File::get($packageDir.'/composer.json'), true);
+        $composer = json_decode(File::get($packageDir.'/composer.json'), true);
         $name = is_string($composer['name'] ?? null) ? $composer['name'] : basename($packageDir);
 
         File::ensureDirectoryExists(dirname($pluginPath));

--- a/src/Console/Commands/MakeColumnCommand.php
+++ b/src/Console/Commands/MakeColumnCommand.php
@@ -12,7 +12,7 @@ final class MakeColumnCommand extends Command
 {
     use GeneratesComponentPair;
 
-    protected $signature = 'lattice:column {name} {--type=} {--force}';
+    protected $signature = 'lattice:column {name} {--type=} {--package=} {--force}';
 
     protected $description = 'Scaffold a custom Lattice table column (PHP + React cell)';
 
@@ -25,26 +25,30 @@ final class MakeColumnCommand extends Command
         $kebab = Str::kebab($name);
         $force = (bool) $this->option('force');
 
+        $target = $this->scaffoldTarget($name, $kebab, 'Tables/Columns', 'columns', 'App\\Tables\\Columns');
+
         $this->writeStub(
             'column.php.stub',
-            app_path('Tables/Columns/'.$name.'.php'),
-            ['namespace' => 'App\\Tables\\Columns', 'class' => $name, 'type' => $attributeType], force: $force);
+            $target['php'],
+            ['namespace' => $target['namespace'], 'class' => $name, 'type' => $attributeType], force: $force);
 
         $this->writeStub(
             'column.tsx.stub',
-            resource_path('js/columns/'.$kebab.'.tsx'),
+            $target['tsx'],
             ['class' => $name, 'type' => $type], force: $force);
 
         $this->registerInPlugin(
-            resource_path('js/registry.ts'),
+            $target['plugin'],
             $wireType,
             $name.'Cell',
-            './columns/'.$kebab,
+            $target['import'],
             blockKey: 'columns',
             entryWrapper: null,
         );
 
-        $this->refreshTypes();
+        if ($target['refresh']) {
+            $this->refreshTypes();
+        }
 
         $this->components->info("Column [$name] created with type [$wireType].");
 

--- a/src/Console/Commands/MakeComponentCommand.php
+++ b/src/Console/Commands/MakeComponentCommand.php
@@ -11,7 +11,7 @@ final class MakeComponentCommand extends Command
 {
     use GeneratesComponentPair;
 
-    protected $signature = 'lattice:component {name} {--type=} {--force}';
+    protected $signature = 'lattice:component {name} {--type=} {--package=} {--force}';
 
     protected $description = 'Scaffold a custom Lattice UI component (PHP + React)';
 
@@ -22,24 +22,23 @@ final class MakeComponentCommand extends Command
         $kebab = Str::kebab($name);
         $force = (bool) $this->option('force');
 
+        $target = $this->scaffoldTarget($name, $kebab, 'Components', 'components', 'App\\Components');
+
         $this->writeStub(
             'component.php.stub',
-            app_path('Components/'.$name.'.php'),
-            ['namespace' => 'App\\Components', 'class' => $name, 'type' => $type], force: $force);
+            $target['php'],
+            ['namespace' => $target['namespace'], 'class' => $name, 'type' => $type], force: $force);
 
         $this->writeStub(
             'component.tsx.stub',
-            resource_path('js/components/'.$kebab.'.tsx'),
+            $target['tsx'],
             ['class' => $name, 'type' => $type], force: $force);
 
-        $this->registerInPlugin(
-            resource_path('js/registry.ts'),
-            $type,
-            $name.'Component',
-            './components/'.$kebab,
-        );
+        $this->registerInPlugin($target['plugin'], $type, $name.'Component', $target['import']);
 
-        $this->refreshTypes();
+        if ($target['refresh']) {
+            $this->refreshTypes();
+        }
 
         $this->components->info("Component [$name] created with type [$type].");
 

--- a/src/Console/Commands/MakeFieldCommand.php
+++ b/src/Console/Commands/MakeFieldCommand.php
@@ -12,7 +12,7 @@ final class MakeFieldCommand extends Command
 {
     use GeneratesComponentPair;
 
-    protected $signature = 'lattice:field {name} {--type=} {--force}';
+    protected $signature = 'lattice:field {name} {--type=} {--package=} {--force}';
 
     protected $description = 'Scaffold a custom Lattice form field (PHP + React)';
 
@@ -25,24 +25,23 @@ final class MakeFieldCommand extends Command
         $kebab = Str::kebab($name);
         $force = (bool) $this->option('force');
 
+        $target = $this->scaffoldTarget($name, $kebab, 'Forms/Fields', 'fields', 'App\\Forms\\Fields');
+
         $this->writeStub(
             'field.php.stub',
-            app_path('Forms/Fields/'.$name.'.php'),
-            ['namespace' => 'App\\Forms\\Fields', 'class' => $name, 'type' => $attributeType], force: $force);
+            $target['php'],
+            ['namespace' => $target['namespace'], 'class' => $name, 'type' => $attributeType], force: $force);
 
         $this->writeStub(
             'field.tsx.stub',
-            resource_path('js/fields/'.$kebab.'.tsx'),
+            $target['tsx'],
             ['class' => $name, 'type' => $wireType], force: $force);
 
-        $this->registerInPlugin(
-            resource_path('js/registry.ts'),
-            $wireType,
-            $name.'Component',
-            './fields/'.$kebab,
-        );
+        $this->registerInPlugin($target['plugin'], $wireType, $name.'Component', $target['import']);
 
-        $this->refreshTypes();
+        if ($target['refresh']) {
+            $this->refreshTypes();
+        }
 
         $this->components->info("Field [$name] created with type [$wireType].");
 

--- a/src/Core/Discovery/ComponentPackages.php
+++ b/src/Core/Discovery/ComponentPackages.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Discovery;
+
+/**
+ * Resolves the discovery roots contributed by installed Composer packages that
+ * declare `extra.lattice.discover` in their composer.json — the PHP counterpart
+ * to the `extra.lattice.plugin` the Vite plugin reads for the JS renderer. This
+ * is what lets a plain `composer require` surface a package's components to
+ * definition discovery and TypeScript generation without editing app config.
+ */
+final class ComponentPackages
+{
+    /** @return list<string> */
+    public static function discoverRoots(): array
+    {
+        return self::fromInstalled(base_path('vendor/composer/installed.json'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function fromInstalled(string $installedJsonPath): array
+    {
+        if (! is_file($installedJsonPath)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($installedJsonPath), true);
+
+        if (! is_array($data)) {
+            return [];
+        }
+
+        /** @var list<array<string, mixed>> $packages */
+        $packages = is_array($data['packages'] ?? null) ? $data['packages'] : [];
+        $composerDir = dirname($installedJsonPath);
+        $roots = [];
+
+        foreach ($packages as $package) {
+            $discover = $package['extra']['lattice']['discover'] ?? null;
+            $name = $package['name'] ?? null;
+
+            if (! is_array($discover) || ! is_string($name)) {
+                continue;
+            }
+
+            $installPath = is_string($package['install-path'] ?? null)
+                ? $package['install-path']
+                : '../'.$name;
+            $packageDir = $composerDir.'/'.$installPath;
+
+            foreach ($discover as $relative) {
+                if (! is_string($relative)) {
+                    continue;
+                }
+
+                $resolved = realpath($packageDir.'/'.$relative);
+
+                if ($resolved !== false) {
+                    $roots[$resolved] = $resolved;
+                }
+            }
+        }
+
+        return array_values($roots);
+    }
+}

--- a/src/Core/Discovery/DiscoveryManifest.php
+++ b/src/Core/Discovery/DiscoveryManifest.php
@@ -86,12 +86,11 @@ final class DiscoveryManifest
     public static function configuredPaths(): array
     {
         $configured = config('lattice.discover', []);
+        $configured = is_array($configured)
+            ? array_values(array_filter($configured, is_string(...)))
+            : [];
 
-        if (! is_array($configured)) {
-            return [];
-        }
-
-        return array_values(array_filter($configured, is_string(...)));
+        return array_values(array_unique([...$configured, ...ComponentPackages::discoverRoots()]));
     }
 
     /** @return array<string, mixed> */

--- a/tests/Browser/ComponentPackageTest.php
+++ b/tests/Browser/ComponentPackageTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+it('renders a component contributed by a third-party Composer package', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    visit('/signature-demo')
+        ->assertSee('Vendor component rendered')
+        ->assertVisible('[data-test="signature-pad"]')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/ComponentPackagesTest.php
+++ b/tests/Feature/ComponentPackagesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Discovery\ComponentPackages;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Lattice\Support\TypeScript\ComponentDiscovery;
+
+it('resolves discover roots from packages that declare extra.lattice.discover', function (): void {
+    $roots = ComponentPackages::fromInstalled(
+        __DIR__.'/../Fixtures/PackageDiscovery/composer/installed.json',
+    );
+
+    expect($roots)->toBe([
+        realpath(__DIR__.'/../Fixtures/PackageDiscovery/acme/widget/src'),
+    ]);
+});
+
+it('returns nothing when installed.json is absent', function (): void {
+    expect(ComponentPackages::fromInstalled('/no/such/installed.json'))->toBe([]);
+});
+
+it('merges installed component-package roots into the configured discover paths', function (): void {
+    expect(DiscoveryManifest::configuredPaths())->toContain(
+        realpath(base_path('vendor/lattice-php/signature-example/src')),
+    );
+});
+
+it('discovers a vendor package component so lattice:typescript can type it', function (): void {
+    $discovery = app(ComponentDiscovery::class);
+
+    $types = [];
+
+    foreach (DiscoveryManifest::configuredPaths() as $path) {
+        foreach ($discovery->discover($path) as $component) {
+            $types[] = $component->type;
+        }
+    }
+
+    expect($types)->toContain('signature');
+});

--- a/tests/Feature/Console/MakeComponentCommandTest.php
+++ b/tests/Feature/Console/MakeComponentCommandTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 
 use function Pest\Laravel\artisan;
 
@@ -32,6 +33,32 @@ it('scaffolds a component class with the AsComponent attribute and registers it'
             ->toContain('import { RatingComponent } from "./components/rating";')
             ->toContain('"rating": eagerComponent(RatingComponent)');
     });
+});
+
+it('scaffolds into a Composer package via --package', function (): void {
+    $dir = sys_get_temp_dir().'/lattice-pkg-'.Str::random(8);
+    File::ensureDirectoryExists($dir);
+    File::put($dir.'/composer.json', (string) json_encode([
+        'name' => 'acme/widgets',
+        'autoload' => ['psr-4' => ['Acme\\Widgets\\' => 'src/']],
+    ]));
+
+    try {
+        artisan('lattice:component', ['name' => 'Widget', '--package' => $dir])->assertSuccessful();
+
+        expect(File::get($dir.'/src/Components/Widget.php'))
+            ->toContain('namespace Acme\\Widgets\\Components;')
+            ->toContain("#[AsComponent('widget')]");
+
+        expect(File::exists($dir.'/resources/js/widget.tsx'))->toBeTrue();
+
+        expect(File::get($dir.'/resources/js/plugin.ts'))
+            ->toContain('createPlugin')
+            ->toContain('import { WidgetComponent } from "./widget";')
+            ->toContain('"widget": eagerComponent(WidgetComponent)');
+    } finally {
+        File::deleteDirectory($dir);
+    }
 });
 
 it('honors a --type override', function (): void {

--- a/tests/Feature/Console/MakeComponentCommandTest.php
+++ b/tests/Feature/Console/MakeComponentCommandTest.php
@@ -61,6 +61,29 @@ it('scaffolds into a Composer package via --package', function (): void {
     }
 });
 
+it('scaffolds a new package on first component when composer.json is absent', function (): void {
+    $dir = sys_get_temp_dir().'/lattice-new-'.Str::random(8).'/acme-signature';
+
+    try {
+        artisan('lattice:component', ['name' => 'Signature', '--package' => $dir])->assertSuccessful();
+
+        $composer = json_decode(File::get($dir.'/composer.json'), true);
+        expect($composer['name'])->toBe('acme/signature')
+            ->and($composer['autoload']['psr-4'])->toHaveKey('Acme\\Signature\\')
+            ->and($composer['extra']['lattice'])->toBe([
+                'plugin' => 'resources/js/plugin.ts',
+                'discover' => ['src'],
+            ]);
+
+        expect(File::get($dir.'/src/Components/Signature.php'))
+            ->toContain('namespace Acme\\Signature\\Components;');
+        expect(File::get($dir.'/resources/js/plugin.ts'))
+            ->toContain('"signature": eagerComponent(SignatureComponent)');
+    } finally {
+        File::deleteDirectory(dirname($dir));
+    }
+});
+
 it('honors a --type override', function (): void {
     withComponentScaffold(function (): void {
         artisan('lattice:component', ['name' => 'Stars', '--type' => 'rating.stars'])->assertSuccessful();

--- a/tests/Fixtures/PackageDiscovery/composer/installed.json
+++ b/tests/Fixtures/PackageDiscovery/composer/installed.json
@@ -1,0 +1,13 @@
+{
+    "packages": [
+        {
+            "name": "acme/widget",
+            "install-path": "../acme/widget",
+            "extra": { "lattice": { "discover": ["src"] } }
+        },
+        {
+            "name": "acme/plain",
+            "install-path": "../acme/plain"
+        }
+    ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import Sonda from "sonda/vite";
 import type { Plugin } from "vite";
+import { componentPackagesPlugin, discoverComponentPackages } from "./resources/js/vite";
 import dts from "vite-plugin-dts";
 import { defineConfig } from "vitest/config";
 
@@ -156,6 +157,10 @@ export default defineConfig(({ mode }) => {
               refresh: ["workbench/resources/**", "workbench/routes/**", "resources/js/**"],
             }),
             inertia(),
+            // The workbench acts as a Lattice consumer: auto-discover component
+            // packages installed via Composer and expose them as
+            // `virtual:lattice/plugins` (external apps get this from `lattice()`).
+            componentPackagesPlugin(discoverComponentPackages(__dirname)),
           ]),
       react(),
       ...(isLibrary

--- a/workbench/app/Pages/SignatureDemoPage.php
+++ b/workbench/app/Pages/SignatureDemoPage.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Components\Heading;
+use Lattice\Lattice\Core\Components\Stack;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\SignatureExample\Components\Signature;
+
+#[AsPage(route: '/signature-demo')]
+final class SignatureDemoPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Signature demo';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('signature-demo')
+                ->gap(Gap::Large)
+                ->schema([
+                    Heading::make('Signature demo'),
+                    Text::make('A component contributed by a third-party Composer package.'),
+                    Signature::make('signature')->label('Vendor component rendered'),
+                ]),
+        ]);
+    }
+}

--- a/workbench/resources/js/app.tsx
+++ b/workbench/resources/js/app.tsx
@@ -12,10 +12,11 @@ import {
 import { configureI18nFromPageProps, LocaleReload } from "@lattice-php/lattice/i18n";
 import { createRoot } from "react-dom/client";
 import sprite from "virtual:svg-sprite";
+import latticePlugins from "virtual:lattice/plugins";
 import { appColumns } from "./columns";
 import { WORKBENCH_I18N_NAMESPACE } from "./i18n";
 
-const appRegistry = extendRegistry(registry, appColumns);
+const appRegistry = extendRegistry(registry, appColumns, ...latticePlugins);
 
 type ReverbProp = {
   host: string;

--- a/workbench/resources/js/virtual-lattice-plugins.d.ts
+++ b/workbench/resources/js/virtual-lattice-plugins.d.ts
@@ -1,0 +1,7 @@
+declare module "virtual:lattice/plugins" {
+  import type { Plugin } from "@lattice-php/lattice";
+
+  const plugins: Plugin[];
+
+  export default plugins;
+}


### PR DESCRIPTION
Lets a third-party package contribute a custom Lattice component — the PHP class **and** its React renderer — through a plain `composer require`, with **no npm package to publish**. This works because a consuming app already pulls Lattice itself from `vendor/` via the `lattice()` Vite plugin, so a component package ships its renderer as source in `vendor/` too.

## The contract
A package declares two keys in `composer.json`:
```json
{ "extra": { "lattice": { "plugin": "resources/js/plugin.ts", "discover": ["src"] } } }
```
- **`plugin`** — the `lattice()` Vite plugin scans `vendor/composer/installed.json`, grants Vite fs access to each declaring package, and exposes their plugins as the virtual module `virtual:lattice/plugins`. The package's TSX compiles into the consumer's bundle: no separate build, one shared React instance, tree-shaking, HMR.
- **`discover`** — PHP discovery merges these roots into `lattice.discover`, so the package's `#[AsComponent]` classes are picked up by `lattice:typescript` (props typing) and definition discovery (forms/tables/pages).

## Consumer DX
```bash
composer require acme/lattice-signature
```
```ts
import latticePlugins from "virtual:lattice/plugins";
createLatticeApp({ plugins: latticePlugins });
```
Then use `Signature::make(...)` like any built-in.

## Author DX — one command starts a package
```bash
php artisan lattice:component Signature --package=packages/acme-signature
```
Pointing `--package` at a directory with no `composer.json` scaffolds the whole package first (vendor/name + PSR-4 namespace derived from the folder, `extra.lattice` prewired), then creates the component, its renderer, and registers it in the package's `plugin.ts`.

## What's in here
- **Vite discovery** (`resources/js/vite.ts`): `collectComponentPackages` / `discoverComponentPackages` / `componentPackagesPlugin` + the `virtual:lattice/plugins` module, wired into `lattice()`.
- **PHP discovery** (`ComponentPackages` + `DiscoveryManifest::configuredPaths()`): merges `extra.lattice.discover` roots into definition discovery and TypeScript generation.
- **`createLatticeApp({ plugins })`** — register discovered packages with no manual `extendRegistry`.
- **Generators**: `--package` on `lattice:component` / `:field` / `:column` scaffolds into a package's own tree, creating the package skeleton on first use when it doesn't exist yet.
- **Docs**: a "Component packages" authoring guide under Extending.
- **In-repo example + proof**: `packages/signature-example` (installed via a path repo) ships a component consumed by the workbench, with a browser test asserting it renders end to end.

## Tests
Vite discovery units, `ComponentPackages` + `configuredPaths` + `ComponentDiscovery` feature tests, `createLatticeApp` plugins test, generator `--package` + auto-scaffold tests, and an end-to-end browser test. Full gate green (`composer check` + `npm run check`, CI all-green).

## Notes
- The runtime pre-built-ESM escape hatch is intentionally **out of scope** (build-time discovery is the single supported path for now).
- Follow-up: `Lattice::discoverIn()` imperative API — deferred; the declarative `extra.lattice` covers the common case.
- The example package adds a dev path-repo to `composer.json`; it's the feature's in-repo test harness (like `workbench/`), contained to dev (`composer.lock` is git-ignored; consumers never receive it).