### PR TITLE
fix: serialize map-typed wire fields as objects, not arrays

### DIFF
--- a/docs/fixtures/table.badge.json
+++ b/docs/fixtures/table.badge.json
@@ -99,7 +99,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.boolean.json
+++ b/docs/fixtures/table.boolean.json
@@ -45,7 +45,7 @@
                     "hiddenByDefault": null,
                     "key": "featured",
                     "label": "Featured",
-                    "props": [],
+                    "props": {},
                     "sortable": true,
                     "toggleable": null,
                     "type": "column.boolean",
@@ -58,7 +58,7 @@
                     "hiddenByDefault": null,
                     "key": "archived",
                     "label": "Archived",
-                    "props": [],
+                    "props": {},
                     "sortable": null,
                     "toggleable": null,
                     "type": "column.boolean",
@@ -105,7 +105,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -67,15 +67,15 @@
                     "key": "verified",
                     "label": "Verified",
                     "props": {
-                        "colors": [
-                            "gray",
-                            "green"
-                        ],
+                        "colors": {
+                            "0": "gray",
+                            "1": "green"
+                        },
                         "icon": null,
-                        "icons": [
-                            "minus",
-                            "check"
-                        ]
+                        "icons": {
+                            "0": "minus",
+                            "1": "check"
+                        }
                     },
                     "sortable": null,
                     "toggleable": null,
@@ -126,7 +126,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.icon.json
+++ b/docs/fixtures/table.icon.json
@@ -32,15 +32,15 @@
                     "key": "verified",
                     "label": "Verified",
                     "props": {
-                        "colors": [
-                            "gray",
-                            "green"
-                        ],
+                        "colors": {
+                            "0": "gray",
+                            "1": "green"
+                        },
                         "icon": null,
-                        "icons": [
-                            "minus",
-                            "check"
-                        ]
+                        "icons": {
+                            "0": "minus",
+                            "1": "check"
+                        }
                     },
                     "sortable": null,
                     "toggleable": null,
@@ -81,7 +81,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.image.json
+++ b/docs/fixtures/table.image.json
@@ -95,7 +95,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.money.json
+++ b/docs/fixtures/table.money.json
@@ -98,7 +98,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.number.json
+++ b/docs/fixtures/table.number.json
@@ -101,7 +101,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -86,7 +86,7 @@
                     "hiddenByDefault": null,
                     "key": "featured",
                     "label": "Featured",
-                    "props": [],
+                    "props": {},
                     "sortable": null,
                     "toggleable": null,
                     "type": "column.boolean",
@@ -158,7 +158,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": true
         },

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -51,7 +51,7 @@
                     "hiddenByDefault": null,
                     "key": "identity",
                     "label": "User",
-                    "props": [],
+                    "props": {},
                     "sortable": null,
                     "toggleable": null,
                     "type": "column.stack",
@@ -112,7 +112,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.text.json
+++ b/docs/fixtures/table.text.json
@@ -107,7 +107,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/docs/fixtures/table.toggleable.json
+++ b/docs/fixtures/table.toggleable.json
@@ -121,7 +121,7 @@
                 "page": 1,
                 "perPage": 25,
                 "sorts": [],
-                "tableFilters": []
+                "tableFilters": {}
             },
             "striped": null
         },

--- a/src/Chat/Components/ToolCallPart.php
+++ b/src/Chat/Components/ToolCallPart.php
@@ -7,6 +7,7 @@ namespace Lattice\Lattice\Chat\Components;
 use Lattice\Lattice\Chat\Attributes\AsChatPart;
 use Lattice\Lattice\Chat\ChatPart;
 use Lattice\Lattice\Chat\Enums\ChatPartType;
+use Lattice\Lattice\Support\Wire;
 
 #[AsChatPart(ChatPartType::ToolCall)]
 final class ToolCallPart extends ChatPart
@@ -28,5 +29,17 @@ final class ToolCallPart extends ChatPart
         $part->args = $args;
 
         return $part;
+    }
+
+    /**
+     * @param  array<string, mixed>  $props
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function decorateProps(array $props): array
+    {
+        $props['args'] = Wire::map($this->args);
+
+        return parent::decorateProps($props);
     }
 }

--- a/src/Core/Components/Component.php
+++ b/src/Core/Components/Component.php
@@ -10,6 +10,7 @@ use Lattice\Lattice\Core\Components\Concerns\HasDataBindings;
 use Lattice\Lattice\Core\Components\Concerns\SerializesToWire;
 use Lattice\Lattice\Core\Concerns\GatesRendering;
 use Lattice\Lattice\Core\Contracts\Renderable;
+use Lattice\Lattice\Support\Wire;
 use ReflectionMethod;
 use Spatie\Attributes\Attributes;
 use Spatie\Attributes\AttributeTarget;
@@ -86,7 +87,7 @@ abstract class Component implements JsonSerializable, Renderable
     {
         return [
             ...$data,
-            'props' => $this->decorateProps($this->wireProps()),
+            'props' => Wire::map($this->decorateProps($this->wireProps())),
         ];
     }
 

--- a/src/Core/Values/Translatable.php
+++ b/src/Core/Values/Translatable.php
@@ -5,6 +5,8 @@ namespace Lattice\Lattice\Core\Values;
 
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Support\Wire;
+use stdClass;
 
 /**
  * A deferred, client-resolved translation: an i18next key plus replacements
@@ -49,14 +51,14 @@ final class Translatable implements JsonSerializable
     }
 
     /**
-     * @return array{key: string, payload: array<string, string>, replacements: array<string, string|int|float|bool>}
+     * @return array{key: string, payload: array<string, string>|stdClass, replacements: array<string, string|int|float|bool>|stdClass}
      */
     public function jsonSerialize(): array
     {
         return [
             'key' => $this->key,
-            'payload' => $this->payload,
-            'replacements' => $this->replacements,
+            'payload' => Wire::map($this->payload),
+            'replacements' => Wire::map($this->replacements),
         ];
     }
 }

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -122,7 +122,7 @@ abstract class Page implements PageContract, Responsable
     }
 
     /**
-     * @return array{title: string|null, layout: array{key: string, schema: array<int, array<string, mixed>>}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, schema: array<int, array<string, mixed>>, listeners?: array<int, array<string, mixed>>}
+     * @return array{title: string|null, layout: array{key: string, schema: mixed}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, schema: mixed, listeners?: mixed}
      */
     public function toArray(PageSchema $schema, Request $request): array
     {
@@ -146,7 +146,7 @@ abstract class Page implements PageContract, Responsable
      * this page's content renders). Returns null when the page opts out of a
      * layout (rendered standalone, e.g. centered auth screens).
      *
-     * @return array{key: string, schema: array<int, array<string, mixed>>}|null
+     * @return array{key: string, schema: mixed}|null
      */
     private function resolveLayout(PageLayout|string $layout, Request $request): ?array
     {
@@ -160,7 +160,7 @@ abstract class Page implements PageContract, Responsable
 
         return [
             'key' => $rendered['key'],
-            'schema' => Wire::toArray($rendered['schema']),
+            'schema' => Wire::toWire($rendered['schema']),
         ];
     }
 
@@ -169,16 +169,14 @@ abstract class Page implements PageContract, Responsable
      * lifecycle, so serialization side effects (such as a Tabs confirmation
      * redirect) fire before the response view is rendered rather than during
      * the final json_encode.
-     *
-     * @return array<int, array<string, mixed>>
      */
-    private function serializeSchema(PageSchema $schema): array
+    private function serializeSchema(PageSchema $schema): mixed
     {
-        return Wire::toArray($schema->renderable());
+        return Wire::toWire($schema->renderable());
     }
 
     /**
-     * @return array{listeners?: array<int, array<string, mixed>>}
+     * @return array{listeners?: mixed}
      */
     private function serializeListeners(): array
     {
@@ -192,7 +190,7 @@ abstract class Page implements PageContract, Responsable
             return [];
         }
 
-        return ['listeners' => Wire::toArray($listeners)];
+        return ['listeners' => Wire::toWire($listeners)];
     }
 
     private function response(PageSchema $schema): Response

--- a/src/Support/Wire.php
+++ b/src/Support/Wire.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Support;
 
 use BackedEnum;
+use stdClass;
 
 /**
  * Helpers for turning PHP values into the scalar shape the frontend receives.
@@ -31,5 +32,29 @@ final class Wire
     public static function toArray(mixed $value): array
     {
         return (array) json_decode(json_encode($value, JSON_THROW_ON_ERROR), true);
+    }
+
+    /**
+     * Like toArray(), but decodes as objects instead of associative arrays, so
+     * an empty map (wrapped via {@see map()} as an stdClass) survives the
+     * round-trip as `{}` instead of collapsing to `[]`.
+     */
+    public static function toWire(mixed $value): mixed
+    {
+        return json_decode(json_encode($value, JSON_THROW_ON_ERROR), false);
+    }
+
+    /**
+     * A wire map (`Record<string, X>` on the TS side) must serialize as a JSON
+     * object even when empty; json_encode() cannot tell an empty PHP array
+     * apart from an empty list, so an empty map is marked as an stdClass here,
+     * at the source, before it enters any array-decoding round-trip.
+     *
+     * @param  array<string, mixed>  $map
+     * @return array<string, mixed>|stdClass
+     */
+    public static function map(array $map): array|stdClass
+    {
+        return $map === [] ? new stdClass : $map;
     }
 }

--- a/src/Support/Wire.php
+++ b/src/Support/Wire.php
@@ -45,16 +45,20 @@ final class Wire
     }
 
     /**
-     * A wire map (`Record<string, X>` on the TS side) must serialize as a JSON
-     * object even when empty; json_encode() cannot tell an empty PHP array
-     * apart from an empty list, so an empty map is marked as an stdClass here,
-     * at the source, before it enters any array-decoding round-trip.
+     * A wire map (`Record<…, X>` on the TS side) must serialize as a JSON object,
+     * not an array. json_encode() emits `[]` for an empty PHP array and a JSON
+     * array for any sequential-integer-keyed one — neither matches a map type.
+     * Marking such a map as an stdClass at the source guarantees an object shape
+     * (`{}` when empty) that survives the serialization round-trips.
      *
-     * @param  array<string, mixed>  $map
-     * @return array<string, mixed>|stdClass
+     * An already-string-keyed, non-empty map is left as an array — it already
+     * encodes to an object — so only the ambiguous cases become stdClass.
+     *
+     * @param  array<array-key, mixed>  $map
+     * @return array<array-key, mixed>|stdClass
      */
     public static function map(array $map): array|stdClass
     {
-        return $map === [] ? new stdClass : $map;
+        return $map === [] || array_is_list($map) ? (object) $map : $map;
     }
 }

--- a/src/Tables/Columns/BadgeColumn.php
+++ b/src/Tables/Columns/BadgeColumn.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Columns;
 
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
 use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
@@ -30,5 +31,19 @@ class BadgeColumn extends Column implements Filterable, Sortable
         $this->colors = $colors === [] ? null : $colors;
 
         return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $props
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function decorateProps(array $props): array
+    {
+        if (is_array($props['colors'] ?? null)) {
+            $props['colors'] = Wire::map($props['colors']);
+        }
+
+        return $props;
     }
 }

--- a/src/Tables/Columns/ColumnData.php
+++ b/src/Tables/Columns/ColumnData.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Tables\Columns;
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\ColumnWidth;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Enums\ColumnAlign;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
@@ -51,7 +52,7 @@ final readonly class ColumnData implements JsonSerializable
             'hiddenByDefault' => $this->hiddenByDefault,
             'filter' => $this->filter,
             'columns' => $this->columns,
-            'props' => $this->props,
+            'props' => Wire::map($this->props),
         ];
     }
 }

--- a/src/Tables/Columns/IconColumn.php
+++ b/src/Tables/Columns/IconColumn.php
@@ -48,4 +48,20 @@ class IconColumn extends Column
 
         return $this;
     }
+
+    /**
+     * @param  array<string, mixed>  $props
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function decorateProps(array $props): array
+    {
+        foreach (['colors', 'icons'] as $key) {
+            if (is_array($props[$key] ?? null)) {
+                $props[$key] = Wire::map($props[$key]);
+            }
+        }
+
+        return $props;
+    }
 }

--- a/src/Tables/Filters/FilterData.php
+++ b/src/Tables/Filters/FilterData.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Tables\Filters;
 
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Enums\FilterControl;
 
 /**
@@ -34,7 +35,7 @@ final readonly class FilterData implements JsonSerializable
             'key' => $this->key,
             'label' => $this->label,
             'type' => $this->type instanceof FilterControl ? $this->type->value : $this->type,
-            'props' => $this->props,
+            'props' => Wire::map($this->props),
         ];
     }
 }

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -9,10 +9,12 @@ use Illuminate\Support\Collection;
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\Filterable;
 use Lattice\Lattice\Tables\Columns\Sortable;
 use Lattice\Lattice\Tables\Filters\BaseFilter;
+use stdClass;
 
 #[TypeScript]
 final readonly class TableQuery implements JsonSerializable
@@ -63,7 +65,7 @@ final readonly class TableQuery implements JsonSerializable
     }
 
     /**
-     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int, tableFilters: array<string, mixed>}
+     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int, tableFilters: array<string, mixed>|stdClass}
      */
     public function jsonSerialize(): array
     {
@@ -72,7 +74,7 @@ final readonly class TableQuery implements JsonSerializable
             'sorts' => $this->sorts,
             'page' => $this->page,
             'perPage' => $this->perPage,
-            'tableFilters' => $this->tableFilters,
+            'tableFilters' => Wire::map($this->tableFilters),
         ];
     }
 

--- a/tests/Feature/Http/LatticeLayoutTest.php
+++ b/tests/Feature/Http/LatticeLayoutTest.php
@@ -69,7 +69,7 @@ test('a page serializes its layout as key and schema with an outlet', function (
 
     $page = new WorkbenchLayoutPage;
 
-    $payload = $page->toArray($page->render(PageSchema::make()), new Request);
+    $payload = wire($page->toArray($page->render(PageSchema::make()), new Request));
 
     expect($payload['layout']['key'])->toBe('app')
         ->and($payload['layout']['schema'][0]['type'])->toBe('stack')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,7 @@ use Lattice\Lattice\Core\Contracts\OptionSource;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tests\BrowserTestCase;
 use Lattice\Lattice\Tests\TestCase;
@@ -128,6 +129,16 @@ function workbenchTestUser(array $attributes = []): User
 function wire(mixed $value): array
 {
     return json_decode(json_encode($value, JSON_THROW_ON_ERROR), true);
+}
+
+/**
+ * The raw JSON a wire object encodes to, with no decode round-trip — the only
+ * way to observe the `{}` vs `[]` distinction an assoc decode (see wire())
+ * collapses.
+ */
+function wireJson(mixed $value): string
+{
+    return json_encode($value, JSON_THROW_ON_ERROR);
 }
 
 /**
@@ -273,11 +284,14 @@ function latticeGet(string $url, string $ref): TestResponse
  * the committed fixtures stable for the CI guard. List order (nodes, options,
  * conditions) is preserved.
  *
+ * Materializes object-preserving (Wire::toWire(), not the assoc wire()) so an
+ * empty map reaches the fixture as `{}` rather than collapsing to `[]`.
+ *
  * @param  array<int, mixed>  $nodes
  */
 function dumpFixture(string $key, array $nodes): void
 {
-    $normalized = wire($nodes);
+    $normalized = Wire::toWire($nodes);
 
     file_put_contents(
         dirname(__DIR__).'/docs/fixtures/'.$key.'.json',
@@ -290,9 +304,19 @@ function dumpFixture(string $key, array $nodes): void
  * props. The ref is encrypted with a random IV and a time-based expiry, so it
  * differs every run; a committed fixture must stay stable, and the static docs
  * preview never calls an endpoint, so the ref is unused there.
+ *
+ * Recurses over stdClass (a wire map, see Wire::toWire()) as well as arrays;
+ * list order is untouched either way.
  */
 function stripFixtureRefs(mixed $value): mixed
 {
+    if ($value instanceof stdClass) {
+        $properties = (array) $value;
+        unset($properties['ref']);
+
+        return (object) array_map(stripFixtureRefs(...), $properties);
+    }
+
     if (! is_array($value)) {
         return $value;
     }
@@ -304,6 +328,13 @@ function stripFixtureRefs(mixed $value): mixed
 
 function sortFixtureKeys(mixed $value): mixed
 {
+    if ($value instanceof stdClass) {
+        $properties = (array) $value;
+        ksort($properties);
+
+        return (object) array_map(sortFixtureKeys(...), $properties);
+    }
+
     if (! is_array($value)) {
         return $value;
     }

--- a/tests/Unit/Core/Values/ToastMessageTranslatableTest.php
+++ b/tests/Unit/Core/Values/ToastMessageTranslatableTest.php
@@ -8,9 +8,9 @@ use Lattice\Lattice\Effects\Effect;
 test('a toast message accepts a Translatable and serializes it', function (): void {
     $toast = ToastMessage::make(Variant::Success, rt('orders.shipped-live')->with(['a' => 'b']));
 
-    expect($toast->jsonSerialize()['message'])->toBe([
+    expect($toast->jsonSerialize()['message'])->toEqual([
         'key' => 'orders.shipped-live',
-        'payload' => [],
+        'payload' => new stdClass,
         'replacements' => ['a' => 'b'],
     ]);
 });
@@ -21,7 +21,7 @@ test('Effect::toast accepts a Translatable message', function (): void {
     expect($effect->jsonSerialize())
         ->toHaveKey('type', 'toast')
         ->and($effect->jsonSerialize()['toast']->jsonSerialize()['message'])
-        ->toBe(['key' => 'orders.shipped-live', 'payload' => [], 'replacements' => []]);
+        ->toEqual(['key' => 'orders.shipped-live', 'payload' => new stdClass, 'replacements' => new stdClass]);
 });
 
 test('Effect::toast accepts a Translatable message with an explicit variant', function (): void {
@@ -30,10 +30,10 @@ test('Effect::toast accepts a Translatable message with an explicit variant', fu
     $toast = $effect->jsonSerialize()['toast'];
 
     expect($toast->variant)->toBe(Variant::Warning)
-        ->and($toast->jsonSerialize()['message'])->toBe([
+        ->and($toast->jsonSerialize()['message'])->toEqual([
             'key' => 'orders.shipped-live',
-            'payload' => [],
-            'replacements' => [],
+            'payload' => new stdClass,
+            'replacements' => new stdClass,
         ]);
 });
 

--- a/tests/Unit/Layouts/Components/CalloutsTest.php
+++ b/tests/Unit/Layouts/Components/CalloutsTest.php
@@ -7,5 +7,5 @@ test('the callouts slot serializes to its wire type', function (): void {
     $wire = Callouts::make()->jsonSerialize();
 
     expect($wire['type'])->toBe('callouts')
-        ->and($wire['props'])->toBe([]);
+        ->and($wire['props'])->toEqual(new stdClass);
 });

--- a/tests/Unit/Support/WireEmptyMapTest.php
+++ b/tests/Unit/Support/WireEmptyMapTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Components\Link;
+use Lattice\Lattice\Layouts\Components\Outlet;
+use Lattice\Lattice\Tables\Columns\BooleanColumn;
+use Lattice\Lattice\Tables\Filters\TernaryFilter;
+
+it('encodes an empty node props map as a JSON object', function (): void {
+    expect(wireJson(Outlet::make()))->toContain('"props":{}');
+});
+
+it('encodes an empty column props map as a JSON object', function (): void {
+    expect(wireJson(BooleanColumn::make('active')->toData()))->toContain('"props":{}');
+});
+
+it('encodes an empty list field as a JSON array, not an object', function (): void {
+    expect(wireJson(Link::make('Register')->href('/register')))->toContain('"effects":[]');
+});
+
+it('encodes a non-empty filter props map as a JSON object unaffected by the empty-map wrapping', function (): void {
+    $json = wireJson(TernaryFilter::make('active')->toData());
+
+    expect($json)->toContain('"trueLabel":"Yes"')
+        ->and($json)->not->toContain('"props":{}');
+});

--- a/tests/Unit/Tables/Columns/ColumnTypesTest.php
+++ b/tests/Unit/Tables/Columns/ColumnTypesTest.php
@@ -64,8 +64,8 @@ it('serializes a number column with a number filter and end alignment', function
         ->and($data['filter']['type'])->toBe(FilterType::Number->value);
 });
 
-it('serialises an empty prop bag as an empty array, not null', function (): void {
+it('serialises an empty prop bag as an empty object, not null', function (): void {
     $wire = BooleanColumn::make('active')->toData()->jsonSerialize();
 
-    expect($wire['props'])->toBe([]);
+    expect($wire['props'])->toEqual(new stdClass);
 });

--- a/tests/Unit/Tables/Filters/FilterTypesTest.php
+++ b/tests/Unit/Tables/Filters/FilterTypesTest.php
@@ -158,20 +158,20 @@ test('a date range filter ignores a non-array value', function (): void {
 });
 
 it('serialises a toggle filter', function (): void {
-    expect(Filter::make('active')->toData()->jsonSerialize())->toBe([
+    expect(Filter::make('active')->toData()->jsonSerialize())->toEqual([
         'key' => 'active',
         'label' => 'Active',
         'type' => 'toggle',
-        'props' => [],
+        'props' => new stdClass,
     ]);
 });
 
 it('serialises a date-range filter', function (): void {
-    expect(DateRangeFilter::make('created')->toData()->jsonSerialize())->toBe([
+    expect(DateRangeFilter::make('created')->toData()->jsonSerialize())->toEqual([
         'key' => 'created',
         'label' => 'Created',
         'type' => 'date-range',
-        'props' => [],
+        'props' => new stdClass,
     ]);
 });
 


### PR DESCRIPTION
## What & why

Map-typed wire fields (TS `Record<…, X>`) could serialize as JSON `[]` instead of `{}`, because PHP's `json_encode` can't tell an empty (or sequential-integer-keyed) array from a list. So the same field was `[]` in some cases and `{…}` in others, contradicting its object type. This makes map fields **always** serialize as objects; lists stay lists.

## Changes

- **`Wire::map()`** marks a map as `stdClass` when it's empty or `array_is_list()` (the shapes `json_encode` would emit as an array); a string-keyed map is left as-is (already encodes to an object). Applied to node `props` (all three families), `tableFilters`, and `Translatable.payload`/`replacements`.
- **`Wire::toWire()`** — object-preserving materialization (`json_decode(…, false)`) — replaces `Wire::toArray` at `Http/Page.php`'s three schema/listener sites, so the `stdClass` survives the eager round-trip into the Inertia payload (the collapse previously hit the **live** wire, not just tests). `Wire::toArray` (assoc) stays for test helpers.
- **`BadgeColumn`/`IconColumn`** route their `colors`/`icons` value-maps through `Wire::map`, so positional `colors(['gray','green'])` serializes as `{"0":"gray",…}` matching the generated `Record<string|number, string>` type.
- **Fixture pipeline** (`tests/Pest.php`): `dumpFixture` materializes object-preserving; `sortFixtureKeys`/`stripFixtureRefs` recurse over `stdClass`. This also **fixes a latent bug** where the old `ksort` listified genuine numeric-keyed maps (e.g. `colors(['1'=>'green','0'=>'gray'])`), making fixtures misrepresent the live wire.
- Guardrail: `wireJson()` raw-JSON test helper + tests asserting `{}` for empty maps and `[]` for lists.

## Notes

- The React client reads these maps by key (`props.colors?.[value]`, `Object.entries(payload)`), so objects are safe — and `Object.*` ops are actually more correct on `{}` than `[]`.
- generated.ts is unchanged (the types were already objects); this only corrects the runtime.
- Depends on the wire-serialization convergence (#233, merged).

## Acceptance

- Fixture diff is only genuine map `[]`→`{}` changes; no list objectified.
- Full gate green: `composer check` (PHPStan 0, Rector, Pest 1009 incl. ArchTest) + `npm run check` (tsc, type-cov ≥99.5%, Vitest 953, lib build).
