### PR TITLE
refactor(types): unify Node/WireNode — generate the augmentable Node

### DIFF
--- a/resources/js/core/types.ts
+++ b/resources/js/core/types.ts
@@ -52,11 +52,24 @@ export type PropsOf<TType extends string> = ResolveProps<
   CommonNodeProps;
 
 /**
+ * The loose wire node an unknown/untyped `type` resolves to: the shape every node
+ * shares, with a loose `props` bag. The single source of the wire-node shape;
+ * generated `WireNode` aliases `Node` (i.e. `Node<string>`), which is this.
+ */
+type LooseNode = {
+  id?: string;
+  key?: string;
+  type: string;
+  props?: NodeProps;
+  schema?: Schema;
+};
+
+/**
  * Built-in `props` is required, not optional — the wire serializes the full prop
- * object, so reads need no optional chaining. Unknown types fall back to `WireNode`.
+ * object, so reads need no optional chaining. Unknown types fall back to `LooseNode`.
  */
 export type NodeOfType<TType extends string = string> = string extends TType
-  ? WireNode
+  ? LooseNode
   : {
       id?: string;
       key?: string;

--- a/resources/js/layout/components/menu-item-action.test.tsx
+++ b/resources/js/layout/components/menu-item-action.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionInteractionProvider } from "@lattice-php/lattice/action";
 import { fakeNode } from "@lattice-php/lattice/test-support";
-import type { Node } from "@lattice-php/lattice/core/types";
+import type { Node, PropsOf } from "@lattice-php/lattice/core/types";
 import MenuItemComponent from "./menu-item";
 
 const http = vi.hoisted(() => ({
@@ -20,13 +20,13 @@ vi.mock("@inertiajs/react", () => ({
   Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
 }));
 
-function actionMenuItem(props: Record<string, unknown> = {}): Node<"menu-item"> {
+function actionMenuItem(props: Partial<PropsOf<"action">> = {}): Node<"menu-item"> {
   return fakeNode({
     id: "log-out",
     type: "menu-item",
     props: {
       label: "Log out",
-      action: {
+      action: fakeNode({
         id: "workbench.logout",
         type: "action",
         props: {
@@ -36,7 +36,7 @@ function actionMenuItem(props: Record<string, unknown> = {}): Node<"menu-item"> 
           ref: "sealed-reference",
           ...props,
         },
-      },
+      }),
     },
   });
 }
@@ -121,7 +121,7 @@ describe("menu item action trigger", () => {
 
   it("opens the modal form when the action carries one", () => {
     const node = actionMenuItem({
-      form: { id: "reason-form", type: "form", props: {}, schema: [] },
+      form: fakeNode({ id: "reason-form", type: "form", props: {}, schema: [] }),
     });
 
     renderActionMenuItem(node);

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1,7 +1,8 @@
+import type { Node } from "@lattice-php/lattice/core/types";
 export type Action = {
   confirmation: Confirmation | null;
   endpoint: string | null;
-  form: WireNode | null;
+  form: Node<"form"> | null;
   icon: string | null;
   label: string | null;
   lazyForm: boolean;
@@ -84,7 +85,7 @@ export type Builder = {
 export type BulkAction = {
   confirmation: Confirmation | null;
   endpoint: string | null;
-  form: WireNode | null;
+  form: Node<"form"> | null;
   icon: string | null;
   label: string | null;
   lazyForm: boolean;
@@ -93,7 +94,7 @@ export type BulkAction = {
   variant: ButtonVariant | null;
 };
 export type Button = {
-  action: WireNode | null;
+  action: Node<"action"> | null;
   buttonType: ButtonType;
   effects: Effect[];
   href: string | null;
@@ -115,7 +116,7 @@ export type ButtonVariant =
 export type Callout = {
   title: string | null;
   dismissible: boolean;
-  action: WireNode | null;
+  action: Node | null;
   variant: Variant;
   message: string;
 };
@@ -164,7 +165,7 @@ export type ChatBox = {
 export type ChatMessage = {
   readonly id: string;
   readonly role: ChatRole;
-  readonly parts: WireNode[];
+  readonly parts: Node[];
 };
 export type ChatRole = "user" | "assistant" | "system";
 export type Checkbox = {
@@ -213,7 +214,7 @@ export type Collapsible = {
   collapsed: boolean;
   rememberState: boolean;
   tooltip: string | null;
-  trigger: WireNode[];
+  trigger: Node[];
 };
 export type Color = "default" | "muted" | "primary" | "success" | "info" | "warning" | "danger";
 export type ColumnAlign = "start" | "center" | "end";
@@ -390,7 +391,7 @@ export type DownloadEffect = {
 };
 export type Dropdown = {
   placement: Placement;
-  trigger: WireNode[];
+  trigger: Node[];
 };
 export type Effect = {
   type: string;
@@ -490,7 +491,7 @@ export type FloatingPanel = {
   label: string | null;
   offset: number;
   placement: FloatingPlacement;
-  trigger: WireNode[];
+  trigger: Node[];
 };
 export type FloatingPlacement = "bottom-end" | "bottom-start" | "top-end" | "top-start";
 export type Form = {
@@ -622,7 +623,7 @@ export type LabelAction = {
   readonly tabIndex: number | null;
 };
 export type Link = {
-  action: WireNode | null;
+  action: Node<"action"> | null;
   effects: Effect[];
   href: string | null;
   icon: string | null;
@@ -643,7 +644,7 @@ export type LocaleChangeEffect = {
 };
 export type Menu = Record<string, never>;
 export type MenuItem = {
-  action: WireNode | null;
+  action: Node<"action"> | null;
   effects: Effect[];
   href: string | null;
   icon: string | null;
@@ -737,7 +738,7 @@ export type NotificationItem = {
   readonly href: string | null;
   readonly isRead: boolean;
   readonly createdAt: string | null;
-  readonly actions: WireNode[];
+  readonly actions: Node[];
 };
 export type Notifications = {
   channel: string;
@@ -966,7 +967,7 @@ export type Section = {
   collapsed: boolean;
   collapsible: boolean;
   description: string | null;
-  headerActions: WireNode[];
+  headerActions: Node[];
   rememberState: boolean;
   title: string | null;
   tooltip: string | null;
@@ -1046,11 +1047,11 @@ export type Tab = {
 };
 export type Table = {
   actionsLabel: string;
-  bulkActions: WireNode[];
+  bulkActions: Node<"action">[];
   columns: Record<string, unknown>[];
   emptyLabel: string;
   endpoint: string | null;
-  filters: WireNode[];
+  filters: Node[];
   layout: string | null;
   lazy: boolean;
   ref: string | null;
@@ -1201,7 +1202,7 @@ export type ToastMessage = {
   duration: number | null;
   persistent: boolean;
   dismissible: boolean;
-  action: WireNode | null;
+  action: Node | null;
   variant: Variant;
   message: Translatable | string;
 };
@@ -1236,7 +1237,7 @@ export type ToolCallPart = {
 };
 export type Tooltip = {
   content: string | null;
-  trigger: WireNode[];
+  trigger: Node[];
 };
 export type Topbar = {
   sticky: boolean;
@@ -1248,10 +1249,4 @@ export type Translatable = {
 };
 export type Variant = "success" | "info" | "warning" | "error";
 export type Width = "full" | "auto" | "sm" | "md" | "lg" | "fill";
-export type WireNode = {
-  id?: string;
-  key?: string;
-  type: string;
-  props?: Record<string, unknown>;
-  schema?: WireNode[];
-};
+export type WireNode = Node;

--- a/resources/js/ui/button-action.test.tsx
+++ b/resources/js/ui/button-action.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionInteractionProvider } from "@lattice-php/lattice/action";
 import { fakeNode } from "@lattice-php/lattice/test-support";
-import type { Node } from "@lattice-php/lattice/core/types";
+import type { Node, PropsOf } from "@lattice-php/lattice/core/types";
 import ButtonComponent from "./button";
 
 const http = vi.hoisted(() => ({
@@ -19,14 +19,14 @@ vi.mock("@inertiajs/react", () => ({
   Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
 }));
 
-function actionButton(props: Record<string, unknown> = {}): Node<"button"> {
+function actionButton(props: Partial<PropsOf<"action">> = {}): Node<"button"> {
   return fakeNode({
     id: "save",
     type: "button",
     props: {
       label: "Save",
       buttonType: "button",
-      action: {
+      action: fakeNode({
         id: "workbench.save",
         type: "action",
         props: {
@@ -36,7 +36,7 @@ function actionButton(props: Record<string, unknown> = {}): Node<"button"> {
           ref: "sealed-reference",
           ...props,
         },
-      },
+      }),
     },
   });
 }

--- a/resources/js/ui/click-behavior.tsx
+++ b/resources/js/ui/click-behavior.tsx
@@ -53,11 +53,11 @@ export function ActionTrigger({
 export function useClickBehavior(props: {
   href?: string | null;
   method?: Method | null;
-  action?: Node | null;
+  action?: Node<"action"> | null;
   effects?: Effect[] | null;
 }): ClickBehavior {
   const dispatch = useEffectDispatcher();
-  const action = (props.action ?? null) as Node<"action"> | null;
+  const action = props.action ?? null;
   const effects = props.effects ?? [];
 
   if (action) {

--- a/resources/js/ui/link-action.test.tsx
+++ b/resources/js/ui/link-action.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionInteractionProvider } from "@lattice-php/lattice/action";
 import { fakeNode } from "@lattice-php/lattice/test-support";
-import type { Node } from "@lattice-php/lattice/core/types";
+import type { Node, PropsOf } from "@lattice-php/lattice/core/types";
 import LinkComponent from "./link";
 
 const http = vi.hoisted(() => ({
@@ -19,13 +19,13 @@ vi.mock("@inertiajs/react", () => ({
   Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
 }));
 
-function actionLink(props: Record<string, unknown> = {}): Node<"link"> {
+function actionLink(props: Partial<PropsOf<"action">> = {}): Node<"link"> {
   return fakeNode({
     id: "log-out",
     type: "link",
     props: {
       label: "Log out",
-      action: {
+      action: fakeNode({
         id: "workbench.logout",
         type: "action",
         props: {
@@ -35,7 +35,7 @@ function actionLink(props: Record<string, unknown> = {}): Node<"link"> {
           ref: "sealed-reference",
           ...props,
         },
-      },
+      }),
     },
   });
 }
@@ -100,7 +100,7 @@ describe("link action trigger", () => {
 
   it("opens the modal form when the action carries one", () => {
     const node = actionLink({
-      form: { id: "reason-form", type: "form", props: {}, schema: [] },
+      form: fakeNode({ id: "reason-form", type: "form", props: {}, schema: [] }),
     });
 
     renderActionLink(node);

--- a/src/Support/TypeScript/ComponentTransformer.php
+++ b/src/Support/TypeScript/ComponentTransformer.php
@@ -123,8 +123,8 @@ final class ComponentTransformer extends ClassTransformer
     {
         return [
             ...parent::classPropertyProcessors(),
-            new MarkerRewriteClassPropertyProcessor(Component::class, fn (): TypeScriptNode => new TypeScriptIdentifier('WireNode')),
-            new MarkerRewriteClassPropertyProcessor(Filter::class, fn (): TypeScriptNode => new TypeScriptIdentifier('WireNode')),
+            new MarkerRewriteClassPropertyProcessor(Component::class, NodeTypeReference::for(...)),
+            new MarkerRewriteClassPropertyProcessor(Filter::class, NodeTypeReference::for(...)),
             new MixedToUnknownClassPropertyProcessor,
         ];
     }

--- a/src/Support/TypeScript/MarkerRewriteClassPropertyProcessor.php
+++ b/src/Support/TypeScript/MarkerRewriteClassPropertyProcessor.php
@@ -15,10 +15,10 @@ use Spatie\TypeScriptTransformer\Visitor\Visitor;
 use Spatie\TypeScriptTransformer\Visitor\VisitorOperation;
 
 /**
- * Rewrites any property whose type references the given marker class to a fixed
- * TypeScript node — e.g. the abstract Component base to the loose `WireNode`. Such
- * markers have no generated type of their own; the replacement is built per match
- * so nodes are never shared.
+ * Rewrites any property whose type references the given marker class to a
+ * TypeScript node derived from the matched class — e.g. a Component subclass to
+ * the augmentable `Node`/`Node<"type">`. Such markers have no generated type of
+ * their own; the replacement is built per match so nodes are never shared.
  */
 final readonly class MarkerRewriteClassPropertyProcessor implements ClassPropertyProcessor
 {
@@ -26,7 +26,7 @@ final readonly class MarkerRewriteClassPropertyProcessor implements ClassPropert
 
     /**
      * @param  class-string  $marker
-     * @param  Closure(): TypeScriptNode  $replacement
+     * @param  Closure(class-string): TypeScriptNode  $replacement  Receives the matched class-string.
      */
     public function __construct(string $marker, Closure $replacement)
     {
@@ -34,7 +34,7 @@ final readonly class MarkerRewriteClassPropertyProcessor implements ClassPropert
             $target = $reference->reference;
 
             if ($target instanceof ClassStringReference && is_a($target->classString, $marker, true)) {
-                return VisitorOperation::replace($replacement());
+                return VisitorOperation::replace($replacement($target->classString));
             }
 
             return VisitorOperation::keep();

--- a/src/Support/TypeScript/NodeModuleWriter.php
+++ b/src/Support/TypeScript/NodeModuleWriter.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\TypeScript;
+
+use Spatie\TypeScriptTransformer\Collections\TransformedCollection;
+use Spatie\TypeScriptTransformer\Data\WriteableFile;
+use Spatie\TypeScriptTransformer\Writers\FlatModuleWriter;
+
+/**
+ * The base-module writer, plus the one import the generated module can't declare
+ * itself: the augmentable `Node` from core/types. Component-typed props generate as
+ * `Node<"type">`/`Node` (see {@see ComponentTransformer}), and `WireNode` aliases it,
+ * so the flat module references `Node` but never defines it. The core↔generated
+ * import cycle is type-only, so it erases at runtime.
+ */
+final class NodeModuleWriter extends FlatModuleWriter
+{
+    private const string HEADER = 'import type { Node } from "@lattice-php/lattice/core/types";'."\n";
+
+    /**
+     * @param  array<mixed>  $transformed
+     * @return array<WriteableFile>
+     */
+    #[\Override]
+    public function output(array $transformed, TransformedCollection $transformedCollection): array
+    {
+        return array_map(
+            fn (WriteableFile $file): WriteableFile => new WriteableFile(
+                $file->path,
+                self::HEADER.$file->contents,
+                $file->changed,
+            ),
+            parent::output($transformed, $transformedCollection),
+        );
+    }
+}

--- a/src/Support/TypeScript/NodeTypeReference.php
+++ b/src/Support/TypeScript/NodeTypeReference.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\TypeScript;
+
+use Lattice\Lattice\Attributes\AsComponent;
+use ReflectionAttribute;
+use ReflectionClass;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptGeneric;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIdentifier;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptLiteral;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptNode;
+
+/**
+ * The augmentable node a Component/Filter-typed property generates as. A concrete
+ * node class (Form, Action, a filter) carries a known wire discriminator, so it
+ * narrows to `Node<"type">`; an abstract base (Component/Filter) or a heterogeneous
+ * child list stays the loose `Node`. Shared by the component and value-object
+ * transformers so every node-typed field resolves the same way.
+ */
+final class NodeTypeReference
+{
+    /**
+     * @param  class-string  $class
+     */
+    public static function for(string $class): TypeScriptNode
+    {
+        $reflection = new ReflectionClass($class);
+
+        if (! $reflection->isInstantiable()
+            || $reflection->getAttributes(AsComponent::class, ReflectionAttribute::IS_INSTANCEOF) === []) {
+            return new TypeScriptIdentifier('Node');
+        }
+
+        return new TypeScriptGeneric(
+            new TypeScriptIdentifier('Node'),
+            [new TypeScriptLiteral(AsComponent::typeForClass($class))],
+        );
+    }
+}

--- a/workbench/app/Support/TypeScript/BaseProfile.php
+++ b/workbench/app/Support/TypeScript/BaseProfile.php
@@ -8,11 +8,11 @@ use Lattice\Lattice\Effects\Contracts\Effect as EffectContract;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Support\TypeScript\ComponentTransformer;
 use Lattice\Lattice\Support\TypeScript\DiscoveredComponent;
+use Lattice\Lattice\Support\TypeScript\NodeModuleWriter;
 use Lattice\Lattice\Support\TypeScript\OxfmtFormatter;
 use Lattice\Lattice\Support\TypeScript\TypeScriptGenerator;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Lattice\Lattice\Support\TypeScript\WireTypeDiscovery;
-use Spatie\TypeScriptTransformer\Writers\FlatModuleWriter;
 
 /**
  * The package's own dev profile: regenerates the built-in TypeScript module
@@ -81,7 +81,7 @@ final class BaseProfile implements TypeScriptProfile
                     self::NODE_TYPE_ALIASES,
                 ),
             ],
-            new FlatModuleWriter('generated.ts'),
+            new NodeModuleWriter('generated.ts'),
             $outputDirectory,
             new OxfmtFormatter,
         );

--- a/workbench/app/Support/TypeScript/NodesProvider.php
+++ b/workbench/app/Support/TypeScript/NodesProvider.php
@@ -8,7 +8,6 @@ use Spatie\TypeScriptTransformer\References\CustomReference;
 use Spatie\TypeScriptTransformer\Transformed\Transformed;
 use Spatie\TypeScriptTransformer\TransformedProviders\TransformedProvider;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptAlias;
-use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptArray;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptGeneric;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIdentifier;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIntersection;
@@ -23,8 +22,9 @@ use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptUnion;
 /**
  * Emits the type-level glue that ties wire `type` strings to their generated props:
  * a per-domain `…NodeType` string union (the client builds its typed node union
- * from it with `NodeUnionOf`), the loose `WireNode`/`Effect` wire shapes, the
- * `NodeType` union, and the augmentable `…PropsMap` maps ({@see AugmentableMap}).
+ * from it with `NodeUnionOf`), the `WireNode` alias of core's `Node` and the loose
+ * `Effect` shape, the `NodeType` union, and the augmentable `…PropsMap` maps
+ * ({@see AugmentableMap}).
  *
  * @phpstan-type ComponentSpec array{type: string, container?: bool, interactive?: bool}
  */
@@ -75,7 +75,7 @@ final readonly class NodesProvider implements TransformedProvider
             $transformed[] = $this->alias($nodeName.'Type', $this->typeUnion($types));
         }
 
-        $transformed[] = $this->alias('WireNode', $this->wireNode());
+        $transformed[] = $this->alias('WireNode', new TypeScriptIdentifier('Node'));
         $transformed[] = $this->alias('NodeType', $this->typeUnion(array_keys($this->componentClassesByType())));
         $transformed[] = $this->alias('ComponentPropsMap', $this->propsMap($this->componentClassesByType()));
 
@@ -151,25 +151,6 @@ final readonly class NodesProvider implements TransformedProvider
         ));
     }
 
-    /**
-     * The loose shape `Component`-typed fields serialize as; core/types' typed
-     * `Node<TType>` resolves props per type through `ComponentPropsMap`.
-     */
-    private function wireNode(): TypeScriptObject
-    {
-        return new TypeScriptObject([
-            new TypeScriptProperty('id', new TypeScriptString, isOptional: true),
-            new TypeScriptProperty('key', new TypeScriptString, isOptional: true),
-            new TypeScriptProperty('type', new TypeScriptString),
-            new TypeScriptProperty('props', $this->looseProps(), isOptional: true),
-            new TypeScriptProperty(
-                'schema',
-                new TypeScriptArray([new TypeScriptReference($this->selfReference('WireNode'))]),
-                isOptional: true,
-            ),
-        ]);
-    }
-
     private function looseProps(): TypeScriptGeneric
     {
         return new TypeScriptGeneric(
@@ -201,11 +182,6 @@ final readonly class NodesProvider implements TransformedProvider
         }
 
         return $map;
-    }
-
-    public static function wireNodeReference(): CustomReference
-    {
-        return new CustomReference(self::REFERENCE_KEY, 'WireNode');
     }
 
     private function selfReference(string $name): CustomReference

--- a/workbench/app/Support/TypeScript/ValueObjectTransformer.php
+++ b/workbench/app/Support/TypeScript/ValueObjectTransformer.php
@@ -6,11 +6,11 @@ namespace Workbench\App\Support\TypeScript;
 use Lattice\Lattice\Support\TypeScript\AllowsListedClasses;
 use Lattice\Lattice\Support\TypeScript\MarkerRewriteClassPropertyProcessor;
 use Lattice\Lattice\Support\TypeScript\MixedToUnknownClassPropertyProcessor;
+use Lattice\Lattice\Support\TypeScript\NodeTypeReference;
 use Lattice\Lattice\Ui\Components\Component;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\Transformers\ClassTransformer;
-use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptReference;
 
 /**
  * Emits TypeScript object types only for an explicit allow-list of value
@@ -44,10 +44,7 @@ final class ValueObjectTransformer extends ClassTransformer
         return [
             ...parent::classPropertyProcessors(),
             new MixedToUnknownClassPropertyProcessor,
-            new MarkerRewriteClassPropertyProcessor(
-                Component::class,
-                fn (): TypeScriptReference => new TypeScriptReference(NodesProvider::wireNodeReference()),
-            ),
+            new MarkerRewriteClassPropertyProcessor(Component::class, NodeTypeReference::for(...)),
         ];
     }
 }


### PR DESCRIPTION
**Stacked on #262** (base is that branch, not `main`).

## Problem
`MarkerRewriteClassPropertyProcessor` rewrote every `Component`/`Filter`-typed prop to the loose generated `WireNode`, discarding discriminators PHP already knew (`Action::$form` is `?Form`, `Triggerable::$action` is `?Action`). The client then re-added the types by hand (casts) and node-carrying payloads couldn't be generated at all.

## Change
The transformer now emits the **augmentable `Node`**:
- a concrete node class carries a known wire discriminator → `Node<"type">` (`Action.form: Node<"form">`, Link/MenuItem `action: Node<"action">`, `Table.bulkActions: Node<"action">[]`);
- an abstract base / heterogeneous child list → the loose `Node`.
- `NodeModuleWriter` emits the one import `generated.ts` can't declare itself (`Node` from `core/types`); the core↔generated cycle is **type-only**.
- `WireNode` becomes an alias of `Node` — one node type, one name resolving everywhere.
- The discriminator logic is shared (`NodeTypeReference`) by the component and value-object transformers, so every node field resolves the same way.

## Payoff
- 16 generated node fields now flow through `Node` (6 discriminated); `node.type` narrows `node.props`.
- Dropped the redundant `as Node<"action">` cast in `useClickBehavior`.
- The stronger types tightened 3 action fixtures (nested nodes now built via `fakeNode`) — the discriminated union catching partial props is the feature working.
- Unblocks generating `PagePayload`/`LayoutPayload`/`RowTemplate` (a generated field can now express `Node[]`) — left as a follow-up.

## Verification
tsc · oxlint · 986 JS tests · type-coverage 99.83% · build:lib · PHPStan · Rector · 1183 PHP tests (incl. the generated-types snapshot) — all green. The wire JSON is unchanged (only types), so docs fixtures are untouched.