### PR TITLE
refactor: TS cleanup — dead exports (E/F/G) + registry import direction (C)

### DIFF
--- a/resources/js/core/components/control.ts
+++ b/resources/js/core/components/control.ts
@@ -1,4 +1,4 @@
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 
 export const FOCUS_RING =
   "focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[3px]";
@@ -27,5 +27,3 @@ export const controlSurface = cva(
     defaultVariants: { density: "comfortable" },
   },
 );
-
-export type ControlSurfaceVariants = VariantProps<typeof controlSurface>;

--- a/resources/js/events/event-bridge.tsx
+++ b/resources/js/events/event-bridge.tsx
@@ -3,7 +3,7 @@ import { onToast as subscribeToToasts } from "@lattice-php/lattice/toast/toast";
 import type { ToastMessage } from "@lattice-php/lattice/toast/toast";
 import { LATTICE_EVENT } from "./event-names";
 
-export const appearances = ["light", "dark", "system"] as const;
+const appearances = ["light", "dark", "system"] as const;
 
 export type Appearance = (typeof appearances)[number];
 

--- a/resources/js/form/components/base/input-otp.tsx
+++ b/resources/js/form/components/base/input-otp.tsx
@@ -20,10 +20,7 @@ function Slot({ char, hasFakeCaret, isActive }: SlotProps) {
   );
 }
 
-export type InputOTPProps = Omit<
-  ComponentProps<typeof OTPInput>,
-  "children" | "maxLength" | "render"
-> & {
+type InputOTPProps = Omit<ComponentProps<typeof OTPInput>, "children" | "maxLength" | "render"> & {
   length: number;
 };
 

--- a/resources/js/form/components/conditions.ts
+++ b/resources/js/form/components/conditions.ts
@@ -9,7 +9,7 @@ export type FieldConditions = {
   disabled?: Condition[];
 };
 
-export type FieldFlags = {
+type FieldFlags = {
   hidden?: boolean;
   required?: boolean;
   readOnly?: boolean;

--- a/resources/js/form/components/field-props.ts
+++ b/resources/js/form/components/field-props.ts
@@ -7,7 +7,7 @@ import type { FieldConditions } from "./conditions";
  * lens the shared hooks read them through. Everything is optional because the
  * lens is also applied to non-field nodes while walking the schema.
  */
-export type FieldProps = {
+type FieldProps = {
   conditions?: FieldConditions | null;
   dependsOnAny?: boolean | null;
   dependsOnKeys?: string[] | null;

--- a/resources/js/form/components/field-scope.tsx
+++ b/resources/js/form/components/field-scope.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useMemo } from "react";
 import { appendPath, getPath, toHtmlName } from "./form-path";
 import { buildOverrideKey, rowIdFrom } from "./override-keys";
 
-export type FieldScopeValue = {
+type FieldScopeValue = {
   row: Record<string, unknown>;
   rowId: string | null;
   path: string;

--- a/resources/js/form/components/fields/row-action-menu.ts
+++ b/resources/js/form/components/fields/row-action-menu.ts
@@ -1,7 +1,7 @@
 import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
 import type { RowAction } from "./row-actions";
 
-export type RowActionTranslate = (key: string, fallback: string) => string;
+type RowActionTranslate = (key: string, fallback: string) => string;
 
 /** Translation key + fallback and icon for each built-in; the server sends null labels. */
 const BUILT_IN: Record<"duplicate" | "remove", { key: string; fallback: string; icon: string }> = {

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -34,7 +34,7 @@ export function RowButton({
   );
 }
 
-export type RowItemProps = {
+type RowItemProps = {
   base: string;
   index: number;
   row: RepeaterRow;

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -21,7 +21,7 @@ const tableViewportQuery = "(min-width: 768px)";
 
 export type TableColumn = { name: string; label: string; columnWidth: ColumnWidth };
 
-export type TableRowModel = {
+type TableRowModel = {
   key: string;
   index: number;
   row: RepeaterRow;

--- a/resources/js/form/components/fields/time-picker-columns.ts
+++ b/resources/js/form/components/fields/time-picker-columns.ts
@@ -2,7 +2,7 @@ export type TimeValue = { hour: number; minute: number; second: number };
 
 export type TimeColumnOption = { value: number; label: string; disabled: boolean };
 
-export type TimeColumns = {
+type TimeColumns = {
   hours: TimeColumnOption[];
   minutes: TimeColumnOption[];
   seconds: TimeColumnOption[] | null;

--- a/resources/js/form/components/fields/time-picker.tsx
+++ b/resources/js/form/components/fields/time-picker.tsx
@@ -2,7 +2,7 @@ import { type KeyboardEvent, useEffect, useRef } from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { buildTimeColumns, type TimeColumnOption, type TimeValue } from "./time-picker-columns";
 
-export type TimePickerProps = {
+type TimePickerProps = {
   value: TimeValue | null;
   onChange: (next: TimeValue) => void;
   step?: number | null;

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -11,7 +11,7 @@ import {
   type RepeaterRow,
 } from "./repeater-rows";
 
-export type RowCollection = {
+type RowCollection = {
   path: string;
   rows: RepeaterRow[];
   onField: (index: number, field: string, value: unknown) => void;

--- a/resources/js/form/components/form-path.ts
+++ b/resources/js/form/components/form-path.ts
@@ -1,4 +1,4 @@
-export function pathParts(path: string): string[] {
+function pathParts(path: string): string[] {
   return path.split(".").filter((part) => part !== "");
 }
 

--- a/resources/js/form/components/prefill-targets.ts
+++ b/resources/js/form/components/prefill-targets.ts
@@ -3,7 +3,7 @@ import { fieldProps } from "./field-props";
 import { appendPath, getPath } from "./form-path";
 import { buildOverrideKey, rowIdFrom } from "./override-keys";
 
-export type PrefillTarget = {
+type PrefillTarget = {
   path: string;
   overrideKey: string;
   resetOn: string[];

--- a/resources/js/form/components/use-field-commit.ts
+++ b/resources/js/form/components/use-field-commit.ts
@@ -3,7 +3,7 @@ import { useFormContext } from "./context";
 import { usePrefillController } from "./prefill-context";
 import { useSetFormValue } from "./values";
 
-export type FieldCommit = {
+type FieldCommit = {
   /** Write the value and validate immediately (precognitive) or clear errors. */
   commit: (name: string, value: unknown) => void;
   /** Write the value and clear errors, deferring validation to a later `blur`. */

--- a/resources/js/form/components/use-form-resolver.ts
+++ b/resources/js/form/components/use-form-resolver.ts
@@ -18,7 +18,7 @@ type ResolveResponse = {
   prefill?: Record<string, unknown>;
 };
 
-export type FormResolver = {
+type FormResolver = {
   nodes: Record<string, Node>;
   markUserEdit: PrefillController["markUserEdit"];
 };

--- a/resources/js/i18n/config.ts
+++ b/resources/js/i18n/config.ts
@@ -1,7 +1,7 @@
 import type { I18nConfig } from "@lattice-php/lattice/types/generated";
 import { useSyncExternalStore } from "react";
 
-export type Config = {
+type Config = {
   readonly locales: readonly string[];
   readonly timezone: string | null;
 };

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -11,7 +11,7 @@ type TranslationFunction = (
   options?: Record<string, unknown>,
 ) => string;
 
-export type TranslationResult = {
+type TranslationResult = {
   t: TranslationFunction;
   i18n: I18nInstance;
   locale: string;

--- a/resources/js/i18n/locale-reload.tsx
+++ b/resources/js/i18n/locale-reload.tsx
@@ -3,7 +3,7 @@ import { router } from "@inertiajs/react";
 import { useCallback } from "react";
 import { EventBridge } from "../events/event-bridge";
 
-export type LocaleReloadProps = Pick<VisitOptions, "preserveScroll" | "preserveState">;
+type LocaleReloadProps = Pick<VisitOptions, "preserveScroll" | "preserveState">;
 
 // preserveState by default: the visit only re-fetches the re-localized props,
 // so keeping the page mounted avoids remounting the whole tree (and losing

--- a/resources/js/notifications/store.ts
+++ b/resources/js/notifications/store.ts
@@ -29,12 +29,12 @@ export function removeIn(list: NotificationItem[], id: string): NotificationItem
 
 export type NotificationsStatus = "loading" | "idle" | "error";
 
-export type UseNotificationsOptions = {
+type UseNotificationsOptions = {
   endpoint: string;
   pollingInterval?: number | null;
 };
 
-export type UseNotificationsReturn = {
+type UseNotificationsReturn = {
   notifications: NotificationItem[];
   unreadCount: number;
   status: NotificationsStatus;

--- a/resources/js/realtime/build-effects.ts
+++ b/resources/js/realtime/build-effects.ts
@@ -2,7 +2,7 @@ import type { Effect } from "@lattice-php/lattice/types/generated";
 import { isTranslatable, resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
 import type { Translate } from "@lattice-php/lattice/i18n/translatable";
 
-export type RawEffect = Record<string, unknown>;
+type RawEffect = Record<string, unknown>;
 
 export function buildEffects(
   effects: readonly RawEffect[],

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -8,7 +8,7 @@ import type { FilterData, Option } from "@lattice-php/lattice/types/generated";
 import { filterOptions, stringProp } from "../filter-values";
 import { fieldClass } from "./filter-value-input";
 
-export type DateRangeValue = { from?: string; until?: string };
+type DateRangeValue = { from?: string; until?: string };
 
 export type FilterOptionSearch = (query: string) => Promise<Option[]>;
 

--- a/resources/js/table/components/table-cell.tsx
+++ b/resources/js/table/components/table-cell.tsx
@@ -1,4 +1,4 @@
-import { useColumnRegistry } from "../../provider";
+import { useColumnRegistry } from "@lattice-php/lattice/core/registry-context";
 import { columnCell, type ColumnRegistry } from "../registry";
 import type { TableColumn, TableRow } from "../types";
 import { BadgeCell } from "./cells/badge-cell";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -155,7 +155,6 @@ export type ChatMessage = {
   readonly role: ChatRole;
   readonly parts: WireNode[];
 };
-export type ChatNodeType = "chat.box" | "chat.part.text" | "chat.part.tool-call";
 export type ChatRole = "user" | "assistant" | "system";
 export type Checkbox = {
   autoFocus: boolean;
@@ -339,26 +338,6 @@ export type Confirmation = {
   readonly confirmLabel: string | null;
   readonly cancelLabel: string | null;
 };
-export type CoreNodeType =
-  | "badge"
-  | "button"
-  | "card"
-  | "chart"
-  | "collapsible"
-  | "floating-panel"
-  | "grid"
-  | "heading"
-  | "icon"
-  | "link"
-  | "modal"
-  | "raw-block"
-  | "section"
-  | "segmented-control"
-  | "stack"
-  | "tab"
-  | "tabs"
-  | "text"
-  | "tooltip";
 export type DataList = {
   dataEndpoint: string | null;
   emptyLabel: string | null;
@@ -586,7 +565,6 @@ export type Fragment = {
   ref: string | null;
   size: Size;
 };
-export type FragmentNodeType = "fragment";
 export type Gap = "none" | "xs" | "sm" | "md" | "lg" | "xl";
 export type Grid = {
   columns: number | null;
@@ -644,15 +622,6 @@ export type ImageColumn = {
   size: number | null;
 };
 export type Justify = "start" | "center" | "end" | "between" | "around" | "evenly";
-export type LayoutNodeType =
-  | "breadcrumbs"
-  | "callouts"
-  | "dropdown"
-  | "menu"
-  | "menu-item"
-  | "outlet"
-  | "sidebar"
-  | "topbar";
 export type Link = {
   action: WireNode | null;
   href: string | null;
@@ -762,7 +731,6 @@ export type NotificationItem = {
   readonly createdAt: string | null;
   readonly actions: WireNode[];
 };
-export type NotificationNodeType = "notifications";
 export type Notifications = {
   channel: string;
   endpoint: string;
@@ -944,7 +912,6 @@ export type RemoteAccess = {
   readonly tokenEndpoint: string;
   readonly ref: string;
 };
-export type RemoteNodeType = "remote.data-list";
 export type Repeater = {
   addLabel: string | null;
   columnWidth: ColumnWidth;
@@ -1100,7 +1067,6 @@ export type Table = {
   resizeIndicator: boolean;
   striped: boolean | null;
 };
-export type TableNodeType = "table";
 export type TablePagination = {
   readonly mode: PaginationType;
   readonly currentPage: number | null;

--- a/workbench/app/Support/TypeScript/BaseProfile.php
+++ b/workbench/app/Support/TypeScript/BaseProfile.php
@@ -38,6 +38,13 @@ final class BaseProfile implements TypeScriptProfile
     ];
 
     /**
+     * Node aliases whose per-domain `…Type` string union a client actually consumes
+     * (via `NodeUnionOf`). Only these are emitted — the rest would be dead exports.
+     * Add one here when a client starts deriving a node union for that domain.
+     */
+    private const array NODE_TYPE_ALIASES = ['ActionNode'];
+
+    /**
      * The component domains this profile emits a node type for. Exposed so the
      * drift-guard test can assert no src/ domain is missing from the hand-list —
      * an unregistered domain's components would silently vanish from the generated
@@ -89,6 +96,7 @@ final class BaseProfile implements TypeScriptProfile
                     EffectContract::class,
                     $effects,
                     $columnProps,
+                    self::NODE_TYPE_ALIASES,
                 ),
             ],
             new FlatModuleWriter('generated.ts'),

--- a/workbench/app/Support/TypeScript/NodesProvider.php
+++ b/workbench/app/Support/TypeScript/NodesProvider.php
@@ -39,6 +39,7 @@ final readonly class NodesProvider implements TransformedProvider
      * @param  class-string|null  $effectContract
      * @param  array<class-string, string>  $effects  Effect value objects keyed by class-string, valued by wire type.
      * @param  array<string, class-string>  $columnProps  wire column type => props VO class-string
+     * @param  list<string>  $nodeTypeAliases  Node-alias names (e.g. 'ActionNode') whose per-domain `…Type` union a client consumes via `NodeUnionOf`; others are not emitted.
      */
     public function __construct(
         private array $formFields,
@@ -48,6 +49,7 @@ final readonly class NodesProvider implements TransformedProvider
         private ?string $effectContract = null,
         private array $effects = [],
         private array $columnProps = [],
+        private array $nodeTypeAliases = [],
     ) {}
 
     /**
@@ -63,6 +65,10 @@ final readonly class NodesProvider implements TransformedProvider
         ];
 
         foreach ($this->domainNodes as $nodeName => $components) {
+            if (! in_array($nodeName, $this->nodeTypeAliases, true)) {
+                continue;
+            }
+
             $types = array_map(static fn (array $spec): string => $spec['type'], array_values($components));
             $transformed[] = $this->alias($nodeName.'Type', $this->typeUnion($types));
         }


### PR DESCRIPTION
Dead-export cleanup from the TypeScript audit — now actionable since internal ≠ public is fine in alpha.

## E · dead per-domain `…NodeType` unions
The generator emitted a `…NodeType` for every domain, but only `ActionNodeType` and the form ones are consumed (via `NodeUnionOf`). The other seven — `CoreNodeType`, `ChatNodeType`, `LayoutNodeType`, `NotificationNodeType`, `RemoteNodeType`, `FragmentNodeType`, `TableNodeType` — were dead. Per-domain emission is now gated on a `NODE_TYPE_ALIASES` allow-list in `BaseProfile`; a domain opts in when a client starts deriving its node union.

## F · orphaned `RawEffect` export
`realtime/build-effects.ts` `export`ed `RawEffect` but nothing imported it (orphaned when the subscriptions cast was removed). Made it local.

## G · internal-only exports un-exported
~20 types used only inside their own file — component prop types, hook return/option types, and other internals — no longer `export`ed. They were public surface only because every file is a build entry. Un-exporting `ControlSurfaceVariants` surfaced that it was **fully dead** (unused even in-file) — removed it and its unused import.

Kept as-is (plausibly public API, not touched): `vite.ts` config option types, `core/registry` registration types, `core/api` helpers, public function param types (`Format`, `DateConfig`), and the derived form node types.

## Verification
Full gate green: `composer check` (Pint, PHPStan, Rector, 983 Pest) and `npm run check` (oxlint, oxfmt, tsc, type-coverage, 949 Vitest, library build).

## C · column-registry import direction
`table-cell.tsx` imported `useColumnRegistry` from the root `provider`; it is defined in `core/registry-context` (the provider only re-exports it). Import it from core so the table stops reaching to the composition root.
