### PR TITLE
refactor(types): generate drifting handwritten types

### DIFF
--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -41,13 +41,16 @@
             "autoFocus": false,
             "columnWidth": "md",
             "conditions": {
+                "disabled": [],
+                "readOnly": [],
                 "required": [
                     {
                         "field": "country",
                         "operator": "eq",
                         "value": "DE"
                     }
-                ]
+                ],
+                "visible": []
             },
             "dependsOnAny": false,
             "dependsOnKeys": null,

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -37,6 +37,9 @@
             "autoFocus": false,
             "columnWidth": "md",
             "conditions": {
+                "disabled": [],
+                "readOnly": [],
+                "required": [],
                 "visible": [
                     {
                         "field": "type",

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -3,7 +3,7 @@ import { InfoTooltip } from "@lattice-php/lattice/ui/info-tooltip";
 import { TextLink } from "@lattice-php/lattice/ui/link";
 import { Label } from "@lattice-php/lattice/ui/label";
 import { useInTableCell } from "@lattice-php/lattice/form/hooks/row-layout-context";
-import type { FormLabelAction } from "@lattice-php/lattice/form/types";
+import type { LabelAction } from "@lattice-php/lattice/form/types";
 
 export function FormFieldFrame({
   children,
@@ -19,7 +19,7 @@ export function FormFieldFrame({
   error?: string;
   helperText?: string;
   label: string;
-  labelAction?: FormLabelAction;
+  labelAction?: LabelAction;
   name: string;
   required?: boolean;
   tooltip?: string;
@@ -51,7 +51,7 @@ export function FormFieldFrame({
         {labelAction && (
           <TextLink
             href={labelAction.href}
-            tabIndex={labelAction.tabIndex}
+            tabIndex={labelAction.tabIndex ?? undefined}
             className="ml-auto text-sm"
           >
             {labelAction.label}

--- a/resources/js/form/components/fields/date-input.test.tsx
+++ b/resources/js/form/components/fields/date-input.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { setLocale } from "@lattice-php/lattice/i18n/locale";
-import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
+import { createFieldRenderer, fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { DateInputComponent } from "./date-input";
 
 const renderField = createFieldRenderer(DateInputComponent);
@@ -98,7 +98,9 @@ describe("DateInputComponent", () => {
         props: {
           name: "due",
           label: "Due",
-          conditions: { visible: [{ field: "scheduled", operator: "eq", value: "1" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "scheduled", operator: "eq", value: "1" }],
+          }),
         },
       }),
       { scheduled: "0" },

--- a/resources/js/form/components/fields/number-input.test.tsx
+++ b/resources/js/form/components/fields/number-input.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
+import { createFieldRenderer, fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { NumberInputComponent } from "./number-input";
 
 const renderField = createFieldRenderer(NumberInputComponent);
@@ -37,7 +37,9 @@ describe("NumberInputComponent", () => {
         props: {
           name: "qty",
           label: "Qty",
-          conditions: { visible: [{ field: "type", operator: "eq", value: "order" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "type", operator: "eq", value: "order" }],
+          }),
         },
       }),
       { type: "quote" },

--- a/resources/js/form/components/fields/otp-input.test.tsx
+++ b/resources/js/form/components/fields/otp-input.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
+import { createFieldRenderer, fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { OtpInputComponent } from "./otp-input";
 
 const renderField = createFieldRenderer(OtpInputComponent);
@@ -38,7 +38,9 @@ describe("OtpInputComponent", () => {
           name: "code",
           label: "Code",
           length: 6,
-          conditions: { visible: [{ field: "mode", operator: "eq", value: "2fa" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "mode", operator: "eq", value: "2fa" }],
+          }),
         },
       }),
       { mode: "off" },

--- a/resources/js/form/components/fields/password-input.test.tsx
+++ b/resources/js/form/components/fields/password-input.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
+import { createFieldRenderer, fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { FormValuesProvider, useFormValue } from "@lattice-php/lattice/form/hooks/values";
 import { PasswordInputComponent } from "./password-input";
 
@@ -18,7 +18,9 @@ describe("PasswordInputComponent conditions", () => {
         props: {
           name: "password",
           label: "Password",
-          conditions: { visible: [{ field: "mode", operator: "eq", value: "reset" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "mode", operator: "eq", value: "reset" }],
+          }),
         },
       }),
       { mode: "login" },
@@ -34,7 +36,9 @@ describe("PasswordInputComponent conditions", () => {
         props: {
           name: "password",
           label: "Password",
-          conditions: { visible: [{ field: "mode", operator: "eq", value: "reset" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "mode", operator: "eq", value: "reset" }],
+          }),
         },
       }),
       { mode: "reset" },

--- a/resources/js/form/components/fields/rich-editor.test.tsx
+++ b/resources/js/form/components/fields/rich-editor.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { FieldScopeProvider } from "@lattice-php/lattice/form/hooks/field-scope";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { RichEditorComponent } from "./rich-editor";
@@ -40,7 +40,9 @@ describe("RichEditorComponent", () => {
         props: {
           name: "body",
           label: "Body",
-          conditions: { visible: [{ field: "mode", operator: "eq", value: "edit" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "mode", operator: "eq", value: "edit" }],
+          }),
         },
       }),
       { mode: "view" },

--- a/resources/js/form/components/fields/text-input.test.tsx
+++ b/resources/js/form/components/fields/text-input.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
+import { createFieldRenderer, fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { TextInputComponent } from "./text-input";
 
 const renderField = createFieldRenderer(TextInputComponent);
@@ -13,7 +13,9 @@ describe("TextInputComponent conditions", () => {
         props: {
           name: "company",
           label: "Company",
-          conditions: { visible: [{ field: "type", operator: "eq", value: "business" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "type", operator: "eq", value: "business" }],
+          }),
         },
       }),
       { type: "personal" },
@@ -29,7 +31,9 @@ describe("TextInputComponent conditions", () => {
         props: {
           name: "company",
           label: "Company",
-          conditions: { visible: [{ field: "type", operator: "eq", value: "business" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "type", operator: "eq", value: "business" }],
+          }),
         },
       }),
       { type: "business" },

--- a/resources/js/form/components/fields/textarea.test.tsx
+++ b/resources/js/form/components/fields/textarea.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { TextareaComponent } from "./textarea";
 
@@ -9,7 +9,7 @@ const node = fakeNode({
   props: {
     name: "bio",
     label: "Bio",
-    conditions: { visible: [{ field: "mode", operator: "eq", value: "edit" }] },
+    conditions: fakeConditions({ visible: [{ field: "mode", operator: "eq", value: "edit" }] }),
   },
 });
 

--- a/resources/js/form/components/fields/toggle.test.tsx
+++ b/resources/js/form/components/fields/toggle.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { createFieldRenderer, fakeNode } from "@lattice-php/lattice/test-support";
+import { createFieldRenderer, fakeConditions, fakeNode } from "@lattice-php/lattice/test-support";
 import { FieldScopeProvider } from "@lattice-php/lattice/form/hooks/field-scope";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { ToggleComponent } from "./toggle";
@@ -71,7 +71,9 @@ describe("ToggleComponent", () => {
         props: {
           label: "Published",
           name: "published",
-          conditions: { visible: [{ field: "status", operator: "eq", value: "live" }] },
+          conditions: fakeConditions({
+            visible: [{ field: "status", operator: "eq", value: "live" }],
+          }),
         },
       }),
       { status: "draft" },

--- a/resources/js/form/lib/conditions.ts
+++ b/resources/js/form/lib/conditions.ts
@@ -1,13 +1,6 @@
-import type { Condition, Op } from "@lattice-php/lattice/types/generated";
+import type { Condition, FieldConditions, Op } from "@lattice-php/lattice/types/generated";
 
-export type { Condition };
-
-export type FieldConditions = {
-  visible?: Condition[];
-  required?: Condition[];
-  readOnly?: Condition[];
-  disabled?: Condition[];
-};
+export type { Condition, FieldConditions };
 
 type FieldFlags = {
   hidden?: boolean;
@@ -23,7 +16,7 @@ export type FieldState = {
   disabled: boolean;
 };
 
-export function conditionFields(conditions: FieldConditions | undefined | null): string[] {
+export function conditionFields(conditions: Partial<FieldConditions> | undefined | null): string[] {
   const fields = new Set<string>();
 
   for (const group of [
@@ -143,7 +136,7 @@ function anyMatch(conditions: Condition[] | undefined, values: Record<string, un
 }
 
 export function evaluateConditions(
-  conditions: FieldConditions | undefined,
+  conditions: Partial<FieldConditions> | undefined,
   values: Record<string, unknown>,
   flags: FieldFlags,
 ): FieldState {

--- a/resources/js/form/lib/field-props.ts
+++ b/resources/js/form/lib/field-props.ts
@@ -1,28 +1,32 @@
 import type { Node } from "@lattice-php/lattice/core/types";
-import type { FieldConditions } from "./conditions";
+import type { ComponentPropsMap } from "@lattice-php/lattice/types/generated";
 
 /**
  * The props every form-field node shares (the PHP Field base). Nodes flow through
  * the form framework loosely typed via the generic schema, so this is the typed
  * lens the shared hooks read them through. Everything is optional because the
- * lens is also applied to non-field nodes while walking the schema.
+ * lens is also applied to non-field nodes while walking the schema. Derived from
+ * a generated field type (every field bakes the base in) rather than hand-written.
  */
-type FieldProps = {
-  conditions?: FieldConditions | null;
-  dependsOnAny?: boolean | null;
-  dependsOnKeys?: string[] | null;
-  disabled?: boolean | null;
-  helperText?: string | null;
-  label?: string | null;
-  name?: string;
-  editablePrefill?: boolean | null;
-  prefillRefreshOn?: string[] | null;
-  prefillResetOn?: string[] | null;
-  readOnly?: boolean | null;
-  required?: boolean | null;
-  tooltip?: string | null;
-  value?: unknown;
-};
+type FieldProps = Partial<
+  Pick<
+    ComponentPropsMap["field.text-input"],
+    | "conditions"
+    | "dependsOnAny"
+    | "dependsOnKeys"
+    | "disabled"
+    | "editablePrefill"
+    | "helperText"
+    | "label"
+    | "name"
+    | "prefillRefreshOn"
+    | "prefillResetOn"
+    | "readOnly"
+    | "required"
+    | "tooltip"
+    | "value"
+  >
+>;
 
 export function fieldProps(node: Node): FieldProps {
   return node.props as FieldProps;

--- a/resources/js/form/types.ts
+++ b/resources/js/form/types.ts
@@ -10,6 +10,7 @@ export type {
   Form,
   FormNodeType,
   HiddenInput,
+  LabelAction,
   NumberInput,
   PasswordInput,
   RichEditor,
@@ -24,9 +25,3 @@ export type FormFieldNode = NodeUnionOf<FormFieldNodeType>;
 export type FormNode = NodeUnionOf<FormNodeType>;
 
 export type FormMethod = Method;
-
-export type FormLabelAction = {
-  href: string;
-  label: string;
-  tabIndex?: number;
-};

--- a/resources/js/table/components/filter-bar.tsx
+++ b/resources/js/table/components/filter-bar.tsx
@@ -6,9 +6,9 @@ import { isActiveFilterValue } from "@lattice-php/lattice/table/lib/filter-value
 import { operatorLabel, VALUELESS_FILTER_OPERATORS } from "@lattice-php/lattice/table/lib/query";
 import type {
   FilterClause,
+  FilterIndicator,
   FilterNode,
   TableColumn,
-  TableFilterIndicator,
 } from "@lattice-php/lattice/table/types";
 import { TableFilterControl } from "./filter-controls";
 
@@ -23,7 +23,7 @@ export function FilterBar({
 }: {
   clauses: FilterClause[];
   columnsByKey: Map<string, TableColumn>;
-  indicators: TableFilterIndicator[];
+  indicators: FilterIndicator[];
   processing: boolean;
   onRemoveClause: (index: number) => void;
   onChange: (key: string, value: unknown) => void;

--- a/resources/js/table/lib/payload.ts
+++ b/resources/js/table/lib/payload.ts
@@ -1,8 +1,8 @@
 import type { Node } from "@lattice-php/lattice/core/types";
 import type {
   FilterClause,
+  FilterIndicator,
   TableColumn,
-  TableFilterIndicator,
   TablePagination,
   TableRow,
   TableState,
@@ -112,13 +112,13 @@ function getTableFilters(value: unknown): Record<string, Record<string, unknown>
   );
 }
 
-function getTableFilterIndicators(value: unknown): TableFilterIndicator[] {
+function getTableFilterIndicators(value: unknown): FilterIndicator[] {
   if (!Array.isArray(value)) {
     return [];
   }
 
   return value.filter(
-    (indicator): indicator is TableFilterIndicator =>
+    (indicator): indicator is FilterIndicator =>
       typeof indicator === "object" &&
       indicator !== null &&
       typeof indicator.filter === "string" &&

--- a/resources/js/table/types.ts
+++ b/resources/js/table/types.ts
@@ -5,6 +5,7 @@ import type {
   ColumnPropsMap,
   ColumnType,
   FilterClause as WireFilterClause,
+  FilterIndicator,
   FilterPropsMap,
   Op,
   Table,
@@ -13,7 +14,7 @@ import type {
   TableSort,
 } from "@lattice-php/lattice/types/generated";
 
-export type { ColumnFilter, ColumnType, TablePagination, TableSort };
+export type { ColumnFilter, ColumnType, FilterIndicator, TablePagination, TableSort };
 
 export type ActionNode = NodeUnionOf<ActionNodeType>;
 
@@ -28,15 +29,8 @@ export type FilterClause = Omit<WireFilterClause, "operator"> & {
   operator: Op;
 };
 
-export type TableFilterIndicator = {
-  filter: string;
-  label: string;
-  value: string;
-};
-
-export type TableState = Omit<TableQuery, "filters" | "tableFilterIndicators"> & {
+export type TableState = Omit<TableQuery, "filters"> & {
   filters: FilterClause[];
-  tableFilterIndicators: TableFilterIndicator[];
 };
 
 export type TableResponse = {

--- a/resources/js/test-support.ts
+++ b/resources/js/test-support.ts
@@ -2,6 +2,12 @@ import { render, type RenderResult } from "@testing-library/react";
 import { createElement, type ComponentType, type ReactNode } from "react";
 import type { Node, PropsOf, Schema } from "./core/types";
 import { FormValuesProvider } from "./form/hooks/values";
+import type { FieldConditions } from "./types/generated";
+
+/** Fill the intents a case omits so a partial reads as the full wire `conditions` shape. */
+export function fakeConditions(partial: Partial<FieldConditions>): FieldConditions {
+  return { visible: [], required: [], readOnly: [], disabled: [], ...partial };
+}
 
 /**
  * Build a node fixture for tests with only the props a case cares about. The wire

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -58,12 +58,7 @@ export type BrowserToken = {
 export type Builder = {
   addLabel: string | null;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   defaultItems: number;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
@@ -175,12 +170,7 @@ export type ChatRole = "user" | "assistant" | "system";
 export type Checkbox = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -199,12 +189,7 @@ export type Checkbox = {
 export type Choice = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -354,12 +339,7 @@ export type DateFormat = {
 export type DateInput = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -383,12 +363,7 @@ export type DateRangeFilter = {
 export type DateTimeInput = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   convertTimezone: boolean;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
@@ -433,6 +408,12 @@ export type EffectPropsMap = {
   toast: ToastEffect;
   "toggle-sidebar": ToggleSidebarEffect;
 };
+export type FieldConditions = {
+  readonly visible: Condition[];
+  readonly required: Condition[];
+  readonly readOnly: Condition[];
+  readonly disabled: Condition[];
+};
 export type FieldType =
   | "field.builder"
   | "field.checkbox"
@@ -454,12 +435,7 @@ export type FieldType =
 export type FileUpload = {
   accept: string | null;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -587,12 +563,7 @@ export type Heading = {
 export type Height = "full" | "screen";
 export type HiddenInput = {
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -645,6 +616,11 @@ export type ImageColumn = {
   width: ColumnWidth;
 };
 export type Justify = "start" | "center" | "end" | "between" | "around" | "evenly";
+export type LabelAction = {
+  readonly href: string;
+  readonly label: string;
+  readonly tabIndex: number | null;
+};
 export type Link = {
   action: WireNode | null;
   effects: Effect[];
@@ -809,12 +785,7 @@ export type NumberFormatUnit =
 export type NumberInput = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -864,12 +835,7 @@ export type Orientation = "horizontal" | "vertical";
 export type OtpInput = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -893,12 +859,7 @@ export type PasswordInput = {
   autoComplete: string | null;
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   confirmation: {
     label: string;
     name: string;
@@ -910,11 +871,7 @@ export type PasswordInput = {
   editablePrefill: boolean;
   helperText: string | null;
   label: string | null;
-  labelAction: {
-    href: string;
-    label: string;
-    tabIndex?: number;
-  } | null;
+  labelAction: LabelAction | null;
   name: string;
   passwordRules: string | null;
   placeholder: string | null;
@@ -951,12 +908,7 @@ export type RemoteAccess = {
 export type Repeater = {
   addLabel: string | null;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   defaultItems: number;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
@@ -985,12 +937,7 @@ export type ResetFormEffect = {
 };
 export type RichEditor = {
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -1034,12 +981,7 @@ export type SegmentedControl = {
 export type Select = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -1186,12 +1128,7 @@ export type TextInput = {
   autoComplete: string | null;
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -1217,12 +1154,7 @@ export type TextPart = {
 export type Textarea = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -1243,12 +1175,7 @@ export type Textarea = {
 export type TimeInput = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;
@@ -1281,12 +1208,7 @@ export type ToastMessage = {
 export type Toggle = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
-  conditions: {
-    visible?: Condition[];
-    required?: Condition[];
-    readOnly?: Condition[];
-    disabled?: Condition[];
-  } | null;
+  conditions: FieldConditions | null;
   dependsOnAny: boolean;
   dependsOnKeys: string[] | null;
   disabled: boolean;

--- a/src/Forms/Components/Field.php
+++ b/src/Forms/Components/Field.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Core\Enums\Op;
 use Lattice\Lattice\Facades\Evaluate;
 use Lattice\Lattice\Forms\Conditions\Condition;
 use Lattice\Lattice\Forms\Conditions\ConditionSet;
+use Lattice\Lattice\Forms\Conditions\FieldConditions;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Support\Evaluation\EvaluationContext;
 use Lattice\Lattice\Ui\Components\Component;
@@ -35,15 +36,7 @@ abstract class Field extends Component
 
     public bool $disabled = false;
 
-    /**
-     * @var array{
-     *     visible?: list<Condition>,
-     *     required?: list<Condition>,
-     *     readOnly?: list<Condition>,
-     *     disabled?: list<Condition>,
-     * }|null
-     */
-    public ?array $conditions = null;
+    public ?FieldConditions $conditions = null;
 
     /**
      * @var array<int, string>|null
@@ -546,14 +539,14 @@ abstract class Field extends Component
     {
         $props = parent::decorateProps($props);
 
-        $conditions = array_filter([
-            'visible' => $this->conditionsFor('visible'),
-            'required' => $this->conditionsFor('required'),
-            'readOnly' => $this->conditionsFor('readOnly'),
-            'disabled' => $this->conditionsFor('disabled'),
-        ], static fn (array $set): bool => $set !== []);
+        $visible = $this->conditionsFor('visible');
+        $required = $this->conditionsFor('required');
+        $readOnly = $this->conditionsFor('readOnly');
+        $disabled = $this->conditionsFor('disabled');
 
-        $props['conditions'] = $conditions === [] ? null : $conditions;
+        $props['conditions'] = ($visible === [] && $required === [] && $readOnly === [] && $disabled === [])
+            ? null
+            : new FieldConditions($visible, $required, $readOnly, $disabled);
 
         $keys = [];
 

--- a/src/Forms/Components/LabelAction.php
+++ b/src/Forms/Components/LabelAction.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+/**
+ * A link rendered next to a field's label (for example a "Forgot password?"
+ * link beside a password field). Fields without one serialize to `null`.
+ */
+#[TypeScript]
+final readonly class LabelAction
+{
+    public function __construct(
+        public string $href,
+        public string $label,
+        public ?int $tabIndex = null,
+    ) {}
+}

--- a/src/Forms/Components/PasswordInput.php
+++ b/src/Forms/Components/PasswordInput.php
@@ -22,10 +22,7 @@ class PasswordInput extends Field
 
     public ?string $passwordRules = null;
 
-    /**
-     * @var array{href: string, label: string, tabIndex?: int}|null
-     */
-    public ?array $labelAction = null;
+    public ?LabelAction $labelAction = null;
 
     /**
      * @var array{label: string, name: string, placeholder: string}|null
@@ -34,11 +31,7 @@ class PasswordInput extends Field
 
     public function labelAction(string $label, string $href, ?int $tabIndex = null): static
     {
-        $this->labelAction = array_filter([
-            'href' => $href,
-            'label' => $label,
-            'tabIndex' => $tabIndex,
-        ], fn (mixed $value): bool => $value !== null);
+        $this->labelAction = new LabelAction($href, $label, $tabIndex);
 
         return $this;
     }

--- a/src/Forms/Conditions/FieldConditions.php
+++ b/src/Forms/Conditions/FieldConditions.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Conditions;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+/**
+ * The four condition intents a field declares, as the value object that
+ * serializes to its `conditions` wire shape. A field without any conditions
+ * serializes to `null` rather than this object.
+ */
+#[TypeScript]
+final readonly class FieldConditions
+{
+    /**
+     * @param  list<Condition>  $visible
+     * @param  list<Condition>  $required
+     * @param  list<Condition>  $readOnly
+     * @param  list<Condition>  $disabled
+     */
+    public function __construct(
+        public array $visible,
+        public array $required,
+        public array $readOnly,
+        public array $disabled,
+    ) {}
+}

--- a/tests/Unit/Forms/Components/PasswordInputTest.php
+++ b/tests/Unit/Forms/Components/PasswordInputTest.php
@@ -17,3 +17,25 @@ describe('docs fixtures', function (): void {
         ]))));
     });
 });
+
+it('serializes a label action to the wire shape', function (): void {
+    $props = wire(PasswordInput::make('password', 'Password')
+        ->labelAction('Forgot password?', '/forgot', 3))['props'];
+
+    expect($props['labelAction'])->toBe([
+        'href' => '/forgot',
+        'label' => 'Forgot password?',
+        'tabIndex' => 3,
+    ]);
+});
+
+it('serializes a label action tabIndex as null when omitted', function (): void {
+    $props = wire(PasswordInput::make('password', 'Password')
+        ->labelAction('Forgot password?', '/forgot'))['props'];
+
+    expect($props['labelAction'])->toBe([
+        'href' => '/forgot',
+        'label' => 'Forgot password?',
+        'tabIndex' => null,
+    ]);
+});

--- a/tests/Unit/Forms/FieldConditionsTest.php
+++ b/tests/Unit/Forms/FieldConditionsTest.php
@@ -16,6 +16,19 @@ it('serializes declarative conditions into props', function (): void {
     ]);
 });
 
+it('serializes every intent, using empty arrays for the unset ones', function (): void {
+    $props = wire(TextInput::make('company', 'Company')->requiredWhen('type', 'business'))['props'];
+
+    expect($props['conditions'])->toBe([
+        'visible' => [],
+        'required' => [
+            ['field' => 'type', 'operator' => 'eq', 'value' => 'business'],
+        ],
+        'readOnly' => [],
+        'disabled' => [],
+    ]);
+});
+
 it('supports the operator form and array in', function (): void {
     $props = wire(TextInput::make('x', 'X')
         ->dependsOn('age', 'gte', 18)


### PR DESCRIPTION
Replaces handwritten TypeScript types that mirrored PHP wire payloads with generated ones, eliminating drift risk. Two logical changes:

## T1 — reuse generated `FilterIndicator`
`TableFilterIndicator` duplicated the generated `FilterIndicator` field-for-field, and `TableState` omitted `tableFilterIndicators` from `TableQuery` only to swap in the identical type. Dropped the duplicate; consumers now use the generated type. **No wire change.**

## T2 — generate `LabelAction` + `FieldConditions` value objects
The `PasswordInput` label action and the field `conditions` grouping serialized as loose arrays whose PHPDoc shapes the transformer *inlined* into every field type, forcing the client to hand-mirror them (`FormLabelAction`, `FieldConditions`, `FieldProps`).

- New `#[TypeScript]` VOs `LabelAction` + `FieldConditions`, wired into `PasswordInput` and the `Field` base → they generate as **named** types the client imports.
- Every field type's inline `conditions: {…}` block collapsed to `conditions: FieldConditions | null` — **generated.ts shrank 107 lines**.
- `FieldProps` now **derives** its base lens from a generated field type via `Pick` (the `CommonColumnProps` pattern) instead of hand-listing.
- Added PHP tests locking the new `labelAction`/`conditions` wire shapes; regenerated the two affected docs fixtures.

### Deliberately left handwritten
- `RowTemplate` — its `schema` is the augmentable client `Node[]`, not `WireNode[]`; generating would downgrade it (same rationale as `PagePayload`/`LayoutPayload`).

## Breaking changes
- `labelAction.tabIndex` is now `number | null` (was optional).
- `conditions` always carries `visible`/`required`/`readOnly`/`disabled` as arrays (empty when unset).
- The `FormLabelAction` type export is replaced by the generated `LabelAction`.

## Verification
tsc · oxlint · 986 JS tests · type-coverage 99.83% · build:lib · PHPStan · Rector · 1183 PHP tests — all green.