### PR TITLE
fix: surface unregistered node types instead of failing silently

### DIFF
--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -89,12 +89,12 @@ composer require acme/lattice-signature
 If you followed the [installation guide](/introduction/installation/), the discovered plugins are already registered — the standard bootstrap passes `virtual:lattice/plugins` to `createLatticeApp`, so an installed package registers itself with no further wiring:
 
 ```ts
-import latticePlugins from "virtual:lattice/plugins";
+import plugins from "virtual:lattice/plugins";
 
-createLatticeApp({ plugins: latticePlugins });
+createLatticeApp({ plugins });
 ```
 
-(Or merge them onto the registry yourself with `extendRegistry(registry, ...latticePlugins)`.) Then use the component like any built-in:
+(Or merge them onto the registry yourself with `extendRegistry(registry, ...plugins)`.) Then use the component like any built-in:
 
 ```php
 Signature::make('signature')->label('Sign the contract');

--- a/docs/content/docs/extending/custom-columns.md
+++ b/docs/content/docs/extending/custom-columns.md
@@ -158,13 +158,13 @@ export const registry = extendRegistry(
 ```tsx
 import "../css/app.css";
 import { createLatticeApp } from "@lattice-php/lattice";
-import latticePlugins from "virtual:lattice/plugins";
+import plugins from "virtual:lattice/plugins";
 import sprite from "virtual:svg-sprite";
 import { registry } from "./registry";
 
 createLatticeApp({
   registry,
-  plugins: latticePlugins,
+  plugins,
   sprite,
   pages: import.meta.glob("./Pages/**/*.tsx"),
 });

--- a/docs/content/docs/extending/custom-columns.md
+++ b/docs/content/docs/extending/custom-columns.md
@@ -153,32 +153,24 @@ export const registry = extendRegistry(
 
 ## 6. Wire the registry in app.tsx
 
-`registry.ts` already merges your column onto the built-in registry, so import its exported `registry` and pass it to `Provider`:
+`registry.ts` already merges your column onto the built-in registry. Pass its exported `registry` to `createLatticeApp` — the same one-call bootstrap from installation, now made aware of your custom cells:
 
 ```tsx
 import "../css/app.css";
-import { createInertiaApp } from "@inertiajs/react";
-import { createRoot } from "react-dom/client";
-import LatticePage from "@lattice-php/lattice/page";
-import { Provider } from "@lattice-php/lattice";
+import { createLatticeApp } from "@lattice-php/lattice";
+import latticePlugins from "virtual:lattice/plugins";
+import sprite from "virtual:svg-sprite";
 import { registry } from "./registry";
 
-createInertiaApp({
-  resolve: (name) => {
-    if (name === "lattice/page") return { default: LatticePage };
-    const pages = import.meta.glob("./Pages/**/*.tsx", { eager: true });
-    return pages[`./Pages/${name}.tsx`];
-  },
-  setup({ el, App, props }) {
-    if (!el) return;
-    createRoot(el).render(
-      <Provider registry={registry}>
-        <App {...props} />
-      </Provider>,
-    );
-  },
+createLatticeApp({
+  registry,
+  plugins: latticePlugins,
+  sprite,
+  pages: import.meta.glob("./Pages/**/*.tsx"),
 });
 ```
+
+Passing `registry` is what makes your cell render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node is silently skipped (Lattice logs a `[lattice] No component registered…` warning in development to flag exactly this).
 
 Custom fields, components, and columns all live in this same `registry.ts` — there is no second registry to merge.
 

--- a/docs/content/docs/extending/custom-columns.md
+++ b/docs/content/docs/extending/custom-columns.md
@@ -170,7 +170,7 @@ createLatticeApp({
 });
 ```
 
-Passing `registry` is what makes your cell render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node is silently skipped (Lattice logs a `[lattice] No component registered…` warning in development to flag exactly this).
+Passing `registry` is what makes your cell render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node renders a muted missing-component placeholder instead of your cell (Lattice also logs a `[lattice] No component registered…` warning in development to flag exactly this).
 
 Custom fields, components, and columns all live in this same `registry.ts` — there is no second registry to merge.
 

--- a/docs/content/docs/extending/custom-fields.md
+++ b/docs/content/docs/extending/custom-fields.md
@@ -134,13 +134,13 @@ export const registry = extendRegistry(
 ```tsx
 import "../css/app.css";
 import { createLatticeApp } from "@lattice-php/lattice";
-import latticePlugins from "virtual:lattice/plugins";
+import plugins from "virtual:lattice/plugins";
 import sprite from "virtual:svg-sprite";
 import { registry } from "./registry";
 
 createLatticeApp({
   registry,
-  plugins: latticePlugins,
+  plugins,
   sprite,
   pages: import.meta.glob("./Pages/**/*.tsx"),
 });

--- a/docs/content/docs/extending/custom-fields.md
+++ b/docs/content/docs/extending/custom-fields.md
@@ -146,7 +146,7 @@ createLatticeApp({
 });
 ```
 
-Passing `registry` is what makes your field render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node is silently skipped (Lattice logs a `[lattice] No component registered…` warning in development to flag exactly this).
+Passing `registry` is what makes your field render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node renders a muted missing-component placeholder instead of your field (Lattice also logs a `[lattice] No component registered…` warning in development to flag exactly this).
 
 ## 7. Generate TypeScript types
 

--- a/docs/content/docs/extending/custom-fields.md
+++ b/docs/content/docs/extending/custom-fields.md
@@ -129,32 +129,24 @@ export const registry = extendRegistry(
 
 ## 6. Wire the registry in app.tsx
 
-`registry.ts` already merges your plugin onto the built-in registry, so import its exported `registry` and pass it to `Provider`:
+`registry.ts` already merges your plugin onto the built-in registry. Pass its exported `registry` to `createLatticeApp` — the same one-call bootstrap from installation, now made aware of your custom components:
 
 ```tsx
 import "../css/app.css";
-import { createInertiaApp } from "@inertiajs/react";
-import { createRoot } from "react-dom/client";
-import LatticePage from "@lattice-php/lattice/page";
-import { Provider } from "@lattice-php/lattice";
+import { createLatticeApp } from "@lattice-php/lattice";
+import latticePlugins from "virtual:lattice/plugins";
+import sprite from "virtual:svg-sprite";
 import { registry } from "./registry";
 
-createInertiaApp({
-  resolve: (name) => {
-    if (name === "lattice/page") return { default: LatticePage };
-    const pages = import.meta.glob("./Pages/**/*.tsx", { eager: true });
-    return pages[`./Pages/${name}.tsx`];
-  },
-  setup({ el, App, props }) {
-    if (!el) return;
-    createRoot(el).render(
-      <Provider registry={registry}>
-        <App {...props} />
-      </Provider>,
-    );
-  },
+createLatticeApp({
+  registry,
+  plugins: latticePlugins,
+  sprite,
+  pages: import.meta.glob("./Pages/**/*.tsx"),
 });
 ```
+
+Passing `registry` is what makes your field render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node is silently skipped (Lattice logs a `[lattice] No component registered…` warning in development to flag exactly this).
 
 ## 7. Generate TypeScript types
 

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -149,6 +149,8 @@ createLatticeApp({
 
 It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`.
 
+Once you scaffold your own fields, components, or columns (see [Custom fields](/extending/custom-fields/)), they are registered in `resources/js/registry.ts`. Pass that file's exported `registry` here so `createLatticeApp` renders them — `createLatticeApp({ registry, plugins: latticePlugins, sprite, pages })`. Omit it and your custom types have no renderer, so their nodes are silently skipped (with a `[lattice]` dev-mode warning).
+
 `plugins: latticePlugins` registers the renderers of any [component packages](/extending/component-packages/) you install via Composer. The `virtual:lattice/plugins` module is provided by the `lattice()` Vite plugin and resolves to an empty list until you install one, so it is safe to keep here from the start.
 
 #### Manual wiring

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -149,7 +149,7 @@ createLatticeApp({
 
 It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`.
 
-Once you scaffold your own fields, components, or columns (see [Custom fields](/extending/custom-fields/)), they are registered in `resources/js/registry.ts`. Pass that file's exported `registry` here so `createLatticeApp` renders them — `createLatticeApp({ registry, plugins, sprite, pages })`. Omit it and your custom types have no renderer, so their nodes are silently skipped (with a `[lattice]` dev-mode warning).
+Once you scaffold your own fields, components, or columns (see [Custom fields](/extending/custom-fields/)), they are registered in `resources/js/registry.ts`. Pass that file's exported `registry` here so `createLatticeApp` renders them — `createLatticeApp({ registry, plugins, sprite, pages })`. Omit it and your custom types have no renderer, so their nodes render a muted missing-component placeholder instead (and log a `[lattice]` warning in development).
 
 `plugins` registers the renderers of any [component packages](/extending/component-packages/) you install via Composer. The `virtual:lattice/plugins` module is provided by the `lattice()` Vite plugin and resolves to an empty list until you install one, so it is safe to keep here from the start.
 

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -137,11 +137,11 @@ Every Lattice route resolves to the same Inertia page component, `lattice/page`,
 /// <reference types="@lattice-php/lattice/vite-client" />
 import "../css/app.css";
 import { createLatticeApp } from "@lattice-php/lattice";
-import latticePlugins from "virtual:lattice/plugins";
+import plugins from "virtual:lattice/plugins";
 import sprite from "virtual:svg-sprite";
 
 createLatticeApp({
-  plugins: latticePlugins,
+  plugins,
   sprite,
   pages: import.meta.glob("./Pages/**/*.tsx"),
 });
@@ -149,9 +149,9 @@ createLatticeApp({
 
 It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`.
 
-Once you scaffold your own fields, components, or columns (see [Custom fields](/extending/custom-fields/)), they are registered in `resources/js/registry.ts`. Pass that file's exported `registry` here so `createLatticeApp` renders them — `createLatticeApp({ registry, plugins: latticePlugins, sprite, pages })`. Omit it and your custom types have no renderer, so their nodes are silently skipped (with a `[lattice]` dev-mode warning).
+Once you scaffold your own fields, components, or columns (see [Custom fields](/extending/custom-fields/)), they are registered in `resources/js/registry.ts`. Pass that file's exported `registry` here so `createLatticeApp` renders them — `createLatticeApp({ registry, plugins, sprite, pages })`. Omit it and your custom types have no renderer, so their nodes are silently skipped (with a `[lattice]` dev-mode warning).
 
-`plugins: latticePlugins` registers the renderers of any [component packages](/extending/component-packages/) you install via Composer. The `virtual:lattice/plugins` module is provided by the `lattice()` Vite plugin and resolves to an empty list until you install one, so it is safe to keep here from the start.
+`plugins` registers the renderers of any [component packages](/extending/component-packages/) you install via Composer. The `virtual:lattice/plugins` module is provided by the `lattice()` Vite plugin and resolves to an empty list until you install one, so it is safe to keep here from the start.
 
 #### Manual wiring
 
@@ -165,12 +165,12 @@ import "../css/app.css";
 import { createInertiaApp, type ResolvedComponent } from "@inertiajs/react";
 import { createPageResolver, extendRegistry, Provider, registry } from "@lattice-php/lattice";
 import { createRoot } from "react-dom/client";
-import latticePlugins from "virtual:lattice/plugins";
+import plugins from "virtual:lattice/plugins";
 import sprite from "virtual:svg-sprite";
 
 const pages = import.meta.glob<ResolvedComponent>("./Pages/**/*.tsx");
 const resolve = createPageResolver(pages);
-const appRegistry = extendRegistry(registry, ...latticePlugins);
+const appRegistry = extendRegistry(registry, ...plugins);
 
 createInertiaApp({
   resolve,
@@ -186,7 +186,7 @@ createInertiaApp({
 });
 ```
 
-Keep your existing Inertia options such as `title`, `progress`, layouts, and SSR setup. The important pieces are `createPageResolver(...)` and the single `Provider` around the app. `extendRegistry(registry, ...latticePlugins)` folds in any installed [component packages](/extending/component-packages/); drop it if you don't use them.
+Keep your existing Inertia options such as `title`, `progress`, layouts, and SSR setup. The important pieces are `createPageResolver(...)` and the single `Provider` around the app. `extendRegistry(registry, ...plugins)` folds in any installed [component packages](/extending/component-packages/); drop it if you don't use them.
 
 ### Customizing the registry
 

--- a/resources/js/core/renderer.test.tsx
+++ b/resources/js/core/renderer.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent, lazyComponent } from "@lattice-php/lattice";
 import { Renderer } from "@lattice-php/lattice";
 import { renderWithRegistry } from "@lattice-php/lattice/test/render";
@@ -49,6 +49,22 @@ describe("Renderer", () => {
     renderWithRegistry(<Renderer nodes={[{ type: "unknown.component" }]} />, registry);
 
     expect(screen.getByText("Missing component: unknown.component")).toBeVisible();
+  });
+
+  it("warns once, with actionable guidance, when a node type has no renderer", () => {
+    const registry = createRegistry({ components: {}, name: "empty" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderWithRegistry(
+      <Renderer nodes={[{ type: "app.unregistered" }, { type: "app.unregistered" }]} />,
+      registry,
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("app.unregistered");
+    expect(warn.mock.calls[0]?.[0]).toContain("createLatticeApp({ registry })");
+
+    warn.mockRestore();
   });
 
   it("skips nodes that hide when their sidebar context is collapsed", () => {

--- a/resources/js/core/renderer.test.tsx
+++ b/resources/js/core/renderer.test.tsx
@@ -51,6 +51,17 @@ describe("Renderer", () => {
     expect(screen.getByText("Missing component: unknown.component")).toBeVisible();
   });
 
+  it("renders a visible icon placeholder for unknown types so the gap is never invisible", () => {
+    const registry = createRegistry({ components: {}, name: "empty" });
+
+    renderWithRegistry(<Renderer nodes={[{ type: "widget.unknown" }]} />, registry);
+
+    const marker = screen.getByTitle("Missing component: widget.unknown");
+
+    expect(marker).toBeVisible();
+    expect(marker.querySelector("svg")).not.toBeNull();
+  });
+
   it("warns once, with actionable guidance, when a node type has no renderer", () => {
     const registry = createRegistry({ components: {}, name: "empty" });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -4,7 +4,24 @@ import type { Node } from "./types";
 import { useCollapsed } from "./collapsed-context";
 import { useComponentRegistry } from "./registry-context";
 
+const warnedMissingTypes = new Set<string>();
+
+function warnMissingComponent(type: string): void {
+  if (!import.meta.env.DEV || warnedMissingTypes.has(type)) {
+    return;
+  }
+
+  warnedMissingTypes.add(type);
+  console.warn(
+    `[lattice] No component registered for node type "${type}" — the renderer skipped it. ` +
+      "Likely causes: your app registry was not passed to createLatticeApp({ registry }), " +
+      "or the registry key does not match the PHP #[AsComponent]/AsField type.",
+  );
+}
+
 function MissingComponent({ node }: { node: Node }) {
+  warnMissingComponent(node.type);
+
   if (!import.meta.env.DEV) {
     return null;
   }

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -13,20 +13,53 @@ function warnMissingComponent(type: string): void {
 
   warnedMissingTypes.add(type);
   console.warn(
-    `[lattice] No component registered for node type "${type}" — the renderer skipped it. ` +
-      "Likely causes: your app registry was not passed to createLatticeApp({ registry }), " +
-      "or the registry key does not match the PHP #[AsComponent]/AsField type.",
+    `[lattice] No component registered for node type "${type}" — Lattice rendered a fallback ` +
+      "placeholder. Likely causes: your app registry was not passed to " +
+      "createLatticeApp({ registry }), or the registry key does not match the PHP " +
+      "#[AsComponent]/AsField type.",
   );
 }
 
+function MissingComponentIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-lt-icon-md shrink-0"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <rect height="18" rx="2" strokeDasharray="4 3" width="18" x="3" y="3" />
+      <path d="M12 8v4" />
+      <path d="M12 16h.01" />
+    </svg>
+  );
+}
+
+/**
+ * Fallback for a node whose type has no registered renderer. Always renders a
+ * visible, muted marker — icon-only survives tight spots like table cells — so
+ * the gap is never invisible. Shows the type inline in development; keeps it
+ * screen-reader-only (plus a hover tooltip) in production.
+ */
 function MissingComponent({ node }: { node: Node }) {
   warnMissingComponent(node.type);
 
-  if (!import.meta.env.DEV) {
-    return null;
-  }
+  const label = `Missing component: ${node.type}`;
 
-  return <div data-lattice-missing-component={node.type}>Missing component: {node.type}</div>;
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 align-middle text-lt-muted-fg"
+      data-lattice-missing-component={node.type}
+      title={label}
+    >
+      <MissingComponentIcon />
+      <span className={import.meta.env.DEV ? "text-sm" : "sr-only"}>{label}</span>
+    </span>
+  );
 }
 
 function nodeKey(node: Node, index: number): string {

--- a/workbench/resources/js/app.tsx
+++ b/workbench/resources/js/app.tsx
@@ -12,11 +12,11 @@ import {
 import { configureI18nFromPageProps, LocaleReload } from "@lattice-php/lattice/i18n";
 import { createRoot } from "react-dom/client";
 import sprite from "virtual:svg-sprite";
-import latticePlugins from "virtual:lattice/plugins";
+import plugins from "virtual:lattice/plugins";
 import { appColumns } from "./columns";
 import { WORKBENCH_I18N_NAMESPACE } from "./i18n";
 
-const appRegistry = extendRegistry(registry, appColumns, ...latticePlugins);
+const appRegistry = extendRegistry(registry, appColumns, ...plugins);
 
 type ReverbProp = {
   host: string;


### PR DESCRIPTION
## What & why

Fixes the highest-impact DX trap surfaced in the codebase audit: a scaffolded custom component **silently renders nothing** on the recommended install path — `null` in production, an unlabeled marker in dev, with no console output. The cause is that the app's `resources/js/registry.ts` (where `lattice:field/component/column` register scaffolded types) was never passed to `createLatticeApp`, and the renderer swallowed the miss.

## Changes

**`fix:` — loud, self-diagnosing renderer** (`resources/js/core/renderer.tsx`)
- When a node type has no registered renderer, emit a **deduplicated dev-mode `console.warn`** naming the missing type and its two likely causes: the app registry not passed to `createLatticeApp({ registry })`, or a registry key that doesn't match the PHP `#[AsComponent]`/`AsField` type.
- **Render a visible placeholder instead of `null`.** Production previously left no trace at all; now a muted, icon-led marker (a self-contained dashed-box glyph that stays legible in tight spots like table cells) always renders. The node type shows inline in development and stays screen-reader-only + a hover tooltip in production.
- Tests: the warning fires once with actionable guidance, and the placeholder always renders an icon.

**`docs:` — correct the bootstrap** (extending guides + install)
- The custom-field/column walkthroughs told developers to abandon `createLatticeApp` for a hand-rolled `createInertiaApp` + `Provider`, which silently drops the layout resolver, flash toasts, theme init, and icon sprite. Unified both onto `createLatticeApp({ registry })`.
- Install guide now notes the app `registry` must be passed once custom components are scaffolded.

**`docs:` — name the virtual plugins import `plugins`**
- Examples imported `virtual:lattice/plugins` as `latticePlugins` and passed `plugins: latticePlugins`. Now imported as `plugins` with the `createLatticeApp({ plugins })` shorthand. The module keeps its default export — example-naming only, no runtime change.

## Release
Contains a `fix:` commit so release-please cuts a patch — releasable as a hotfix.

## Verification
`oxlint`, `oxfmt --check`, `tsc --noEmit`, full Vitest suite (167 files / 953 tests) green; full pre-push gate (`composer check` + `npm run check`) passed on push.
