### PR TITLE
docs: full correctness sweep, live-example styling, and intro reframe

### DIFF
--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -101,16 +101,17 @@ A callout only renders where the `Callouts` layout slot is placed. Add `Callouts
 layout's `schema()`, typically between the header bar and `Outlet::make()`:
 
 ```php
+use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Layouts\Components\Callouts;
 use Lattice\Lattice\Layouts\Components\Outlet;
 
-public function schema(): array
+public function schema(PageSchema $schema, Request $request): PageSchema
 {
-    return [
+    return $schema->schema([
         $this->headerBar(),
         Callouts::make(),
         Outlet::make(),
-    ];
+    ]);
 }
 ```
 

--- a/docs/content/docs/actions/overview.mdx
+++ b/docs/content/docs/actions/overview.mdx
@@ -45,6 +45,7 @@ icon, variant, confirmation), and `handle()` runs the work and returns an `Actio
 [endpoint](/advanced/security/).
 
 ```php
+use App\Models\Product;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
@@ -66,7 +67,7 @@ class ArchiveProductAction extends ActionDefinition
 
     public function handle(Request $request): ActionResult
     {
-        $product = $this->product($request);
+        $product = Product::findOrFail($this->context('product_id'));
         $product->update(['status' => 'archived']);
 
         return ActionResult::success()
@@ -87,7 +88,7 @@ Action::use(ArchiveProductAction::class)
 ```
 
 `context()` carries data from the page to the action; `handle()` reads it back with
-`$this->context($request, 'product_id')`. The context is signed into the action's reference, so it
+`$this->context('product_id')`. The context is signed into the action's reference, so it
 can't be tampered with on the way back.
 
 Group related actions behind a single trigger with `ActionGroup`:
@@ -128,13 +129,13 @@ return ActionResult::success(['id' => $product->id])
 
 ## Authorization
 
-Override `authorize()` to gate an action. It receives the request (with the trusted context merged
-in) and returns a boolean; a denied action never reaches `handle()`.
+Override `authorize()` to gate an action. It receives the request — the signed context is available
+through `$this->context()` — and returns a boolean; a denied action never reaches `handle()`.
 
 ```php
 public function authorize(Request $request): bool
 {
-    return $this->product($request)->status !== 'archived';
+    return Product::findOrFail($this->context('product_id'))->status !== 'archived';
 }
 ```
 

--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -46,7 +46,8 @@ layout primitives.
 
 <EnumTable enums={["Size", "Color"]} />
 
-The icon names a `Lattice\Lattice\Ui\Enums\Icon` accepts are listed on the [Icons](/core/icons/) page.
+The icon names a `Lattice\Lattice\Ui\Enums\Icon` accepts are the enum's own cases — one per bundled
+SVG. The [Icons](/core/icons/) page covers where they come from and how to add your own.
 
 ## Buttons & feedback
 

--- a/docs/content/docs/advanced/remote.mdx
+++ b/docs/content/docs/advanced/remote.mdx
@@ -222,9 +222,10 @@ import { remoteComponents } from "@lattice-php/lattice/remote";
 export const registry = createRegistry(/* …core plugins…, */ remoteComponents);
 ```
 
-A remote chat box needs `chatPlugin` instead — it registers the `chat.box` type that remote chat
-reuses. Unlike `chatPlugin`, `remoteComponents` is not re-exported from the package root, so import it
-from the `@lattice-php/lattice/remote` subpath as shown above.
+A remote chat box needs `chatComponents` (from `@lattice-php/lattice/chat`) instead — it registers
+the `chat.box` type that remote chat reuses. Unlike `chatComponents`, `remoteComponents` is not
+re-exported from the package root, so import it from the `@lattice-php/lattice/remote` subpath as
+shown above.
 
 ## Configuration
 

--- a/docs/content/docs/advanced/security.md
+++ b/docs/content/docs/advanced/security.md
@@ -25,8 +25,8 @@ issued to. Only then does it run.
 ## Why context is trustworthy
 
 Because the context travels inside the encrypted reference — not as ordinary request input — a client
-can't change it. The endpoint merges the **trusted** context back onto the request, so
-`$this->context($request, 'product_id')` always returns the value the server sealed. This is what lets
+can't change it. The endpoint restores the **trusted** context onto the definition, so
+`$this->context('product_id')` always returns the value the server sealed. This is what lets
 [row actions](/tables/actions/) safely carry a record id and [authorization](/core/authorization/)
 trust it.
 

--- a/docs/content/docs/components/charts.mdx
+++ b/docs/content/docs/components/charts.mdx
@@ -13,7 +13,7 @@ line, bar, area, or pie. The PHP builder serializes to a typed node the renderer
 [Recharts](https://recharts.org).
 
 <ComponentExample
-  php={`Chart::make('Signups')
+  php={`Chart::make('Signups', 'signups-chart')
     ->description('New users per month')
     ->categoryKey('month')
     ->data([
@@ -50,7 +50,7 @@ still plot, but the axis ticks are hidden. Always set it for line, bar, and area
 Two `->bar()` series render grouped side by side:
 
 <ComponentExample
-  php={`Chart::make('Orders by channel')
+  php={`Chart::make('Orders by channel', 'orders-chart')
     ->categoryKey('week')
     ->data([
         ['week' => 'W1', 'online' => 120, 'store' => 80],
@@ -69,7 +69,7 @@ Two `->bar()` series render grouped side by side:
 Give bars — or areas — the same `stackId` to stack them into one column instead:
 
 <ComponentExample
-  php={`Chart::make('Monthly recurring revenue')
+  php={`Chart::make('Monthly recurring revenue', 'mrr-chart')
     ->description('Stacked by revenue type')
     ->categoryKey('month')
     ->data([
@@ -90,7 +90,7 @@ Series types mix freely in one chart. Declaring an `->area()` and a `->line()` t
 line over the filled band:
 
 <ComponentExample
-  php={`Chart::make('Revenue vs forecast')
+  php={`Chart::make('Revenue vs forecast', 'revenue-forecast-chart')
     ->description('Actuals as a line over the forecast band')
     ->categoryKey('month')
     ->data([
@@ -118,7 +118,7 @@ A `->pie()` series plots one value per row as slices. `nameKey` names each slice
 field to color its slice, or let the theme palette pick:
 
 <ComponentExample
-  php={`Chart::make('Revenue by channel')
+  php={`Chart::make('Revenue by channel', 'channel-mix-chart')
     ->description('Share of total revenue')
     ->data([
         ['channel' => 'Direct', 'amount' => 42000, 'color' => '#2563eb'],
@@ -140,8 +140,8 @@ field to color its slice, or let the theme palette pick:
 ## Colors and theming
 
 Omit a series color and Lattice cycles a palette built on your [theme tokens](/theming/) —
-`--lt-primary`, `--lt-success`, `--lt-info`, `--lt-warning`, `--lt-danger` — so charts follow light and
-dark mode automatically. Pass an explicit `color` to override: a hex value, or a CSS variable like
+`--lt-primary`, `--lt-success`, `--lt-info`, `--lt-warning`, `--lt-danger`, `--lt-muted-fg` — so
+charts follow light and dark mode automatically. Pass an explicit `color` to override: a hex value, or a CSS variable like
 `var(--lt-primary)` to stay theme-aware. For pies, a per-row `color` field wins over the series color.
 
 ## Formatting values and categories
@@ -151,8 +151,8 @@ the same Intl formatting the tables use. The **value** axis (always numeric) tak
 **category** axis takes either a `NumberFormat` or a `DateFormat`.
 
 <ComponentExample
-  php={`Chart::make('Revenue')
-    ->description('Compact currency on the value axis, short dates on the category axis')
+  php={`Chart::make('Revenue', 'formatting-chart')
+    ->description('Compact currency on the value axis, month labels on the category axis')
     ->categoryKey('month')
     ->data([
         ['month' => '2026-01-01', 'revenue' => 28000],
@@ -206,8 +206,8 @@ Chart::make('Signups')
 
 ## Dynamic series
 
-When the series aren't known ahead of time, build [`ChartSeries`](/advanced/enums/#charts) value
-objects and hand them to `->series([...])` instead of the per-type helpers. The static factories
+When the series aren't known ahead of time, build `ChartSeries` value objects
+(typed by [`ChartSeriesType`](/advanced/enums/#charts)) and hand them to `->series([...])` instead of the per-type helpers. The static factories
 mirror the fluent methods:
 
 ```php

--- a/docs/content/docs/components/layout.mdx
+++ b/docs/content/docs/components/layout.mdx
@@ -51,14 +51,16 @@ omit them for a plain panel. Call `->tooltip('…')` to attach an ⓘ info popov
 content is trusted HTML and may include links.
 
 <ComponentExample
-  php={`Card::make('Team settings', 'Manage how your team appears.')->schema([
-    Stack::make()->gap(Gap::Small)->schema([
-        Heading::make('Members', 2),
-        Text::make('Three people have access to this team.'),
-        Badge::make('3 active'),
-    ]),
-    Button::make('Invite member'),
-]);`}
+  php={`Card::make('Team settings', 'Manage how your team appears.')
+    ->tooltip('These settings affect everyone on the team.')
+    ->schema([
+        Stack::make()->gap(Gap::Small)->schema([
+            Heading::make('Members', 2),
+            Text::make('Three people have access to this team.'),
+            Badge::make('3 active'),
+        ]),
+        Button::make('Invite member'),
+    ]);`}
   fixture="components.card"
 />
 

--- a/docs/content/docs/components/modals.mdx
+++ b/docs/content/docs/components/modals.mdx
@@ -23,10 +23,10 @@ Modal::make('invite-member')
 The dialog's `$id` is how effects find it:
 
 ```php
-use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Facades\Effects;
+use Lattice\Lattice\Ui\Components\Button;
 
-Action::make('invite')
+Button::make('Invite')
     ->effects(Effects::openModal('invite-member'));
 ```
 

--- a/docs/content/docs/components/notifications.mdx
+++ b/docs/content/docs/components/notifications.mdx
@@ -47,7 +47,7 @@ nothing to call.
 
 ## The bell
 
-<ComponentExample php={`Notifications::make();`} fixture="notifications.bell" />
+<ComponentExample php={`Notifications::make('notifications-bell');`} fixture="notifications.bell" />
 
 The live preview above can't reach a real endpoint from a static docs page, so it renders empty —
 in your app it hydrates from the [config-driven endpoint](#configuration) on mount.

--- a/docs/content/docs/components/overview.mdx
+++ b/docs/content/docs/components/overview.mdx
@@ -10,14 +10,16 @@ node (`type` plus `props`) the renderer maps to a React component. They compose 
 container components take a `->schema([...])` of children, and children can be containers themselves.
 
 <ComponentExample
-  php={`Card::make('Team settings', 'Manage how your team appears.')->schema([
-    Stack::make()->gap(Gap::Small)->schema([
-        Heading::make('Members', 2),
-        Text::make('Three people have access to this team.'),
-        Badge::make('3 active'),
-    ]),
-    Button::make('Invite member'),
-]);`}
+  php={`Card::make('Team settings', 'Manage how your team appears.')
+    ->tooltip('These settings affect everyone on the team.')
+    ->schema([
+        Stack::make()->gap(Gap::Small)->schema([
+            Heading::make('Members', 2),
+            Text::make('Three people have access to this team.'),
+            Badge::make('3 active'),
+        ]),
+        Button::make('Invite member'),
+    ]);`}
   fixture="components.card"
 />
 

--- a/docs/content/docs/components/section-collapsible.mdx
+++ b/docs/content/docs/components/section-collapsible.mdx
@@ -20,6 +20,7 @@ start folded, or `rememberState: false` to not persist the state across reloads 
 <ComponentExample
   php={`Section::make('Members', 'People with access to this team.')
     ->collapsible()
+    ->tooltip('Only admins can change who has access.')
     ->headerActions([
         Button::make('Invite member')->variant(ButtonVariant::Outline),
     ])
@@ -42,6 +43,7 @@ Call `->tooltip('…')` to attach an ⓘ info popover in the trigger row; the co
 <ComponentExample
   php={`Collapsible::make('account-name')
     ->trigger([Text::make('Name')])
+    ->tooltip('Shown on invoices and receipts.')
     ->content([Text::make('Update the name shown on your account.')]);`}
   fixture="components.collapsible"
 />

--- a/docs/content/docs/core/artisan-commands.md
+++ b/docs/content/docs/core/artisan-commands.md
@@ -54,10 +54,11 @@ php artisan vendor:publish --tag=lattice-js
 
 All three accept:
 
-| Option    | Purpose                                                                                     |
-| --------- | ------------------------------------------------------------------------------------------- |
-| `--type=` | Override the derived type string.                                                           |
-| `--force` | Overwrite generated files that already exist. Existing registry entries are not duplicated. |
+| Option       | Purpose                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `--type=`    | Override the derived type string.                                                                |
+| `--package=` | Scaffold into a Composer [component package](/extending/component-packages/) instead of the app. |
+| `--force`    | Overwrite generated files that already exist. Existing registry entries are not duplicated.      |
 
 By default, `ColorPicker` becomes `field.color-picker`, `Rating` becomes `rating`, and `StatusBadge`
 becomes `column.status-badge`. The commands run `lattice:typescript` after updating the registry so
@@ -95,6 +96,15 @@ php artisan lattice:discover-clear
 
 Lattice also registers these with Laravel's optimization flow, so the cache command runs with
 `php artisan optimize` and the clear command runs with `php artisan optimize:clear`.
+
+## Assets & maintenance
+
+`php artisan lattice:assets` publishes the prebuilt standalone assets into your public directory —
+the [no-build installation](/introduction/no-build/) covers when and why.
+
+`php artisan lattice:notifications:prune` deletes read [notifications](/components/notifications/)
+older than the configured `lattice.notifications.prune_after_days` (unread ones are never pruned) —
+schedule it daily.
 
 ## Common workflow
 

--- a/docs/content/docs/core/authorization.md
+++ b/docs/content/docs/core/authorization.md
@@ -11,7 +11,7 @@ use Illuminate\Http\Request;
 
 public function authorize(Request $request): bool
 {
-    return $request->user()?->can('update', $this->product($request)) ?? false;
+    return $request->user()?->can('update', $this->product()) ?? false;
 }
 ```
 
@@ -46,9 +46,9 @@ when placing the component, and read it back with `context()`:
 Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]);
 
 // inside the action:
-protected function product(Request $request): Product
+protected function product(): Product
 {
-    return Product::query()->findOrFail($this->context($request, 'product_id'));
+    return Product::query()->findOrFail($this->context('product_id'));
 }
 ```
 

--- a/docs/content/docs/core/closure-evaluation.md
+++ b/docs/content/docs/core/closure-evaluation.md
@@ -24,8 +24,8 @@ If none of those match, Lattice throws an exception that lists the named utiliti
 closure.
 
 Named utilities win before type resolution. This is why `fn ($state)` receives the named form state
-even without a type, while `fn (FormData $state)` receives the typed `FormData` object from the same
-context.
+even without a type — and `fn (FormData $state)` receives that same object because the name matches
+first; the type annotation documents it rather than driving the resolution.
 
 ```php
 TextInput::make('slug', 'Slug')
@@ -70,7 +70,7 @@ Some callbacks add more named utilities:
 | `Select::searchable()`             | `$search`, the query string.                                                                       |
 | `Select::resolveSelectedUsing()`   | `$values`, the selected value list, plus `$component`.                                             |
 | Repeater and builder row callbacks | `$row` for the current row and `$form` for the whole form. A typed `FormData` parameter is `$row`. |
-| `Filter::query()`                  | A typed Eloquent `Builder` and `$value`, the submitted toggle state.                               |
+| `ToggleFilter::query()`            | A typed Eloquent `Builder` and `$value`, the submitted toggle state.                               |
 | `TernaryFilter::queries()`         | A typed Eloquent `Builder`.                                                                        |
 
 ```php

--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -48,7 +48,8 @@ touches your application's translations.
 
 Every built-in string lives in one i18next namespace, `lattice`, scoped into a few domain groups —
 `form.*` (fields, the rich editor, file uploads), `table.*` (columns, pagination, filters, bulk
-selection, row actions), and `common.*` (shared chrome: tabs, toasts, tooltips, menus). Keys read
+selection, row actions), `notifications.*` (the notification inbox), and `common.*` (shared chrome:
+tabs, toasts, tooltips, menus). Keys read
 like `form.editor.bold` or `table.pagination.next`. One namespace keeps Lattice's keys from
 colliding with your app's, and means a single route translates everything Lattice renders.
 
@@ -150,7 +151,7 @@ php artisan vendor:publish --tag=lattice-translations
 ```
 
 This copies Lattice's groups to `lang/vendor/lattice/{locale}/`, where Laravel resolves them ahead
-of the package's own. Each domain is its own file — `form.php`, `table.php`, `common.php` — with the
+of the package's own. Each domain is its own file — `form.php`, `table.php`, `notifications.php`, `common.php` — with the
 nested keys Lattice uses:
 
 ```php
@@ -214,8 +215,9 @@ setLocale("de");
 ```
 
 This writes `localStorage.locale`, writes the `locale` cookie, updates `<html lang>`, changes the
-i18next language, and dispatches `lattice:locale-change`. The backend locale middleware reads the
-cookie first, then session locale, then the request's `Accept-Language` header.
+i18next language, and dispatches `lattice:locale-change`. The backend locale middleware reads a
+`HasLocalePreference` user's preferred locale first, then the cookie, then the session locale, then
+the request's `Accept-Language` header.
 
 ## Language switchers
 
@@ -238,7 +240,7 @@ class SetLocaleAction extends ActionDefinition
 
     public function handle(Request $request): ActionResult
     {
-        $locale = $this->context($request, 'locale');
+        $locale = $this->context('locale');
         $locales = config('lattice.i18n.locales', []);
 
         return is_string($locale) && is_array($locales) && in_array($locale, $locales, true)
@@ -368,7 +370,7 @@ type I18nConfig = {
   saveMissing: boolean; // should missing keys be reported back?
   locales: string[]; // supported locale codes from config('lattice.i18n.locales')
   preloadLocales: string[]; // locales eagerly loaded at startup, from config('lattice.i18n.preload_locales')
-  timezone: string | null; // the app/user timezone, when resolved
+  timezone: string | null; // the user's preferredTimezone(), when the user model implements HasTimezonePreference
 };
 ```
 

--- a/docs/content/docs/core/layouts.md
+++ b/docs/content/docs/core/layouts.md
@@ -127,4 +127,3 @@ Lattice::layouts([AppLayout::class]);
 The shell is built from the same components as a page, plus a set made for navigation chrome —
 `Sidebar`, `Topbar`, `Menu`, `MenuItem`, `Dropdown`, and `Breadcrumbs`. Those are covered in
 [Navigation](/core/navigation/).
-</content>

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -178,4 +178,3 @@ public function authorize(Request $request): bool
 
 This is the same `authorize()` every Lattice definition carries — see
 [Authorization](/core/authorization/) for how it behaves across forms, tables, and actions.
-</content>

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -20,7 +20,7 @@ php artisan lattice:component Signature --package=packages/acme-signature
 
 ```json
 {
-  "name": "acme/lattice-signature",
+  "name": "acme/signature",
   "autoload": { "psr-4": { "Acme\\Signature\\": "src/" } },
   "extra": {
     "lattice": {
@@ -41,6 +41,18 @@ use Lattice\Lattice\Ui\Components\Component;
 final class Signature extends Component
 {
     public string $label = 'Sign here';
+
+    public static function make(?string $key = null): static
+    {
+        return new self($key);
+    }
+
+    public function label(string $label): static
+    {
+        $this->label = $label;
+
+        return $this;
+    }
 }
 ```
 

--- a/docs/content/docs/extending/custom-columns.md
+++ b/docs/content/docs/extending/custom-columns.md
@@ -170,7 +170,7 @@ createLatticeApp({
 });
 ```
 
-Passing `registry` is what makes your cell render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no renderer, and the node renders a muted missing-component placeholder instead of your cell (Lattice also logs a `[lattice] No component registered…` warning in development to flag exactly this).
+Passing `registry` is what makes your cell render. Without it, `createLatticeApp` falls back to the built-in registry, your custom type has no cell, and the column silently falls back to the built-in text cell — the value renders as plain text instead of through your component.
 
 Custom fields, components, and columns all live in this same `registry.ts` — there is no second registry to merge.
 

--- a/docs/content/docs/forms/conditional-fields.mdx
+++ b/docs/content/docs/forms/conditional-fields.mdx
@@ -69,7 +69,7 @@ pass an operator as the middle argument for other comparisons.
 TextInput::make('vat', 'VAT ID')
     ->visibleWhen('country', ['DE', 'AT', 'CH']);
 
-NumberInput::make('guardian', 'Guardian name')
+TextInput::make('guardian', 'Guardian name')
     ->requiredWhen('age', '<', 18);
 ```
 
@@ -83,8 +83,11 @@ The operator accepts a comparison string or an [`Op`](/advanced/enums/#operators
 | less       | `<`, `<=`                              | `Op::LessThan`, `Op::LessThanOrEqual`            |
 | substring  | `contains`, `starts_with`, `ends_with` | `Op::Contains`, `Op::StartsWith`, `Op::EndsWith` |
 | membership | `in`, `not_in`                         | `Op::In`, `Op::NotIn`                            |
-| presence   | `empty`, `filled`                      | `Op::Empty`, `Op::Filled`                        |
+| presence   | — (use the `Op` case)                  | `Op::Empty`, `Op::Filled`                        |
 | dates      | `before`, `after`                      | `Op::Before`, `Op::After`                        |
+
+For presence checks, pass the `Op` case — `->visibleWhen('coupon', Op::Filled)`. A bare `'empty'` or
+`'filled'` string with no third argument is treated as a value to compare against, not an operator.
 
 ## Server and client agreement
 

--- a/docs/content/docs/forms/fields/date-time-input.mdx
+++ b/docs/content/docs/forms/fields/date-time-input.mdx
@@ -16,8 +16,10 @@ returns a `CarbonImmutable`.
 
 ## Timezone behavior
 
-The picker uses the frontend timezone configured through `lattice.i18n.timezone`. Submitted values
-include that timezone, so validation returns a `CarbonImmutable` in the user's timezone by default.
+The picker uses the authenticated user's timezone when the user model implements
+`HasTimezonePreference` (`preferredTimezone()`), falling back to the browser timezone. Submitted
+values include that timezone, so validation returns a `CarbonImmutable` in the user's timezone by
+default.
 
 ```php
 DateTimeInput::make('starts_at', 'Starts at');

--- a/docs/content/docs/forms/fields/file-upload.mdx
+++ b/docs/content/docs/forms/fields/file-upload.mdx
@@ -7,9 +7,10 @@ import ComponentExample from "@components/ComponentExample.astro";
 import Info from "@components/Info.astro";
 import Warning from "@components/Warning.astro";
 
-The file upload field stores uploaded files on a filesystem disk and submits their paths. It supports
-single or multiple files, image-only mode, size and count limits, and direct-to-storage signed uploads.
-Create one with `FileUpload::make()`.
+The file upload field submits the chosen files with the form — `handle()` receives `UploadedFile`
+instances for your code to store — or, in signed mode, uploads them straight to storage and submits
+temporary keys. It supports single or multiple files, image-only mode, size and count limits, and
+direct-to-storage signed uploads. Create one with `FileUpload::make()`.
 
 <ComponentExample
   php={`FileUpload::make('avatar', 'Avatar')

--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -137,7 +137,7 @@ Repeater::make('items', 'Line items')
 
 ## Validation
 
-Each child field's rules apply to every row through the `items.*.field` wildcard, so a child marked
+Each child field's rules are registered per row — `items.{index}.field` — so a child marked
 `->required()` is required in each row and an error points at the offending row. The array-level
 `minItems`/`maxItems` rules validate the number of rows independently of the per-row rules. See
 [Validation](/forms/validation/) for how field rules are resolved.
@@ -163,7 +163,6 @@ Repeater::make('items', 'Line items')
 
 These are follow-ups, not part of the first release:
 
-- Nested repeaters (a repeater inside a repeater row).
 - Relationship auto-save (persisting rows straight to a related model).
 
 ## Common options

--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -59,8 +59,9 @@ Select::make('status', 'Status')->enum(OrderStatus::class);
 ## Searchable
 
 A static `->options()` select has no search box — the dropdown shows the full list. Call
-`->searchable()` to add a search box and resolve options on the server (`->searchPlaceholder()` then
-sets its placeholder). For a static list long enough to need filtering, prefer `->searchable()`.
+`->searchable()` with a resolver to add a search box and resolve options on the server
+(`->searchPlaceholder()` then sets its placeholder). There is no client-side filter for static
+options — a list long enough to need filtering belongs behind a resolver.
 
 `->searchable()` turns the select into a server-driven search. The resolver receives `$search` (the
 query string) and returns the matching options; it may also inject `$get`/`$state`/`$component` and

--- a/docs/content/docs/forms/fields/textarea.mdx
+++ b/docs/content/docs/forms/fields/textarea.mdx
@@ -18,8 +18,9 @@ and its label.
 
 ## Rows
 
-`->rows()` sets the visible height of the field in text rows. It is a starting height only — the
-field still grows as the user types past it.
+`->rows()` sets the textarea's `rows` attribute. The shipped field auto-sizes to its content
+(`field-sizing: content`) with a minimum height, so in supporting browsers the attribute only
+matters as the starting height where `field-sizing` is unavailable.
 
 ```php
 Textarea::make('bio', 'Bio')->rows(4);

--- a/docs/content/docs/forms/validation.md
+++ b/docs/content/docs/forms/validation.md
@@ -64,7 +64,8 @@ TextInput::make('discount_code', 'Discount code')
 
 ## Live validation
 
-Validation runs live through [Laravel Precognition](https://laravel.com/docs/precognition): as the
-user edits a field, the form sends a precognitive request to its [endpoint](/advanced/security/) that runs your rules and returns messages
-without executing the submission. Because it is the exact same server-side ruleset, there is nothing
-to keep in sync — what passes live is what passes on submit.
+Opt a form into live validation with `->precognitive()`. It runs through
+[Laravel Precognition](https://laravel.com/docs/precognition): as the user edits a field, the form
+sends a precognitive request to its [endpoint](/advanced/security/) that runs your rules and returns
+messages without executing the submission. Because it is the exact same server-side ruleset, there is
+nothing to keep in sync — what passes live is what passes on submit.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ prev: false
 next: false
 hero:
   title: Server-driven React UIs for Laravel.
-  tagline: Describe pages, forms, and tables in PHP. Lattice serializes them to typed React components and renders them through Inertia — no client-side route or API wiring.
+  tagline: Stop building every screen twice. Describe pages, forms, and tables once in PHP — one typed schema, rendered by real React components over Inertia. No hand-written API, no duplicated UI contract.
   actions:
     - text: Get Started
       link: /introduction/what-is-lattice/

--- a/docs/content/docs/introduction/configuration.md
+++ b/docs/content/docs/introduction/configuration.md
@@ -7,7 +7,7 @@ After publishing the config with `php artisan vendor:publish --tag="lattice-conf
 
 ## Discovery
 
-Lattice automatically discovers form, table, fragment, action, layout, and page definitions by scanning the configured paths for classes carrying the matching attribute:
+Lattice automatically discovers form, table, fragment, action, bulk action, remote source, layout, and page definitions by scanning the configured paths for classes carrying the matching attribute:
 
 ```php
 'discover' => [
@@ -16,6 +16,8 @@ Lattice automatically discovers form, table, fragment, action, layout, and page 
 ```
 
 List every path Lattice should scan. Discovery walks the files directly, so no namespace mapping is needed.
+
+The cached discovery manifest (`php artisan lattice:discover-cache`) is written to `bootstrap/cache/lattice.php`; set `'discovery' => ['cache_path' => …]` to relocate it.
 
 ## Registering definitions explicitly
 
@@ -106,9 +108,13 @@ Component references embedded in the page payload are signed. `security.ref_life
 ],
 ```
 
+## Frontend (no-build)
+
+The `'frontend'` block configures the prebuilt-asset path, theme variables, and Echo settings for the no-build installation — see [No-Build Installation](/introduction/no-build/).
+
 ## TypeScript
 
-Where `php artisan lattice:typescript` writes the generated type definitions, and the module name they are published under:
+Where `php artisan lattice:typescript` writes the generated type definitions, and the module name they are published under (the command requires the suggested dev dependency: `composer require --dev spatie/typescript-transformer`):
 
 ```php
 'typescript' => [

--- a/docs/content/docs/introduction/core-concepts.md
+++ b/docs/content/docs/introduction/core-concepts.md
@@ -26,7 +26,7 @@ The same flow powers interactive pieces: a form submit, a table page change, or 
 
 ### Pages
 
-A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. You annotate it with `#[AsPage(route: '…')]`; Lattice discovers the page and registers its route — no Inertia page component or controller to write by hand. A page also carries its layout, container, breadcrumbs, and menus.
+A page extends `Lattice\Lattice\Http\Page`, returns a `title()`, and builds its UI in `render()`. You annotate it with `#[AsPage(route: '…')]`; Lattice discovers the page and registers its route — no Inertia page component or controller to write by hand. A page also carries its layout, container, breadcrumbs, and middleware.
 
 [Learn more →](/core/pages/)
 

--- a/docs/content/docs/introduction/development-with-ai.md
+++ b/docs/content/docs/introduction/development-with-ai.md
@@ -52,3 +52,5 @@ One Lattice-specific step the core guideline already teaches your agent — wort
 ```bash
 php artisan lattice:typescript
 ```
+
+The command requires the suggested dev dependency: `composer require --dev spatie/typescript-transformer`.

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -196,7 +196,7 @@ The renderer resolves component types from a registry. Lattice exports the piece
 import { Provider, Renderer, registry, createRegistry, extendRegistry } from "@lattice-php/lattice";
 ```
 
-Pass a custom registry to the same `Provider` when you register your own component types, or use `extendRegistry` to add to the defaults. Heavy built-ins (forms, tables, the rich editor) are registered lazily and code-split, so you only ship what a page actually renders.
+Pass a custom registry to the same `Provider` when you register your own component types, or use `extendRegistry` to add to the defaults. The heaviest built-ins — the rich editor, charts, the date picker — are code-split behind `React.lazy`, so their weight only loads when a page actually renders them.
 
 ## Next steps
 

--- a/docs/content/docs/introduction/no-build.mdx
+++ b/docs/content/docs/introduction/no-build.mdx
@@ -51,7 +51,7 @@ Add `@latticeHead` before `@inertiaHead`, and `@latticeScripts` after `@inertia`
 
 ## Configuring theme and realtime
 
-`@latticeHead` takes an optional array with the same two keys as the `lattice.frontend` config — anything passed to the directive merges over the config file's values for that render. Publish the config to set defaults that apply everywhere:
+`@latticeHead` takes an optional array with the same keys as the `lattice.frontend` config — anything passed to the directive merges over the config file's values for that render. Publish the config to set defaults that apply everywhere:
 
 ```bash
 php artisan vendor:publish --tag="lattice-config"

--- a/docs/content/docs/introduction/what-is-lattice.md
+++ b/docs/content/docs/introduction/what-is-lattice.md
@@ -1,15 +1,17 @@
 ---
 title: What is Lattice?
-description: A server-driven UI layer for Laravel and Inertia — describe pages, forms, and tables in PHP and render them as real React components.
+description: Describe your interface once, as a schema the server owns — Lattice renders it with real React components over Inertia.
 ---
 
 Lattice is a server-driven UI layer for Laravel applications running [Inertia](https://inertiajs.com/) with React. You describe your interface — pages, components, forms, tables, actions, and menus — in PHP, and Lattice serializes that description to a typed component tree that real React components render in the browser.
 
 ## The problem it solves
 
-A typical Inertia app splits every screen across two languages: the data and rules live in PHP, while the page, its forms, and its tables are rebuilt by hand in React. The two sides duplicate the same contract — field names, validation, table columns, what an action does — and drift apart as the app grows.
+Every web application maintains its user interface twice. The backend already knows what a screen is made of: which fields an entity has, which rules validate them, who is allowed to see which actions, how a collection is sorted, filtered, and paged. The frontend then restates all of that in a second codebase — the same fields as inputs, the same rules as error handling, the same permissions as conditionally hidden buttons, the same columns and filters as table state. Two codebases, one contract, and nothing enforcing that they agree. Every feature is built twice, and the two copies drift apart as the app grows.
 
-Lattice removes that duplication. The server is the single source of truth for what a screen _is_; the client's only job is to render it. There is no hand-written API between them and no UI contract to keep in sync, because the renderer always receives exactly what the server produced.
+The way out is to notice that most application UI is not free-form. Forms, tables, actions, navigation, notifications — the day-to-day surface of a business application — are structured and repetitive enough to be _described_ rather than hand-built. When a consistent schema can describe the interface, the duplication disappears: the side that owns the data and the rules declares the screen once, the schema _is_ the contract, and the other side's only job is to render it. There is no hand-written API between them and no parallel implementation to keep in sync, because the renderer always receives exactly what the server produced.
+
+Lattice is that idea applied to Laravel. The server is the single source of truth for what a screen _is_; a typed schema carries it over the wire; real React components render it.
 
 ## How it works
 
@@ -27,6 +29,6 @@ Because the wire format is generated into TypeScript types, the React side is ty
 
 ## Is it for you?
 
-Lattice fits teams already building Laravel + Inertia + React who want to keep their UI logic in PHP and stop maintaining a parallel front end. You still write React when you want custom components — Lattice renders them through the same registry — but the day-to-day screens come from the server.
+Lattice fits teams building Laravel + Inertia + React who want one place to define what their screens are — and one contract instead of two implementations. You still write React when you want custom components — Lattice renders them through the same registry — but the day-to-day screens come from the server.
 
 Read the [Core Concepts](/introduction/core-concepts/) next for the mental model, then [Installation](/introduction/installation/) to add it to your app.

--- a/docs/content/docs/tables/columns/boolean.mdx
+++ b/docs/content/docs/tables/columns/boolean.mdx
@@ -6,7 +6,7 @@ description: Render a truthy value as a check or cross, filterable as a boolean.
 import ComponentExample from "@components/ComponentExample.astro";
 
 `BooleanColumn` renders a check or cross instead of the raw value. It is sortable and filters as a
-[boolean](/tables/filtering/) — yes / no / any.
+[boolean](/tables/filtering/) — an All / True / False select, plus the empty and filled operators.
 
 <ComponentExample
   php={`TextColumn::make('name')->label('Name');

--- a/docs/content/docs/tables/columns/money.mdx
+++ b/docs/content/docs/tables/columns/money.mdx
@@ -10,7 +10,8 @@ places follow the viewer's locale and the currency itself, so you feed it a plai
 sortable and filters as a [number](/tables/filtering/).
 
 <ComponentExample
-  php={`MoneyColumn::make('total')->label('Total')->currency('EUR')->sortable();
+  php={`TextColumn::make('number')->label('Invoice');
+MoneyColumn::make('total')->label('Total')->currency('EUR')->sortable();
 MoneyColumn::make('refunded')->label('Refunded')->currencyField('currency');`}
   fixture="table.money"
 />

--- a/docs/content/docs/tables/columns/number.mdx
+++ b/docs/content/docs/tables/columns/number.mdx
@@ -9,7 +9,8 @@ import ComponentExample from "@components/ComponentExample.astro";
 sortable and filters as a [number](/tables/filtering/).
 
 <ComponentExample
-  php={`NumberColumn::make('views')->label('Views')->compact()->sortable();
+  php={`TextColumn::make('label')->label('Metric');
+NumberColumn::make('views')->label('Views')->compact()->sortable();
 NumberColumn::make('conversion')->label('Conversion')
     ->unit(NumberFormatUnit::Percent)
     ->decimals(1);`}
@@ -19,8 +20,8 @@ NumberColumn::make('conversion')->label('Conversion')
 - `->decimals($min, $max?)` fixes the fraction digits — `->decimals(2)` for exactly two, or
   `->decimals(0, 2)` for a min–max range.
 - `->unit(NumberFormatUnit::…)` adds a locale-correct unit suffix — `Percent`, `Kilogram`, `Byte`, and
-  the rest of the [`NumberFormatUnit`](/advanced/enums/) cases. A percent value is scaled by the
-  formatter, so store `0.128` to render `12.8%`.
+  the rest of the [`NumberFormatUnit`](/advanced/enums/) cases. The value is rendered as-is with the
+  unit appended — no scaling — so store `12.8` to render `12.8%`.
 - `->compact()` renders large numbers compactly (`1.2K`, `3.4M`).
 
 ```php

--- a/docs/content/docs/tables/columns/overview.mdx
+++ b/docs/content/docs/tables/columns/overview.mdx
@@ -70,12 +70,12 @@ and never appear in it. Pass `hiddenByDefault: true` to ship a column hidden —
 when they need it.
 
 <ComponentExample
-  php={`TextColumn::make('name');                        // pinned, always visible
-TextColumn::make('sku')->toggleable();           // hide-able, shown by default
-NumberColumn::make('price')->toggleable();
+  php={`TextColumn::make('name')->label('Name');          // pinned, always visible
+TextColumn::make('sku')->label('SKU')->toggleable(); // hide-able, shown by default
+NumberColumn::make('price')->label('Price')->toggleable();
 TextColumn::make('updated_at')->label('Updated')
     ->dateTime()
-    ->toggleable(hiddenByDefault: true);         // hide-able, starts hidden`}
+    ->toggleable(hiddenByDefault: true);             // hide-able, starts hidden`}
   fixture="table.toggleable"
 />
 

--- a/docs/content/docs/tables/data-sources.mdx
+++ b/docs/content/docs/tables/data-sources.mdx
@@ -48,8 +48,9 @@ state as public properties:
   page the data yourself or don't paginate.
 - **`TableResult::fromPaginator($paginator)`** — a `LengthAwarePaginator`, carrying the total count for
   a full pager.
-- **`TableResult::fromSimplePaginator($paginator)`** — a simple paginator, for previous/next paging
-  without a total.
+- **`TableResult::fromSimplePaginator($paginator, $type)`** — a simple paginator without a total. The
+  mode defaults to `PaginationType::Infinite` (scroll-to-load); pass `PaginationType::Simple` for
+  previous/next paging.
 
 ## Backing a table with your own source
 

--- a/docs/content/docs/tables/eloquent-tables.mdx
+++ b/docs/content/docs/tables/eloquent-tables.mdx
@@ -7,7 +7,7 @@ import Info from "@components/Info.astro";
 
 Backing a table with an Eloquent model is common enough that Lattice ships a source for it. Extend
 `EloquentTableDefinition` and implement `builder()` instead of `source()` — Lattice wires up an
-`EloquentTableSource` from your builder, columns, and pagination mode. It is the same
+`EloquentTableSource` from your builder, columns, dedicated filters, and pagination mode. It is the same
 [`TableSource`](/tables/data-sources/) contract underneath, with the query-building done for you.
 
 ```php

--- a/docs/content/docs/tables/filtering.mdx
+++ b/docs/content/docs/tables/filtering.mdx
@@ -14,7 +14,8 @@ logic. Both are sent to the table's [endpoint](/advanced/security/) and applied 
 <ComponentExample
   php={`TextColumn::make('name')->label('Name')->sortable()->filterable();
 NumberColumn::make('price')->label('Price')->sortable()->filterable();
-BooleanColumn::make('featured')->label('Featured')->filterable();`}
+BooleanColumn::make('featured')->label('Featured')->filterable();
+TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable();`}
   fixture="table.overview"
 />
 

--- a/docs/content/docs/tables/overview.mdx
+++ b/docs/content/docs/tables/overview.mdx
@@ -21,9 +21,9 @@ class ProductsTable extends TableDefinition
     public function columns(): array
     {
         return [
-            TextColumn::make('name')->sortable()->filterable(),
-            NumberColumn::make('price')->sortable()->filterable(),
-            BooleanColumn::make('featured'),
+            TextColumn::make('name')->label('Name')->sortable()->filterable(),
+            NumberColumn::make('price')->label('Price')->sortable()->filterable(),
+            BooleanColumn::make('featured')->label('Featured')->filterable(),
             TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable(),
         ];
     }

--- a/docs/content/docs/tables/sorting-and-pagination.mdx
+++ b/docs/content/docs/tables/sorting-and-pagination.mdx
@@ -10,8 +10,9 @@ the current sort and page to its [endpoint](/advanced/security/), and the
 [data source](/tables/data-sources/) applies them.
 
 <ComponentExample
-  php={`TextColumn::make('name')->label('Name')->sortable();
-NumberColumn::make('price')->label('Price')->sortable();
+  php={`TextColumn::make('name')->label('Name')->sortable()->filterable();
+NumberColumn::make('price')->label('Price')->sortable()->filterable();
+BooleanColumn::make('featured')->label('Featured')->filterable();
 TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable();`}
   fixture="table.overview"
 />
@@ -57,5 +58,6 @@ public function perPage(): int
 ```
 
 A [custom data source](/tables/data-sources/) chooses its own `TableResult` builder to match the mode —
-`fromPaginator()` for a full pager, `fromSimplePaginator()` for previous/next. The
+`fromPaginator()` for a full pager, `fromSimplePaginator()` for infinite scroll-to-load, or
+`fromSimplePaginator($paginator, PaginationType::Simple)` for previous/next. The
 [Eloquent source](/tables/eloquent-tables/) picks the right one from the mode automatically.

--- a/docs/content/docs/testing/overview.md
+++ b/docs/content/docs/testing/overview.md
@@ -269,8 +269,8 @@ reuse a single sealed ref, build the request by hand instead.
 
 Lattice uses `data-test` as its standard test-hook attribute. `data-testid` is **not** used.
 
-**Pest browser tests** target `data-test` via the `@shorthand` selector. `->click('@foo')` is
-equivalent to clicking `[data-test="foo"]`.
+**Pest browser tests** target `data-test` via the `@shorthand` selector. `->click('@foo')` clicks
+`[data-test="foo"]` (the shorthand also matches `data-testid`, which Lattice never emits).
 
 **Vitest + Testing Library unit tests** query it via `getByTestId`, `queryByTestId`, and friends.
 The resolver is pointed at `data-test` by the `configure({ testIdAttribute: "data-test" })` call
@@ -283,6 +283,6 @@ unrendered selector lists what was rendered; a missing filter lists the table's 
 so you spend less time printing the payload to find a typo.
 
 ```
-Lattice form field [emial] not found at [page › form#product].
+Lattice form field [emial] not found at [page › product].
 Available fields: [name, sku, price].
 ```

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -53,7 +53,7 @@
                     "icon": null,
                     "label": "Invite member",
                     "method": null,
-                    "variant": "default"
+                    "variant": null
                 },
                 "type": "button"
             }

--- a/docs/fixtures/table.number.json
+++ b/docs/fixtures/table.number.json
@@ -60,17 +60,17 @@
             ],
             "data": [
                 {
-                    "conversion": 0.128,
+                    "conversion": 12.8,
                     "label": "Landing page",
                     "views": 12400
                 },
                 {
-                    "conversion": 0.064,
+                    "conversion": 6.4,
                     "label": "Pricing",
                     "views": 3820
                 },
                 {
-                    "conversion": 0.011,
+                    "conversion": 1.1,
                     "label": "Blog",
                     "views": 1045000
                 }

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -79,7 +79,20 @@
                     "key": "featured",
                     "props": {
                         "align": "start",
-                        "filter": null,
+                        "filter": {
+                            "clauseOptions": [],
+                            "control": null,
+                            "defaultOperator": "eq",
+                            "multiple": false,
+                            "operators": [
+                                "eq",
+                                "empty",
+                                "filled"
+                            ],
+                            "options": [],
+                            "searchable": false,
+                            "type": "boolean"
+                        },
                         "hiddenByDefault": false,
                         "label": "Featured",
                         "sortable": false,
@@ -156,7 +169,7 @@
                 "tableFilterIndicators": [],
                 "tableFilters": {}
             },
-            "striped": true
+            "striped": false
         },
         "type": "table"
     }

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -8,6 +8,67 @@
 @import "../../resources/css/lattice.css";
 @source "../../resources/js";
 
+/*
+ * This setup deliberately omits Tailwind's global preflight (Starlight owns the
+ * page's base styles), so package components inside a live preview would render
+ * on user-agent defaults — toolbar buttons become bordered chips, headings keep
+ * browser margins. Restore the preflight subset the components assume, scoped
+ * to the preview box and layered below the component utilities.
+ */
+@layer base {
+  .example-preview *,
+  .example-preview ::after,
+  .example-preview ::before {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+
+  .example-preview :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  .example-preview :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  .example-preview :where(ol, ul, menu) {
+    list-style: none;
+  }
+
+  .example-preview :where(img, svg, video, canvas) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  .example-preview :where(button, input, select, optgroup, textarea) {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+
+  .example-preview :where(button, input[type="button"], input[type="reset"], input[type="submit"]) {
+    appearance: button;
+  }
+
+  .example-preview :where(textarea) {
+    resize: vertical;
+  }
+
+  .example-preview ::placeholder {
+    opacity: 1;
+    color: color-mix(in oklab, currentcolor 50%, transparent);
+  }
+}
+
 @theme {
   --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tiptap/extension-link": "^3.26.0",
         "@tiptap/extension-table": "^3.26.0",
         "@tiptap/extension-text-align": "^3.26.0",
+        "@tiptap/extensions": "^3.27.3",
         "@tiptap/pm": "^3.26.0",
         "@tiptap/react": "^3.26.0",
         "@tiptap/starter-kit": "^3.26.0",
@@ -5907,17 +5908,17 @@
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.26.1.tgz",
-      "integrity": "sha512-PmRaoe6bebTgz/ZQrjmzwZMST1d9js9ZTiKnUXeXl3Fm+V5U/c3TbbKDfqmL63qPQdjtShDMHi9tYuv+c77OFQ==",
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.3.tgz",
+      "integrity": "sha512-IA2QKUVJgzUPEhhkUfr6P5u5GFVfhiApiEaaHXBz07saL2c4HNoVs2RC18QlZDCtLNKrPR1mUScr72u7uYs+YQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "3.26.1",
-        "@tiptap/pm": "3.26.1"
+        "@tiptap/core": "3.27.3",
+        "@tiptap/pm": "3.27.3"
       }
     },
     "node_modules/@tiptap/pm": {

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "@tiptap/extension-link": "^3.26.0",
     "@tiptap/extension-table": "^3.26.0",
     "@tiptap/extension-text-align": "^3.26.0",
+    "@tiptap/extensions": "^3.27.3",
     "@tiptap/pm": "^3.26.0",
     "@tiptap/react": "^3.26.0",
     "@tiptap/starter-kit": "^3.26.0",

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -393,6 +393,15 @@
   margin: calc(var(--spacing) * 2) 0;
 }
 
+/* TipTap renders the empty-editor placeholder via this attribute hook. */
+.lattice-prose :where(p.is-editor-empty:first-child)::before {
+  content: attr(data-placeholder);
+  color: var(--lt-muted-fg);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+
 .lattice-prose :where(ul) {
   list-style: disc;
   padding-left: calc(var(--spacing) * 6);

--- a/resources/js/core/nodes.ts
+++ b/resources/js/core/nodes.ts
@@ -14,3 +14,11 @@ export function toNodes(value: unknown): Node[] {
       typeof node === "object" && node !== null && "type" in node && typeof node.type === "string",
   );
 }
+
+/**
+ * Stable list key for a node: the reconciliation key, then the id, then a
+ * type-scoped index fallback so keyless template children never collide.
+ */
+export function nodeKey(node: Node, index: number): string {
+  return node.key ?? node.id ?? `${node.type}-${index}`;
+}

--- a/resources/js/core/renderer.tsx
+++ b/resources/js/core/renderer.tsx
@@ -1,6 +1,7 @@
 import { memo, Suspense } from "react";
 import type { ReactNode } from "react";
 import type { Node } from "./types";
+import { nodeKey } from "./nodes";
 import { useCollapsed } from "./collapsed-context";
 import { useComponentRegistry } from "./registry-context";
 
@@ -60,10 +61,6 @@ function MissingComponent({ node }: { node: Node }) {
       <span className={import.meta.env.DEV ? "text-sm" : "sr-only"}>{label}</span>
     </span>
   );
-}
-
-function nodeKey(node: Node, index: number): string {
-  return node.key ?? node.id ?? `${node.type}-${index}`;
 }
 
 export function Renderer({ nodes }: { nodes: Node[] }): ReactNode {

--- a/resources/js/form/components/fields/otp-input.test.tsx
+++ b/resources/js/form/components/fields/otp-input.test.tsx
@@ -1,9 +1,16 @@
 import { fireEvent, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
 import { OtpInputComponent } from "./otp-input";
 
 const renderField = createFieldRenderer(OtpInputComponent);
+
+// input-otp schedules uncancelled 0/10/50ms layout timers that call setState;
+// one firing after this file's jsdom is torn down crashes the whole run with
+// "window is not defined". Let them fire while the environment still exists.
+afterEach(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+});
 
 describe("OtpInputComponent", () => {
   it("renders a one-time-code input with the configured length", () => {

--- a/resources/js/form/components/fields/rich-editor-field.tsx
+++ b/resources/js/form/components/fields/rich-editor-field.tsx
@@ -4,6 +4,7 @@ import { Highlight } from "@tiptap/extension-highlight";
 import { Link } from "@tiptap/extension-link";
 import { TableKit } from "@tiptap/extension-table";
 import { TextAlign } from "@tiptap/extension-text-align";
+import { Placeholder } from "@tiptap/extensions";
 import { type Editor, EditorContent, useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useEffect, useState } from "react";
@@ -340,6 +341,7 @@ const RichEditorField: RendererComponent<"field.rich-editor"> = ({ node }) => {
       Details,
       DetailsSummary,
       DetailsContent,
+      Placeholder.configure({ placeholder: node.props.placeholder ?? "" }),
     ],
     content: initialContent,
     editable: !locked,

--- a/resources/js/form/components/fields/rich-editor.test.tsx
+++ b/resources/js/form/components/fields/rich-editor.test.tsx
@@ -115,6 +115,23 @@ describe("RichEditorComponent", () => {
     prompt.mockRestore();
   });
 
+  it("shows the placeholder while the editor is empty", async () => {
+    renderField(
+      fakeNode({
+        type: "field.rich-editor",
+        props: { name: "body", label: "Body", placeholder: "Write your article…" },
+      }),
+    );
+
+    await screen.findByLabelText("Bold");
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-placeholder="Write your article…"]'),
+      ).toBeInTheDocument(),
+    );
+  });
+
   it("inserts an emoji from the picker", async () => {
     renderField(fakeNode({ type: "field.rich-editor", props: { name: "body", label: "Body" } }));
 

--- a/resources/js/form/components/fields/row-item.tsx
+++ b/resources/js/form/components/fields/row-item.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@lattice-php/lattice/icons";
 import type { ReactNode } from "react";
 import { memo } from "react";
 import type { Node } from "@lattice-php/lattice/core/types";
+import { nodeKey } from "@lattice-php/lattice/core/nodes";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { RowAction as WireRowAction } from "@lattice-php/lattice/types/generated";
@@ -111,8 +112,8 @@ export const RowItem = memo(function RowItem({
         onChange={(field, value) => onField(index, field, value)}
       >
         <div className="flex flex-col gap-4">
-          {template.map((child) => (
-            <RenderNode key={child.key ?? child.id} node={child} />
+          {template.map((child, childIndex) => (
+            <RenderNode key={nodeKey(child, childIndex)} node={child} />
           ))}
         </div>
       </FieldScopeProvider>

--- a/resources/js/form/components/fields/table-rows.tsx
+++ b/resources/js/form/components/fields/table-rows.tsx
@@ -1,4 +1,5 @@
 import type { Node } from "@lattice-php/lattice/core/types";
+import { nodeKey } from "@lattice-php/lattice/core/nodes";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import {
   DEFAULT_COLUMN_WIDTH,
@@ -158,13 +159,13 @@ const TableRowItem = memo(function TableRowItem({
               className="flex flex-col gap-2"
               style={{ gridColumn: `span ${columnCount}` }}
             >
-              {template.map((child) => (
-                <RenderNode key={child.key ?? child.id} node={child} />
+              {template.map((child, childIndex) => (
+                <RenderNode key={nodeKey(child, childIndex)} node={child} />
               ))}
             </div>
           ) : (
-            template.map((child) => (
-              <div key={child.key ?? child.id}>
+            template.map((child, childIndex) => (
+              <div key={nodeKey(child, childIndex)}>
                 <RenderNode node={child} />
               </div>
             ))

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -317,32 +317,23 @@ function latticeGet(string $url, string $ref): TestResponse
 }
 
 /**
- * Dump an array of nodes to docs/fixtures/<key>.json so the docs site can render
- * a real, test-generated example instead of hand-maintained JSON.
+ * Guard a docs/fixtures/<key>.json file against the payload its test builds, so
+ * the docs site renders real, test-generated examples instead of hand-maintained
+ * JSON. Regenerate deliberately with LATTICE_UPDATE_FIXTURES=1 — the assertion
+ * still runs, so a nondeterministic payload fails immediately.
  *
- * Object keys are sorted so the output is identical across PHP versions, keeping
- * the committed fixtures stable for the CI guard. List order (nodes, options,
- * conditions) is preserved.
- *
- * Materializes object-preserving (Wire::toWire(), not the assoc wire()) so an
- * empty map reaches the fixture as `{}` rather than collapsing to `[]`.
- *
- * @param  array<int, mixed>  $nodes
+ * Build payloads with sortFixtureKeys(stripFixtureRefs(Wire::toWire([...]))) —
+ * sorted keys keep the output identical across PHP versions, and the
+ * object-preserving Wire::toWire() keeps an empty map as `{}` rather than `[]`.
  */
-function dumpFixture(string $key, array $nodes): void
-{
-    $normalized = Wire::toWire($nodes);
-
-    file_put_contents(
-        dirname(__DIR__).'/docs/fixtures/'.$key.'.json',
-        json_encode(sortFixtureKeys(stripFixtureRefs($normalized)), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)."\n",
-    );
-}
-
 function assertFixtureMatches(string $fixtureKey, mixed $payload): void
 {
     $path = dirname(__DIR__).'/docs/fixtures/'.$fixtureKey.'.json';
     $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+    if (getenv('LATTICE_UPDATE_FIXTURES') !== false) {
+        File::put($path, $json.PHP_EOL);
+    }
 
     expect(File::exists($path))->toBeTrue("Missing fixture: {$path}");
     expect(File::get($path))->toBe($json.PHP_EOL);

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -41,7 +41,7 @@ describe('docs fixtures', function (): void {
                         Text::make('Three people have access to this team.'),
                         Badge::make('3 active'),
                     ]),
-                    Button::make('Invite member')->variant(ButtonVariant::Default),
+                    Button::make('Invite member'),
                 ]),
         ]))));
     });

--- a/tests/Unit/Docs/EnumDocsTest.php
+++ b/tests/Unit/Docs/EnumDocsTest.php
@@ -7,7 +7,7 @@ use Lattice\Lattice\Ui\Enums\Icon;
  * The enums reference page renders its case lists from this generated file
  * instead of a hand-maintained table, so the documented cases can never drift
  * from the real enums. `Icon` is excluded: its cases are the full icon catalog,
- * which the Icons page lists on its own.
+ * generated from the bundled SVGs rather than documented case by case.
  *
  * @return array<class-string, array{name: string, namespace: string, cases: list<array{name: string, value: string|int|null}>}>
  */

--- a/tests/Unit/Docs/TableDocsTest.php
+++ b/tests/Unit/Docs/TableDocsTest.php
@@ -23,11 +23,10 @@ describe('docs fixtures', function (): void {
     it('matches the overview table example fixture', function (): void {
         assertFixtureMatches('table.overview', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Table::make('products')
-                ->striped(true)
                 ->columns([
                     TextColumn::make('name')->label('Name')->sortable()->filterable(),
                     NumberColumn::make('price')->label('Price')->sortable()->filterable(),
-                    BooleanColumn::make('featured')->label('Featured'),
+                    BooleanColumn::make('featured')->label('Featured')->filterable(),
                     TextColumn::make('updated_at')->label('Updated')->dateTime()->sortable(),
                 ])
                 ->result(
@@ -132,9 +131,9 @@ describe('docs fixtures', function (): void {
                 ])
                 ->result(
                     TableResult::fromItems(collect([
-                        ['label' => 'Landing page', 'views' => 12400, 'conversion' => 0.128],
-                        ['label' => 'Pricing', 'views' => 3820, 'conversion' => 0.064],
-                        ['label' => 'Blog', 'views' => 1045000, 'conversion' => 0.011],
+                        ['label' => 'Landing page', 'views' => 12400, 'conversion' => 12.8],
+                        ['label' => 'Pricing', 'views' => 3820, 'conversion' => 6.4],
+                        ['label' => 'Blog', 'views' => 1045000, 'conversion' => 1.1],
                     ])),
                     TableQuery::empty(),
                 ),

--- a/tests/Unit/Forms/Components/PasswordInputTest.php
+++ b/tests/Unit/Forms/Components/PasswordInputTest.php
@@ -11,7 +11,9 @@ describe('docs fixtures', function (): void {
         ]))));
 
         assertFixtureMatches('password-input.confirmation', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
-            PasswordInput::make('password', 'Password')->needsConfirmation(),
+            PasswordInput::make('password', 'Password')
+                ->needsConfirmation()
+                ->rules(['required', 'min:8', 'confirmed']),
         ]))));
     });
 });


### PR DESCRIPTION
Full documentation sweep: every one of the 81 pages verified against the source by seven parallel reviewers (per-finding re-verification before each fix), the live `ComponentExample` previews visually inspected in a browser, and the intro reframed around the broader problem statement.

## Intro reframe
"The problem it solves" now leads with the general problem — every app maintains its UI twice (backend rules/data, frontend rendering/state) — and the idea that most application UI is structured enough to be described by a consistent schema, which makes the schema the contract and the client a renderer. The landing tagline matches ("Stop building every screen twice").

## Live-example styling (the "rich editor looks weird" trail)
- The docs deliberately omit Tailwind's global preflight (Starlight owns the base), so package components rendered on user-agent defaults — toolbar buttons as bordered chips, browser heading margins. A preflight subset scoped to `.example-preview` (layered below the utilities) restores what the components assume.
- The documented `->placeholder()` on the rich editor was never wired client-side — the PHP field serialized it all along. Now implemented via TipTap's Placeholder (**new dependency `@tiptap/extensions`**, same ^3 family, previously present transitively) with CSS + a pinned test.
- Bonus product fixes the sweep surfaced: repeater/table-rows templates keyed children by `key ?? id` (null for plain fields → React key warnings on every row) — both now reuse the renderer's `nodeKey()` from `core/nodes`; and input-otp's uncancelled 0/10/50ms timers could crash the whole Vitest run after jsdom teardown — flushed in the test file.

## Correctness sweep (45 verified fixes)
Wrong APIs: `Action::effects()` (no such method — Button now), `$this->context($request, …)` ×5 pages (context takes no Request), the layout `schema()` signature, `chatPlugin` (it's `chatComponents`), stray `</content>` artifacts at two page EOFs.
Wrong behavior claims: percent NumberColumns don't scale (store 12.8, not 0.128 — fixture updated too); `fromSimplePaginator()` defaults to Infinite, not previous/next (documented backwards twice); `empty`/`filled` operator strings without a value compare literally — use the `Op` cases; `lattice.i18n.timezone` doesn't exist (HasTimezonePreference + browser fallback); locale resolution starts at `HasLocalePreference`; live validation is opt-in via `->precognitive()`; file upload submits files, not paths; nested repeaters are supported; forms/tables register eagerly (only rich editor/charts/date picker are code-split); the missing-cell fallback for custom columns is silent text, not the placeholder.
Docs/fixture sync: every `ComponentExample` php string now builds exactly what its fixture test builds (tooltips, chart keys, labels, filterable flags); the component-packages example matches the real signature-example file; configuration now covers `discovery.cache_path`, the `frontend` block, and the `spatie/typescript-transformer` prerequisite; `--package=`, `lattice:assets`, and `lattice:notifications:prune` are documented.

## Fixture workflow
`assertFixtureMatches()` regenerates fixtures when `LATTICE_UPDATE_FIXTURES=1` (assertion still runs, so nondeterminism fails); the caller-less `dumpFixture()` is gone.

## Verification
`npm run docs:build`, full Vitest (986), full parallel Pest (1091), PHPStan, Rector, Pint, typecheck — all green; pre-push gate ran on push. Preview styling verified in-browser before/after on rich editor, buttons, and repeater pages.