### PR TITLE
test: clean up Pest suite stability

### DIFF
--- a/docs/fixtures/rich-editor.basic.json
+++ b/docs/fixtures/rich-editor.basic.json
@@ -11,7 +11,7 @@
             "hidden": false,
             "label": "Article",
             "name": "article",
-            "placeholder": "Write your article\u2026",
+            "placeholder": "Write your article…",
             "prefillRefreshOn": null,
             "prefillResetOn": null,
             "readOnly": false,

--- a/docs/fixtures/select.basic.json
+++ b/docs/fixtures/select.basic.json
@@ -37,7 +37,7 @@
             "prefillResetOn": null,
             "readOnly": false,
             "required": false,
-            "searchPlaceholder": "Search\u2026",
+            "searchPlaceholder": "Search…",
             "searchable": false,
             "tabIndex": null,
             "tooltip": null,

--- a/docs/fixtures/select.multiple.json
+++ b/docs/fixtures/select.multiple.json
@@ -37,7 +37,7 @@
             "prefillResetOn": null,
             "readOnly": false,
             "required": false,
-            "searchPlaceholder": "Search\u2026",
+            "searchPlaceholder": "Search…",
             "searchable": false,
             "tabIndex": null,
             "tooltip": null,

--- a/src/Support/Testing/InteractsWithLatticeComponents.php
+++ b/src/Support/Testing/InteractsWithLatticeComponents.php
@@ -104,7 +104,7 @@ trait InteractsWithLatticeComponents
             $url .= '?'.http_build_query($query);
         }
 
-        return $this->getJson($url, $this->latticeHeaders($this->latticeRef($component)));
+        return $this->getJson($url, $this->latticeHeaders($component));
     }
 
     /**
@@ -118,7 +118,7 @@ trait InteractsWithLatticeComponents
 
         return $this->getJson(
             $component['props']['endpoint'],
-            $this->latticeHeaders($this->latticeRef($component)),
+            $this->latticeHeaders($component),
         );
     }
 
@@ -131,10 +131,14 @@ trait InteractsWithLatticeComponents
     }
 
     /**
-     * @param  array<string, mixed>  $component
+     * @param  array<string, mixed>|string  $component
      */
-    private function latticeRef(array $component): string
+    protected function latticeRef(array|string $component): string
     {
+        if (is_string($component)) {
+            return $component;
+        }
+
         $props = $component['props'] ?? [];
         $ref = is_array($props) ? ($props['ref'] ?? null) : null;
 
@@ -146,11 +150,13 @@ trait InteractsWithLatticeComponents
     }
 
     /**
+     * @param  array<string, mixed>|string  $component
+     * @param  array<string, string>  $headers
      * @return array<string, string>
      */
-    private function latticeHeaders(string $ref): array
+    protected function latticeHeaders(array|string $component, array $headers = []): array
     {
-        return ['X-Lattice-Ref' => $ref];
+        return array_merge(['X-Lattice-Ref' => $this->latticeRef($component)], $headers);
     }
 
     /**

--- a/tests/Browser/ChartsPageTest.php
+++ b/tests/Browser/ChartsPageTest.php
@@ -19,9 +19,13 @@ it('loads dashboard chart examples through lazy fragments', function (): void {
 it('translates dashboard chart examples in lazy fragments', function (): void {
     $this->actingAs(workbenchTestUser());
 
-    visit('/')
+    $page = visit('/')
         ->click('@locale-switcher')
-        ->click('@locale-de')
+        ->click('@locale-de');
+
+    eventually(fn () => $page->assertSee('Umsatz'));
+
+    $page
         ->assertSee('Dashboard-Diagramme')
         ->assertSee('Umsatztrend')
         ->assertSee('Prognose')

--- a/tests/Browser/ChartsPageTest.php
+++ b/tests/Browser/ChartsPageTest.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-use Pest\Browser\Api\Webpage;
 
 it('loads dashboard chart examples through lazy fragments', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -24,7 +23,9 @@ it('translates dashboard chart examples in lazy fragments', function (): void {
         ->click('@locale-switcher')
         ->click('@locale-de');
 
-    eventually(fn (): Webpage => $page->assertSee('Umsatz'));
+    eventually(function () use ($page): void {
+        $page->assertSee('Umsatz');
+    });
 
     $page
         ->assertSee('Dashboard-Diagramme')

--- a/tests/Browser/ChartsPageTest.php
+++ b/tests/Browser/ChartsPageTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+use Pest\Browser\Api\Webpage;
 
 it('loads dashboard chart examples through lazy fragments', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -23,7 +24,7 @@ it('translates dashboard chart examples in lazy fragments', function (): void {
         ->click('@locale-switcher')
         ->click('@locale-de');
 
-    eventually(fn () => $page->assertSee('Umsatz'));
+    eventually(fn (): Webpage => $page->assertSee('Umsatz'));
 
     $page
         ->assertSee('Dashboard-Diagramme')

--- a/tests/Browser/Chat/FloatingChatTest.php
+++ b/tests/Browser/Chat/FloatingChatTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Pest\Browser\Api\Webpage;
 
 it('mounts the floating chat trigger on every page', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -30,7 +31,7 @@ it('shows an optimistic user bubble when a message is sent', function (): void {
         ->click('@assistant-chat-trigger')
         ->assertVisible('@chat-box');
 
-    $page->script(<<<'JS'
+    $page->script(<<<'JS_WRAP'
         (() => {
             const originalFetch = window.fetch.bind(window);
 
@@ -53,13 +54,13 @@ it('shows an optimistic user bubble when a message is sent', function (): void {
                 return originalFetch(input, init);
             };
         })();
-    JS);
+    JS_WRAP);
 
     $page->type('@chat-input', 'Hello from the browser test')
         ->click('@chat-send');
 
-    eventually(fn () => $page->assertSee('Hello from the browser test'));
-    eventually(fn () => $page->assertSee('Stubbed assistant response.'));
+    eventually(fn (): Webpage => $page->assertSee('Hello from the browser test'));
+    eventually(fn (): Webpage => $page->assertSee('Stubbed assistant response.'));
 
     $page->assertNoSmoke()
         ->assertNoJavaScriptErrors();

--- a/tests/Browser/Chat/FloatingChatTest.php
+++ b/tests/Browser/Chat/FloatingChatTest.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-use Pest\Browser\Api\Webpage;
 
 it('mounts the floating chat trigger on every page', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -59,8 +58,12 @@ it('shows an optimistic user bubble when a message is sent', function (): void {
     $page->type('@chat-input', 'Hello from the browser test')
         ->click('@chat-send');
 
-    eventually(fn (): Webpage => $page->assertSee('Hello from the browser test'));
-    eventually(fn (): Webpage => $page->assertSee('Stubbed assistant response.'));
+    eventually(function () use ($page): void {
+        $page->assertSee('Hello from the browser test');
+    });
+    eventually(function () use ($page): void {
+        $page->assertSee('Stubbed assistant response.');
+    });
 
     $page->assertNoSmoke()
         ->assertNoJavaScriptErrors();

--- a/tests/Browser/Chat/FloatingChatTest.php
+++ b/tests/Browser/Chat/FloatingChatTest.php
@@ -28,11 +28,38 @@ it('shows an optimistic user bubble when a message is sent', function (): void {
 
     $page = visit('/')
         ->click('@assistant-chat-trigger')
-        ->assertVisible('@chat-box')
-        ->type('@chat-input', 'How do I export a table?')
+        ->assertVisible('@chat-box');
+
+    $page->script(<<<'JS'
+        (() => {
+            const originalFetch = window.fetch.bind(window);
+
+            window.fetch = (input, init) => {
+                const url = typeof input === 'string' ? input : input.url;
+
+                if (url.includes('/workbench/chat/stream')) {
+                    const body = [
+                        JSON.stringify({ type: 'text', value: 'Stubbed assistant response.' }),
+                        JSON.stringify({ type: 'done' }),
+                        '',
+                    ].join('\n');
+
+                    return Promise.resolve(new Response(body, {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/x-ndjson' },
+                    }));
+                }
+
+                return originalFetch(input, init);
+            };
+        })();
+    JS);
+
+    $page->type('@chat-input', 'Hello from the browser test')
         ->click('@chat-send');
 
-    $page->assertSee('How do I export a table?');
+    eventually(fn () => $page->assertSee('Hello from the browser test'));
+    eventually(fn () => $page->assertSee('Stubbed assistant response.'));
 
     $page->assertNoSmoke()
         ->assertNoJavaScriptErrors();

--- a/tests/Browser/Forms/FileUploadFieldTest.php
+++ b/tests/Browser/Forms/FileUploadFieldTest.php
@@ -6,16 +6,14 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Rules\FileUploadItem;
-use Pest\Browser\Api\Webpage;
 
 it('uploads a file through a multipart payload', function (): void {
     $this->actingAs(workbenchTestUser());
 
     $page = visit('/uploads/create')
         ->assertSee('Drop files here or click to browse');
-    $webpage = new Webpage($page->page(), $page->url());
 
-    attachBrowserFilePayload($webpage, '@avatar-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
+    attachBrowserFilePayload($page, '@avatar-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
 
     eventually(fn () => $page->assertSee('avatar.jpg'));
 
@@ -43,9 +41,8 @@ it('uploads directly to s3 via the signed flow', function (): void {
 
     $page = visit('/uploads/create?signed=1')
         ->assertPresent('@document-input');
-    $webpage = new Webpage($page->page(), $page->url());
 
-    attachBrowserFilePayload($webpage, '@document-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
+    attachBrowserFilePayload($page, '@document-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
 
     eventually(fn () => $page->assertSee('avatar.jpg'));
     eventually(fn () => $page->assertPresent('[data-test="document-uploaded"]'));

--- a/tests/Browser/Forms/FileUploadFieldTest.php
+++ b/tests/Browser/Forms/FileUploadFieldTest.php
@@ -6,14 +6,20 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Rules\FileUploadItem;
+use Pest\Browser\Api\Webpage;
 
-it('uploads a file via multipart and shows it in the dropzone', function (): void {
+it('uploads a file through a multipart payload', function (): void {
     $this->actingAs(workbenchTestUser());
-    visit('/uploads/create')
-        ->assertSee('Drop files here or click to browse')
-        ->attach('@avatar-input', __DIR__.'/fixtures/avatar.jpg')
-        ->assertSee('avatar.jpg')
-        ->click('@form-submit')
+
+    $page = visit('/uploads/create')
+        ->assertSee('Drop files here or click to browse');
+    $webpage = new Webpage($page->page(), $page->url());
+
+    attachBrowserFilePayload($webpage, '@avatar-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
+
+    eventually(fn () => $page->assertSee('avatar.jpg'));
+
+    $page->click('@form-submit')
         ->assertSee('Uploads')
         ->assertNoSmoke();
 });
@@ -29,16 +35,30 @@ it('removes an existing file from the edit form', function (): void {
 });
 
 it('uploads directly to s3 via the signed flow', function (): void {
+    if (! rustfsIsReachable()) {
+        $this->markTestSkipped('RustFS/S3 is not reachable.');
+    }
+
     $this->actingAs(workbenchTestUser());
-    visit('/uploads/create')
-        ->assertSee('Drop files here or click to browse')
-        ->attach('@document-input', __DIR__.'/fixtures/avatar.jpg')
-        ->assertPresent('[data-test="document-uploaded"]')
-        ->click('@form-submit')
+
+    $page = visit('/uploads/create?signed=1')
+        ->assertPresent('@document-input');
+    $webpage = new Webpage($page->page(), $page->url());
+
+    attachBrowserFilePayload($webpage, '@document-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
+
+    eventually(fn () => $page->assertSee('avatar.jpg'));
+    eventually(fn () => $page->assertPresent('[data-test="document-uploaded"]'));
+
+    $page->click('@form-submit')
         ->assertNoSmoke();
 })->group('rustfs');
 
 it('signs, uploads, and validates a key against rustfs end-to-end', function (): void {
+    if (! rustfsIsReachable()) {
+        $this->markTestSkipped('RustFS/S3 is not reachable.');
+    }
+
     $this->actingAs(workbenchTestUser());
     $signed = FileUpload::make('document')->disk('s3')->signedUpload()
         ->signUpload(Request::create('/', 'POST', ['filename' => 'invoice.pdf']));

--- a/tests/Browser/Forms/FileUploadFieldTest.php
+++ b/tests/Browser/Forms/FileUploadFieldTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Rules\FileUploadItem;
-use Pest\Browser\Api\Webpage;
 
 it('uploads a file through a multipart payload', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -16,7 +15,9 @@ it('uploads a file through a multipart payload', function (): void {
 
     attachBrowserFilePayload($page, '@avatar-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
 
-    eventually(fn (): Webpage => $page->assertSee('avatar.jpg'));
+    eventually(function () use ($page): void {
+        $page->assertSee('avatar.jpg');
+    });
 
     $page->click('@form-submit')
         ->assertSee('Uploads')
@@ -45,8 +46,12 @@ it('uploads directly to s3 via the signed flow', function (): void {
 
     attachBrowserFilePayload($page, '@document-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
 
-    eventually(fn (): Webpage => $page->assertSee('avatar.jpg'));
-    eventually(fn (): Webpage => $page->assertPresent('[data-test="document-uploaded"]'));
+    eventually(function () use ($page): void {
+        $page->assertSee('avatar.jpg');
+    });
+    eventually(function () use ($page): void {
+        $page->assertPresent('[data-test="document-uploaded"]');
+    });
 
     $page->click('@form-submit')
         ->assertNoSmoke();

--- a/tests/Browser/Forms/FileUploadFieldTest.php
+++ b/tests/Browser/Forms/FileUploadFieldTest.php
@@ -13,7 +13,7 @@ it('uploads a file through a multipart payload', function (): void {
     $page = visit('/uploads/create')
         ->assertSee('Drop files here or click to browse');
 
-    attachBrowserFilePayload($page, '@avatar-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
+    $page->attach('@avatar-input', __DIR__.'/fixtures/avatar.jpg');
 
     eventually(function () use ($page): void {
         $page->assertSee('avatar.jpg');
@@ -44,7 +44,7 @@ it('uploads directly to s3 via the signed flow', function (): void {
     $page = visit('/uploads/create?signed=1')
         ->assertPresent('@document-input');
 
-    attachBrowserFilePayload($page, '@document-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
+    $page->attach('@document-input', __DIR__.'/fixtures/avatar.jpg');
 
     eventually(function () use ($page): void {
         $page->assertSee('avatar.jpg');

--- a/tests/Browser/Forms/FileUploadFieldTest.php
+++ b/tests/Browser/Forms/FileUploadFieldTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Rules\FileUploadItem;
+use Pest\Browser\Api\Webpage;
 
 it('uploads a file through a multipart payload', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -15,7 +16,7 @@ it('uploads a file through a multipart payload', function (): void {
 
     attachBrowserFilePayload($page, '@avatar-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
 
-    eventually(fn () => $page->assertSee('avatar.jpg'));
+    eventually(fn (): Webpage => $page->assertSee('avatar.jpg'));
 
     $page->click('@form-submit')
         ->assertSee('Uploads')
@@ -44,8 +45,8 @@ it('uploads directly to s3 via the signed flow', function (): void {
 
     attachBrowserFilePayload($page, '@document-input', __DIR__.'/fixtures/avatar.jpg', 'image/jpeg');
 
-    eventually(fn () => $page->assertSee('avatar.jpg'));
-    eventually(fn () => $page->assertPresent('[data-test="document-uploaded"]'));
+    eventually(fn (): Webpage => $page->assertSee('avatar.jpg'));
+    eventually(fn (): Webpage => $page->assertPresent('[data-test="document-uploaded"]'));
 
     $page->click('@form-submit')
         ->assertNoSmoke();

--- a/tests/Browser/I18nTest.php
+++ b/tests/Browser/I18nTest.php
@@ -47,7 +47,7 @@ it('dumps missing React lattice keys back into the package lang file', function 
 
     try {
         $page->assertSee('Article')
-            ->assertPresent('[aria-label="Italic"]')
+            ->assertPresent('@editor-italic')
             ->assertNoJavaScriptErrors();
 
         expect(waitForLatticeBrowserTestTranslation($file, 'editor.italic'))

--- a/tests/Browser/I18nTest.php
+++ b/tests/Browser/I18nTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
+use Pest\Browser\Api\Webpage;
 
 use function Orchestra\Testbench\package_path;
 
@@ -57,7 +58,7 @@ it('dumps missing React lattice keys back into the package lang file', function 
     } finally {
         try {
             $page->script('window.location.assign("/")');
-            eventually(fn () => $page->assertPathIs('/'), attempts: 15, sleepMicroseconds: 100_000);
+            eventually(fn (): Webpage => $page->assertPathIs('/'), attempts: 15, sleepMicroseconds: 100_000);
         } finally {
             File::replace($file, $original, 0644);
         }

--- a/tests/Browser/I18nTest.php
+++ b/tests/Browser/I18nTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
-use Pest\Browser\Api\Webpage;
 
 use function Orchestra\Testbench\package_path;
 
@@ -58,7 +57,9 @@ it('dumps missing React lattice keys back into the package lang file', function 
     } finally {
         try {
             $page->script('window.location.assign("/")');
-            eventually(fn (): Webpage => $page->assertPathIs('/'), attempts: 15, sleepMicroseconds: 100_000);
+            eventually(function () use ($page): void {
+                $page->assertPathIs('/');
+            }, attempts: 15, sleepMicroseconds: 100_000);
         } finally {
             File::replace($file, $original, 0644);
         }

--- a/tests/Browser/I18nTest.php
+++ b/tests/Browser/I18nTest.php
@@ -57,7 +57,7 @@ it('dumps missing React lattice keys back into the package lang file', function 
     } finally {
         try {
             $page->script('window.location.assign("/")');
-            $page->wait(0.5);
+            eventually(fn () => $page->assertPathIs('/'), attempts: 15, sleepMicroseconds: 100_000);
         } finally {
             File::replace($file, $original, 0644);
         }

--- a/tests/Browser/Layout/ChatLayoutToggleTest.php
+++ b/tests/Browser/Layout/ChatLayoutToggleTest.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 it('reveals the docked chat panel when the chat layout is toggled', function (): void {
     $this->actingAs(workbenchTestUser());
 
-    visit('/')
+    $page = visit('/')
         ->assertVisible('@assistant-chat-trigger')
         ->assertMissing('@chat-box')
         ->click('@user-menu')
         ->assertSee('Reveal chat in a side rail')
-        ->click('@chat-layout-toggle')
-        ->assertVisible('@chat-box')
+        ->click('@chat-layout-toggle');
+
+    eventually(fn () => $page->assertVisible('@chat-box'));
+
+    $page
         ->assertMissing('@assistant-chat-trigger')
         ->assertSee('Dock chat back to floating')
         ->click('@chat-layout-toggle')

--- a/tests/Browser/Layout/ChatLayoutToggleTest.php
+++ b/tests/Browser/Layout/ChatLayoutToggleTest.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-use Pest\Browser\Api\Webpage;
 
 it('reveals the docked chat panel when the chat layout is toggled', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -13,7 +12,9 @@ it('reveals the docked chat panel when the chat layout is toggled', function ():
         ->assertSee('Reveal chat in a side rail')
         ->click('@chat-layout-toggle');
 
-    eventually(fn (): Webpage => $page->assertVisible('@chat-box'));
+    eventually(function () use ($page): void {
+        $page->assertVisible('@chat-box');
+    });
 
     $page
         ->assertMissing('@assistant-chat-trigger')

--- a/tests/Browser/Layout/ChatLayoutToggleTest.php
+++ b/tests/Browser/Layout/ChatLayoutToggleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Pest\Browser\Api\Webpage;
 
 it('reveals the docked chat panel when the chat layout is toggled', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -12,7 +13,7 @@ it('reveals the docked chat panel when the chat layout is toggled', function ():
         ->assertSee('Reveal chat in a side rail')
         ->click('@chat-layout-toggle');
 
-    eventually(fn () => $page->assertVisible('@chat-box'));
+    eventually(fn (): Webpage => $page->assertVisible('@chat-box'));
 
     $page
         ->assertMissing('@assistant-chat-trigger')

--- a/tests/Browser/Layout/DropdownTest.php
+++ b/tests/Browser/Layout/DropdownTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+use Pest\Browser\Api\Webpage;
 
 it('opens the composed user dropdown and reveals its items', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -17,7 +18,7 @@ it('keeps the user dropdown usable when the sidebar is collapsed', function (): 
     $page = visit('/')
         ->click('@sidebar-toggle');
 
-    eventually(fn () => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
+    eventually(fn (): Webpage => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
 
     $page
         ->click('@user-menu')

--- a/tests/Browser/Layout/DropdownTest.php
+++ b/tests/Browser/Layout/DropdownTest.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-use Pest\Browser\Api\Webpage;
 
 it('opens the composed user dropdown and reveals its items', function (): void {
     $this->actingAs(workbenchTestUser());
@@ -18,7 +17,9 @@ it('keeps the user dropdown usable when the sidebar is collapsed', function (): 
     $page = visit('/')
         ->click('@sidebar-toggle');
 
-    eventually(fn (): Webpage => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
+    eventually(function () use ($page): void {
+        $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true');
+    });
 
     $page
         ->click('@user-menu')

--- a/tests/Browser/Layout/DropdownTest.php
+++ b/tests/Browser/Layout/DropdownTest.php
@@ -13,9 +13,13 @@ it('opens the composed user dropdown and reveals its items', function (): void {
 
 it('keeps the user dropdown usable when the sidebar is collapsed', function (): void {
     $this->actingAs(workbenchTestUser());
-    visit('/')
-        ->click('@sidebar-toggle')
-        ->assertPresent('[data-test="sidebar"][data-collapsed="true"]')
+
+    $page = visit('/')
+        ->click('@sidebar-toggle');
+
+    eventually(fn () => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
+
+    $page
         ->click('@user-menu')
         ->assertSee('Log out')
         ->assertNoSmoke();

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\Product;
 
 it('expands a collapsed menu group and navigates to a sub-page', function (): void {
@@ -35,7 +36,7 @@ it('collapses to an icon rail and opens a group submenu as a flyout', function (
         ->assertPresent('[data-test="sidebar"][data-collapsed="false"]')
         ->click('@sidebar-toggle');
 
-    eventually(fn () => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
+    eventually(fn (): Webpage => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
 
     $page
         ->click('@menu-commerce')
@@ -53,7 +54,7 @@ it('opens the sidebar as an off-canvas drawer on mobile', function (): void {
         ->assertMissing('[data-test="sidebar-backdrop"]')
         ->click('@sidebar-toggle');
 
-    eventually(fn () => $page->assertPresent('[data-test="sidebar-backdrop"]'));
+    eventually(fn (): Webpage => $page->assertPresent('[data-test="sidebar-backdrop"]'));
 
     $page
         ->click('@menu-tabs')

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -1,7 +1,6 @@
 <?php
 declare(strict_types=1);
 
-use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\Product;
 
 it('expands a collapsed menu group and navigates to a sub-page', function (): void {
@@ -36,7 +35,9 @@ it('collapses to an icon rail and opens a group submenu as a flyout', function (
         ->assertPresent('[data-test="sidebar"][data-collapsed="false"]')
         ->click('@sidebar-toggle');
 
-    eventually(fn (): Webpage => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
+    eventually(function () use ($page): void {
+        $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true');
+    });
 
     $page
         ->click('@menu-commerce')
@@ -54,7 +55,9 @@ it('opens the sidebar as an off-canvas drawer on mobile', function (): void {
         ->assertMissing('[data-test="sidebar-backdrop"]')
         ->click('@sidebar-toggle');
 
-    eventually(fn (): Webpage => $page->assertPresent('[data-test="sidebar-backdrop"]'));
+    eventually(function () use ($page): void {
+        $page->assertPresent('[data-test="sidebar-backdrop"]');
+    });
 
     $page
         ->click('@menu-tabs')

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -31,10 +31,13 @@ it('collapses to an icon rail and opens a group submenu as a flyout', function (
     $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp']);
 
-    visit('/')
+    $page = visit('/')
         ->assertPresent('[data-test="sidebar"][data-collapsed="false"]')
-        ->click('@sidebar-toggle')
-        ->assertPresent('[data-test="sidebar"][data-collapsed="true"]')
+        ->click('@sidebar-toggle');
+
+    eventually(fn () => $page->assertAttribute('[data-test="sidebar"]', 'data-collapsed', 'true'));
+
+    $page
         ->click('@menu-commerce')
         ->click('@menu-products')
         ->assertSee('Desk Lamp')
@@ -45,11 +48,14 @@ it('collapses to an icon rail and opens a group submenu as a flyout', function (
 it('opens the sidebar as an off-canvas drawer on mobile', function (): void {
     $this->actingAs(workbenchTestUser());
 
-    visit('/')
+    $page = visit('/')
         ->on()->mobile()
         ->assertMissing('[data-test="sidebar-backdrop"]')
-        ->click('@sidebar-toggle')
-        ->assertPresent('[data-test="sidebar-backdrop"]')
+        ->click('@sidebar-toggle');
+
+    eventually(fn () => $page->assertPresent('[data-test="sidebar-backdrop"]'));
+
+    $page
         ->click('@menu-tabs')
         ->assertMissing('[data-test="sidebar-backdrop"]')
         ->assertNoSmoke();

--- a/tests/Browser/LocaleSwitchTest.php
+++ b/tests/Browser/LocaleSwitchTest.php
@@ -7,11 +7,15 @@ it('switches the server-driven UI language in place when the locale changes', fu
     $this->actingAs(workbenchTestUser());
     Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
-    visit('/products')
+    $page = visit('/products')
         ->assertSee('Updated at')
         ->click('@locale-switcher')
-        ->click('@locale-de')
+        ->click('@locale-de');
+
+    eventually(fn () => $page
         ->assertSee('Aktualisiert am')
-        ->assertDontSee('Updated at')
+        ->assertDontSee('Updated at'));
+
+    $page
         ->assertNoSmoke();
 });

--- a/tests/Browser/LocaleSwitchTest.php
+++ b/tests/Browser/LocaleSwitchTest.php
@@ -1,7 +1,6 @@
 <?php
 declare(strict_types=1);
 
-use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\Product;
 
 it('switches the server-driven UI language in place when the locale changes', function (): void {
@@ -13,9 +12,11 @@ it('switches the server-driven UI language in place when the locale changes', fu
         ->click('@locale-switcher')
         ->click('@locale-de');
 
-    eventually(fn (): Webpage => $page
-        ->assertSee('Aktualisiert am')
-        ->assertDontSee('Updated at'));
+    eventually(function () use ($page): void {
+        $page
+            ->assertSee('Aktualisiert am')
+            ->assertDontSee('Updated at');
+    });
 
     $page
         ->assertNoSmoke();

--- a/tests/Browser/LocaleSwitchTest.php
+++ b/tests/Browser/LocaleSwitchTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\Product;
 
 it('switches the server-driven UI language in place when the locale changes', function (): void {
@@ -12,7 +13,7 @@ it('switches the server-driven UI language in place when the locale changes', fu
         ->click('@locale-switcher')
         ->click('@locale-de');
 
-    eventually(fn () => $page
+    eventually(fn (): Webpage => $page
         ->assertSee('Aktualisiert am')
         ->assertDontSee('Updated at'));
 

--- a/tests/Browser/Notifications/NotificationBellTest.php
+++ b/tests/Browser/Notifications/NotificationBellTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Notifications\Notification;
+use Pest\Browser\Api\Webpage;
 
 it('shows the bell, opens the panel, and marks notifications read', function (): void {
     $user = workbenchTestUser();
@@ -34,7 +35,7 @@ it('renders the slide-out variant when configured', function (): void {
         ->assertSee('Notification Slide Out')
         ->click('@notifications-trigger');
 
-    eventually(fn () => $page
+    eventually(fn (): Webpage => $page
         ->assertVisible('[data-slot="dialog-overlay"]')
         ->assertVisible('[data-slot="dialog-content"]')
         ->assertNotPresent('[data-slot="popover-content"]')

--- a/tests/Browser/Notifications/NotificationBellTest.php
+++ b/tests/Browser/Notifications/NotificationBellTest.php
@@ -35,6 +35,9 @@ it('renders the slide-out variant when configured', function (): void {
         ->click('@notifications-trigger');
 
     eventually(fn () => $page
+        ->assertVisible('[data-slot="dialog-overlay"]')
+        ->assertVisible('[data-slot="dialog-content"]')
+        ->assertNotPresent('[data-slot="popover-content"]')
         ->assertVisible('@notifications-panel')
         ->assertSee('Slide out notice')
         ->assertSee('This notification opens inside the slide-out panel.'));

--- a/tests/Browser/Notifications/NotificationBellTest.php
+++ b/tests/Browser/Notifications/NotificationBellTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Notifications\Notification;
-use Pest\Browser\Api\Webpage;
 
 it('shows the bell, opens the panel, and marks notifications read', function (): void {
     $user = workbenchTestUser();
@@ -35,13 +34,15 @@ it('renders the slide-out variant when configured', function (): void {
         ->assertSee('Notification Slide Out')
         ->click('@notifications-trigger');
 
-    eventually(fn (): Webpage => $page
-        ->assertVisible('[data-slot="dialog-overlay"]')
-        ->assertVisible('[data-slot="dialog-content"]')
-        ->assertNotPresent('[data-slot="popover-content"]')
-        ->assertVisible('@notifications-panel')
-        ->assertSee('Slide out notice')
-        ->assertSee('This notification opens inside the slide-out panel.'));
+    eventually(function () use ($page): void {
+        $page
+            ->assertVisible('[data-slot="dialog-overlay"]')
+            ->assertVisible('[data-slot="dialog-content"]')
+            ->assertNotPresent('[data-slot="popover-content"]')
+            ->assertVisible('@notifications-panel')
+            ->assertSee('Slide out notice')
+            ->assertSee('This notification opens inside the slide-out panel.');
+    });
 
     $page->assertNoSmoke();
 });

--- a/tests/Browser/Notifications/NotificationBellTest.php
+++ b/tests/Browser/Notifications/NotificationBellTest.php
@@ -20,6 +20,24 @@ it('shows the bell, opens the panel, and marks notifications read', function ():
         ->assertNoSmoke();
 });
 
-it('renders the slide-out variant when configured')->todo(
-    'Requires a workbench route/layout variant using Notifications::make()->slideOut(); add a dedicated workbench demo page if AppLayout uses the default popover bell.'
-);
+it('renders the slide-out variant when configured', function (): void {
+    $user = workbenchTestUser();
+
+    Notification::make()
+        ->title('Slide out notice')
+        ->body('This notification opens inside the slide-out panel.')
+        ->sendToDatabase($user);
+
+    $this->actingAs($user);
+
+    $page = visit('/notifications-slide-out')
+        ->assertSee('Notification Slide Out')
+        ->click('@notifications-trigger');
+
+    eventually(fn () => $page
+        ->assertVisible('@notifications-panel')
+        ->assertSee('Slide out notice')
+        ->assertSee('This notification opens inside the slide-out panel.'));
+
+    $page->assertNoSmoke();
+});

--- a/tests/Feature/Actions/ActionFormTest.php
+++ b/tests/Feature/Actions/ActionFormTest.php
@@ -40,7 +40,7 @@ it('validates submitted values against a lazy form schema', function (): void {
     $ref = componentRef(wire(ActionComponent::use(EditActionFixture::class)->context(['current_title' => 'Existing'])));
 
     postJson('/lattice/actions/test.edit', ['title' => ''], latticeHeaders($ref))
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors('title');
 
     postJson('/lattice/actions/test.edit', ['title' => 'Renamed'], latticeHeaders($ref))
@@ -82,7 +82,7 @@ it('rejects an invalid embedded form with a 422', function (): void {
     Lattice::actions([RejectActionFixture::class]);
 
     $this->callAction(RejectActionFixture::class, ['reason' => ''])
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors('reason');
 });
 
@@ -90,7 +90,7 @@ it('validates final embedded form submissions before handle is called', function
     Lattice::actions([UnvalidatedRejectActionFixture::class]);
 
     $this->callAction(UnvalidatedRejectActionFixture::class, ['reason' => ''])
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors('reason');
 
     expect(session('handled-unvalidated-reject'))->toBeNull();
@@ -106,7 +106,7 @@ it('validates the embedded form precognitively without running handle', function
     ]);
 
     postJson('/lattice/actions/test.reject', ['reason' => 'this reason is far too long'], $precognition)
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors('reason');
 
     postJson('/lattice/actions/test.reject', ['reason' => 'ok'], $precognition)

--- a/tests/Feature/Actions/ProductActionsTest.php
+++ b/tests/Feature/Actions/ProductActionsTest.php
@@ -128,12 +128,12 @@ test('bulk form actions validate the submitted reason before archiving', functio
         ['table' => 'workbench.products'],
     );
 
-    $headers = ['Accept' => 'application/json', 'X-Lattice-Ref' => $ref];
+    $headers = $this->latticeHeaders($ref, ['Accept' => 'application/json']);
 
     patch('/lattice/bulk-actions/workbench.products.reject-selected', [
         'selected' => [$product->getKey()],
     ], $headers)
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors('reason');
 
     expect($product->fresh()->status)->toBe('active');
@@ -161,16 +161,15 @@ test('bulk form actions validate precognitively without archiving', function ():
         ['table' => 'workbench.products'],
     );
 
-    $precognition = [
-        'X-Lattice-Ref' => $ref,
+    $precognition = $this->latticeHeaders($ref, [
         'Precognition' => 'true',
         'Precognition-Validate-Only' => 'reason',
-    ];
+    ]);
 
     patch('/lattice/bulk-actions/workbench.products.reject-selected', [
         'reason' => '',
         'selected' => [$product->getKey()],
-    ], $precognition)->assertStatus(422)->assertJsonValidationErrors('reason');
+    ], $precognition)->assertUnprocessable()->assertJsonValidationErrors('reason');
 
     patch('/lattice/bulk-actions/workbench.products.reject-selected', [
         'reason' => 'Counterfeit',

--- a/tests/Feature/Forms/FileUploadFieldTest.php
+++ b/tests/Feature/Forms/FileUploadFieldTest.php
@@ -91,7 +91,7 @@ it('returns 422 when the field does not use signed uploads', function (): void {
     Lattice::forms([UploadForm::class]);
 
     $this->submitForm(UploadForm::class, ['_upload' => 'avatar', 'filename' => 'photo.jpg'])
-        ->assertStatus(422);
+        ->assertUnprocessable();
 });
 
 it('returns 404 when the upload field does not exist', function (): void {
@@ -129,7 +129,7 @@ it('rejects a multipart image upload that exceeds maxSize', function (): void {
 
     post('/lattice/forms/workbench.upload.form', [
         'avatar' => UploadedFile::fake()->create('huge.jpg', 5000, 'image/jpeg'),
-    ], ['X-Lattice-Ref' => componentRef($form)])
+    ], $this->latticeHeaders($form))
         ->assertSessionHasErrors(['avatar']);
 });
 
@@ -142,10 +142,10 @@ it('accepts a signed tmp key that exists and rejects an out-of-prefix key', func
 
     $form = wire(Form::use(UploadForm::class));
 
-    post('/lattice/forms/workbench.upload.form', ['document' => 'tmp/real.pdf'], ['X-Lattice-Ref' => componentRef($form)])
+    post('/lattice/forms/workbench.upload.form', ['document' => 'tmp/real.pdf'], $this->latticeHeaders($form))
         ->assertRedirect('/uploads');
 
-    post('/lattice/forms/workbench.upload.form', ['document' => 'uploads/secret.pdf'], ['X-Lattice-Ref' => componentRef($form)])
+    post('/lattice/forms/workbench.upload.form', ['document' => 'uploads/secret.pdf'], $this->latticeHeaders($form))
         ->assertSessionHasErrors(['document']);
 });
 

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -80,7 +80,7 @@ test('registered form endpoints require a valid component reference', function (
 
     patch('/lattice/forms/settings.profile', [
         'name' => 'Taylor',
-    ], latticeHeaders('tampered'))
+    ], $this->latticeHeaders('tampered'))
         ->assertForbidden();
 });
 
@@ -89,8 +89,8 @@ test('registered form submissions validate before handle is called', function ()
 
     $ref = componentRef(wire(Form::use(WorkbenchRequiredProfileForm::class)));
 
-    patchJson('/lattice/forms/workbench.required-profile', [], latticeHeaders($ref))
-        ->assertStatus(422)
+    patchJson('/lattice/forms/workbench.required-profile', [], $this->latticeHeaders($ref))
+        ->assertUnprocessable()
         ->assertJsonValidationErrors('name');
 
     expect(session('handled-required-profile'))->toBeNull();

--- a/tests/Feature/Forms/ProductFormTest.php
+++ b/tests/Feature/Forms/ProductFormTest.php
@@ -10,7 +10,6 @@ use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Support\Testing\Assertions\FieldAssertions;
 use Lattice\Lattice\Support\Testing\Assertions\FormAssertions;
-use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Actions\EditProductAction;
 use Workbench\App\Forms\ProductForm;
 use Workbench\App\Models\File;
@@ -20,16 +19,6 @@ use function Pest\Laravel\get;
 use function Pest\Laravel\patch;
 use function Pest\Laravel\post;
 use function Pest\Laravel\withoutVite;
-
-/**
- * @param  array<string, mixed>  $component
- * @param  array<string, string>  $extra
- * @return array<string, string>
- */
-function productHeaders(array $component, array $extra = []): array
-{
-    return ['X-Lattice-Ref' => componentRef($component), ...$extra];
-}
 
 test('forms serialize initial state for bound edit values', function (): void {
     $form = Form::make('product-form')
@@ -288,14 +277,14 @@ test('the product form validates required fields', function (): void {
         'sales_prices' => [
             ['group_id' => '', 'amount' => 'invalid'],
         ],
-    ], productHeaders($form))
+    ], $this->latticeHeaders($form))
         ->assertSessionHasErrors([
             'name',
             'sku',
             'status',
             'sales_prices.0.amount',
         ])
-        ->assertStatus(Response::HTTP_FOUND);
+        ->assertFound();
 });
 
 test('the product form returns precognitive validation errors without creating products', function (): void {
@@ -310,14 +299,14 @@ test('the product form returns precognitive validation errors without creating p
         'sales_prices' => [
             ['group_id' => '', 'amount' => 'invalid'],
         ],
-    ], productHeaders($form, [
+    ], $this->latticeHeaders($form, [
         'Accept' => 'application/json',
         'Precognition' => 'true',
         'Precognition-Validate-Only' => 'name,sales_prices.0.amount',
     ]))
         ->assertHeader('Precognition', 'true')
         ->assertJsonValidationErrors(['name', 'sales_prices.0.amount'])
-        ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        ->assertUnprocessable();
 
     expect(Product::query()->count())->toBe(0);
 });
@@ -334,7 +323,7 @@ test('the product form accepts valid precognitive validation without creating pr
         'sales_prices' => [
             ['group_id' => '', 'amount' => '49.99'],
         ],
-    ], productHeaders($form, [
+    ], $this->latticeHeaders($form, [
         'Accept' => 'application/json',
         'Precognition' => 'true',
     ]))
@@ -366,7 +355,7 @@ test('the product form validates edit uniqueness from sealed context during prec
         'name' => 'Desk Lamp',
         'sku' => 'LAMP-001',
         'status' => 'active',
-    ], productHeaders($form, [
+    ], $this->latticeHeaders($form, [
         'Accept' => 'application/json',
         'Precognition' => 'true',
         'Precognition-Validate-Only' => 'sku',
@@ -379,14 +368,14 @@ test('the product form validates edit uniqueness from sealed context during prec
         'name' => 'Desk Lamp',
         'sku' => 'SHELF-001',
         'status' => 'active',
-    ], productHeaders($form, [
+    ], $this->latticeHeaders($form, [
         'Accept' => 'application/json',
         'Precognition' => 'true',
         'Precognition-Validate-Only' => 'sku',
     ]))
         ->assertHeader('Precognition', 'true')
         ->assertJsonValidationErrors(['sku'])
-        ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        ->assertUnprocessable();
 
     $trustedProduct->refresh();
 
@@ -407,7 +396,7 @@ test('the product form create rejects two default sales prices', function (): vo
             ['group_id' => '', 'amount' => '49.99'],
             ['group_id' => '', 'amount' => '59.99'],
         ],
-    ], productHeaders($form))
+    ], $this->latticeHeaders($form))
         ->assertSessionHasErrors(['sales_prices']);
 
     expect(Product::query()->count())->toBe(0);
@@ -434,7 +423,7 @@ test('the product form update rejects two default sales prices', function (): vo
             ['group_id' => '', 'amount' => '49.99'],
             ['group_id' => '', 'amount' => '59.99'],
         ],
-    ], productHeaders($form))
+    ], $this->latticeHeaders($form))
         ->assertSessionHasErrors(['sales_prices']);
 
     expect($product->salesPrices()->whereNull('group_id')->count())->toBeLessThanOrEqual(1);
@@ -558,7 +547,7 @@ test('the edit product action rejects two default sales prices with a 422', func
             ['group_id' => '', 'amount' => '59.99'],
         ],
     ], ['product_id' => $product->getKey()])
-        ->assertStatus(422)
+        ->assertUnprocessable()
         ->assertJsonValidationErrors(['sales_prices']);
 
     expect($product->salesPrices()->whereNull('group_id')->count())->toBe(1);

--- a/tests/Feature/Forms/ProductRelatedProductsTest.php
+++ b/tests/Feature/Forms/ProductRelatedProductsTest.php
@@ -24,7 +24,7 @@ test('the product form syncs related products on create', function (): void {
         'sku' => 'GAD-001',
         'status' => 'active',
         'related_products' => [$alpha->getKey(), $beta->getKey()],
-    ], ['X-Lattice-Ref' => $form['props']['ref']])
+    ], $this->latticeHeaders($form))
         ->assertRedirect('/products');
 
     $product = Product::query()->where('sku', 'GAD-001')->firstOrFail();
@@ -55,7 +55,7 @@ test('the product form replaces related products on update', function (): void {
         'sku' => 'LAMP-001',
         'status' => 'draft',
         'related_products' => [$gamma->getKey()],
-    ], ['X-Lattice-Ref' => $form['props']['ref']])
+    ], $this->latticeHeaders($form))
         ->assertRedirect('/products');
 
     expect($product->fresh()->relatedProducts->pluck('id')->all())
@@ -74,7 +74,7 @@ test('the product form ignores related ids that do not exist', function (): void
         'sku' => 'GAD-002',
         'status' => 'active',
         'related_products' => [$alpha->getKey(), 999999],
-    ], ['X-Lattice-Ref' => $form['props']['ref']])
+    ], $this->latticeHeaders($form))
         ->assertRedirect('/products');
 
     $product = Product::query()->where('sku', 'GAD-002')->firstOrFail();

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -228,7 +228,7 @@ it('searches options through the form endpoint with a signed reference', functio
     post('/lattice/forms/workbench.showcase.form', [
         '_search' => 'related_products',
         'q' => 'walnut',
-    ], ['X-Lattice-Ref' => $ref])
+    ], $this->latticeHeaders($ref))
         ->assertOk()
         ->assertExactJson([
             'options' => [

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -250,7 +250,7 @@ test('directly returned pages resolve render dependencies through the container,
     // The form request is resolved and validated on the responsable path too,
     // so a missing required field fails validation rather than rendering.
     get('/responsable-form-request')
-        ->assertStatus(302);
+        ->assertFound();
 });
 
 final class WorkbenchTabsPage extends Page

--- a/tests/Feature/Tables/ProductTableTest.php
+++ b/tests/Feature/Tables/ProductTableTest.php
@@ -101,7 +101,7 @@ test('bulk actions can target every row matching the current filter', function (
     patch('/lattice/bulk-actions/workbench.products.archive-selected', [
         'allMatching' => true,
         'filter' => 'status:eq:active',
-    ], ['X-Lattice-Ref' => $ref])
+    ], $this->latticeHeaders($ref))
         ->assertOk()
         ->assertJsonPath('data.archived', 3);
 
@@ -122,7 +122,7 @@ test('bulk all-matching validates the filter against the table columns', functio
     patch('/lattice/bulk-actions/workbench.products.archive-selected', [
         'allMatching' => true,
         'filter' => 'id:eq:1',
-    ], ['X-Lattice-Ref' => $ref])
+    ], $this->latticeHeaders($ref))
         ->assertUnprocessable()
         ->assertJsonPath('errors.filter.0', 'Filter [id] is not allowed for table [workbench.products].');
 });

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -108,7 +108,7 @@ test('a table rejects searching a filter that is not searchable', function (): v
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
     $this->loadTable(WorkbenchFilteredProductsTable::class, ['_search' => 'filter:status', 'q' => 'a'])
-        ->assertStatus(422);
+        ->assertUnprocessable();
 });
 
 test('a table accepts column filter clause option operators', function (): void {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -380,7 +380,7 @@ function dumpFixture(string $key, array $nodes): void
 
     file_put_contents(
         dirname(__DIR__).'/docs/fixtures/'.$key.'.json',
-        json_encode(sortFixtureKeys(stripFixtureRefs($normalized)), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n",
+        json_encode(sortFixtureKeys(stripFixtureRefs($normalized)), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)."\n",
     );
 }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -109,8 +109,13 @@ function rustfsIsReachable(): bool
     $key = 'lattice-test-probes/'.Str::uuid().'.txt';
 
     try {
-        Storage::disk('s3')->put($key, 'ok');
-        Storage::disk('s3')->delete($key);
+        $disk = Storage::disk('s3');
+
+        if ($disk->put($key, 'ok') !== true) {
+            return false;
+        }
+
+        $disk->delete($key);
 
         return true;
     } catch (Throwable) {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\ParallelTesting;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Testing\TestResponse;
 use Lattice\Lattice\Core\Contracts\OptionSource;
@@ -17,6 +18,7 @@ use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tests\BrowserTestCase;
 use Lattice\Lattice\Tests\TestCase;
 use Orchestra\Testbench\Factories\UserFactory;
+use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\User;
 
 use function Pest\Laravel\getJson;
@@ -52,6 +54,67 @@ function retryUntil(Closure $assert, int $attempts = 10, int $sleepMicroseconds 
 
             usleep($sleepMicroseconds);
         }
+    }
+}
+
+function eventually(Closure $assert, int $attempts = 10, int $sleepMicroseconds = 100_000, ?Closure $between = null): void
+{
+    retryUntil($assert, $attempts, $sleepMicroseconds, $between);
+}
+
+function browserSelector(string $selector): string
+{
+    if (str_starts_with($selector, '@')) {
+        return sprintf('[data-test="%s"]', substr($selector, 1));
+    }
+
+    return $selector;
+}
+
+function attachBrowserFilePayload(Webpage $page, string $selector, string $path, string $mimeType = 'application/octet-stream'): void
+{
+    $fileName = basename($path);
+    $base64 = base64_encode((string) file_get_contents($path));
+    $cssSelector = browserSelector($selector);
+    $selectorJson = json_encode($cssSelector, JSON_THROW_ON_ERROR);
+    $fileNameJson = json_encode($fileName, JSON_THROW_ON_ERROR);
+    $mimeTypeJson = json_encode($mimeType, JSON_THROW_ON_ERROR);
+    $base64Json = json_encode($base64, JSON_THROW_ON_ERROR);
+
+    $page->script(<<<JS
+        (() => {
+            const input = document.querySelector({$selectorJson});
+            if (! input) {
+                throw new Error('File input not found: ' + {$selectorJson});
+            }
+
+            const binary = atob({$base64Json});
+            const bytes = new Uint8Array(binary.length);
+
+            for (let index = 0; index < binary.length; index += 1) {
+                bytes[index] = binary.charCodeAt(index);
+            }
+
+            const transfer = new DataTransfer();
+            transfer.items.add(new File([bytes], {$fileNameJson}, { type: {$mimeTypeJson} }));
+            input.files = transfer.files;
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+        })();
+    JS);
+}
+
+function rustfsIsReachable(): bool
+{
+    $key = 'lattice-test-probes/'.Str::uuid().'.txt';
+
+    try {
+        Storage::disk('s3')->put($key, 'ok');
+        Storage::disk('s3')->delete($key);
+
+        return true;
+    } catch (Throwable) {
+        return false;
     }
 }
 
@@ -314,6 +377,15 @@ function dumpFixture(string $key, array $nodes): void
         dirname(__DIR__).'/docs/fixtures/'.$key.'.json',
         json_encode(sortFixtureKeys(stripFixtureRefs($normalized)), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n",
     );
+}
+
+function assertFixtureMatches(string $fixtureKey, mixed $payload): void
+{
+    $path = dirname(__DIR__).'/docs/fixtures/'.$fixtureKey.'.json';
+    $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+    expect(File::exists($path))->toBeTrue("Missing fixture: {$path}");
+    expect(File::get($path))->toBe($json.PHP_EOL);
 }
 
 /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,6 +18,7 @@ use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tests\BrowserTestCase;
 use Lattice\Lattice\Tests\TestCase;
 use Orchestra\Testbench\Factories\UserFactory;
+use Pest\Browser\Api\AwaitableWebpage;
 use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\User;
 
@@ -71,7 +72,7 @@ function browserSelector(string $selector): string
     return $selector;
 }
 
-function attachBrowserFilePayload(Webpage $page, string $selector, string $path, string $mimeType = 'application/octet-stream'): void
+function attachBrowserFilePayload(AwaitableWebpage|Webpage $page, string $selector, string $path, string $mimeType = 'application/octet-stream'): void
 {
     $fileName = basename($path);
     $base64 = base64_encode((string) file_get_contents($path));

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,8 +18,6 @@ use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tests\BrowserTestCase;
 use Lattice\Lattice\Tests\TestCase;
 use Orchestra\Testbench\Factories\UserFactory;
-use Pest\Browser\Api\AwaitableWebpage;
-use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\User;
 
 use function Pest\Laravel\getJson;
@@ -61,48 +59,6 @@ function retryUntil(Closure $assert, int $attempts = 10, int $sleepMicroseconds 
 function eventually(Closure $assert, int $attempts = 10, int $sleepMicroseconds = 100_000, ?Closure $between = null): void
 {
     retryUntil($assert, $attempts, $sleepMicroseconds, $between);
-}
-
-function browserSelector(string $selector): string
-{
-    if (str_starts_with($selector, '@')) {
-        return sprintf('[data-test="%s"]', substr($selector, 1));
-    }
-
-    return $selector;
-}
-
-function attachBrowserFilePayload(AwaitableWebpage|Webpage $page, string $selector, string $path, string $mimeType = 'application/octet-stream'): void
-{
-    $fileName = basename($path);
-    $base64 = base64_encode((string) file_get_contents($path));
-    $cssSelector = browserSelector($selector);
-    $selectorJson = json_encode($cssSelector, JSON_THROW_ON_ERROR);
-    $fileNameJson = json_encode($fileName, JSON_THROW_ON_ERROR);
-    $mimeTypeJson = json_encode($mimeType, JSON_THROW_ON_ERROR);
-    $base64Json = json_encode($base64, JSON_THROW_ON_ERROR);
-
-    $page->script(<<<JS
-        (() => {
-            const input = document.querySelector({$selectorJson});
-            if (! input) {
-                throw new Error('File input not found: ' + {$selectorJson});
-            }
-
-            const binary = atob({$base64Json});
-            const bytes = new Uint8Array(binary.length);
-
-            for (let index = 0; index < binary.length; index += 1) {
-                bytes[index] = binary.charCodeAt(index);
-            }
-
-            const transfer = new DataTransfer();
-            transfer.items.add(new File([bytes], {$fileNameJson}, { type: {$mimeTypeJson} }));
-            input.files = transfer.files;
-            input.dispatchEvent(new Event('input', { bubbles: true }));
-            input.dispatchEvent(new Event('change', { bubbles: true }));
-        })();
-    JS);
 }
 
 function rustfsIsReachable(): bool

--- a/tests/Unit/Core/ChartTest.php
+++ b/tests/Unit/Core/ChartTest.php
@@ -6,6 +6,7 @@ use Lattice\Lattice\Core\Enums\DateTimeStyle;
 use Lattice\Lattice\Core\Values\ChartSeries;
 use Lattice\Lattice\Core\Values\DateFormat;
 use Lattice\Lattice\Core\Values\NumberFormat;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a cartesian chart with fluent series helpers', function (): void {
     $node = wire(
@@ -146,8 +147,8 @@ it('defaults both formats to null', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the line chart example', function (): void {
-        dumpFixture('charts.line', [
+    it('matches the line chart example fixture', function (): void {
+        assertFixtureMatches('charts.line', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Chart::make('Signups', 'signups-chart')
                 ->description('New users per month')
                 ->categoryKey('month')
@@ -161,13 +162,11 @@ describe('docs fixtures', function (): void {
                 ->line('free', 'Free')
                 ->line('pro', 'Pro')
                 ->height(260),
-        ]);
-
-        expect('docs/fixtures/charts.line.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the grouped bar chart example', function (): void {
-        dumpFixture('charts.grouped-bar', [
+    it('matches the grouped bar chart example fixture', function (): void {
+        assertFixtureMatches('charts.grouped-bar', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Chart::make('Orders by channel', 'orders-chart')
                 ->categoryKey('week')
                 ->data([
@@ -179,13 +178,11 @@ describe('docs fixtures', function (): void {
                 ->bar('online', 'Online')
                 ->bar('store', 'In-store')
                 ->height(260),
-        ]);
-
-        expect('docs/fixtures/charts.grouped-bar.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the stacked bar chart example', function (): void {
-        dumpFixture('charts.stacked-bar', [
+    it('matches the stacked bar chart example fixture', function (): void {
+        assertFixtureMatches('charts.stacked-bar', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Chart::make('Monthly recurring revenue', 'mrr-chart')
                 ->description('Stacked by revenue type')
                 ->categoryKey('month')
@@ -198,13 +195,11 @@ describe('docs fixtures', function (): void {
                 ->bar('new', 'New', stackId: 'mrr')
                 ->bar('expansion', 'Expansion', stackId: 'mrr')
                 ->height(260),
-        ]);
-
-        expect('docs/fixtures/charts.stacked-bar.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the composed area and line chart example', function (): void {
-        dumpFixture('charts.composed', [
+    it('matches the composed area and line chart example fixture', function (): void {
+        assertFixtureMatches('charts.composed', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Chart::make('Revenue vs forecast', 'revenue-forecast-chart')
                 ->description('Actuals as a line over the forecast band')
                 ->categoryKey('month')
@@ -218,13 +213,11 @@ describe('docs fixtures', function (): void {
                 ->area('forecast', 'Forecast')
                 ->line('revenue', 'Revenue')
                 ->height(260),
-        ]);
-
-        expect('docs/fixtures/charts.composed.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the pie chart example', function (): void {
-        dumpFixture('charts.pie', [
+    it('matches the pie chart example fixture', function (): void {
+        assertFixtureMatches('charts.pie', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Chart::make('Revenue by channel', 'channel-mix-chart')
                 ->description('Share of total revenue')
                 ->data([
@@ -235,13 +228,11 @@ describe('docs fixtures', function (): void {
                 ])
                 ->pie('amount', nameKey: 'channel')
                 ->height(260),
-        ]);
-
-        expect('docs/fixtures/charts.pie.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the formatting example', function (): void {
-        dumpFixture('charts.formatting', [
+    it('matches the formatting example fixture', function (): void {
+        assertFixtureMatches('charts.formatting', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Chart::make('Revenue', 'formatting-chart')
                 ->description('Compact currency on the value axis, month labels on the category axis')
                 ->categoryKey('month')
@@ -255,8 +246,6 @@ describe('docs fixtures', function (): void {
                 ->categoryFormat(DateFormat::monthYear())
                 ->valueFormat(NumberFormat::currency('USD')->compact())
                 ->height(260),
-        ]);
-
-        expect('docs/fixtures/charts.formatting.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Core/Components/CollapsibleTest.php
+++ b/tests/Unit/Core/Components/CollapsibleTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Core\Components\Collapsible;
 use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes its trigger, content, and default flags', function (): void {
     $node = wire(
@@ -49,14 +50,12 @@ it('omits trigger components hidden by a condition', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the collapsible example', function (): void {
-        dumpFixture('components.collapsible', [
+    it('matches the collapsible example fixture', function (): void {
+        assertFixtureMatches('components.collapsible', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Collapsible::make('account-name')
                 ->trigger([Text::make('Name')])
                 ->tooltip('Shown on invoices and receipts.')
                 ->content([Text::make('Update the name shown on your account.')]),
-        ]);
-
-        expect('docs/fixtures/components.collapsible.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Docs/BuilderDocsTest.php
+++ b/tests/Unit/Docs/BuilderDocsTest.php
@@ -5,10 +5,11 @@ use Lattice\Lattice\Forms\Components\Builder;
 use Lattice\Lattice\Forms\Components\RowTemplate;
 use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Wire;
 
 describe('docs fixtures', function (): void {
-    it('dumps the builder example', function (): void {
-        dumpFixture('builder.basic', [
+    it('matches the builder example fixture', function (): void {
+        assertFixtureMatches('builder.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Builder::make('items', 'Line items')
                 ->templates([
                     RowTemplate::make('text')->label('Text')->schema([
@@ -22,8 +23,6 @@ describe('docs fixtures', function (): void {
                 ])
                 ->minItems(1)
                 ->addLabel('Add block'),
-        ]);
-
-        expect('docs/fixtures/builder.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -16,6 +16,7 @@ use Lattice\Lattice\Core\Components\Text;
 use Lattice\Lattice\Core\Components\Tooltip;
 use Lattice\Lattice\Core\Enums\ButtonVariant;
 use Lattice\Lattice\Core\Enums\Gap;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a card tooltip', function (): void {
     $node = wire(Card::make('Plan')->tooltip('Billed monthly.'));
@@ -30,8 +31,8 @@ it('serializes a null card tooltip when unset', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the card example', function (): void {
-        dumpFixture('components.card', [
+    it('matches the card example fixture', function (): void {
+        assertFixtureMatches('components.card', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Card::make('Team settings', 'Manage how your team appears.')
                 ->tooltip('These settings affect everyone on the team.')
                 ->schema([
@@ -42,25 +43,21 @@ describe('docs fixtures', function (): void {
                     ]),
                     Button::make('Invite member')->variant(ButtonVariant::Default),
                 ]),
-        ]);
-
-        expect('docs/fixtures/components.card.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the grid example', function (): void {
-        dumpFixture('components.grid', [
+    it('matches the grid example fixture', function (): void {
+        assertFixtureMatches('components.grid', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Grid::make()->columns(3)->schema([
                 Badge::make('First'),
                 Badge::make('Second'),
                 Badge::make('Third'),
             ]),
-        ]);
-
-        expect('docs/fixtures/components.grid.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the section example', function (): void {
-        dumpFixture('components.section', [
+    it('matches the section example fixture', function (): void {
+        assertFixtureMatches('components.section', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Section::make('Members', 'People with access to this team.')
                 ->collapsible()
                 ->tooltip('Only admins can change who has access.')
@@ -69,24 +66,20 @@ describe('docs fixtures', function (): void {
                     Text::make('Three people have access to this team.'),
                     Badge::make('3 active'),
                 ]),
-        ]);
-
-        expect('docs/fixtures/components.section.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the tooltip example', function (): void {
-        dumpFixture('components.tooltip', [
+    it('matches the tooltip example fixture', function (): void {
+        assertFixtureMatches('components.tooltip', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Stack::make()->direction('row')->gap(Gap::Small)->schema([
                 Badge::make('Plan: Pro'),
                 Tooltip::make()->content('Includes unlimited seats and priority support.'),
             ]),
-        ]);
-
-        expect('docs/fixtures/components.tooltip.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the button variants example', function (): void {
-        dumpFixture('components.buttons', [
+    it('matches the button variants example fixture', function (): void {
+        assertFixtureMatches('components.buttons', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Stack::make()->direction('row')->gap(Gap::Small)->schema([
                 Button::make('Default')->variant(ButtonVariant::Default),
                 Button::make('Secondary')->variant(ButtonVariant::Secondary),
@@ -96,44 +89,36 @@ describe('docs fixtures', function (): void {
                 Button::make('Outline')->variant(ButtonVariant::Outline),
                 Button::make('Ghost')->variant(ButtonVariant::Ghost),
             ]),
-        ]);
-
-        expect('docs/fixtures/components.buttons.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the stack example', function (): void {
-        dumpFixture('components.stack', [
+    it('matches the stack example fixture', function (): void {
+        assertFixtureMatches('components.stack', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Stack::make()->direction('row')->gap(Gap::Small)->schema([
                 Button::make('Save')->variant(ButtonVariant::Default),
                 Button::make('Cancel')->variant(ButtonVariant::Ghost),
             ]),
-        ]);
-
-        expect('docs/fixtures/components.stack.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the display example', function (): void {
-        dumpFixture('components.text', [
+    it('matches the display example fixture', function (): void {
+        assertFixtureMatches('components.text', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Stack::make()->gap(Gap::Small)->schema([
                 Heading::make('Billing', 2),
                 Text::make('Invoices are sent on the first of each month.'),
                 Badge::make('Trialing'),
             ]),
-        ]);
-
-        expect('docs/fixtures/components.text.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the raw block example', function (): void {
-        dumpFixture('components.raw-block', [
+    it('matches the raw block example fixture', function (): void {
+        assertFixtureMatches('components.raw-block', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             RawBlock::make()->html('<p>Rendered from <strong>trusted</strong> server HTML.</p>'),
-        ]);
-
-        expect('docs/fixtures/components.raw-block.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the segmented control example', function (): void {
-        dumpFixture('components.segmented-control', [
+    it('matches the segmented control example fixture', function (): void {
+        assertFixtureMatches('components.segmented-control', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             SegmentedControl::make('appearance', 'Appearance')
                 ->options([
                     SegmentedControl::option('Light', 'light'),
@@ -142,13 +127,11 @@ describe('docs fixtures', function (): void {
                 ])
                 ->value('light')
                 ->emits('appearance-changed'),
-        ]);
-
-        expect('docs/fixtures/components.segmented-control.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the tabs example', function (): void {
-        dumpFixture('components.tabs', [
+    it('matches the tabs example fixture', function (): void {
+        assertFixtureMatches('components.tabs', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Tabs::make()->defaultValue('details')->schema([
                 Tab::make('details', 'Details')->schema([
                     Text::make('Team details go here.'),
@@ -157,8 +140,6 @@ describe('docs fixtures', function (): void {
                     Text::make('Recent activity for the team.'),
                 ]),
             ]),
-        ]);
-
-        expect('docs/fixtures/components.tabs.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Docs/EnumDocsTest.php
+++ b/tests/Unit/Docs/EnumDocsTest.php
@@ -46,15 +46,10 @@ function generateEnumReference(): array
 }
 
 describe('docs fixtures', function (): void {
-    it('dumps the enum reference the docs page renders from', function (): void {
+    it('matches the enum reference fixture the docs page renders from', function (): void {
         $enums = generateEnumReference();
 
-        file_put_contents(
-            dirname(__DIR__, 3).'/docs/fixtures/enums.json',
-            json_encode($enums, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)."\n",
-        );
-
-        expect('docs/fixtures/enums.json')->toBeReadableFile();
+        assertFixtureMatches('enums', $enums);
     });
 });
 

--- a/tests/Unit/Docs/RepeaterDocsTest.php
+++ b/tests/Unit/Docs/RepeaterDocsTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\RowAction;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Support\Wire;
 
 describe('docs fixtures', function (): void {
-    it('dumps the repeater example', function (): void {
-        dumpFixture('repeater.basic', [
+    it('matches the repeater example fixture', function (): void {
+        assertFixtureMatches('repeater.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Repeater::make('items', 'Line items')
                 ->schema([
                     TextInput::make('name', 'Name')->required(),
@@ -18,13 +19,11 @@ describe('docs fixtures', function (): void {
                 ->reorderable()
                 ->addLabel('Add line')
                 ->defaultItems(1),
-        ]);
-
-        expect('docs/fixtures/repeater.basic.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the repeater row-actions example', function (): void {
-        dumpFixture('repeater.row-actions', [
+    it('matches the repeater row-actions example fixture', function (): void {
+        assertFixtureMatches('repeater.row-actions', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Repeater::make('items', 'Line items')
                 ->schema([
                     TextInput::make('name', 'Name'),
@@ -34,8 +33,6 @@ describe('docs fixtures', function (): void {
                     RowAction::duplicate(),
                     RowAction::remove()->label('Delete'),
                 ]),
-        ]);
-
-        expect('docs/fixtures/repeater.row-actions.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Docs/TableDocsTest.php
+++ b/tests/Unit/Docs/TableDocsTest.php
@@ -6,6 +6,7 @@ use Lattice\Lattice\Core\Enums\Color;
 use Lattice\Lattice\Core\Enums\Icon;
 use Lattice\Lattice\Core\Enums\NumberFormatUnit;
 use Lattice\Lattice\Core\Enums\Size;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Columns\BadgeColumn;
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
 use Lattice\Lattice\Tables\Columns\IconColumn;
@@ -19,8 +20,8 @@ use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableResult;
 
 describe('docs fixtures', function (): void {
-    it('dumps the overview table example', function (): void {
-        dumpFixture('table.overview', [
+    it('matches the overview table example fixture', function (): void {
+        assertFixtureMatches('table.overview', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('products')
                 ->striped(true)
                 ->columns([
@@ -37,13 +38,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.overview.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the stack column table example', function (): void {
-        dumpFixture('table.stack', [
+    it('matches the stack column table example fixture', function (): void {
+        assertFixtureMatches('table.stack', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('users')
                 ->columns([
                     StackColumn::make('identity')->label('User')->schema([
@@ -59,13 +58,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.stack.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the toggleable columns table example', function (): void {
-        dumpFixture('table.toggleable', [
+    it('matches the toggleable columns table example fixture', function (): void {
+        assertFixtureMatches('table.toggleable', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('products')
                 ->columns([
                     TextColumn::make('name')->label('Name'),
@@ -80,13 +77,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.toggleable.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the column types table example', function (): void {
-        dumpFixture('table.column-types', [
+    it('matches the column types table example fixture', function (): void {
+        assertFixtureMatches('table.column-types', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('members')
                 ->columns([
                     ImageColumn::make('avatar')->label('')->circular()->size(32),
@@ -105,13 +100,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.column-types.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the text column example', function (): void {
-        dumpFixture('table.text', [
+    it('matches the text column example fixture', function (): void {
+        assertFixtureMatches('table.text', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('people')
                 ->columns([
                     TextColumn::make('name')->label('Name')->link('/people/{value}')->sortable(),
@@ -125,13 +118,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.text.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the number column example', function (): void {
-        dumpFixture('table.number', [
+    it('matches the number column example fixture', function (): void {
+        assertFixtureMatches('table.number', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('metrics')
                 ->columns([
                     TextColumn::make('label')->label('Metric'),
@@ -147,13 +138,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.number.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the money column example', function (): void {
-        dumpFixture('table.money', [
+    it('matches the money column example fixture', function (): void {
+        assertFixtureMatches('table.money', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('invoices')
                 ->columns([
                     TextColumn::make('number')->label('Invoice'),
@@ -167,13 +156,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.money.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the boolean column example', function (): void {
-        dumpFixture('table.boolean', [
+    it('matches the boolean column example fixture', function (): void {
+        assertFixtureMatches('table.boolean', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('flags')
                 ->columns([
                     TextColumn::make('name')->label('Name'),
@@ -188,13 +175,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.boolean.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the badge column example', function (): void {
-        dumpFixture('table.badge', [
+    it('matches the badge column example fixture', function (): void {
+        assertFixtureMatches('table.badge', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('orders')
                 ->columns([
                     TextColumn::make('reference')->label('Reference'),
@@ -210,13 +195,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.badge.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the icon column example', function (): void {
-        dumpFixture('table.icon', [
+    it('matches the icon column example fixture', function (): void {
+        assertFixtureMatches('table.icon', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('checks')
                 ->columns([
                     TextColumn::make('name')->label('Name'),
@@ -231,13 +214,11 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.icon.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the image column example', function (): void {
-        dumpFixture('table.image', [
+    it('matches the image column example fixture', function (): void {
+        assertFixtureMatches('table.image', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('members')
                 ->columns([
                     ImageColumn::make('avatar')->label('')->circular()->size(32),
@@ -251,8 +232,6 @@ describe('docs fixtures', function (): void {
                     ])),
                     TableQuery::empty(),
                 ),
-        ]);
-
-        expect('docs/fixtures/table.image.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/CheckboxTest.php
+++ b/tests/Unit/Forms/Components/CheckboxTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Checkbox;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes the shared focus options', function (): void {
     $node = wire(Checkbox::make('terms', 'Accept terms')->autoFocus()->tabIndex(3));
@@ -11,11 +12,9 @@ it('serializes the shared focus options', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the checkbox example', function (): void {
-        dumpFixture('checkbox.basic', [
+    it('matches the checkbox example fixture', function (): void {
+        assertFixtureMatches('checkbox.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Checkbox::make('newsletter', 'Subscribe to the newsletter'),
-        ]);
-
-        expect('docs/fixtures/checkbox.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/ChoiceTest.php
+++ b/tests/Unit/Forms/Components/ChoiceTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Choice;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes the shared focus options', function (): void {
     $node = wire(Choice::make('plan', 'Plan')->autoFocus()->tabIndex(2));
@@ -11,15 +12,13 @@ it('serializes the shared focus options', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the choice example', function (): void {
-        dumpFixture('choice.basic', [
+    it('matches the choice example fixture', function (): void {
+        assertFixtureMatches('choice.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Choice::make('plan', 'Plan')->options([
                 Choice::option('Free', 'free'),
                 Choice::option('Pro', 'pro'),
                 Choice::option('Enterprise', 'enterprise'),
             ]),
-        ]);
-
-        expect('docs/fixtures/choice.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/DateInputTest.php
+++ b/tests/Unit/Forms/Components/DateInputTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\DateInput;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a date input', function (): void {
     $node = wire(DateInput::make('due', 'Due date')->min('2026-01-01')->max('2026-12-31'));
@@ -16,11 +17,9 @@ it('serializes a date input', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the date input example', function (): void {
-        dumpFixture('date-input.basic', [
+    it('matches the date input example fixture', function (): void {
+        assertFixtureMatches('date-input.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             DateInput::make('birthday', 'Birthday')->max('2026-01-01'),
-        ]);
-
-        expect('docs/fixtures/date-input.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/DateTimeInputTest.php
+++ b/tests/Unit/Forms/Components/DateTimeInputTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Lattice\Lattice\Forms\Components\DateTimeInput;
 use Lattice\Lattice\Forms\FieldValidator;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a datetime input', function (): void {
     $node = wire(DateTimeInput::make('starts_at', 'Starts at')
@@ -75,11 +76,9 @@ it('hydrates Carbon values to datetime plus timezone', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the datetime input example', function (): void {
-        dumpFixture('date-time-input.basic', [
+    it('matches the datetime input example fixture', function (): void {
+        assertFixtureMatches('date-time-input.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             DateTimeInput::make('starts_at', 'Starts at'),
-        ]);
-
-        expect('docs/fixtures/date-time-input.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/FileUploadTest.php
+++ b/tests/Unit/Forms/Components/FileUploadTest.php
@@ -2,13 +2,12 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\FileUpload;
+use Lattice\Lattice\Support\Wire;
 
 describe('docs fixtures', function (): void {
-    it('dumps the file upload example', function (): void {
-        dumpFixture('file-upload.basic', [
+    it('matches the file upload example fixture', function (): void {
+        assertFixtureMatches('file-upload.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             FileUpload::make('avatar', 'Avatar')->image()->maxSize(2048),
-        ]);
-
-        expect('docs/fixtures/file-upload.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/NumberInputTest.php
+++ b/tests/Unit/Forms/Components/NumberInputTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\NumberInput;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a number input', function (): void {
     $node = wire(NumberInput::make('qty', 'Qty')->min(0)->max(100)->step(1));
@@ -17,16 +18,13 @@ it('serializes a number input with a slider flag', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the number input examples', function (): void {
-        dumpFixture('number-input.basic', [
+    it('matches the number input examples fixture', function (): void {
+        assertFixtureMatches('number-input.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             NumberInput::make('age', 'Age')->min(0)->max(120),
-        ]);
+        ]))));
 
-        dumpFixture('number-input.slider', [
+        assertFixtureMatches('number-input.slider', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             NumberInput::make('satisfaction', 'Satisfaction')->slider()->min(0)->max(10),
-        ]);
-
-        expect('docs/fixtures/number-input.basic.json')->toBeReadableFile()
-            ->and('docs/fixtures/number-input.slider.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/PasswordInputTest.php
+++ b/tests/Unit/Forms/Components/PasswordInputTest.php
@@ -2,18 +2,16 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\PasswordInput;
+use Lattice\Lattice\Support\Wire;
 
 describe('docs fixtures', function (): void {
-    it('dumps the password input examples', function (): void {
-        dumpFixture('password-input.basic', [
+    it('matches the password input examples fixture', function (): void {
+        assertFixtureMatches('password-input.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             PasswordInput::make('password', 'Password')->placeholder('Your password'),
-        ]);
+        ]))));
 
-        dumpFixture('password-input.confirmation', [
+        assertFixtureMatches('password-input.confirmation', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             PasswordInput::make('password', 'Password')->needsConfirmation(),
-        ]);
-
-        expect('docs/fixtures/password-input.basic.json')->toBeReadableFile()
-            ->and('docs/fixtures/password-input.confirmation.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/RichEditorTest.php
+++ b/tests/Unit/Forms/Components/RichEditorTest.php
@@ -2,13 +2,12 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\RichEditor;
+use Lattice\Lattice\Support\Wire;
 
 describe('docs fixtures', function (): void {
-    it('dumps the rich editor example', function (): void {
-        dumpFixture('rich-editor.basic', [
+    it('matches the rich editor example fixture', function (): void {
+        assertFixtureMatches('rich-editor.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             RichEditor::make('article', 'Article')->placeholder('Write your article…'),
-        ]);
-
-        expect('docs/fixtures/rich-editor.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes static options without search flags', function (): void {
     $field = Select::make('plan', 'Plan')->options([
@@ -75,8 +76,8 @@ it('serializes the shared focus options', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the select examples', function (): void {
-        dumpFixture('select.basic', [
+    it('matches the select examples fixture', function (): void {
+        assertFixtureMatches('select.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Select::make('country', 'Country')
                 ->placeholder('Pick a country')
                 ->options([
@@ -85,9 +86,9 @@ describe('docs fixtures', function (): void {
                     Select::option('Spain', 'es'),
                     Select::option('Italy', 'it'),
                 ]),
-        ]);
+        ]))));
 
-        dumpFixture('select.multiple', [
+        assertFixtureMatches('select.multiple', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Select::make('languages', 'Languages')
                 ->multiple()
                 ->placeholder('Choose languages')
@@ -97,9 +98,6 @@ describe('docs fixtures', function (): void {
                     Select::option('Go', 'go'),
                     Select::option('Rust', 'rust'),
                 ]),
-        ]);
-
-        expect('docs/fixtures/select.basic.json')->toBeReadableFile()
-            ->and('docs/fixtures/select.multiple.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/TextInputTest.php
+++ b/tests/Unit/Forms/Components/TextInputTest.php
@@ -7,6 +7,7 @@ use Lattice\Lattice\Forms\Components\NumberInput;
 use Lattice\Lattice\Forms\Components\PasswordInput;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Support\Affix;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a text input', function (): void {
     $node = wire(TextInput::make('name', 'Team name')->placeholder('My team')->required());
@@ -66,77 +67,66 @@ describe('affixes', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the required text input example', function (): void {
-        dumpFixture('text-input.required', [
+    it('matches the required text input example fixture', function (): void {
+        assertFixtureMatches('text-input.required', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('name', 'Team name')->placeholder('My team')->required(),
-        ]);
-
-        expect('docs/fixtures/text-input.required.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the email text input example', function (): void {
-        dumpFixture('text-input.email', [
+    it('matches the email text input example fixture', function (): void {
+        assertFixtureMatches('text-input.email', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('email', 'Email address')->email()->placeholder('you@example.com'),
-        ]);
-
-        expect('docs/fixtures/text-input.email.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the affix examples', function (): void {
-        dumpFixture('text-input.affixes', [
+    it('matches the affix examples fixture', function (): void {
+        assertFixtureMatches('text-input.affixes', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('price', 'Price')->prefix('$')->suffix('USD'),
-        ]);
+        ]))));
 
-        dumpFixture('text-input.affix-icon', [
+        assertFixtureMatches('text-input.affix-icon', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('search', 'Search')->prefix(Icon::Search),
-        ]);
-
-        expect('docs/fixtures/text-input.affixes.json')->toBeReadableFile()
-            ->and('docs/fixtures/text-input.affix-icon.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the common field option examples', function (): void {
-        dumpFixture('field.required', [
+    it('matches the common field option examples fixture', function (): void {
+        assertFixtureMatches('field.required', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('name', 'Team name')->required(),
-        ]);
+        ]))));
 
-        dumpFixture('field.default-value', [
+        assertFixtureMatches('field.default-value', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('name', 'Team name')->value('Acme Inc'),
-        ]);
+        ]))));
 
-        dumpFixture('field.disabled', [
+        assertFixtureMatches('field.disabled', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('name', 'Team name')->value('Acme Inc')->disabled(),
-        ]);
+        ]))));
 
-        dumpFixture('field.read-only', [
+        assertFixtureMatches('field.read-only', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('slug', 'Slug')->value('acme-inc')->readOnly(),
-        ]);
+        ]))));
 
-        dumpFixture('field.helper-text', [
+        assertFixtureMatches('field.helper-text', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TextInput::make('slug', 'Slug')->helperText('Used in the public URL for your team.'),
-        ]);
-
-        expect('docs/fixtures/field.required.json')->toBeReadableFile();
+        ]))));
     });
 
-    it('dumps the conditional field examples', function (): void {
-        dumpFixture('field.visible-when', [
+    it('matches the conditional field examples fixture', function (): void {
+        assertFixtureMatches('field.visible-when', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Choice::make('type', 'Account type')->options([
                 Choice::option('Business', 'business'),
                 Choice::option('Individual', 'individual'),
             ]),
             TextInput::make('vat', 'VAT ID')->visibleWhen('type', 'business'),
-        ]);
+        ]))));
 
-        dumpFixture('field.required-when', [
+        assertFixtureMatches('field.required-when', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Choice::make('country', 'Country')->options([
                 Choice::option('Germany', 'DE'),
                 Choice::option('Austria', 'AT'),
                 Choice::option('United States', 'US'),
             ]),
             TextInput::make('vat', 'VAT ID')->requiredWhen('country', 'DE'),
-        ]);
-
-        expect('docs/fixtures/field.required-when.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/TextareaTest.php
+++ b/tests/Unit/Forms/Components/TextareaTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Textarea;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a textarea', function (): void {
     $node = wire(Textarea::make('bio', 'Bio')->rows(4)->placeholder('Tell us about yourself'));
@@ -16,11 +17,9 @@ it('serializes a textarea', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the textarea example', function (): void {
-        dumpFixture('textarea.basic', [
+    it('matches the textarea example fixture', function (): void {
+        assertFixtureMatches('textarea.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Textarea::make('bio', 'Bio')->rows(4)->placeholder('Tell us about yourself'),
-        ]);
-
-        expect('docs/fixtures/textarea.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/TimeInputTest.php
+++ b/tests/Unit/Forms/Components/TimeInputTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Lattice\Lattice\Forms\Components\TimeInput;
 use Lattice\Lattice\Forms\FieldValidator;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes a time input', function (): void {
     $node = wire(TimeInput::make('starts_at', 'Start time')->min('08:00')->max('18:00')->step(900));
@@ -45,11 +46,9 @@ it('rejects malformed time values', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the time input example', function (): void {
-        dumpFixture('time-input.basic', [
+    it('matches the time input example fixture', function (): void {
+        assertFixtureMatches('time-input.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             TimeInput::make('starts_at', 'Start time')->min('08:00')->max('18:00'),
-        ]);
-
-        expect('docs/fixtures/time-input.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Forms/Components/ToggleTest.php
+++ b/tests/Unit/Forms/Components/ToggleTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\Toggle;
+use Lattice\Lattice\Support\Wire;
 
 it('serializes the shared focus options', function (): void {
     $node = wire(Toggle::make('published', 'Published')->autoFocus()->tabIndex(3));
@@ -21,11 +22,9 @@ it('serializes a default boolean value', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the toggle example', function (): void {
-        dumpFixture('toggle.basic', [
+    it('matches the toggle example fixture', function (): void {
+        assertFixtureMatches('toggle.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Toggle::make('published', 'Published')->helperText('Show this item publicly.'),
-        ]);
-
-        expect('docs/fixtures/toggle.basic.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/tests/Unit/Notifications/NotificationsComponentTest.php
+++ b/tests/Unit/Notifications/NotificationsComponentTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Notifications\Components\Notifications;
+use Lattice\Lattice\Support\Wire;
 use Workbench\App\Models\User;
 
 use function Pest\Laravel\actingAs;
@@ -35,11 +36,9 @@ test('the bell defaults to popover mode', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('dumps the bell example', function (): void {
-        dumpFixture('notifications.bell', [
+    it('matches the bell example fixture', function (): void {
+        assertFixtureMatches('notifications.bell', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Notifications::make('notifications-bell'),
-        ]);
-
-        expect('docs/fixtures/notifications.bell.json')->toBeReadableFile();
+        ]))));
     });
 });

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -140,10 +140,21 @@ class AppLayout extends LayoutDefinition
                             ->icon(Icon::Settings)
                             ->href('/settings'),
                     ]),
-                    Notifications::make(),
+                    $this->notifications(),
                     $this->userMenu(),
                 ]),
         ]);
+    }
+
+    private function notifications(): Notifications
+    {
+        $notifications = Notifications::make();
+
+        if (request()->is('notifications-slide-out')) {
+            $notifications->slideOut();
+        }
+
+        return $notifications;
     }
 
     protected function userMenu(): Dropdown

--- a/workbench/app/Pages/NotificationSlideOutPage.php
+++ b/workbench/app/Pages/NotificationSlideOutPage.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Components\Text;
+use Lattice\Lattice\Core\PageSchema;
+
+#[AsPage(route: '/notifications-slide-out')]
+final class NotificationSlideOutPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Notification Slide Out';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Text::make('Notification Slide Out', 'notification-slide-out-marker'),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- clean up shared Pest/browser helpers for polling, fixture assertions, and RustFS reachability
- keep payload upload coverage always active while skipping only RustFS-dependent upload flows when S3/RustFS is unreachable
- replace brittle browser waits and selector workarounds with native Pest browser selectors/assertions, including i18n, notifications, chat, and upload flows

## Verification
- composer check
- npm run check
- composer test:browser:coverage
- CI green on b0c4e725