### PR TITLE
feat: let createLatticeApp own the i18n bootstrap, plus boot/wrap hooks

### DIFF
--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -97,49 +97,31 @@ load each locale lazily on first switch.
 
 ### Wire the frontend
 
-Lattice shares an `i18n` block under `lattice.i18n`. Configure the frontend from the initial Inertia
-page props before the first render, and add the locale header to every Inertia visit:
+Lattice shares an `i18n` block under `lattice.i18n`, and `createLatticeApp` wires the whole
+frontend from it by default — pass your extra namespaces and you're done:
 
 ```tsx
 // resources/js/app.tsx
-import { createInertiaApp } from "@inertiajs/react";
-import { Provider, withVisitHeaders } from "@lattice-php/lattice";
-import { configureI18nFromPageProps, LocaleReload } from "@lattice-php/lattice/i18n";
-import { createRoot } from "react-dom/client";
+import { createLatticeApp } from "@lattice-php/lattice";
 
-createInertiaApp({
-  // …resolve, layout…
-  defaults: {
-    visitOptions: withVisitHeaders,
-  },
-  setup({ el, App, props }) {
-    if (!el) {
-      return;
-    }
-
-    const root = createRoot(el);
-    const render = () => {
-      root.render(
-        <Provider>
-          <App {...props} />
-          <LocaleReload />
-        </Provider>,
-      );
-    };
-
-    void configureI18nFromPageProps(props.initialPage.props, {
-      namespaces: ["lattice", "app"],
-    }).then(render, render);
-  },
+createLatticeApp({
+  // …registry, sprite, pages…
+  i18n: { namespaces: ["lattice", "app"] },
 });
 ```
 
-When the backend reports i18n as enabled, `configureI18nFromPageProps` attaches i18next's HTTP
-backend and loads translations from laravel-i18next's routes, overriding the inline English. When
-it's disabled — or the prop is absent — the inline English stands. `withVisitHeaders` sends
-`Accept-Language` on Inertia page visits; Lattice's own form, action, table, and fragment requests
-send it internally. `LocaleReload` reloads the current page after `setLocale()` dispatches the
-`lattice:locale-change` event, so server-rendered labels are refreshed in the new locale.
+When the backend reports i18n as enabled, the first render waits for the translation setup (no
+flash of untranslated fallbacks), i18next's HTTP backend loads translations from laravel-i18next's
+routes, `LocaleReload` re-fetches the page after `setLocale()` dispatches `lattice:locale-change`,
+and every Inertia visit carries the `Accept-Language` header (Lattice's own form, action, table,
+and fragment requests send it internally). When i18n is disabled — or the shared prop is absent —
+the inline English stands and the i18next chunk is never loaded. Pass `i18n: false` to opt out
+entirely.
+
+Wiring `createInertiaApp` by hand instead? The building blocks are exported: run
+`configureI18nFromPageProps(props.initialPage.props, { namespaces })` (from
+`@lattice-php/lattice/i18n`) before the first render, mount `<LocaleReload />` next to `<App />`,
+and set `defaults: { visitOptions: withVisitHeaders }`.
 
 ### Customize or add a locale
 

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -147,7 +147,7 @@ createLatticeApp({
 });
 ```
 
-It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`.
+It forwards any other `createInertiaApp` option — `title`, `progress`, SSR setup — and accepts a custom `registry` and a `defaultLayout`. Three hooks cover the app-specific bootstrap without falling back to manual wiring: `i18n` configures the [translation frontend](/core/i18n/#wire-the-frontend) from the shared page props (on by default; pass namespaces, or `false` to opt out), `boot` runs before the first render with the initial page (e.g. `configureEcho` from a shared connection prop — a returned promise delays that render), and `wrap` composes your own providers around the app inside the Lattice `Provider`.
 
 Once you scaffold your own fields, components, or columns (see [Custom fields](/extending/custom-fields/)), they are registered in `resources/js/registry.ts`. Pass that file's exported `registry` here so `createLatticeApp` renders them — `createLatticeApp({ registry, plugins, sprite, pages })`. Omit it and your custom types have no renderer, so their nodes render a muted missing-component placeholder instead (and log a `[lattice]` warning in development).
 

--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -1,10 +1,19 @@
-import type { Page as InertiaPage } from "@inertiajs/core";
+import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
+import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createInertiaApp = vi.hoisted(() => vi.fn<(options?: unknown) => void>());
+const router = vi.hoisted(() => ({
+  on: vi.fn<() => () => void>(() => () => {}),
+  visit: vi.fn<() => void>(),
+}));
+const configureI18nFromPageProps = vi.hoisted(() =>
+  vi.fn<(props: unknown, options?: unknown) => Promise<void>>(() => Promise.resolve()),
+);
 
-vi.mock("@inertiajs/react", () => ({ createInertiaApp }));
+vi.mock("@inertiajs/react", () => ({ createInertiaApp, router }));
+vi.mock("./i18n/page-props", () => ({ configureI18nFromPageProps }));
 
 import { createLatticeApp } from "./create-app";
 import { pageComponentName } from "./inertia";
@@ -14,14 +23,31 @@ import { ProviderBase } from "./provider-base";
 type CapturedOptions = {
   resolve: (name: string) => unknown;
   layout: (name: string, page: InertiaPage) => unknown;
-  withApp: (node: ReactElement) => ReactElement;
+  withApp: (node: ReactElement, context: { ssr: boolean; page: InertiaPage }) => ReactElement;
   strictMode: boolean;
   title?: (title: string) => string;
+  defaults?: { visitOptions?: (href: string, options: VisitOptions) => VisitOptions };
 };
 
 function captureOptions(): CapturedOptions {
   return createInertiaApp.mock.calls[0]?.[0] as CapturedOptions;
 }
+
+function fakePage(props: Record<string, unknown> = {}): InertiaPage {
+  return { component: pageComponentName, props, url: "/" } as unknown as InertiaPage;
+}
+
+const i18nProps = {
+  lattice: {
+    i18n: {
+      enabled: true,
+      saveMissing: false,
+      locales: ["en", "de"],
+      preloadLocales: ["en"],
+      timezone: null,
+    },
+  },
+};
 
 beforeEach(() => {
   vi.stubGlobal(
@@ -39,6 +65,7 @@ beforeEach(() => {
 
 afterEach(() => {
   createInertiaApp.mockReset();
+  configureI18nFromPageProps.mockClear();
   localStorage.clear();
   vi.unstubAllGlobals();
 });
@@ -66,7 +93,7 @@ describe("createLatticeApp", () => {
 
     createLatticeApp({ registry, sprite });
 
-    const wrapped = captureOptions().withApp(<div />);
+    const wrapped = captureOptions().withApp(<div />, { ssr: false, page: fakePage() });
 
     expect(wrapped.type).toBe(ProviderBase);
     expect((wrapped.props as { registry: unknown }).registry).toBe(registry);
@@ -82,7 +109,7 @@ describe("createLatticeApp", () => {
       ],
     });
 
-    const wrapped = captureOptions().withApp(<div />);
+    const wrapped = captureOptions().withApp(<div />, { ssr: false, page: fakePage() });
     const registry = (wrapped.props as { registry: { components: Record<string, unknown> } })
       .registry;
 
@@ -104,5 +131,132 @@ describe("createLatticeApp", () => {
     createLatticeApp();
 
     expect(localStorage.getItem("appearance")).toBe("system");
+  });
+
+  it("gates the first render on the i18n bootstrap when the backend shares the prop", async () => {
+    let resolveConfigure = (): void => {};
+    configureI18nFromPageProps.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveConfigure = resolve;
+      }),
+    );
+
+    createLatticeApp();
+
+    render(
+      captureOptions().withApp(<div data-test="app" />, {
+        ssr: false,
+        page: fakePage(i18nProps),
+      }),
+    );
+
+    expect(screen.queryByTestId("app")).not.toBeInTheDocument();
+
+    resolveConfigure();
+    await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+
+    expect(configureI18nFromPageProps).toHaveBeenCalledWith(i18nProps, {});
+  });
+
+  it("passes the configured namespaces to the i18n bootstrap", async () => {
+    createLatticeApp({ i18n: { namespaces: ["lattice", "app"] } });
+
+    render(
+      captureOptions().withApp(<div data-test="app" />, {
+        ssr: false,
+        page: fakePage(i18nProps),
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+
+    expect(configureI18nFromPageProps).toHaveBeenCalledWith(i18nProps, {
+      namespaces: ["lattice", "app"],
+    });
+  });
+
+  it("renders immediately and skips the i18n chunk when the prop is absent", () => {
+    createLatticeApp();
+
+    render(captureOptions().withApp(<div data-test="app" />, { ssr: false, page: fakePage() }));
+
+    expect(screen.getByTestId("app")).toBeInTheDocument();
+    expect(configureI18nFromPageProps).not.toHaveBeenCalled();
+  });
+
+  it("composes the locale visit headers into the caller's visitOptions", () => {
+    const userVisitOptions = vi.fn<(href: string, options: VisitOptions) => VisitOptions>(
+      (_href, options) => ({ ...options, headers: { ...options.headers, "X-App": "1" } }),
+    );
+
+    createLatticeApp({ defaults: { visitOptions: userVisitOptions } });
+
+    const visitOptions = captureOptions().defaults?.visitOptions;
+    const composed = visitOptions?.("/dashboard", { headers: {} } as VisitOptions);
+
+    expect(userVisitOptions).toHaveBeenCalled();
+    expect(composed?.headers).toMatchObject({ "X-App": "1" });
+    expect(composed?.headers).toHaveProperty("Accept-Language");
+  });
+
+  it("opts out of i18n entirely with i18n: false", () => {
+    const userDefaults = { visitOptions: undefined };
+
+    createLatticeApp({ i18n: false, defaults: userDefaults });
+
+    expect(captureOptions().defaults).toBe(userDefaults);
+
+    render(
+      captureOptions().withApp(<div data-test="app" />, {
+        ssr: false,
+        page: fakePage(i18nProps),
+      }),
+    );
+
+    expect(screen.getByTestId("app")).toBeInTheDocument();
+    expect(configureI18nFromPageProps).not.toHaveBeenCalled();
+  });
+
+  it("runs the boot hook with the initial page and gates the render until it resolves", async () => {
+    let resolveBoot = (): void => {};
+    const boot = vi.fn<(context: { page: InertiaPage }) => Promise<void>>(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveBoot = resolve;
+        }),
+    );
+    const page = fakePage({ reverb: { host: "localhost" } });
+
+    createLatticeApp({ boot });
+
+    render(captureOptions().withApp(<div data-test="app" />, { ssr: false, page }));
+
+    expect(boot).toHaveBeenCalledWith({ page });
+    expect(screen.queryByTestId("app")).not.toBeInTheDocument();
+
+    resolveBoot();
+    await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+  });
+
+  it("skips boot and the i18n bootstrap on the server render", () => {
+    const boot = vi.fn<() => void>();
+
+    createLatticeApp({ boot });
+
+    captureOptions().withApp(<div />, { ssr: true, page: fakePage(i18nProps) });
+
+    expect(boot).not.toHaveBeenCalled();
+    expect(configureI18nFromPageProps).not.toHaveBeenCalled();
+  });
+
+  it("composes wrap around the app inside the Provider", () => {
+    createLatticeApp({
+      wrap: (app) => <section data-test="shell">{app}</section>,
+    });
+
+    render(captureOptions().withApp(<div data-test="app" />, { ssr: false, page: fakePage() }));
+
+    expect(screen.getByTestId("shell")).toBeInTheDocument();
+    expect(screen.getByTestId("app")).toBeInTheDocument();
   });
 });

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -1,12 +1,16 @@
+import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
 import { createInertiaApp } from "@inertiajs/react";
-import type { ReactElement } from "react";
+import { useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { initializeTheme } from "./appearance";
 import { extendRegistry, type Plugin, type Registry } from "./core/registry";
 import { setDefaultRegistry } from "./core/registry-context";
 import type { SpriteValue } from "./icons/sprite";
+import { LocaleReload } from "./i18n/locale-reload";
+import { i18nConfigFromPageProps } from "./i18n/shared-props";
 import {
   createLayoutResolver,
   createPageResolver,
+  withVisitHeaders,
   type CreateLayoutResolverOptions,
   type PageModules,
 } from "./inertia";
@@ -14,6 +18,11 @@ import { ProviderBase } from "./provider-base";
 import { registry as defaultRegistry } from "./registry";
 
 type InertiaAppOptions = NonNullable<Parameters<typeof createInertiaApp>[0]>;
+
+export type CreateLatticeAppI18nOptions = {
+  /** i18next namespaces to load, e.g. `["lattice", "app"]`. Defaults to the package's own. */
+  namespaces?: string[];
+};
 
 export type CreateLatticeAppOptions = Omit<
   InertiaAppOptions,
@@ -30,13 +39,57 @@ export type CreateLatticeAppOptions = Omit<
   /** Normal Inertia page modules, e.g. `import.meta.glob('./pages/**\/*.tsx')`. */
   pages?: PageModules;
   defaultLayout?: CreateLayoutResolverOptions["defaultLayout"];
+  /**
+   * Lattice's i18n bootstrap, on by default: when the backend shares the
+   * `lattice.i18n` prop, the first render waits for the translation setup (no
+   * flash of untranslated fallbacks), `LocaleReload` re-fetches the page after
+   * a locale switch, and every visit carries the locale/timezone headers. The
+   * i18next chunk only loads when the backend actually shares the prop. Pass
+   * `false` to opt out entirely.
+   */
+  i18n?: CreateLatticeAppI18nOptions | false;
+  /**
+   * App bootstrap that needs the initial page — e.g. `configureEcho` from a
+   * shared connection prop. Runs on the client before the first render; a
+   * returned promise delays that render until it resolves.
+   */
+  boot?: (context: { page: InertiaPage }) => void | Promise<void>;
+  /**
+   * Compose providers or siblings around the app. Applied inside the Lattice
+   * Provider, so the registry, sprite, and toaster contexts are available.
+   */
+  wrap?: (app: ReactElement) => ReactElement;
 };
+
+// Fail-open: a failed bootstrap renders the app anyway (with fallback strings)
+// rather than a blank page.
+function AwaitReady({ ready, children }: { ready: Promise<unknown>; children: ReactNode }) {
+  const [isReady, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const reveal = (): void => {
+      if (active) {
+        setReady(true);
+      }
+    };
+
+    void ready.then(reveal, reveal);
+
+    return () => {
+      active = false;
+    };
+  }, [ready]);
+
+  return isReady ? children : null;
+}
 
 /**
  * Bootstrap an Inertia app with the Lattice shell: the page/layout resolvers
  * (server-driven Lattice pages and normal Inertia pages alike), the Provider —
- * registry, sprite, flash toasts via Lattice's own Toaster — and theme
- * initialization. Forwards any other createInertiaApp option.
+ * registry, sprite, flash toasts via Lattice's own Toaster — theme
+ * initialization, and the i18n bootstrap. Forwards any other createInertiaApp
+ * option.
  */
 export function createLatticeApp({
   registry,
@@ -45,6 +98,9 @@ export function createLatticeApp({
   pages = {},
   defaultLayout,
   strictMode = true,
+  i18n,
+  boot,
+  wrap,
   ...inertiaOptions
 }: CreateLatticeAppOptions = {}) {
   const baseRegistry = registry ?? defaultRegistry;
@@ -53,16 +109,66 @@ export function createLatticeApp({
 
   setDefaultRegistry(activeRegistry);
 
+  const userVisitOptions = inertiaOptions.defaults?.visitOptions;
+  const defaults =
+    i18n === false
+      ? inertiaOptions.defaults
+      : {
+          ...inertiaOptions.defaults,
+          visitOptions: (href: string, options: VisitOptions): VisitOptions =>
+            withVisitHeaders(href, userVisitOptions?.(href, options) ?? options),
+        };
+
   const app = createInertiaApp({
     ...inertiaOptions,
+    defaults,
     strictMode,
     resolve: createPageResolver(pages),
     layout: createLayoutResolver({ defaultLayout }),
-    withApp: (node: ReactElement): ReactElement => (
-      <ProviderBase registry={activeRegistry} sprite={sprite}>
-        {node}
-      </ProviderBase>
-    ),
+    withApp: (node: ReactElement, { ssr, page }: { ssr: boolean; page: InertiaPage }) => {
+      const pending: Promise<unknown>[] = [];
+
+      if (!ssr) {
+        // Loaded on demand so apps without the shared i18n prop never ship the
+        // i18next backend; the disabled-config call still stores the timezone.
+        if (i18n !== false && i18nConfigFromPageProps(page.props) !== undefined) {
+          pending.push(
+            import("./i18n/page-props").then((module) =>
+              module.configureI18nFromPageProps(page.props, i18n ?? {}),
+            ),
+          );
+        }
+
+        const booted = boot?.({ page });
+
+        if (booted) {
+          pending.push(booted);
+        }
+      }
+
+      const inner = (
+        <>
+          {node}
+          {i18n === false ? null : <LocaleReload />}
+        </>
+      );
+
+      // The whole shell waits, not just the page: anything rendering a
+      // translated string (the Toaster included) would otherwise initialize
+      // i18next before the backend can register — init runs exactly once,
+      // first caller wins.
+      const shell = (
+        <ProviderBase registry={activeRegistry} sprite={sprite}>
+          {wrap ? wrap(inner) : inner}
+        </ProviderBase>
+      );
+
+      return pending.length > 0 ? (
+        <AwaitReady ready={Promise.all(pending)}>{shell}</AwaitReady>
+      ) : (
+        shell
+      );
+    },
   });
 
   initializeTheme();

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -109,15 +109,15 @@ export function createLatticeApp({
 
   setDefaultRegistry(activeRegistry);
 
+  const i18nEnabled = i18n !== false;
   const userVisitOptions = inertiaOptions.defaults?.visitOptions;
-  const defaults =
-    i18n === false
-      ? inertiaOptions.defaults
-      : {
-          ...inertiaOptions.defaults,
-          visitOptions: (href: string, options: VisitOptions): VisitOptions =>
-            withVisitHeaders(href, userVisitOptions?.(href, options) ?? options),
-        };
+  const defaults = i18nEnabled
+    ? {
+        ...inertiaOptions.defaults,
+        visitOptions: (href: string, options: VisitOptions): VisitOptions =>
+          withVisitHeaders(href, userVisitOptions?.(href, options) ?? options),
+      }
+    : inertiaOptions.defaults;
 
   const app = createInertiaApp({
     ...inertiaOptions,
@@ -131,7 +131,7 @@ export function createLatticeApp({
       if (!ssr) {
         // Loaded on demand so apps without the shared i18n prop never ship the
         // i18next backend; the disabled-config call still stores the timezone.
-        if (i18n !== false && i18nConfigFromPageProps(page.props) !== undefined) {
+        if (i18nEnabled && i18nConfigFromPageProps(page.props) !== undefined) {
           pending.push(
             import("./i18n/page-props").then((module) =>
               module.configureI18nFromPageProps(page.props, i18n ?? {}),
@@ -149,7 +149,7 @@ export function createLatticeApp({
       const inner = (
         <>
           {node}
-          {i18n === false ? null : <LocaleReload />}
+          {i18nEnabled ? <LocaleReload /> : null}
         </>
       );
 

--- a/resources/js/i18n/page-props.ts
+++ b/resources/js/i18n/page-props.ts
@@ -1,34 +1,7 @@
-import { configureI18n, type ConfigureI18nOptions, type I18nConfig } from "./backend";
+import { configureI18n, type ConfigureI18nOptions } from "./backend";
+import { i18nConfigFromPageProps } from "./shared-props";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string");
-}
-
-function isI18nConfig(value: unknown): value is I18nConfig {
-  return (
-    isRecord(value) &&
-    typeof value.enabled === "boolean" &&
-    typeof value.saveMissing === "boolean" &&
-    isStringArray(value.locales) &&
-    isStringArray(value.preloadLocales) &&
-    (value.timezone === undefined || value.timezone === null || typeof value.timezone === "string")
-  );
-}
-
-export function i18nConfigFromPageProps(props: unknown): I18nConfig | undefined {
-  if (!isRecord(props)) {
-    return undefined;
-  }
-
-  const shared = props.lattice;
-  const config = isRecord(shared) ? shared.i18n : undefined;
-
-  return isI18nConfig(config) ? config : undefined;
-}
+export { i18nConfigFromPageProps };
 
 export function configureI18nFromPageProps(
   props: unknown,

--- a/resources/js/i18n/shared-props.ts
+++ b/resources/js/i18n/shared-props.ts
@@ -1,0 +1,36 @@
+import type { I18nConfig } from "@lattice-php/lattice/types/generated";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isI18nConfig(value: unknown): value is I18nConfig {
+  return (
+    isRecord(value) &&
+    typeof value.enabled === "boolean" &&
+    typeof value.saveMissing === "boolean" &&
+    isStringArray(value.locales) &&
+    isStringArray(value.preloadLocales) &&
+    (value.timezone === undefined || value.timezone === null || typeof value.timezone === "string")
+  );
+}
+
+/**
+ * Parse the backend-shared `lattice.i18n` Inertia prop. Lives apart from the
+ * configure entrypoint so callers can inspect the prop without pulling the
+ * i18next backend into their bundle.
+ */
+export function i18nConfigFromPageProps(props: unknown): I18nConfig | undefined {
+  if (!isRecord(props)) {
+    return undefined;
+  }
+
+  const shared = props.lattice;
+  const config = isRecord(shared) ? shared.i18n : undefined;
+
+  return isI18nConfig(config) ? config : undefined;
+}

--- a/resources/js/index.ts
+++ b/resources/js/index.ts
@@ -11,7 +11,11 @@ export { useEffectDispatcher } from "./effects/use-effect-dispatcher";
 export { builtinEffectHandlers, effectHandler, mergeEffectHandlers } from "./effects/registry";
 export { initializeTheme, updateAppearance, useAppearance } from "./appearance";
 export { copyToClipboard, useClipboard } from "./clipboard";
-export { createLatticeApp, type CreateLatticeAppOptions } from "./create-app";
+export {
+  createLatticeApp,
+  type CreateLatticeAppI18nOptions,
+  type CreateLatticeAppOptions,
+} from "./create-app";
 export { EventBridge } from "./event-bridge";
 export { Icon, IconRenderer, IconRendererProvider, SpriteProvider } from "./icons";
 export {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -35,7 +35,7 @@ uses(RefreshDatabase::class)->in(__DIR__);
  * @param  Closure(): void  $assert
  * @param  (Closure(): void)|null  $between
  */
-function retryUntil(Closure $assert, int $attempts = 20, int $sleepMicroseconds = 250_000, ?Closure $between = null): void
+function retryUntil(Closure $assert, int $attempts = 20, int $sleepMicroseconds = 500_000, ?Closure $between = null): void
 {
     foreach (range(1, $attempts) as $attempt) {
         try {
@@ -56,7 +56,7 @@ function retryUntil(Closure $assert, int $attempts = 20, int $sleepMicroseconds 
     }
 }
 
-function eventually(Closure $assert, int $attempts = 20, int $sleepMicroseconds = 250_000, ?Closure $between = null): void
+function eventually(Closure $assert, int $attempts = 20, int $sleepMicroseconds = 500_000, ?Closure $between = null): void
 {
     retryUntil($assert, $attempts, $sleepMicroseconds, $between);
 }

--- a/workbench/resources/js/app.tsx
+++ b/workbench/resources/js/app.tsx
@@ -1,22 +1,10 @@
 import "../css/app.css";
-import { createInertiaApp } from "@inertiajs/react";
 import { configureEcho } from "@laravel/echo-react";
-import {
-  createLayoutResolver,
-  createPageResolver,
-  extendRegistry,
-  Provider,
-  registry,
-  withVisitHeaders,
-} from "@lattice-php/lattice";
-import { configureI18nFromPageProps, LocaleReload } from "@lattice-php/lattice/i18n";
-import { createRoot } from "react-dom/client";
+import { createLatticeApp } from "@lattice-php/lattice";
 import sprite from "virtual:svg-sprite";
 import plugins from "virtual:lattice/plugins";
 import { appColumns } from "./columns";
 import { WORKBENCH_I18N_NAMESPACE } from "./i18n";
-
-const appRegistry = extendRegistry(registry, appColumns, ...plugins);
 
 type ReverbProp = {
   host: string;
@@ -25,48 +13,23 @@ type ReverbProp = {
   scheme: string;
 };
 
-function configureEchoFromProps(reverb: ReverbProp): void {
-  configureEcho({
-    broadcaster: "reverb",
-    key: reverb.key,
-    wsHost: reverb.host,
-    wsPort: reverb.port,
-    wssPort: reverb.port,
-    forceTLS: false,
-    enabledTransports: ["ws"],
-  });
-}
+void createLatticeApp({
+  plugins: [appColumns, ...plugins],
+  sprite,
+  i18n: { namespaces: ["lattice", WORKBENCH_I18N_NAMESPACE] },
+  boot: ({ page }) => {
+    const reverb = page.props.reverb as ReverbProp | null | undefined;
 
-createInertiaApp({
-  strictMode: true,
-  resolve: createPageResolver({}),
-  layout: createLayoutResolver(),
-  defaults: {
-    visitOptions: withVisitHeaders,
-  },
-  setup({ el, App, props }) {
-    if (!el) {
-      return;
+    if (reverb) {
+      configureEcho({
+        broadcaster: "reverb",
+        key: reverb.key,
+        wsHost: reverb.host,
+        wsPort: reverb.port,
+        wssPort: reverb.port,
+        forceTLS: false,
+        enabledTransports: ["ws"],
+      });
     }
-
-    const reverb = props.initialPage.props.reverb as ReverbProp | null | undefined;
-
-    if (typeof window !== "undefined" && reverb) {
-      configureEchoFromProps(reverb);
-    }
-
-    const root = createRoot(el);
-    const render = () => {
-      root.render(
-        <Provider registry={appRegistry} sprite={sprite}>
-          <App {...props} />
-          <LocaleReload />
-        </Provider>,
-      );
-    };
-
-    void configureI18nFromPageProps(props.initialPage.props, {
-      namespaces: ["lattice", WORKBENCH_I18N_NAMESPACE],
-    }).then(render, render);
   },
 });


### PR DESCRIPTION
Closes the gap that forced every i18n consumer (the workbench and the starter kit included) to abandon `createLatticeApp` for ~40 lines of hand-rolled `createInertiaApp` wiring.

## Why the shell couldn't host i18n
The bootstrap needs three things only the manual `setup` provided: the **initial page props** (`configureI18nFromPageProps`), **gating the first render** — i18next initializes exactly once, first caller wins, so anything rendering a translated string (the Provider's own Toaster included) before `enableBackend` registers permanently locks the app to inline English — and mounting **`LocaleReload`**. That first-caller-wins interaction was caught the hard way: an earlier draft gated only the page while the Provider rendered immediately, and the browser I18nTest exposed the silent no-backend init.

## What's new
- **`i18n` option (on by default):** when the backend shares `lattice.i18n`, the whole shell waits for the translation setup (no flash of untranslated fallbacks), `LocaleReload` re-fetches after locale switches, and the locale headers are composed into `defaults.visitOptions` (caller-provided visitOptions still run first). The i18next chunk is a dynamic import guarded by a dependency-free prop check (`i18n/shared-props`), so apps without the prop ship zero new bytes. `i18n: false` opts out.
- **`boot` hook:** pre-render app bootstrap with the initial page — e.g. `configureEcho` from a shared connection prop; a returned promise delays the first render; skipped on the server.
- **`wrap` hook:** compose app providers around the app inside the Lattice Provider.
- Bootstrap failures fail open (app renders with fallback strings), matching the manual pattern's `.then(render, render)`.

## Dogfood
The workbench entry drops its manual wiring for `createLatticeApp({ plugins, sprite, i18n, boot })` — 55 lines down to 18, and the full browser suite (89 tests, including the i18n saveMissing dump and the Reverb realtime test through the new `boot` hook) passes against the rebuilt bundle.

## Verification
14 create-app unit tests (render gating, namespace pass-through, chunk-skip when the prop is absent, `i18n: false`, visit-header composition, boot with page + async gating, ssr skip, wrap composition), full Vitest + typecheck + type-coverage + build, browser suite 89/89, docs build green. Docs updated: installation (the three hooks) and i18n (frontend wiring is now one option; manual building blocks still documented).