### PR TITLE
chore: comment-guidelines sweep

### DIFF
--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -25,7 +25,6 @@
   --lt-success-fg: var(--success-foreground, oklch(0.985 0 0));
   --lt-info: var(--info, oklch(0.62 0.14 240));
   --lt-info-fg: var(--info-foreground, oklch(0.985 0 0));
-  /* Interaction states (hover / active / disabled) */
   --lt-primary-hover: var(--primary-hover, oklch(0.43 0.092 182));
   --lt-primary-active: var(--primary-active, oklch(0.39 0.092 182));
   --lt-danger-hover: var(--destructive-hover, oklch(0.53 0.21 27.3));
@@ -60,15 +59,14 @@
   --lt-control-h-lg: 2.5rem;
 
   /* Table cell padding — table density lever */
-  --lt-table-cell-x: calc(var(--spacing) * 4); /* 1rem */
-  --lt-table-cell-y: calc(var(--spacing) * 4); /* 1rem */
+  --lt-table-cell-x: calc(var(--spacing) * 4);
+  --lt-table-cell-y: calc(var(--spacing) * 4);
 
   --lt-font-weight-normal: 400;
   --lt-font-weight-medium: 500;
   --lt-font-weight-semibold: 600;
   --lt-font-weight-bold: 700;
 
-  /* Elevation */
   --lt-shadow-xs: 0 1px 1px 0 oklch(0 0 0 / 0.04);
   --lt-shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.05);
   --lt-shadow-md:
@@ -76,7 +74,6 @@
   --lt-shadow-lg:
     0 8px 16px -4px oklch(0 0 0 / 0.12), 0 2px 4px -2px oklch(0 0 0 / 0.08);
 
-  /* Z-index scale */
   --lt-z-dropdown: 1000;
   --lt-z-sticky: 1100;
   --lt-z-overlay: 1200;
@@ -84,17 +81,15 @@
   --lt-z-popover: 1400;
   --lt-z-toast: 1500;
 
-  /* Motion */
   --lt-duration-fast: 120ms;
   --lt-duration-base: 160ms;
 
-  /* Layout dimensions */
   --lt-sidebar-w: 16rem;
   --lt-sidebar-w-collapsed: 4rem;
   --lt-container-max: 80rem;
 
   /* Card / section content inset — the gutter apps can break out of */
-  --lt-gutter: calc(var(--spacing) * 6); /* 1.5rem */
+  --lt-gutter: calc(var(--spacing) * 6);
 
   color-scheme: light;
 }
@@ -127,7 +122,6 @@
   --lt-info: var(--info, oklch(0.7 0.14 240));
   --lt-info-fg: var(--info-foreground, oklch(0.205 0 0));
 
-  /* Interaction states (dark) */
   --lt-primary-hover: var(--primary-hover, oklch(0.79 0.105 182));
   --lt-primary-active: var(--primary-active, oklch(0.84 0.105 182));
   --lt-danger-hover: var(--destructive-hover, oklch(0.47 0.13 26));
@@ -217,7 +211,6 @@
     "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";
 
-  /* Base spacing unit */
   --spacing: 0.25rem;
 
   --text-xs: 0.625rem;

--- a/resources/js/icons/icon-renderer.tsx
+++ b/resources/js/icons/icon-renderer.tsx
@@ -39,7 +39,6 @@ export function IconRenderer({ className, icon }: IconRendererProps) {
   const renderers = useContext(IconRenderersContext);
   const { ids } = useSprite();
 
-  // Custom renderers (the override stack) take precedence over the sprite.
   for (const renderer of renderers) {
     const rendered = renderer({ className, icon });
 

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -29,10 +29,6 @@ class Action extends Component
 
     public ?string $endpoint = null;
 
-    /**
-     * The confirmation dialog shown before the action runs, or `null` until
-     * {@see confirm()} sets one.
-     */
     public ?Confirmation $confirmation = null;
 
     public ?Form $form = null;

--- a/src/Core/EloquentOptions.php
+++ b/src/Core/EloquentOptions.php
@@ -114,9 +114,6 @@ final class EloquentOptions implements OptionSource
         return $this->toOptions($this->query()->whereIn($this->valueColumn(), $values)->get());
     }
 
-    /**
-     * The value column, defaulting to the model's primary key when not set explicitly.
-     */
     private function valueColumn(): string
     {
         return $this->resolvedValueKey ??= $this->valueKey ?? (new $this->model)->getKeyName();

--- a/src/Effects/Attributes/AsEffect.php
+++ b/src/Effects/Attributes/AsEffect.php
@@ -25,8 +25,6 @@ final readonly class AsEffect extends TypeScript
     }
 
     /**
-     * Resolve the wire type declared by the #[AsEffect] attribute on $class.
-     *
      * @param  class-string  $class
      */
     public static function wireTypeForClass(string $class): string

--- a/src/Support/Testing/Assertions/ComponentAssertions.php
+++ b/src/Support/Testing/Assertions/ComponentAssertions.php
@@ -192,10 +192,6 @@ final readonly class ComponentAssertions
         );
     }
 
-    /**
-     * Accept either a wire type (`'menu-item'`) or a component class
-     * (`MenuItem::class`), resolving the class to its declared wire type.
-     */
     private function resolveType(string $type): string
     {
         if (is_subclass_of($type, Component::class)) {

--- a/src/Ui/Concerns/HasOptions.php
+++ b/src/Ui/Concerns/HasOptions.php
@@ -45,8 +45,6 @@ trait HasOptions
     }
 
     /**
-     * The configured option values.
-     *
      * @return list<string>
      */
     public function optionValues(): array

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -122,8 +122,6 @@ test('eloquent tables can disable pagination for small datasets', function (): v
 
 /**
  * @extends EloquentTableDefinition<User>
- *
- * @phpstan-extends EloquentTableDefinition<User>
  */
 #[AsTable('workbench.infinite-users')]
 class WorkbenchInfiniteUsersTable extends EloquentTableDefinition
@@ -159,8 +157,6 @@ class WorkbenchInfiniteUsersTable extends EloquentTableDefinition
 
 /**
  * @extends EloquentTableDefinition<User>
- *
- * @phpstan-extends EloquentTableDefinition<User>
  */
 #[AsTable('workbench.default-users')]
 class WorkbenchDefaultUsersTable extends EloquentTableDefinition
@@ -189,8 +185,6 @@ class WorkbenchDefaultUsersTable extends EloquentTableDefinition
 
 /**
  * @extends EloquentTableDefinition<User>
- *
- * @phpstan-extends EloquentTableDefinition<User>
  */
 #[AsTable('workbench.simple-users')]
 class WorkbenchSimpleUsersTable extends EloquentTableDefinition
@@ -225,8 +219,6 @@ class WorkbenchSimpleUsersTable extends EloquentTableDefinition
 
 /**
  * @extends EloquentTableDefinition<User>
- *
- * @phpstan-extends EloquentTableDefinition<User>
  */
 #[AsTable('workbench.small-users')]
 class WorkbenchSmallUsersTable extends EloquentTableDefinition

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -309,8 +309,6 @@ function withoutRowIds(array $rows): array
 }
 
 /**
- * Perform a JSON GET request with a Lattice component ref header.
- *
  * @return TestResponse<JsonResponse>
  */
 function latticeGet(string $url, string $ref): TestResponse

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -245,7 +245,6 @@ export default defineConfig(({ mode }) => {
               tsconfigPath: path.resolve(__dirname, "tsconfig.json"),
               include: ["resources/js"],
               copyDtsFiles: true,
-              // Exclude test files and declaration sources from .d.ts generation.
               exclude: [
                 "resources/js/**/*.test.*",
                 "resources/js/**/*.test-d.*",


### PR DESCRIPTION
Rigorous two-pass audit of every comment in the codebase against the .ai comment guidelines.

**Pass 1** — three parallel reviewers over src, tests+workbench PHP, and resources/js TS (~1,300 comment lines): 7 violations.
**Pass 2** — six domain-sliced reviewers each reading every file in full (src/Ui, src/Forms+Fragments, src/Tables+Actions, src/Core+Support+Attributes, remaining src domains+roots, and a misc scope pass 1 missed: vite.config.ts, resources/css, docs code, .githooks, config, packages), plus an independent orchestrator pass over all 41 short-prose docblocks in src and per-finding verification against the code: 14 more violations.

**Removed (21 total):**
- resources/css/lattice.css: 7 section banners over self-naming token groups (Interaction states ×2, Elevation, Z-index scale, Motion, Layout dimensions, Base spacing unit) and 3 stale computed-value narrations (`/* 1rem */`); the banners carrying real semantics (density levers, radius mapping, gutter contract) stay
- vite.config.ts: a dts comment that mislabeled its exclude list (it also excludes `standalone/**`)
- 4 docblocks restating their declaration: `Action::$confirmation` (duplicates `Confirmation`'s class doc), `EloquentOptions::valueColumn` + `ComponentAssertions::resolveType` (private one-line bodies), `AsEffect::wireTypeForClass` prose (`class-string` tag kept)
- 4× `@phpstan-extends` duplicating the adjacent `@extends` (TablePaginationTest) — PHPStan verified green without them
- 2 docblock sentences restating the method name (`latticeGet`, `HasOptions::optionValues`) — type tags kept
- 1 comment narrating a loop's visible control flow (icon-renderer.tsx)

Everything else was verified compliant: line comments are why-comments (framework quirks, ordering, timing, parallel isolation, generated-file markers) and docblocks carry shapes/generics, API intent, or non-obvious constraints. Docblocks confirmed not to flow into `generated.ts`.

Verification: Pint, PHPStan, Rector green; typescript snapshot, affected Pest + Vitest suites pass; pre-push gate ran on both pushes.