### PR TITLE
refactor: internal domain boundaries — form/embed, click-model ownership, lint enforcement

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,7 +15,29 @@
   },
   "rules": {
     "jsx-a11y/no-autofocus": "off",
-    "jsx-a11y/prefer-tag-over-role": "off"
+    "jsx-a11y/prefer-tag-over-role": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": [
+              "@lattice-php/lattice/action/*",
+              "@lattice-php/lattice/chat/*",
+              "@lattice-php/lattice/layout/*",
+              "@lattice-php/lattice/notifications/*",
+              "@lattice-php/lattice/remote/*",
+              "@lattice-php/lattice/table/*",
+              "@lattice-php/lattice/toast/*",
+              "@lattice-php/lattice/form/*",
+              "!@lattice-php/lattice/form/toolkit",
+              "!@lattice-php/lattice/form/embed"
+            ],
+            "message": "Feature domains are imported through their barrel (or a named surface like form/toolkit and form/embed); their implementation files are internal. Within the owning domain, use a relative import."
+          }
+        ]
+      }
+    ]
   },
   "env": {
     "builtin": true

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
       "types": "./dist/form/index.d.ts",
       "import": "./dist/form/index.js"
     },
+    "./form/embed": {
+      "types": "./dist/form/embed.d.ts",
+      "import": "./dist/form/embed.js"
+    },
     "./form/toolkit": {
       "types": "./dist/form/toolkit.d.ts",
       "import": "./dist/form/toolkit.js"

--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRegistry, Renderer } from "@lattice-php/lattice";
 import type { Node } from "@lattice-php/lattice";
-import { formComponents } from "@lattice-php/lattice/form/plugin";
+import { formComponents } from "@lattice-php/lattice/form";
 import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 import { actionComponents } from "../plugin";

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -6,13 +6,16 @@ import { Skeleton } from "@lattice-php/lattice/ui/skeleton";
 import { Spinner } from "@lattice-php/lattice/ui/spinner";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
 import type { Node } from "@lattice-php/lattice/core/types";
-import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
-import { walkFields } from "@lattice-php/lattice/form/lib/field-props";
-import { FORM_DEBOUNCE_MS } from "@lattice-php/lattice/form/lib/form-transport";
-import { PrefillProvider } from "@lattice-php/lattice/form/hooks/prefill-context";
-import { ResolvedNodesProvider } from "@lattice-php/lattice/form/hooks/resolved-nodes";
-import { useFormResolver } from "@lattice-php/lattice/form/hooks/use-form-resolver";
-import { FormValuesProvider, useFormValues } from "@lattice-php/lattice/form/hooks/values";
+import {
+  FORM_DEBOUNCE_MS,
+  FormProvider,
+  FormValuesProvider,
+  PrefillProvider,
+  ResolvedNodesProvider,
+  useFormResolver,
+  useFormValues,
+  walkFields,
+} from "@lattice-php/lattice/form/embed";
 import { useT } from "@lattice-php/lattice/i18n";
 import { dispatchActionError } from "@lattice-php/lattice/effects/dispatch";
 import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";

--- a/resources/js/action/hooks/use-click-behavior.tsx
+++ b/resources/js/action/hooks/use-click-behavior.tsx
@@ -1,6 +1,6 @@
 import type { Method } from "@inertiajs/core";
 import type { ReactNode } from "react";
-import { useAction } from "@lattice-php/lattice/action/hooks/use-action";
+import { useAction } from "./use-action";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { getActionEffects } from "@lattice-php/lattice/effects/dispatch";
 import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";

--- a/resources/js/action/index.ts
+++ b/resources/js/action/index.ts
@@ -1,3 +1,6 @@
+export { default as ActionComponent } from "./components/action";
+export { ActionForm } from "./components/action-form";
+export { default as ActionGroupComponent } from "./components/action-group";
 export {
   ActionMenuProvider,
   actionMenuItemClassName,

--- a/resources/js/action/index.ts
+++ b/resources/js/action/index.ts
@@ -1,3 +1,10 @@
+export {
+  ActionMenuProvider,
+  actionMenuItemClassName,
+  useActionMenu,
+} from "./components/action-menu-context";
 export { useAction } from "./hooks/use-action";
+export { ActionTrigger, useClickBehavior } from "./hooks/use-click-behavior";
+export type { ClickBehavior, TriggerState } from "./hooks/use-click-behavior";
 export { runAction } from "./lib/run-action";
 export { actionComponents } from "./plugin";

--- a/resources/js/events/event-bridge.tsx
+++ b/resources/js/events/event-bridge.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
-import { onToast as subscribeToToasts } from "@lattice-php/lattice/toast/toast";
-import type { ToastMessage } from "@lattice-php/lattice/toast/toast";
+import { onToast as subscribeToToasts } from "@lattice-php/lattice/toast";
+import type { ToastMessage } from "@lattice-php/lattice/toast";
 import { LATTICE_EVENT } from "./event-names";
 
 const appearances = ["light", "dark", "system"] as const;

--- a/resources/js/form/embed.ts
+++ b/resources/js/form/embed.ts
@@ -1,0 +1,17 @@
+/**
+ * Entry point for hosting a form runtime outside the `<Form>` component — action
+ * dialogs, table filter rows, and similar schema-driven surfaces. The counterpart
+ * to `toolkit.ts` (which serves custom-field authors): everything a host needs to
+ * provide form state, prefill, and dependent-field resolution around rendered
+ * fields. Form modules not re-exported here or in the toolkit are internal and
+ * may change without notice.
+ */
+export { FormProvider } from "./hooks/context";
+export { PrefillProvider } from "./hooks/prefill-context";
+export { ResolvedNodesProvider } from "./hooks/resolved-nodes";
+export { FieldCommitOverrideProvider } from "./hooks/use-field-commit";
+export { useFormResolver } from "./hooks/use-form-resolver";
+export { FormValuesProvider, useFormValues, useSetFormValue } from "./hooks/values";
+export { walkFields } from "./lib/field-props";
+export { appendPath, getPath, setPath } from "./lib/form-path";
+export { FORM_DEBOUNCE_MS } from "./lib/form-transport";

--- a/resources/js/layout/components/callouts.tsx
+++ b/resources/js/layout/components/callouts.tsx
@@ -3,10 +3,10 @@ import { useEffect, useState } from "react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import type { Callout } from "@lattice-php/lattice/types/generated";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
-import { onCallout } from "@lattice-php/lattice/toast/callout";
+import { onCallout } from "@lattice-php/lattice/toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
-import { variantStyles } from "@lattice-php/lattice/toast/variant-styles";
+import { variantStyles } from "@lattice-php/lattice/toast";
 
 type CalloutItem = Callout & { id: number };
 

--- a/resources/js/layout/components/menu-item.tsx
+++ b/resources/js/layout/components/menu-item.tsx
@@ -3,11 +3,7 @@ import { useState } from "react";
 import type { ReactNode } from "react";
 import { prefixedNodeTestId } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent, Schema } from "@lattice-php/lattice/core/types";
-import {
-  ActionTrigger,
-  type TriggerState,
-  useClickBehavior,
-} from "@lattice-php/lattice/core/hooks/use-click-behavior";
+import { ActionTrigger, type TriggerState, useClickBehavior } from "@lattice-php/lattice/action";
 import { Icon, IconRenderer } from "@lattice-php/lattice/icons";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import type { Affix } from "@lattice-php/lattice/types/generated";

--- a/resources/js/remote/components/data-list.test.tsx
+++ b/resources/js/remote/components/data-list.test.tsx
@@ -3,7 +3,7 @@ import type { Node } from "@lattice-php/lattice/core/types";
 import { clearRemoteTokenCache } from "@lattice-php/lattice/core/api";
 import { createRegistry } from "@lattice-php/lattice/core/registry";
 import { RegistryContext } from "@lattice-php/lattice/core/registry-context";
-import { actionComponents } from "@lattice-php/lattice/action/plugin";
+import { actionComponents } from "@lattice-php/lattice/action";
 import { coreComponents } from "@lattice-php/lattice/ui/plugin";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -1,7 +1,6 @@
 import { useHttp } from "@inertiajs/react";
 import { useState } from "react";
-import { ActionForm } from "@lattice-php/lattice/action/components/action-form";
-import { runAction } from "@lattice-php/lattice/action/lib/run-action";
+import { ActionForm, runAction } from "@lattice-php/lattice/action";
 import { getActionEffects } from "@lattice-php/lattice/effects/dispatch";
 import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";
 import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";

--- a/resources/js/table/components/column-visibility-menu.test.tsx
+++ b/resources/js/table/components/column-visibility-menu.test.tsx
@@ -1,4 +1,4 @@
-import type { ToggleableColumn } from "@lattice-php/lattice/table/hooks/use-column-visibility";
+import type { ToggleableColumn } from "../hooks/use-column-visibility";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ColumnVisibilityMenu } from "./column-visibility-menu";

--- a/resources/js/table/components/column-visibility-menu.tsx
+++ b/resources/js/table/components/column-visibility-menu.tsx
@@ -1,5 +1,5 @@
 import { Checkbox } from "@lattice-php/lattice/ui/checkbox";
-import type { ToggleableColumn } from "@lattice-php/lattice/table/hooks/use-column-visibility";
+import type { ToggleableColumn } from "../hooks/use-column-visibility";
 import { Icon } from "@lattice-php/lattice/icons";
 import { useT } from "@lattice-php/lattice/i18n";
 import { Popover, PopoverContent, PopoverTrigger } from "@lattice-php/lattice/ui/popover";

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -3,16 +3,17 @@ import type { ReactNode } from "react";
 import { Checkbox } from "@lattice-php/lattice/ui/checkbox";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
 import type { Node, Option } from "@lattice-php/lattice/core/types";
-import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
-import { FieldCommitOverrideProvider } from "@lattice-php/lattice/form/hooks/use-field-commit";
-import { getPath, setPath } from "@lattice-php/lattice/form/lib/form-path";
-import { PrefillProvider } from "@lattice-php/lattice/form/hooks/prefill-context";
-import { ResolvedNodesProvider } from "@lattice-php/lattice/form/hooks/resolved-nodes";
 import {
+  FieldCommitOverrideProvider,
+  FormProvider,
   FormValuesProvider,
+  getPath,
+  PrefillProvider,
+  ResolvedNodesProvider,
+  setPath,
   useFormValues,
   useSetFormValue,
-} from "@lattice-php/lattice/form/hooks/values";
+} from "@lattice-php/lattice/form/embed";
 import { Icon } from "@lattice-php/lattice/icons";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import type { FilterData } from "@lattice-php/lattice/types/generated";

--- a/resources/js/table/components/table-action-node.tsx
+++ b/resources/js/table/components/table-action-node.tsx
@@ -1,6 +1,5 @@
 import type { Node } from "@lattice-php/lattice/core/types";
-import ActionComponent from "@lattice-php/lattice/action/components/action";
-import ActionGroupComponent from "@lattice-php/lattice/action/components/action-group";
+import { ActionComponent, ActionGroupComponent } from "@lattice-php/lattice/action";
 import LinkComponent from "@lattice-php/lattice/ui/link";
 
 export function TableActionNode({ node }: { node: Node }) {

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useMemo } from "react";
 import { useT } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useColumnResizing } from "@lattice-php/lattice/core/hooks/use-column-resizing";
-import { useColumnVisibility } from "@lattice-php/lattice/table/hooks/use-column-visibility";
+import { useColumnVisibility } from "../hooks/use-column-visibility";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import { Checkbox } from "@lattice-php/lattice/ui/checkbox";
 import { Icon } from "@lattice-php/lattice/icons";

--- a/resources/js/toast/callout.test.ts
+++ b/resources/js/toast/callout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeCallout } from "@lattice-php/lattice/toast/callout";
+import { normalizeCallout } from "./callout";
 
 describe("normalizeCallout", () => {
   it("coerces a raw effect detail into a Callout", () => {

--- a/resources/js/toast/callout.ts
+++ b/resources/js/toast/callout.ts
@@ -1,6 +1,6 @@
 import type { Callout } from "@lattice-php/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
-import { isVariant } from "@lattice-php/lattice/toast/toast";
+import { isVariant } from "./toast";
 
 export type { Callout };
 

--- a/resources/js/toast/index.ts
+++ b/resources/js/toast/index.ts
@@ -3,3 +3,4 @@ export type { Callout } from "./callout";
 export { Toaster } from "./toaster";
 export { isVariant, normalizeToast, normalizeToastMessage, onToast, showToast } from "./toast";
 export type { ToastMessage, Variant } from "./toast";
+export { variantStyles } from "./variant-styles";

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -3,10 +3,10 @@ import * as Toast from "@radix-ui/react-toast";
 import { useEffect, useState } from "react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import type { ToastMessage } from "@lattice-php/lattice/types/generated";
-import { onToast } from "@lattice-php/lattice/toast/toast";
+import { onToast } from "./toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
-import { variantStyles } from "@lattice-php/lattice/toast/variant-styles";
+import { variantStyles } from "./variant-styles";
 import { resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
 
 type ToastItem = ToastMessage & { id: number };

--- a/resources/js/ui/button.tsx
+++ b/resources/js/ui/button.tsx
@@ -6,11 +6,7 @@ import { cn } from "@lattice-php/lattice/lib/utils";
 import { IconRenderer } from "@lattice-php/lattice/icons";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
-import {
-  ActionTrigger,
-  type TriggerState,
-  useClickBehavior,
-} from "@lattice-php/lattice/core/hooks/use-click-behavior";
+import { ActionTrigger, type TriggerState, useClickBehavior } from "@lattice-php/lattice/action";
 import type { ButtonVariant } from "@lattice-php/lattice/types/generated";
 
 export type { ButtonVariant };

--- a/resources/js/ui/link.test.tsx
+++ b/resources/js/ui/link.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { ActionMenuProvider } from "@lattice-php/lattice/action/components/action-menu-context";
+import { ActionMenuProvider } from "@lattice-php/lattice/action";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 import LinkComponent, { TextLink } from "./link";
 

--- a/resources/js/ui/link.tsx
+++ b/resources/js/ui/link.tsx
@@ -3,17 +3,10 @@ import type { ComponentProps } from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
-import {
-  ActionTrigger,
-  type TriggerState,
-  useClickBehavior,
-} from "@lattice-php/lattice/core/hooks/use-click-behavior";
+import { ActionTrigger, type TriggerState, useClickBehavior } from "@lattice-php/lattice/action";
 import { IconRenderer } from "@lattice-php/lattice/icons";
 import type { Affix } from "@lattice-php/lattice/types/generated";
-import {
-  actionMenuItemClassName,
-  useActionMenu,
-} from "@lattice-php/lattice/action/components/action-menu-context";
+import { actionMenuItemClassName, useActionMenu } from "@lattice-php/lattice/action";
 
 const textLinkClassName =
   "text-lt-fg underline decoration-lt-border underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-lt-border";


### PR DESCRIPTION
Completes the Phase 3 layering follow-up from #242. Three commits, behavior-neutral.

## 1. `form/embed` — the form-hosting surface (`cf09e629`)

Action dialogs and table filter controls both embed a full form runtime; each reached into six form internals to do it. `form/embed.ts` now exports the host kit (providers, resolver, path helpers, transport constant) as a declared contract — the counterpart to `form/toolkit` (custom-field authors). Exposed as `./form/embed` in package.json.

## 2. Click model re-homed into `action/` (`9561efaa`)

`useClickBehavior`/`ActionTrigger` resolve a clickable's server-action branch, so they move from `core/hooks/` to `action/hooks/`. Button, Link, and MenuItem import the click model and menu context through the action barrel — the `ui → action` edge is now explicit instead of a core→feature inversion. The `ui ↔ action` module cycle predates this change and stays init-safe (all cross-references happen inside render).

## 3. Barrel-only imports for feature domains, enforced (`421e7590`)

The remaining cross-domain deep imports are rewired (`bulk-bar`/`table-action-node` → action barrel, `layout`/`events` → toast barrel, same-domain alias imports → relative), with `ActionComponent`/`ActionGroupComponent`/`ActionForm` and `variantStyles` promoted to their barrels. A `no-restricted-imports` rule in `.oxlintrc.json` now enforces the boundary: feature domains (action, chat, form, layout, notifications, remote, table, toast) are importable only via their barrel or a named surface (`form/toolkit`, `form/embed`); foundation domains (core, ui, lib, types, i18n, icons, format, effects, events) stay freely importable. Verified the rule fires (custom message, exceptions honored) before landing it.

The one known allowlisted edge: `core/registry` imports `type { ColumnRegistry }` from table — type-only, erased at runtime, and every alternative costs more than it saves.

## Verification

Full `npm run check` green: lint (including the new rule), format, typecheck, 99.5% type coverage, 956 tests across 166 files (jsdom + browser), library build.