### PR TITLE
fix: export the ./format/* subpath from the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,10 @@
       "types": "./dist/form/*.d.ts",
       "import": "./dist/form/*.js"
     },
+    "./format/*": {
+      "types": "./dist/format/*.d.ts",
+      "import": "./dist/format/*.js"
+    },
     "./i18n": {
       "types": "./dist/i18n/index.d.ts",
       "import": "./dist/i18n/index.js"


### PR DESCRIPTION
## What

Adds the missing `./format/*` entry to `package.json` `exports`.

## Why

The date-formatter refactor (`d170f62e`) created `resources/js/format/date-time.ts` and made two files import it via the self-referencing package subpath:

- `resources/js/table/format.ts` → `@lattice-php/lattice/format/date-time`
- `resources/js/i18n/date-time.tsx` → `@lattice-php/lattice/format/date-time`

…but no `./format/*` export existed. Vite's alias resolution masks this for the library build and vitest, so **main CI's JS job stayed green** — while the **Astro docs build** resolves the bare specifier through the package `exports` field (conditions include `astro`) and failed:

```
"./format/date-time" is not exported under the conditions [...,"astro","import"] from package .../lattice/package.json
```

This is what's been failing the **Deploy docs to GitHub Pages** workflow on `main`. Real consumers importing the `table`/`i18n` subpaths would hit the same unresolved-export error.

## Verification

- `npm run docs:build` → passes (was failing)
- `npm run build:lib` → emits `dist/format/date-time.{js,d.ts}`, so the new export resolves for published consumers
- Full pre-push gate passed

## Note (out of scope)

The separate **CI** failure on `main` is a transient Codecov OIDC-token fetch (`Failed to get ID Token ... socket hang up`) on the browser-coverage upload step, which uses `fail_ci_if_error: true`. All 87 browser tests passed; a re-run should go green. Not addressed here.