### PR TITLE
refactor: improve render and resize performance

### DIFF
--- a/resources/js/core/hooks/use-column-resizing.browser.test.tsx
+++ b/resources/js/core/hooks/use-column-resizing.browser.test.tsx
@@ -9,7 +9,7 @@ const columns: SizableColumn[] = [
 ];
 
 function Harness() {
-  const { gridTemplateColumns, getResizeHandleProps } = useColumnResizing({
+  const { gridTemplateColumns, getResizeHandleProps, resizeRootRef } = useColumnResizing({
     enabled: true,
     columns,
     columnGapPx: 12,
@@ -19,6 +19,7 @@ function Harness() {
 
   return (
     <div
+      ref={resizeRootRef}
       data-test="grid"
       style={{
         columnGap: "12px",

--- a/resources/js/core/hooks/use-column-resizing.test.tsx
+++ b/resources/js/core/hooks/use-column-resizing.test.tsx
@@ -59,7 +59,7 @@ function Harness({
   storageKey?: string;
   trailingTracks?: string[];
 }) {
-  const { gridTemplateColumns, getResizeHandleProps, hasOverrides, resetColumns } =
+  const { gridTemplateColumns, getResizeHandleProps, hasOverrides, resizeRootRef, resetColumns } =
     useColumnResizing({
       enabled,
       columns: hookColumns,
@@ -73,7 +73,7 @@ function Harness({
   onGetter?.(getResizeHandleProps);
 
   return (
-    <div data-test="grid" style={{ gridTemplateColumns }}>
+    <div ref={resizeRootRef} data-test="grid" style={{ gridTemplateColumns }}>
       <span data-test="has-overrides">{String(hasOverrides)}</span>
       <button data-test="reset" onClick={resetColumns} type="button">
         reset
@@ -102,6 +102,11 @@ describe("useColumnResizing", () => {
     fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
 
     expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "208px" });
+    expect(screen.getByTestId("has-overrides")).toHaveTextContent("false");
+    expect(window.localStorage.getItem("cols")).toBeNull();
+
+    fireEvent.pointerUp(handle, { clientX: 180, pointerId: 1 });
+
     expect(screen.getByTestId("has-overrides")).toHaveTextContent("true");
     expect(window.localStorage.getItem("cols")).not.toBeNull();
 
@@ -243,6 +248,10 @@ describe("useColumnResizing", () => {
     fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
     fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
 
+    expect(window.localStorage.getItem("lattice:table-columns:orders")).toBeNull();
+
+    fireEvent.pointerUp(handle, { clientX: 180, pointerId: 1 });
+
     expect(JSON.parse(window.localStorage.getItem("lattice:table-columns:orders") ?? "")).toEqual({
       columns: ["qty", "price"],
       overrides: {
@@ -272,6 +281,10 @@ describe("useColumnResizing", () => {
 
     fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
     fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
+
+    expect(getters).toHaveLength(1);
+
+    fireEvent.pointerUp(handle, { clientX: 180, pointerId: 1 });
 
     expect(getters.length).toBeGreaterThan(1);
     expect(new Set(getters).size).toBe(1);

--- a/resources/js/core/hooks/use-column-resizing.test.tsx
+++ b/resources/js/core/hooks/use-column-resizing.test.tsx
@@ -379,6 +379,25 @@ describe("useColumnResizing", () => {
     expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "208px" });
   });
 
+  it("commits pending widths when a pointer drag is cancelled", () => {
+    render(<Harness storageKey="cols" />);
+
+    const handle = screen.getByRole("separator", { name: "Resize Qty" });
+
+    fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
+    fireEvent.pointerCancel(handle, { clientX: 180, pointerId: 1 });
+
+    expect(screen.getByTestId("grid")).toHaveStyle({ gridTemplateColumns: "208px" });
+    expect(screen.getByTestId("has-overrides")).toHaveTextContent("true");
+    expect(JSON.parse(window.localStorage.getItem("cols") ?? "")).toEqual({
+      columns: ["qty"],
+      overrides: {
+        qty: 208,
+      },
+    });
+  });
+
   it("ignores a pointer up for a column that is not actively dragging", () => {
     render(<Harness hookColumns={twoColumns} />);
 

--- a/resources/js/core/hooks/use-column-resizing.ts
+++ b/resources/js/core/hooks/use-column-resizing.ts
@@ -162,6 +162,23 @@ export function useColumnResizing({
       const resizeBy = (handle: HTMLDivElement, delta: number): void =>
         setColumnWidth(column, current + delta, maxWidthForHandle(handle));
 
+      const finishDrag = (event: PointerEvent<HTMLDivElement>, releaseCapture: boolean): void => {
+        const active = drag.current;
+
+        if (active?.key !== column.key) {
+          return;
+        }
+
+        drag.current = null;
+        if (active.overrides !== null) {
+          commitOverrides(active.overrides);
+        }
+
+        if (releaseCapture) {
+          event.currentTarget.releasePointerCapture?.(event.pointerId);
+        }
+      };
+
       return {
         "aria-label": `Resize ${label}`,
         "aria-orientation": "vertical",
@@ -238,17 +255,13 @@ export function useColumnResizing({
           applyTemplate(templateForOverrides(next));
         },
         onPointerUp: (event: PointerEvent<HTMLDivElement>) => {
-          const active = drag.current;
-
-          if (active?.key !== column.key) {
-            return;
-          }
-
-          drag.current = null;
-          if (active.overrides !== null) {
-            commitOverrides(active.overrides);
-          }
-          event.currentTarget.releasePointerCapture?.(event.pointerId);
+          finishDrag(event, true);
+        },
+        onPointerCancel: (event: PointerEvent<HTMLDivElement>) => {
+          finishDrag(event, true);
+        },
+        onLostPointerCapture: (event: PointerEvent<HTMLDivElement>) => {
+          finishDrag(event, false);
         },
         role: "separator",
         tabIndex: 0,

--- a/resources/js/core/hooks/use-column-resizing.ts
+++ b/resources/js/core/hooks/use-column-resizing.ts
@@ -11,6 +11,7 @@ import {
 type DragState = {
   key: string;
   maxWidth: number;
+  overrides: Record<string, number | undefined> | null;
   startWidth: number;
   startX: number;
 };
@@ -55,58 +56,81 @@ export function useColumnResizing({
   );
   const overridesRef = useRef(overrides);
   const drag = useRef<DragState | null>(null);
+  const resizeRootRef = useRef<HTMLDivElement | null>(null);
 
-  const gridTemplateColumns = useMemo(
-    () =>
+  const templateForOverrides = useCallback(
+    (nextOverrides: Record<string, number | undefined>): string =>
       buildColumnGridTemplate({
         columns,
         leadingTracks,
         trailingTracks,
-        overrides: enabled ? overrides : {},
+        overrides: enabled ? nextOverrides : {},
       }),
-    [columns, enabled, leadingTracks, overrides, trailingTracks],
+    [columns, enabled, leadingTracks, trailingTracks],
+  );
+
+  const gridTemplateColumns = useMemo(
+    () => templateForOverrides(overrides),
+    [overrides, templateForOverrides],
+  );
+
+  const applyTemplate = useCallback((template: string): void => {
+    const root = resizeRootRef.current;
+
+    if (!root) {
+      return;
+    }
+
+    root.style.gridTemplateColumns = template;
+    root.style.setProperty("--lattice-table-columns", template);
+  }, []);
+
+  const commitOverrides = useCallback(
+    (next: Record<string, number | undefined>) => {
+      overridesRef.current = next;
+      setOverrides(next);
+      writeStoredOverrides(storageKey, columnKeys, next);
+      applyTemplate(templateForOverrides(next));
+    },
+    [applyTemplate, columnKeys, storageKey, templateForOverrides],
+  );
+
+  const overridesWithColumnWidth = useCallback(
+    (
+      current: Record<string, number | undefined>,
+      column: SizableColumn,
+      width: number,
+      maxWidth?: number,
+    ): Record<string, number | undefined> => ({
+      ...current,
+      [column.key]: Math.min(
+        maxWidth ?? maxColumnWidthPx(column),
+        Math.max(minColumnWidthPx(column), width),
+      ),
+    }),
+    [],
   );
 
   const setColumnWidth = useCallback(
     (column: SizableColumn, width: number, maxWidth?: number) => {
-      setOverrides((current) => {
-        const next = {
-          ...current,
-          [column.key]: Math.min(
-            maxWidth ?? maxColumnWidthPx(column),
-            Math.max(minColumnWidthPx(column), width),
-          ),
-        };
-
-        overridesRef.current = next;
-        writeStoredOverrides(storageKey, columnKeys, next);
-
-        return next;
-      });
+      commitOverrides(overridesWithColumnWidth(overridesRef.current, column, width, maxWidth));
     },
-    [columnKeys, storageKey],
+    [commitOverrides, overridesWithColumnWidth],
   );
 
   const resetColumnWidth = useCallback(
     (column: SizableColumn) => {
-      setOverrides((current) => {
-        const next = { ...current };
-        delete next[column.key];
+      const next = { ...overridesRef.current };
+      delete next[column.key];
 
-        overridesRef.current = next;
-        writeStoredOverrides(storageKey, columnKeys, next);
-
-        return next;
-      });
+      commitOverrides(next);
     },
-    [columnKeys, storageKey],
+    [commitOverrides],
   );
 
   const resetColumns = useCallback(() => {
-    setOverrides({});
-    overridesRef.current = {};
-    writeStoredOverrides(storageKey, columnKeys, {});
-  }, [columnKeys, storageKey]);
+    commitOverrides({});
+  }, [commitOverrides]);
 
   const hasOverrides =
     enabled && Object.values(overrides).some((width) => typeof width === "number");
@@ -130,7 +154,7 @@ export function useColumnResizing({
           column,
           columnGapPx,
           columns,
-          grid: handle.parentElement?.parentElement,
+          grid: resizeRootRef.current ?? handle.parentElement?.parentElement,
           leadingTracks,
           trailingTracks,
         });
@@ -188,6 +212,7 @@ export function useColumnResizing({
           drag.current = {
             key: column.key,
             maxWidth: maxWidthForHandle(event.currentTarget),
+            overrides: null,
             startWidth: parentWidth > 0 ? parentWidth : current,
             startX: event.clientX,
           };
@@ -201,11 +226,16 @@ export function useColumnResizing({
             return;
           }
 
-          setColumnWidth(
+          const next = overridesWithColumnWidth(
+            overridesRef.current,
             column,
             active.startWidth + event.clientX - active.startX,
             active.maxWidth,
           );
+
+          active.overrides = next;
+          overridesRef.current = next;
+          applyTemplate(templateForOverrides(next));
         },
         onPointerUp: (event: PointerEvent<HTMLDivElement>) => {
           const active = drag.current;
@@ -215,6 +245,9 @@ export function useColumnResizing({
           }
 
           drag.current = null;
+          if (active.overrides !== null) {
+            commitOverrides(active.overrides);
+          }
           event.currentTarget.releasePointerCapture?.(event.pointerId);
         },
         role: "separator",
@@ -227,9 +260,13 @@ export function useColumnResizing({
       currentColumnWidth,
       enabled,
       leadingTracks,
+      applyTemplate,
+      commitOverrides,
+      overridesWithColumnWidth,
       resetColumnWidth,
       setColumnWidth,
       showIndicator,
+      templateForOverrides,
       trailingTracks,
     ],
   );
@@ -238,6 +275,7 @@ export function useColumnResizing({
     getResizeHandleProps,
     gridTemplateColumns,
     hasOverrides,
+    resizeRootRef,
     resetColumns,
     resetColumnWidth,
   };

--- a/resources/js/core/renderer.test.tsx
+++ b/resources/js/core/renderer.test.tsx
@@ -1,4 +1,5 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent, lazyComponent } from "@lattice-php/lattice";
 import { Renderer } from "@lattice-php/lattice";
@@ -140,5 +141,41 @@ describe("Renderer", () => {
     );
 
     expect(screen.getByTestId("lazy-node-fallback")).toBeVisible();
+  });
+
+  it("does not rerender stable nodes when a parent updates", () => {
+    let renders = 0;
+    const node = { id: "stable-node", type: "test.counter" };
+    const CounterComponent: RendererComponent<"test.counter"> = ({ node }) => {
+      renders++;
+
+      return <div data-test={node.id} />;
+    };
+    const Parent = () => {
+      const [count, setCount] = useState(0);
+
+      return (
+        <>
+          <button type="button" onClick={() => setCount((current) => current + 1)}>
+            {count}
+          </button>
+          <Renderer nodes={[node]} />
+        </>
+      );
+    };
+    const registry = createRegistry({
+      components: {
+        "test.counter": eagerComponent(CounterComponent),
+      },
+      name: "test",
+    });
+
+    renderWithRegistry(<Parent />, registry);
+
+    expect(renders).toBe(1);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(renders).toBe(1);
   });
 });

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { memo, Suspense } from "react";
 import type { ReactNode } from "react";
 import type { Node } from "./types";
 import { useCollapsed } from "./collapsed-context";
@@ -74,7 +74,7 @@ export function RenderNode({ node }: { node: Node }): ReactNode {
   return <NodeRenderer node={node} />;
 }
 
-function NodeRenderer({ node }: { node: Node }) {
+const NodeRenderer = memo(function NodeRenderer({ node }: { node: Node }) {
   const collapsed = useCollapsed();
   const registry = useComponentRegistry();
   const registration = registry[node.type];
@@ -101,4 +101,4 @@ function NodeRenderer({ node }: { node: Node }) {
   }
 
   return renderedComponent;
-}
+});

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -152,9 +152,9 @@ it("uses column width hints when building the table grid", () => {
     />,
   );
 
-  expect(screen.getByText("Qty").parentElement).toHaveStyle({
-    gridTemplateColumns: "3rem minmax(4rem, 0.35fr) minmax(16rem, 2fr) 3rem",
-  });
+  expect(screen.getByText("Qty").parentElement?.parentElement).toHaveStyle(
+    "--lattice-table-columns: 3rem minmax(4rem, 0.35fr) minmax(16rem, 2fr) 3rem",
+  );
 });
 
 it("does not render column resize handles unless enabled", () => {
@@ -217,6 +217,10 @@ it("stores table layout column widths under the field base", () => {
 
   fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
   fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
+
+  expect(window.localStorage.getItem("lattice:table-columns:form:items")).toBeNull();
+
+  fireEvent.pointerUp(handle, { clientX: 180, pointerId: 1 });
 
   expect(JSON.parse(window.localStorage.getItem("lattice:table-columns:form:items") ?? "")).toEqual(
     {

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -85,7 +85,6 @@ type TableRowItemProps = {
   isFirst: boolean;
   isLast: boolean;
   columnCount: number;
-  gridTemplateColumns: string;
   flipKey: string;
   reorderable: boolean;
   removable: boolean;
@@ -106,7 +105,6 @@ const TableRowItem = memo(function TableRowItem({
   isFirst,
   isLast,
   columnCount,
-  gridTemplateColumns,
   flipKey,
   reorderable,
   removable,
@@ -124,8 +122,7 @@ const TableRowItem = memo(function TableRowItem({
       ref={(el) => registerRow?.(flipKey, el)}
       data-flip-key={flipKey}
       data-test={`table-row-${base}-${index}`}
-      className="grid items-start gap-x-3"
-      style={{ gridTemplateColumns }}
+      className="grid grid-cols-[var(--lattice-table-columns)] items-start gap-x-3"
     >
       <div className="flex items-center gap-1 [&_svg]:size-lt-icon-sm">
         {reorderable && !isFirst && (
@@ -224,7 +221,7 @@ export function TableRows({
       })),
     [columns],
   );
-  const { getResizeHandleProps, gridTemplateColumns, hasOverrides, resetColumns } =
+  const { getResizeHandleProps, gridTemplateColumns, hasOverrides, resizeRootRef, resetColumns } =
     useColumnResizing({
       columns: sizingColumns,
       enabled: resizableColumns,
@@ -277,8 +274,12 @@ export function TableRows({
         </button>
       )}
       <div className="overflow-x-auto">
-        <div className="flex min-w-max flex-col gap-2">
-          <div className="grid items-center gap-x-3" style={{ gridTemplateColumns }}>
+        <div
+          ref={resizeRootRef}
+          className="flex min-w-max flex-col gap-2"
+          style={{ "--lattice-table-columns": gridTemplateColumns } as never}
+        >
+          <div className="grid grid-cols-[var(--lattice-table-columns)] items-center gap-x-3">
             <div />
             {columns.map((column, index) => (
               <div
@@ -303,7 +304,6 @@ export function TableRows({
               isFirst={row.index === 0}
               isLast={row.index === rows.length - 1}
               columnCount={columns.length}
-              gridTemplateColumns={gridTemplateColumns}
               flipKey={row.key}
               reorderable={reorderable}
               removable={removable(row.index)}

--- a/resources/js/form/hooks/use-dependent-field.test.tsx
+++ b/resources/js/form/hooks/use-dependent-field.test.tsx
@@ -70,6 +70,15 @@ describe("useDependentField", () => {
     expect(result.current.hidden).toBe(false);
   });
 
+  it("evaluates dotted condition fields against nested form values", () => {
+    const { result } = renderScopedField({
+      global: { address: { city: "Berlin" } },
+      node: conditionNode(".address..city", "Berlin"),
+    });
+
+    expect(result.current.hidden).toBe(false);
+  });
+
   it("falls back to ancestor row values from inside nested rows", () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <FormValuesProvider

--- a/resources/js/form/hooks/use-dependent-field.test.tsx
+++ b/resources/js/form/hooks/use-dependent-field.test.tsx
@@ -1,11 +1,11 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 import { FieldScopeProvider } from "./field-scope";
 import { useDependentField } from "./use-dependent-field";
-import { FormValuesProvider } from "./values";
+import { FormValuesProvider, useSetFormValue } from "./values";
 
 function conditionNode(field: string, value: string): Node {
   return fakeNode({
@@ -106,5 +106,38 @@ describe("useDependentField", () => {
     });
 
     expect(result.current.hidden).toBe(false);
+  });
+
+  it("does not rerender when unrelated form values change", () => {
+    let renders = 0;
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FormValuesProvider initial={{ product: "sku-1", unrelated: "A" }}>
+        {children}
+      </FormValuesProvider>
+    );
+
+    const { result } = renderHook(
+      () => {
+        renders++;
+
+        return {
+          state: useDependentField(conditionNode("product", "sku-1")),
+          setValue: useSetFormValue(),
+        };
+      },
+      { wrapper },
+    );
+
+    expect(result.current.state.hidden).toBe(false);
+    expect(renders).toBe(1);
+
+    act(() => result.current.setValue("unrelated", "B"));
+
+    expect(renders).toBe(1);
+
+    act(() => result.current.setValue("product", "other"));
+
+    expect(result.current.state.hidden).toBe(true);
+    expect(renders).toBe(2);
   });
 });

--- a/resources/js/form/hooks/use-dependent-field.ts
+++ b/resources/js/form/hooks/use-dependent-field.ts
@@ -1,13 +1,15 @@
 import type { Node } from "@lattice-php/lattice/core/types";
-import { type FieldState, evaluateConditions } from "../lib/conditions";
+import { useMemo } from "react";
+import { conditionFields, type FieldState, evaluateConditions } from "../lib/conditions";
 import { fieldProps } from "../lib/field-props";
 import { useFieldScope } from "./field-scope";
-import { useFormValues } from "./values";
+import { useFormValuesFor } from "./values";
 
 export function useDependentField(node: Node): FieldState {
-  const values = useFormValues();
   const scope = useFieldScope();
   const props = fieldProps(node);
+  const fields = useMemo(() => conditionFields(props.conditions), [props.conditions]);
+  const values = useFormValuesFor(fields);
   // Bare condition names resolve to row siblings first; form values remain the fallback.
   const conditionValues = scope ? { ...values, ...scope.values } : values;
 

--- a/resources/js/form/hooks/values.test.tsx
+++ b/resources/js/form/hooks/values.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { FormValuesProvider, useFormValue, useFormValues, useSetFormValue } from "./values";
@@ -39,5 +39,131 @@ describe("FormValues", () => {
 
     expect(result.current.value).toBe("B");
     expect(result.current.values).toEqual({ items: [{ children: [{ name: "B" }] }] });
+  });
+
+  it("rerenders only the field whose selected value changed", () => {
+    let firstRenders = 0;
+    let secondRenders = 0;
+    let formRenders = 0;
+    let setValue: ReturnType<typeof useSetFormValue> = () => {};
+
+    function FirstProbe() {
+      firstRenders++;
+      useFormValue("first");
+
+      return null;
+    }
+
+    function SecondProbe() {
+      secondRenders++;
+      useFormValue("second");
+
+      return null;
+    }
+
+    function FormProbe() {
+      formRenders++;
+      useFormValues();
+
+      return null;
+    }
+
+    function SetterProbe() {
+      setValue = useSetFormValue();
+
+      return null;
+    }
+
+    render(
+      <FormValuesProvider initial={{ first: "A", second: "B" }}>
+        <FirstProbe />
+        <SecondProbe />
+        <FormProbe />
+        <SetterProbe />
+      </FormValuesProvider>,
+    );
+
+    expect(firstRenders).toBe(1);
+    expect(secondRenders).toBe(1);
+    expect(formRenders).toBe(1);
+
+    act(() => setValue("first", "A2"));
+
+    expect(firstRenders).toBe(2);
+    expect(secondRenders).toBe(1);
+    expect(formRenders).toBe(2);
+  });
+
+  it("keeps setter-only consumers stable when values change", () => {
+    let setterRenders = 0;
+    let setValue: ReturnType<typeof useSetFormValue> = () => {};
+
+    function SetterProbe() {
+      setterRenders++;
+      setValue = useSetFormValue();
+
+      return null;
+    }
+
+    render(
+      <FormValuesProvider initial={{ name: "A" }}>
+        <SetterProbe />
+      </FormValuesProvider>,
+    );
+
+    expect(setterRenders).toBe(1);
+
+    act(() => setValue("name", "B"));
+
+    expect(setterRenders).toBe(1);
+  });
+
+  it("updates parent and child path subscribers without rerendering siblings", () => {
+    let parentRenders = 0;
+    let childRenders = 0;
+    let siblingRenders = 0;
+    let setValue: ReturnType<typeof useSetFormValue> = () => {};
+
+    function ParentProbe() {
+      parentRenders++;
+      useFormValue("items");
+
+      return null;
+    }
+
+    function ChildProbe() {
+      childRenders++;
+      useFormValue("items.0.name");
+
+      return null;
+    }
+
+    function SiblingProbe() {
+      siblingRenders++;
+      useFormValue("items.1.name");
+
+      return null;
+    }
+
+    function SetterProbe() {
+      setValue = useSetFormValue();
+
+      return null;
+    }
+
+    render(
+      <FormValuesProvider initial={{ items: [{ name: "A" }, { name: "B" }] }}>
+        <ParentProbe />
+        <ChildProbe />
+        <SiblingProbe />
+        <SetterProbe />
+      </FormValuesProvider>,
+    );
+
+    act(() => setValue("items.0.name", "A2"));
+
+    expect(parentRenders).toBe(2);
+    expect(childRenders).toBe(2);
+    expect(siblingRenders).toBe(1);
   });
 });

--- a/resources/js/form/hooks/values.test.tsx
+++ b/resources/js/form/hooks/values.test.tsx
@@ -1,7 +1,13 @@
 import { act, render, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { FormValuesProvider, useFormValue, useFormValues, useSetFormValue } from "./values";
+import {
+  FormValuesProvider,
+  useFormValue,
+  useFormValues,
+  useFormValuesFor,
+  useSetFormValue,
+} from "./values";
 
 function wrapper(initial: Record<string, unknown>) {
   return ({ children }: { children: ReactNode }) => (
@@ -165,5 +171,40 @@ describe("FormValues", () => {
     expect(parentRenders).toBe(2);
     expect(childRenders).toBe(2);
     expect(siblingRenders).toBe(1);
+  });
+
+  it("uses a stable fallback store outside a provider", () => {
+    const snapshots: Record<string, unknown>[] = [];
+
+    function Probe({ tick }: { tick: number }) {
+      snapshots.push(useFormValuesFor(["field"]));
+
+      return <span>{tick}</span>;
+    }
+
+    const { rerender } = render(<Probe tick={1} />);
+
+    rerender(<Probe tick={2} />);
+
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[1]).toBe(snapshots[0]);
+  });
+
+  it("returns selected values keyed by the caller's original path", () => {
+    let selected: Record<string, unknown> = {};
+
+    function Probe() {
+      selected = useFormValuesFor([".address..city"]);
+
+      return null;
+    }
+
+    render(
+      <FormValuesProvider initial={{ address: { city: "Berlin" } }}>
+        <Probe />
+      </FormValuesProvider>,
+    );
+
+    expect(selected).toEqual({ ".address..city": "Berlin" });
   });
 });

--- a/resources/js/form/hooks/values.tsx
+++ b/resources/js/form/hooks/values.tsx
@@ -134,7 +134,7 @@ function createFormValuesStore(initial: Record<string, unknown>): FormValuesStor
       }
 
       const normalizedPaths = paths.map(normalizePath);
-      const key = normalizedPaths.join("\0");
+      const key = JSON.stringify(paths);
       const selectedValues = normalizedPaths.map((path) => getPath(values, path));
       const cached = selectedCache.get(key);
 
@@ -147,7 +147,7 @@ function createFormValuesStore(initial: Record<string, unknown>): FormValuesStor
       }
 
       const snapshot = Object.fromEntries(
-        normalizedPaths.map((path, index) => [path, selectedValues[index]]),
+        paths.map((path, index) => [path, selectedValues[index]]),
       );
 
       selectedCache.set(key, { snapshot, values: selectedValues });
@@ -193,6 +193,8 @@ function createFormValuesStore(initial: Record<string, unknown>): FormValuesStor
   };
 }
 
+const fallbackFormValuesStore = createFormValuesStore(emptyValues);
+
 export function FormValuesProvider({
   initial,
   children,
@@ -220,7 +222,7 @@ export function FormValuesProvider({
 }
 
 function useFormValuesStore(): FormValuesStore {
-  return useContext(FormValuesStoreContext) ?? createFormValuesStore(emptyValues);
+  return useContext(FormValuesStoreContext) ?? fallbackFormValuesStore;
 }
 
 export function useFormValues(): Record<string, unknown> {
@@ -242,14 +244,15 @@ export function useFormValue(name: string): unknown {
 
 export function useFormValuesFor(paths: string[]): Record<string, unknown> {
   const store = useFormValuesStore();
-  const normalizedPaths = useMemo(() => paths.map(normalizePath), [paths]);
+  const pathsKey = JSON.stringify(paths);
+  const selectedPaths = useMemo(() => JSON.parse(pathsKey) as string[], [pathsKey]);
   const subscribe = useCallback(
-    (listener: () => void) => store.subscribePaths(normalizedPaths, listener),
-    [normalizedPaths, store],
+    (listener: () => void) => store.subscribePaths(selectedPaths, listener),
+    [selectedPaths, store],
   );
   const getSnapshot = useCallback(
-    () => store.getPathsSnapshot(normalizedPaths),
-    [normalizedPaths, store],
+    () => store.getPathsSnapshot(selectedPaths),
+    [selectedPaths, store],
   );
 
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/resources/js/form/hooks/values.tsx
+++ b/resources/js/form/hooks/values.tsx
@@ -5,19 +5,31 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState,
+  useSyncExternalStore,
 } from "react";
 import { getPath, setPath } from "../lib/form-path";
 
-type FormValuesContextValue = {
-  values: Record<string, unknown>;
-  setValue: (name: string, value: unknown) => void;
+export type SetFormValue = (
+  name: string,
+  value: unknown | ((previous: unknown) => unknown),
+) => void;
+
+type FormValuesStore = {
+  getPathSnapshot: (path: string) => unknown;
+  getPathsSnapshot: (paths: string[]) => Record<string, unknown>;
+  getSnapshot: () => Record<string, unknown>;
+  replaceInitial: (initial: Record<string, unknown>) => void;
+  setValue: SetFormValue;
+  subscribe: (listener: () => void) => () => void;
+  subscribePath: (path: string, listener: () => void) => () => void;
+  subscribePaths: (paths: string[], listener: () => void) => () => void;
 };
 
-const FormValuesContext = createContext<FormValuesContextValue>({
-  values: {},
-  setValue: () => {},
-});
+const emptyValues: Record<string, unknown> = {};
+const emptySelectedValues: Record<string, unknown> = {};
+
+const FormValuesStoreContext = createContext<FormValuesStore | null>(null);
+const SetFormValueContext = createContext<SetFormValue>(() => {});
 
 function valuesEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) {
@@ -46,6 +58,141 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   );
 }
 
+function normalizePath(path: string): string {
+  return path
+    .split(".")
+    .filter((part) => part !== "")
+    .join(".");
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return (
+    left === "" ||
+    right === "" ||
+    left === right ||
+    left.startsWith(`${right}.`) ||
+    right.startsWith(`${left}.`)
+  );
+}
+
+function createFormValuesStore(initial: Record<string, unknown>): FormValuesStore {
+  let initialValues = initial;
+  let values = initial;
+  const listeners = new Set<() => void>();
+  const pathListeners = new Map<string, Set<() => void>>();
+  const selectedCache = new Map<string, { snapshot: Record<string, unknown>; values: unknown[] }>();
+
+  const notify = (path: string): void => {
+    for (const listener of listeners) {
+      listener();
+    }
+
+    const normalizedPath = normalizePath(path);
+
+    for (const [subscribedPath, subscribedListeners] of pathListeners) {
+      if (!pathsOverlap(subscribedPath, normalizedPath)) {
+        continue;
+      }
+
+      for (const listener of subscribedListeners) {
+        listener();
+      }
+    }
+  };
+
+  const updateValues = (next: Record<string, unknown>, path: string): void => {
+    if (Object.is(values, next)) {
+      return;
+    }
+
+    values = next;
+    selectedCache.clear();
+    notify(path);
+  };
+
+  const subscribePath = (path: string, listener: () => void): (() => void) => {
+    const normalizedPath = normalizePath(path);
+    const listenersForPath = pathListeners.get(normalizedPath) ?? new Set<() => void>();
+
+    listenersForPath.add(listener);
+    pathListeners.set(normalizedPath, listenersForPath);
+
+    return () => {
+      listenersForPath.delete(listener);
+
+      if (listenersForPath.size === 0) {
+        pathListeners.delete(normalizedPath);
+      }
+    };
+  };
+
+  return {
+    getPathSnapshot: (path: string): unknown => getPath(values, path),
+    getPathsSnapshot: (paths: string[]): Record<string, unknown> => {
+      if (paths.length === 0) {
+        return emptySelectedValues;
+      }
+
+      const normalizedPaths = paths.map(normalizePath);
+      const key = normalizedPaths.join("\0");
+      const selectedValues = normalizedPaths.map((path) => getPath(values, path));
+      const cached = selectedCache.get(key);
+
+      if (
+        cached &&
+        cached.values.length === selectedValues.length &&
+        selectedValues.every((value, index) => Object.is(value, cached.values[index]))
+      ) {
+        return cached.snapshot;
+      }
+
+      const snapshot = Object.fromEntries(
+        normalizedPaths.map((path, index) => [path, selectedValues[index]]),
+      );
+
+      selectedCache.set(key, { snapshot, values: selectedValues });
+
+      return snapshot;
+    },
+    getSnapshot: () => values,
+    replaceInitial: (nextInitial: Record<string, unknown>): void => {
+      if (valuesEqual(initialValues, nextInitial)) {
+        return;
+      }
+
+      initialValues = nextInitial;
+      updateValues(nextInitial, "");
+    },
+    setValue: (name: string, value: unknown | ((previous: unknown) => unknown)): void => {
+      const previous = getPath(values, name);
+      const next = typeof value === "function" ? value(previous) : value;
+
+      if (Object.is(previous, next)) {
+        return;
+      }
+
+      updateValues(setPath(values, name, next), name);
+    },
+    subscribe: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+
+      return () => listeners.delete(listener);
+    },
+    subscribePath,
+    subscribePaths: (paths: string[], listener: () => void): (() => void) => {
+      const unsubscribers = Array.from(new Set(paths.map(normalizePath))).map((path) =>
+        subscribePath(path, listener),
+      );
+
+      return () => {
+        for (const unsubscribe of unsubscribers) {
+          unsubscribe();
+        }
+      };
+    },
+  };
+}
+
 export function FormValuesProvider({
   initial,
   children,
@@ -53,42 +200,61 @@ export function FormValuesProvider({
   initial: Record<string, unknown>;
   children: React.ReactNode;
 }) {
-  const [values, setValues] = useState<Record<string, unknown>>(initial);
-  const initialRef = useRef(initial);
+  const storeRef = useRef<FormValuesStore>(null);
+
+  if (storeRef.current === null) {
+    storeRef.current = createFormValuesStore(initial);
+  }
 
   useEffect(() => {
-    if (valuesEqual(initialRef.current, initial)) {
-      return;
-    }
-
-    initialRef.current = initial;
-    setValues(initial);
+    storeRef.current?.replaceInitial(initial);
   }, [initial]);
 
-  const setValue = useCallback((name: string, value: unknown) => {
-    setValues((current) => {
-      const next =
-        typeof value === "function"
-          ? (value as (previous: unknown) => unknown)(getPath(current, name))
-          : value;
+  return (
+    <FormValuesStoreContext.Provider value={storeRef.current}>
+      <SetFormValueContext.Provider value={storeRef.current.setValue}>
+        {children}
+      </SetFormValueContext.Provider>
+    </FormValuesStoreContext.Provider>
+  );
+}
 
-      return Object.is(getPath(current, name), next) ? current : setPath(current, name, next);
-    });
-  }, []);
-
-  const contextValue = useMemo(() => ({ values, setValue }), [values, setValue]);
-
-  return <FormValuesContext.Provider value={contextValue}>{children}</FormValuesContext.Provider>;
+function useFormValuesStore(): FormValuesStore {
+  return useContext(FormValuesStoreContext) ?? createFormValuesStore(emptyValues);
 }
 
 export function useFormValues(): Record<string, unknown> {
-  return useContext(FormValuesContext).values;
+  const store = useFormValuesStore();
+
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
 }
 
 export function useFormValue(name: string): unknown {
-  return getPath(useContext(FormValuesContext).values, name);
+  const store = useFormValuesStore();
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribePath(name, listener),
+    [name, store],
+  );
+  const getSnapshot = useCallback(() => store.getPathSnapshot(name), [name, store]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
-export function useSetFormValue(): (name: string, value: unknown) => void {
-  return useContext(FormValuesContext).setValue;
+export function useFormValuesFor(paths: string[]): Record<string, unknown> {
+  const store = useFormValuesStore();
+  const normalizedPaths = useMemo(() => paths.map(normalizePath), [paths]);
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribePaths(normalizedPaths, listener),
+    [normalizedPaths, store],
+  );
+  const getSnapshot = useCallback(
+    () => store.getPathsSnapshot(normalizedPaths),
+    [normalizedPaths, store],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function useSetFormValue(): SetFormValue {
+  return useContext(SetFormValueContext);
 }

--- a/resources/js/form/lib/conditions.test.ts
+++ b/resources/js/form/lib/conditions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { evaluateConditions, type Condition } from "./conditions";
+import { conditionFields, evaluateConditions, type Condition } from "./conditions";
 
 describe("evaluateConditions", () => {
   it("hides when a visible condition fails", () => {
@@ -125,5 +125,15 @@ describe("evaluateConditions", () => {
   it("treats equal dates as neither before nor after", () => {
     expect(shows("before", "2024-01-01", "2024-01-01")).toBe(false);
     expect(shows("after", "2024-01-01", "2024-01-01")).toBe(false);
+  });
+
+  it("lists each condition field once in declaration order", () => {
+    expect(
+      conditionFields({
+        visible: [{ field: "type", operator: "eq", value: "business" }],
+        required: [{ field: "type", operator: "eq", value: "business" }],
+        disabled: [{ field: "status", operator: "neq", value: "archived" }],
+      }),
+    ).toEqual(["type", "status"]);
   });
 });

--- a/resources/js/form/lib/conditions.ts
+++ b/resources/js/form/lib/conditions.ts
@@ -23,6 +23,23 @@ export type FieldState = {
   disabled: boolean;
 };
 
+export function conditionFields(conditions: FieldConditions | undefined | null): string[] {
+  const fields = new Set<string>();
+
+  for (const group of [
+    conditions?.visible,
+    conditions?.required,
+    conditions?.readOnly,
+    conditions?.disabled,
+  ]) {
+    for (const condition of group ?? []) {
+      fields.add(condition.field);
+    }
+  }
+
+  return Array.from(fields);
+}
+
 const BOOLEAN_TRUE_VALUES = new Set(["1", "true", "on", "yes"]);
 
 // Mirrors PHP filter_var(FILTER_VALIDATE_BOOLEAN) so conditions evaluate

--- a/resources/js/table/components/table.browser.test.tsx
+++ b/resources/js/table/components/table.browser.test.tsx
@@ -177,10 +177,10 @@ describe("Lattice table component in a browser", () => {
       </div>,
     );
     const skuHeader = screen.getByRole("columnheader", { name: "SKU" }).element();
-    const headerRow = skuHeader.parentElement;
+    const table = skuHeader.closest('[role="table"]');
 
-    expect(headerRow).toBeInstanceOf(HTMLElement);
-    expect((headerRow as HTMLElement).style.getPropertyValue("--lattice-table-columns")).toBe(
+    expect(table).toBeInstanceOf(HTMLElement);
+    expect((table as HTMLElement).style.getPropertyValue("--lattice-table-columns")).toBe(
       "180px minmax(8rem, 1fr)",
     );
     await expect.element(screen.getByTestId("table-reset-columns")).toBeInTheDocument();
@@ -198,10 +198,10 @@ describe("Lattice table component in a browser", () => {
       </div>,
     );
     const skuHeader = screen.getByRole("columnheader", { name: "SKU" }).element();
-    const headerRow = skuHeader.parentElement;
+    const table = skuHeader.closest('[role="table"]');
 
-    expect(headerRow).toBeInstanceOf(HTMLElement);
-    expect((headerRow as HTMLElement).style.getPropertyValue("--lattice-table-columns")).toBe(
+    expect(table).toBeInstanceOf(HTMLElement);
+    expect((table as HTMLElement).style.getPropertyValue("--lattice-table-columns")).toBe(
       "240px minmax(8rem, 1fr)",
     );
     await expect.element(screen.getByTestId("table-reset-columns")).toBeInTheDocument();
@@ -241,15 +241,15 @@ describe("Lattice table component in a browser", () => {
     );
     const handle = screen.getByRole("separator", { name: "Resize SKU" }).element();
     const skuHeader = screen.getByRole("columnheader", { name: "SKU" }).element();
-    const headerRow = skuHeader.parentElement;
+    const table = skuHeader.closest('[role="table"]');
 
     handle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
 
     await expect
       .poll(() => window.localStorage.getItem(storageKey))
       .toBe(JSON.stringify({ columns: ["sku", "name"], overrides: { name: 224 } }));
-    expect(headerRow).toBeInstanceOf(HTMLElement);
-    expect((headerRow as HTMLElement).style.getPropertyValue("--lattice-table-columns")).toBe(
+    expect(table).toBeInstanceOf(HTMLElement);
+    expect((table as HTMLElement).style.getPropertyValue("--lattice-table-columns")).toBe(
       "minmax(6rem, 0.5fr) 224px",
     );
     await expect.element(screen.getByTestId("table-reset-columns")).toBeInTheDocument();

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -376,6 +376,10 @@ describe("Lattice table component", () => {
     fireEvent.pointerDown(handle, { clientX: 100, pointerId: 1 });
     fireEvent.pointerMove(handle, { clientX: 180, pointerId: 1 });
 
+    expect(window.localStorage.getItem("lattice:table-columns:workbench.products")).toBeNull();
+
+    fireEvent.pointerUp(handle, { clientX: 180, pointerId: 1 });
+
     expect(
       JSON.parse(window.localStorage.getItem("lattice:table-columns:workbench.products") ?? ""),
     ).toEqual({
@@ -384,6 +388,41 @@ describe("Lattice table component", () => {
         qty: 256,
       },
     });
+  });
+
+  it("keeps resized table column styles on the table root instead of every row", () => {
+    const node = {
+      id: "workbench.products",
+      props: {
+        columns: [
+          col({
+            key: "qty",
+            label: "Qty",
+          }),
+          col({
+            key: "price",
+            label: "Price",
+          }),
+        ],
+        data: [{ id: 1, qty: 1, price: "$10" }],
+        resizableColumns: true,
+        state: {
+          filters: [],
+          page: 1,
+          perPage: 25,
+          sorts: [],
+        },
+      },
+      type: "table",
+    } satisfies TableNode;
+
+    render(<TableComponent node={node}>{null}</TableComponent>);
+
+    const row = screen.getByRole("cell", { name: "1" }).closest('[data-slot="table-row"]');
+    const table = row?.parentElement?.parentElement;
+
+    expect(table).toHaveStyle("--lattice-table-columns: minmax(8rem, 1fr) minmax(8rem, 1fr)");
+    expect(row?.getAttribute("style") ?? "").not.toContain("--lattice-table-columns");
   });
 
   it("renders grid rows with stack columns and row actions without table cells", async () => {

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -106,7 +106,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   );
   const resizingEnabled = node.props?.resizableColumns === true;
   const resizeStorageIdentity = nodeIdentity(node);
-  const { getResizeHandleProps, gridTemplateColumns, hasOverrides, resetColumns } =
+  const { getResizeHandleProps, gridTemplateColumns, hasOverrides, resizeRootRef, resetColumns } =
     useColumnResizing({
       columns: sizingColumns,
       enabled: resizingEnabled,
@@ -171,7 +171,12 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
             onClear={clearSort}
           />
         )}
-        <div className="min-w-full text-base" role="table">
+        <div
+          ref={resizeRootRef}
+          className="min-w-full text-base"
+          role="table"
+          style={{ "--lattice-table-columns": gridTemplateColumns } as never}
+        >
           <div
             data-slot="table-header"
             className="border-b border-lt-border bg-lt-muted/50"
@@ -180,7 +185,6 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
             <div
               className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
               role="row"
-              style={{ "--lattice-table-columns": gridTemplateColumns } as never}
             >
               {hasBulkActions && (
                 <div className="flex items-center px-4 py-3" role="columnheader">
@@ -237,7 +241,6 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
               <div
                 className="hidden min-w-full border-t border-lt-border md:grid md:grid-cols-[var(--lattice-table-columns)]"
                 role="row"
-                style={{ "--lattice-table-columns": gridTemplateColumns } as never}
               >
                 {hasBulkActions && <div className="px-4 py-2" role="cell" />}
                 {visibleColumns.map((column) => (
@@ -281,7 +284,6 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                       striped ? "odd:bg-lt-muted/30" : ""
                     }`}
                     role="row"
-                    style={{ "--lattice-table-columns": gridTemplateColumns } as never}
                   >
                     {hasBulkActions && (
                       <div className="flex items-center px-lt-cell-x py-lt-cell-y" role="cell">

--- a/src/Core/PageMetadata.php
+++ b/src/Core/PageMetadata.php
@@ -6,7 +6,6 @@ namespace Lattice\Lattice\Core;
 
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\Contracts\PageContract;
-use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
 use Lattice\Lattice\Support\Wire;
@@ -29,19 +28,7 @@ final readonly class PageMetadata
 
     public static function for(PageContract|string $page): self
     {
-        $class = is_object($page) ? $page::class : $page;
-
-        $manifest = app(DiscoveryManifest::class);
-
-        if ($manifest->isCached()) {
-            $descriptor = $manifest->descriptorFor($class);
-
-            if ($descriptor !== null) {
-                return self::fromArray($descriptor);
-            }
-        }
-
-        return self::reflect($class);
+        return app(PageMetadataResolver::class)->for($page);
     }
 
     public static function reflect(PageContract|string $page): self

--- a/src/Core/PageMetadataResolver.php
+++ b/src/Core/PageMetadataResolver.php
@@ -12,14 +12,15 @@ final class PageMetadataResolver
     /** @var array<string, PageMetadata> */
     private array $metadata = [];
 
+    private ?bool $manifestCached = null;
+
     public function __construct(private readonly DiscoveryManifest $manifest) {}
 
     public function for(PageContract|string $page): PageMetadata
     {
         $class = is_object($page) ? $page::class : $page;
-        $key = $this->cacheKey($class);
 
-        return $this->metadata[$key] ??= $this->resolve($class);
+        return $this->metadata[$class] ??= $this->resolve($class);
     }
 
     /**
@@ -27,7 +28,7 @@ final class PageMetadataResolver
      */
     private function resolve(string $class): PageMetadata
     {
-        if ($this->manifest->isCached()) {
+        if ($this->manifestIsCached()) {
             $descriptor = $this->manifest->descriptorFor($class);
 
             if ($descriptor !== null) {
@@ -38,11 +39,8 @@ final class PageMetadataResolver
         return PageMetadata::reflect($class);
     }
 
-    /**
-     * @param  class-string  $class
-     */
-    private function cacheKey(string $class): string
+    private function manifestIsCached(): bool
     {
-        return $class.'|'.($this->manifest->isCached() ? 'manifest' : 'reflection');
+        return $this->manifestCached ??= $this->manifest->isCached();
     }
 }

--- a/src/Core/PageMetadataResolver.php
+++ b/src/Core/PageMetadataResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core;
+
+use Lattice\Lattice\Core\Contracts\PageContract;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+
+final class PageMetadataResolver
+{
+    /** @var array<string, PageMetadata> */
+    private array $metadata = [];
+
+    public function __construct(private readonly DiscoveryManifest $manifest) {}
+
+    public function for(PageContract|string $page): PageMetadata
+    {
+        $class = is_object($page) ? $page::class : $page;
+        $key = $this->cacheKey($class);
+
+        return $this->metadata[$key] ??= $this->resolve($class);
+    }
+
+    /**
+     * @param  class-string  $class
+     */
+    private function resolve(string $class): PageMetadata
+    {
+        if ($this->manifest->isCached()) {
+            $descriptor = $this->manifest->descriptorFor($class);
+
+            if ($descriptor !== null) {
+                return PageMetadata::fromArray($descriptor);
+            }
+        }
+
+        return PageMetadata::reflect($class);
+    }
+
+    /**
+     * @param  class-string  $class
+     */
+    private function cacheKey(string $class): string
+    {
+        return $class.'|'.($this->manifest->isCached() ? 'manifest' : 'reflection');
+    }
+}

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -196,7 +196,7 @@ abstract class Page implements PageContract, Responsable
     private function response(PageSchema $schema): Response
     {
         return Inertia::render($this->component(), [
-            'lattice' => app()->call([$this, 'toArray'], ['schema' => $schema]),
+            'lattice' => app()->call($this->toArray(...), ['schema' => $schema]),
         ]);
     }
 

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -12,7 +12,7 @@ use Inertia\Response;
 use Lattice\Lattice\Core\Contracts\PageContract;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
-use Lattice\Lattice\Core\PageMetadataResolver;
+use Lattice\Lattice\Core\PageMetadata;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Realtime\Listen;
@@ -124,9 +124,9 @@ abstract class Page implements PageContract, Responsable
     /**
      * @return array{title: string|null, layout: array{key: string, schema: mixed}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, schema: mixed, listeners?: mixed}
      */
-    public function toArray(PageSchema $schema, Request $request, ?PageMetadataResolver $metadataResolver = null): array
+    public function toArray(PageSchema $schema, Request $request): array
     {
-        $metadata = ($metadataResolver ?? app(PageMetadataResolver::class))->for($this);
+        $metadata = PageMetadata::for($this);
         $layout = $this->layout() ?? $metadata->layout;
         $container = $this->container() ?? $metadata->container;
 
@@ -196,7 +196,7 @@ abstract class Page implements PageContract, Responsable
     private function response(PageSchema $schema): Response
     {
         return Inertia::render($this->component(), [
-            'lattice' => app()->call($this->toArray(...), ['schema' => $schema]),
+            'lattice' => $this->toArray($schema, app(Request::class)),
         ]);
     }
 

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -12,7 +12,7 @@ use Inertia\Response;
 use Lattice\Lattice\Core\Contracts\PageContract;
 use Lattice\Lattice\Core\Enums\PageContainer;
 use Lattice\Lattice\Core\Enums\PageLayout;
-use Lattice\Lattice\Core\PageMetadata;
+use Lattice\Lattice\Core\PageMetadataResolver;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Realtime\Listen;
@@ -124,9 +124,9 @@ abstract class Page implements PageContract, Responsable
     /**
      * @return array{title: string|null, layout: array{key: string, schema: mixed}|null, container: string, breadcrumbs: array<int, array{title: string, href: string}>, schema: mixed, listeners?: mixed}
      */
-    public function toArray(PageSchema $schema, Request $request): array
+    public function toArray(PageSchema $schema, Request $request, ?PageMetadataResolver $metadataResolver = null): array
     {
-        $metadata = PageMetadata::for($this);
+        $metadata = ($metadataResolver ?? app(PageMetadataResolver::class))->for($this);
         $layout = $this->layout() ?? $metadata->layout;
         $container = $this->container() ?? $metadata->container;
 
@@ -196,7 +196,7 @@ abstract class Page implements PageContract, Responsable
     private function response(PageSchema $schema): Response
     {
         return Inertia::render($this->component(), [
-            'lattice' => $this->toArray($schema, app(Request::class)),
+            'lattice' => app()->call([$this, 'toArray'], ['schema' => $schema]),
         ]);
     }
 

--- a/src/Http/PageRegistry.php
+++ b/src/Http/PageRegistry.php
@@ -7,6 +7,7 @@ namespace Lattice\Lattice\Http;
 use Lattice\Lattice\Core\Contracts\PageContract;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\PageMetadata;
+use Lattice\Lattice\Core\PageMetadataResolver;
 use ReflectionClass;
 
 final class PageRegistry
@@ -14,7 +15,10 @@ final class PageRegistry
     /** @var array<class-string, class-string> */
     private array $registered = [];
 
-    public function __construct(private readonly DiscoveryManifest $manifest) {}
+    public function __construct(
+        private readonly DiscoveryManifest $manifest,
+        private readonly PageMetadataResolver $metadata,
+    ) {}
 
     /**
      * @param  class-string|array<int, class-string>  $pages
@@ -34,7 +38,7 @@ final class PageRegistry
         $pages = [];
 
         foreach ($this->manifest->pageDescriptors() as $descriptor) {
-            $pages[$descriptor['class']] = PageMetadata::fromArray($descriptor);
+            $pages[$descriptor['class']] = $this->metadata->for($descriptor['class']);
         }
 
         foreach ($this->registered as $page) {
@@ -46,7 +50,7 @@ final class PageRegistry
                 continue;
             }
 
-            $metadata = PageMetadata::reflect($page);
+            $metadata = $this->metadata->for($page);
 
             if ($metadata->route !== null) {
                 $pages[$page] = $metadata;

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -39,6 +39,7 @@ use Lattice\Lattice\Core\Contracts\ResolvesReferenceIdentity;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Lattice\Core\PageMetadataResolver;
 use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
 use Lattice\Lattice\Core\Services\RequestReferenceIdentity;
 use Lattice\Lattice\Effects\EffectFlasher;
@@ -109,6 +110,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);
         $this->app->singleton(LatticeRegistry::class);
         $this->app->singleton(DiscoveryManifest::class);
+        $this->app->singleton(PageMetadataResolver::class);
         $this->app->singleton(Evaluator::class, fn ($app): Evaluator => new Evaluator($app, [Component::class]));
         $this->app->scoped(EffectFlasher::class);
 

--- a/tests/Unit/Core/PageMetadataResolverTest.php
+++ b/tests/Unit/Core/PageMetadataResolverTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Filesystem\Filesystem;
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Enums\PageContainer;
@@ -48,3 +49,27 @@ test('resolver memoizes metadata loaded from the discovery manifest', function (
         $manifest->clear();
     }
 });
+
+test('resolver checks the manifest mode once per instance', function (): void {
+    $files = new CountingManifestFilesystem;
+    $manifest = new DiscoveryManifest(app(), $files);
+    $resolver = new PageMetadataResolver($manifest);
+
+    $resolver->for(ResolverPage::class);
+    $resolver->for(new ResolverPage);
+
+    expect($files->existsCalls)->toBe(1);
+});
+
+final class CountingManifestFilesystem extends Filesystem
+{
+    public int $existsCalls = 0;
+
+    #[Override]
+    public function exists($path): bool
+    {
+        $this->existsCalls++;
+
+        return false;
+    }
+}

--- a/tests/Unit/Core/PageMetadataResolverTest.php
+++ b/tests/Unit/Core/PageMetadataResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Lattice\Core\Enums\PageContainer;
+use Lattice\Lattice\Core\Enums\PageLayout;
+use Lattice\Lattice\Core\PageMetadataResolver;
+use Lattice\Lattice\Http\Page as BasePage;
+use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredDemoPage;
+
+#[AsPage(layout: PageLayout::App, container: PageContainer::Default)]
+abstract class ResolverBasePage extends BasePage {}
+
+#[AsPage(route: '/resolver', name: 'resolver.index')]
+final class ResolverPage extends ResolverBasePage {}
+
+test('resolver memoizes reflected metadata by page class', function (): void {
+    $resolver = app(PageMetadataResolver::class);
+
+    $first = $resolver->for(ResolverPage::class);
+    $second = $resolver->for(new ResolverPage);
+
+    expect($second)->toBe($first)
+        ->and($first->route)->toBe('/resolver')
+        ->and($first->layout)->toBe(PageLayout::App);
+});
+
+test('resolver memoizes metadata loaded from the discovery manifest', function (): void {
+    config(['lattice.discover' => [
+        __DIR__.'/../Fixtures/Discovery',
+    ]]);
+
+    $manifest = app(DiscoveryManifest::class);
+    $manifest->cache();
+    app()->forgetInstance(PageMetadataResolver::class);
+
+    try {
+        $resolver = app(PageMetadataResolver::class);
+
+        $first = $resolver->for(DiscoveredDemoPage::class);
+        $second = $resolver->for(DiscoveredDemoPage::class);
+
+        expect($second)->toBe($first)
+            ->and($first->name)->toBe('discovered.demo');
+    } finally {
+        $manifest->clear();
+    }
+});

--- a/tests/Unit/Http/PageSerializationTest.php
+++ b/tests/Unit/Http/PageSerializationTest.php
@@ -32,6 +32,15 @@ test('pages serialize layout and container metadata', function (): void {
         ->toMatchArray(['layout' => null, 'container' => 'default']);
 });
 
+test('page array serialization keeps the public contract narrow', function (): void {
+    $parameters = array_map(
+        static fn (ReflectionParameter $parameter): string => $parameter->getName(),
+        new ReflectionMethod(Page::class, 'toArray')->getParameters(),
+    );
+
+    expect($parameters)->toBe(['schema', 'request']);
+});
+
 test('the layout() method takes precedence over the page attribute', function (): void {
     $page = new #[AsPage(layout: PageLayout::App)] class extends Page
     {


### PR DESCRIPTION
## What changed
- Added selector-based form value subscriptions so individual fields and dependency checks avoid whole-form rerenders.
- Dotted condition fields now resolve through the same nested form path logic and are covered by regression tests.
- Memoized node rendering for stable schema nodes.
- Added an injected, memoized page metadata resolver for registry paths, with response serialization using the narrower public page array contract.
- Moved table column resize dragging off the React state/storage hot path and committed cancelled drags consistently.

## Validation
- composer check
- npm run check
- npm run test:browser