### PR TITLE
feat: rich select options via per-option schema

### DIFF
--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -126,7 +126,8 @@ label — a second line, a badge, an avatar. Components bind option fields with
 `->dataKey($prop, $key)`, exactly like the [stack column](/tables/columns/stack/). The bindings
 resolve against the option's `data` record plus its `label` and `value` (`label` and `value` are
 reserved and always resolve to the option's own fields). The schema is declared once and ships once;
-each option only carries its `data`, passed as the third argument to `Select::option()`.
+each option only carries its `data`, passed as the third argument to `Select::option()`. For static
+options, the dropdown filter matches the option label; text rendered from `data` stays display-only.
 
 <ComponentExample
   php={`Select::make('customer', 'Customer')

--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -168,8 +168,8 @@ Select::make('customer_id', 'Customer')
 ```
 
 <Info>
-  Option rows are buttons, so the schema must stay presentational. Keep interactive components —
-  a copyable text, a previewable image — out of the option schema; they nest a control inside the
+  Option rows are buttons, so the schema must stay presentational. Keep interactive components — a
+  copyable text, a previewable image — out of the option schema; they nest a control inside the
   option button.
 </Info>
 

--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -119,6 +119,62 @@ to constrain the query, and `->limit(50)` to cap results.
 value, so it is validated and returned in the submitted array like any other — your handler persists
 it. Lattice forms stay decoupled from the model.
 
+## Rich options
+
+`->optionSchema()` renders each option through a schema of bound components instead of the plain
+label — a second line, a badge, an avatar. Components bind option fields with
+`->dataKey($prop, $key)`, exactly like the [stack column](/tables/columns/stack/). The bindings
+resolve against the option's `data` record plus its `label` and `value` (`label` and `value` are
+reserved and always resolve to the option's own fields). The schema is declared once and ships once;
+each option only carries its `data`, passed as the third argument to `Select::option()`.
+
+<ComponentExample
+  php={`Select::make('customer', 'Customer')
+    ->placeholder('Pick a customer')
+    ->options([
+        Select::option('Acme GmbH', '1', ['email' => 'kontakt@acme.de', 'number' => 'K-10021']),
+        Select::option('Globex AG', '2', ['email' => 'info@globex.de', 'number' => 'K-10022']),
+    ])
+    ->optionSchema([
+        Stack::make()->schema([
+            Text::make('')->dataKey('text', 'label'),
+            Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::Muted),
+        ]),
+        Badge::make('')->dataKey('label', 'number'),
+    ])`}
+  fixture="select.rich"
+  values={{ customer: "" }}
+/>
+
+Searchable selects work the same way: a resolver returns options with data
+(`Select::option($user->name, (string) $user->id, ['email' => $user->email])`), and
+`EloquentOptions` attaches it with `->data()` — pass the columns to include, or a closure receiving
+the model for computed values:
+
+```php
+Select::make('customer_id', 'Customer')
+    ->optionsFrom(
+        EloquentOptions::make(Customer::class)
+            ->searchColumns(['name', 'email', 'customer_number'])
+            ->data(['email', 'customer_number']),
+    )
+    ->optionSchema([
+        Stack::make()->schema([
+            Text::make('')->dataKey('text', 'label'),
+            Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::Muted),
+        ]),
+        Badge::make('')->dataKey('label', 'customer_number'),
+    ]);
+```
+
+<Info>
+  Option rows are buttons, so the schema must stay presentational. Keep interactive components —
+  a copyable text, a previewable image — out of the option schema; they nest a control inside the
+  option button.
+</Info>
+
+The selected value renders as the plain option label in the trigger and in multi-select chips.
+
 ## Common options
 
 `Select` shares label, default value, required, disabled, read-only, and visibility options with

--- a/docs/fixtures/choice.basic.json
+++ b/docs/fixtures/choice.basic.json
@@ -13,14 +13,17 @@
             "name": "plan",
             "options": [
                 {
+                    "data": null,
                     "label": "Free",
                     "value": "free"
                 },
                 {
+                    "data": null,
                     "label": "Pro",
                     "value": "pro"
                 },
                 {
+                    "data": null,
                     "label": "Enterprise",
                     "value": "enterprise"
                 }

--- a/docs/fixtures/components.segmented-control.json
+++ b/docs/fixtures/components.segmented-control.json
@@ -6,14 +6,17 @@
             "name": "appearance",
             "options": [
                 {
+                    "data": null,
                     "label": "Light",
                     "value": "light"
                 },
                 {
+                    "data": null,
                     "label": "Dark",
                     "value": "dark"
                 },
                 {
+                    "data": null,
                     "label": "System",
                     "value": "system"
                 }

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -13,14 +13,17 @@
             "name": "country",
             "options": [
                 {
+                    "data": null,
                     "label": "Germany",
                     "value": "DE"
                 },
                 {
+                    "data": null,
                     "label": "Austria",
                     "value": "AT"
                 },
                 {
+                    "data": null,
                     "label": "United States",
                     "value": "US"
                 }

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -13,10 +13,12 @@
             "name": "type",
             "options": [
                 {
+                    "data": null,
                     "label": "Business",
                     "value": "business"
                 },
                 {
+                    "data": null,
                     "label": "Individual",
                     "value": "individual"
                 }

--- a/docs/fixtures/select.basic.json
+++ b/docs/fixtures/select.basic.json
@@ -15,18 +15,22 @@
             "name": "country",
             "options": [
                 {
+                    "data": null,
                     "label": "Germany",
                     "value": "de"
                 },
                 {
+                    "data": null,
                     "label": "France",
                     "value": "fr"
                 },
                 {
+                    "data": null,
                     "label": "Spain",
                     "value": "es"
                 },
                 {
+                    "data": null,
                     "label": "Italy",
                     "value": "it"
                 }

--- a/docs/fixtures/select.multiple.json
+++ b/docs/fixtures/select.multiple.json
@@ -15,18 +15,22 @@
             "name": "languages",
             "options": [
                 {
+                    "data": null,
                     "label": "PHP",
                     "value": "php"
                 },
                 {
+                    "data": null,
                     "label": "JavaScript",
                     "value": "js"
                 },
                 {
+                    "data": null,
                     "label": "Go",
                     "value": "go"
                 },
                 {
+                    "data": null,
                     "label": "Rust",
                     "value": "rust"
                 }

--- a/docs/fixtures/select.rich.json
+++ b/docs/fixtures/select.rich.json
@@ -1,0 +1,98 @@
+[
+    {
+        "props": {
+            "autoFocus": false,
+            "columnWidth": "md",
+            "conditions": null,
+            "dependsOnAny": false,
+            "dependsOnKeys": null,
+            "disabled": false,
+            "editablePrefill": false,
+            "emptyLabel": "No options",
+            "helperText": null,
+            "label": "Customer",
+            "multiple": false,
+            "name": "customer",
+            "optionSchema": [
+                {
+                    "props": {
+                        "align": null,
+                        "direction": null,
+                        "float": null,
+                        "gap": null,
+                        "height": null,
+                        "justify": null,
+                        "width": null
+                    },
+                    "schema": [
+                        {
+                            "props": {
+                                "align": null,
+                                "color": null,
+                                "copyable": false,
+                                "dataBindings": {
+                                    "text": "label"
+                                },
+                                "size": "md",
+                                "text": ""
+                            },
+                            "type": "text"
+                        },
+                        {
+                            "props": {
+                                "align": null,
+                                "color": "muted",
+                                "copyable": false,
+                                "dataBindings": {
+                                    "text": "email"
+                                },
+                                "size": "sm",
+                                "text": ""
+                            },
+                            "type": "text"
+                        }
+                    ],
+                    "type": "stack"
+                },
+                {
+                    "props": {
+                        "dataBindings": {
+                            "label": "number"
+                        },
+                        "label": ""
+                    },
+                    "type": "badge"
+                }
+            ],
+            "options": [
+                {
+                    "data": {
+                        "email": "kontakt@acme.de",
+                        "number": "K-10021"
+                    },
+                    "label": "Acme GmbH",
+                    "value": "1"
+                },
+                {
+                    "data": {
+                        "email": "info@globex.de",
+                        "number": "K-10022"
+                    },
+                    "label": "Globex AG",
+                    "value": "2"
+                }
+            ],
+            "placeholder": "Pick a customer",
+            "prefillRefreshOn": null,
+            "prefillResetOn": null,
+            "readOnly": false,
+            "required": false,
+            "searchPlaceholder": "Search…",
+            "searchable": false,
+            "tabIndex": null,
+            "tooltip": null,
+            "value": null
+        },
+        "type": "field.select"
+    }
+]

--- a/resources/js/form/components/fields/choice.test.tsx
+++ b/resources/js/form/components/fields/choice.test.tsx
@@ -11,8 +11,8 @@ describe("Lattice form choice component", () => {
         label: "Plan",
         name: "plan",
         options: [
-          { label: "Free", value: "free" },
-          { label: "Pro", value: "pro" },
+          { label: "Free", value: "free", data: null },
+          { label: "Pro", value: "pro", data: null },
         ],
         value: "free",
       },

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -1,5 +1,8 @@
 import { act, configure, fireEvent, getConfig, render, screen } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FieldScopeProvider } from "@lattice-php/lattice/form/hooks/field-scope";
@@ -242,5 +245,58 @@ describe("SelectComponent options", () => {
 
     expect(screen.getByTestId("select-color-option-red")).toHaveAttribute("aria-selected", "true");
     expect(screen.getByTestId("select-color-option-blue")).toHaveAttribute("aria-selected", "true");
+  });
+});
+
+describe("SelectComponent option schema", () => {
+  const MetaText: RendererComponent = ({ node }) => <span>{String(node.props?.text ?? "")}</span>;
+
+  it("materializes the option schema against each option's data", () => {
+    const registry = createRegistry({
+      components: { "test.meta": eagerComponent(MetaText) },
+      name: "test",
+    });
+
+    const node = fakeNode({
+      type: "field.select",
+      props: {
+        name: "customer",
+        label: "Customer",
+        emptyLabel: "No customers",
+        searchPlaceholder: "Search",
+        options: [
+          { label: "Acme GmbH", value: "42", data: { email: "kontakt@acme.de" } },
+          { label: "Globex AG", value: "43", data: { email: "info@globex.de" } },
+        ],
+      },
+    });
+    (node.props as { optionSchema?: Node[] }).optionSchema = [
+      { type: "test.meta", props: { dataBindings: { text: "email" } } },
+    ];
+
+    renderWithRegistry(
+      <FormProvider
+        value={{
+          action: "/forms/customers",
+          clearErrors: () => {},
+          componentRef: "ref-1",
+          errors: {},
+          fieldLabels: {},
+          precognitive: false,
+          processing: false,
+          validate: () => {},
+        }}
+      >
+        <FormValuesProvider initial={{}}>
+          <SelectComponent node={node}>{null}</SelectComponent>
+        </FormValuesProvider>
+      </FormProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByTestId("select-customer"));
+
+    expect(screen.getByRole("option", { name: "Acme GmbH" })).toHaveTextContent("kontakt@acme.de");
+    expect(screen.getByRole("option", { name: "Globex AG" })).toHaveTextContent("info@globex.de");
   });
 });

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -299,4 +299,41 @@ describe("SelectComponent option schema", () => {
     expect(screen.getByRole("option", { name: "Acme GmbH" })).toHaveTextContent("kontakt@acme.de");
     expect(screen.getByRole("option", { name: "Globex AG" })).toHaveTextContent("info@globex.de");
   });
+
+  it("falls back to the plain label when the option schema is empty", () => {
+    const node = fakeNode({
+      type: "field.select",
+      props: {
+        name: "customer",
+        label: "Customer",
+        emptyLabel: "No customers",
+        searchPlaceholder: "Search",
+        options: [{ label: "Acme GmbH", value: "42", data: { email: "kontakt@acme.de" } }],
+      },
+    });
+    (node.props as { optionSchema?: Node[] }).optionSchema = [];
+
+    render(
+      <FormProvider
+        value={{
+          action: "/forms/customers",
+          clearErrors: () => {},
+          componentRef: "ref-1",
+          errors: {},
+          fieldLabels: {},
+          precognitive: false,
+          processing: false,
+          validate: () => {},
+        }}
+      >
+        <FormValuesProvider initial={{}}>
+          <SelectComponent node={node}>{null}</SelectComponent>
+        </FormValuesProvider>
+      </FormProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId("select-customer"));
+
+    expect(screen.getByRole("option", { name: "Acme GmbH" }).textContent).toBe("Acme GmbH");
+  });
 });

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -4,7 +4,9 @@ import { Combobox } from "@lattice-php/lattice/ui/combobox";
 import { controlSurface } from "@lattice-php/lattice/ui/control";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
-import type { Option, RendererComponent } from "@lattice-php/lattice/core/types";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { materializeSchema } from "@lattice-php/lattice/core/materialize";
+import type { Node, Option, RendererComponent } from "@lattice-php/lattice/core/types";
 import { FormFieldFrame } from "@lattice-php/lattice/form/components/base/field";
 import { useFormContext } from "@lattice-php/lattice/form/hooks/context";
 import { fieldDomName } from "@lattice-php/lattice/form/lib/field-dom-name";
@@ -48,6 +50,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
     () => (resolvedNode.props as { options?: Option[] }).options ?? [],
     [resolvedNode.props],
   );
+  const optionSchema = (resolvedNode.props as { optionSchema?: Node[] }).optionSchema;
 
   const globalValue = useFormValue(name);
   const values = useFormValues();
@@ -139,6 +142,18 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
 
   const options = searchable ? (results ?? staticOptions) : staticOptions;
 
+  const renderOption = optionSchema
+    ? (option: Option) => (
+        <Renderer
+          nodes={materializeSchema(optionSchema, {
+            ...option.data,
+            label: option.label,
+            value: option.value,
+          })}
+        />
+      )
+    : undefined;
+
   return (
     <FormFieldFrame
       error={errors[errorKey]}
@@ -198,6 +213,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
             }
           }}
           options={options}
+          renderOption={renderOption}
           searchPlaceholder={props.searchPlaceholder ?? undefined}
           showSearch={Boolean(searchable)}
           selected={selected}

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -142,7 +142,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
 
   const options = searchable ? (results ?? staticOptions) : staticOptions;
 
-  const renderOption = optionSchema
+  const renderOption = optionSchema?.length
     ? (option: Option) => (
         <Renderer
           nodes={materializeSchema(optionSchema, {

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -237,8 +237,8 @@ describe("Lattice form schema components", () => {
         label: "Status",
         name: "status",
         options: [
-          { label: "Draft", value: "draft" },
-          { label: "Active", value: "active" },
+          { label: "Draft", value: "draft", data: null },
+          { label: "Active", value: "active", data: null },
         ],
       },
       type: "field.choice",

--- a/resources/js/table/components/column-filter-control.test.tsx
+++ b/resources/js/table/components/column-filter-control.test.tsx
@@ -99,8 +99,8 @@ describe("ColumnFilterControl", () => {
         operators: ["eq", "neq"],
         defaultOperator: "eq",
         options: [
-          { label: "Active", value: "active" },
-          { label: "Draft", value: "draft" },
+          { label: "Active", value: "active", data: null },
+          { label: "Draft", value: "draft", data: null },
         ],
         clauseOptions: [],
         ...overrides,
@@ -147,7 +147,7 @@ describe("ColumnFilterControl", () => {
     it("expands a clause option into its underlying clauses", () => {
       const h = handlers();
       const filter = selectFilter({
-        options: [{ label: "Unset", value: "unset" }],
+        options: [{ label: "Unset", value: "unset", data: null }],
         clauseOptions: [
           { label: "Unset", value: "unset", clauses: [{ operator: "empty", value: "" }] },
         ],
@@ -166,7 +166,7 @@ describe("ColumnFilterControl", () => {
     it("reflects the active clause-option as the current selection", () => {
       const h = handlers();
       const filter = selectFilter({
-        options: [{ label: "Unset", value: "unset" }],
+        options: [{ label: "Unset", value: "unset", data: null }],
         clauseOptions: [
           { label: "Unset", value: "unset", clauses: [{ operator: "empty", value: "" }] },
         ],

--- a/resources/js/table/components/column-select-filter.test.tsx
+++ b/resources/js/table/components/column-select-filter.test.tsx
@@ -13,8 +13,8 @@ function selectFilter(multiple: boolean): ColumnFilter {
     defaultOperator: multiple ? "in" : "eq",
     control: "filter.select",
     options: [
-      { label: "Active", value: "active" },
-      { label: "Draft", value: "draft" },
+      { label: "Active", value: "active", data: null },
+      { label: "Draft", value: "draft", data: null },
     ],
     clauseOptions: [],
     multiple,
@@ -29,9 +29,9 @@ function clauseFilter(): ColumnFilter {
     defaultOperator: "eq",
     control: "filter.select",
     options: [
-      { label: "Yes", value: "yes" },
-      { label: "No", value: "no" },
-      { label: "Unset", value: "unset" },
+      { label: "Yes", value: "yes", data: null },
+      { label: "No", value: "no", data: null },
+      { label: "Unset", value: "unset", data: null },
     ],
     clauseOptions: [
       { label: "Yes", value: "yes", clauses: [{ operator: "eq", value: "true" }] },
@@ -49,7 +49,7 @@ function rangeFilter(): ColumnFilter {
     operators: ["eq", "neq", "gte", "lte"],
     defaultOperator: "eq",
     control: "filter.select",
-    options: [{ label: "June 2026", value: "june-2026" }],
+    options: [{ label: "June 2026", value: "june-2026", data: null }],
     clauseOptions: [
       {
         label: "June 2026",

--- a/resources/js/table/components/filter-bar.test.tsx
+++ b/resources/js/table/components/filter-bar.test.tsx
@@ -11,8 +11,8 @@ const selectFilter: FilterNode = {
   props: {
     label: "Status",
     options: [
-      { label: "Active", value: "active" },
-      { label: "Draft", value: "draft" },
+      { label: "Active", value: "active", data: null },
+      { label: "Draft", value: "draft", data: null },
     ],
     multiple: false,
     searchable: false,

--- a/resources/js/table/components/searchable-filter.test.tsx
+++ b/resources/js/table/components/searchable-filter.test.tsx
@@ -10,7 +10,7 @@ const filter: FilterNode = {
   type: "filter.select",
   props: {
     label: "Author",
-    options: [{ label: "Ada", value: "1" }],
+    options: [{ label: "Ada", value: "1", data: null }],
     multiple: false,
     searchable: true,
     placeholder: null,

--- a/resources/js/table/components/table-filters.test.tsx
+++ b/resources/js/table/components/table-filters.test.tsx
@@ -28,8 +28,8 @@ const filters: FilterNode[] = [
     props: {
       label: "Status",
       options: [
-        { label: "Active", value: "active" },
-        { label: "Draft", value: "draft" },
+        { label: "Active", value: "active", data: null },
+        { label: "Draft", value: "draft", data: null },
       ],
       multiple: true,
       searchable: false,

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -895,6 +895,7 @@ export type OpenModal = {
 export type Option = {
   readonly label: string;
   readonly value: string;
+  readonly data: Record<string, unknown> | null;
 };
 export type Orientation = "horizontal" | "vertical";
 export type OtpInput = {

--- a/resources/js/ui/combobox.test.tsx
+++ b/resources/js/ui/combobox.test.tsx
@@ -5,8 +5,8 @@ import type { Option } from "@lattice-php/lattice/core/types";
 import { Combobox } from "./combobox";
 
 const OPTIONS: Option[] = [
-  { label: "Red", value: "red" },
-  { label: "Blue", value: "blue" },
+  { label: "Red", value: "red", data: null },
+  { label: "Blue", value: "blue", data: null },
 ];
 
 function Harness({

--- a/resources/js/ui/combobox.test.tsx
+++ b/resources/js/ui/combobox.test.tsx
@@ -105,4 +105,31 @@ describe("Combobox", () => {
     expect(onSearch).toHaveBeenCalledWith("x");
     expect(screen.getByRole("option", { name: "Red" })).toBeVisible();
   });
+
+  it("renders rich option content while keeping the label as accessible name", () => {
+    const onSelect = vi.fn<(v: string) => void>();
+    render(
+      <Combobox
+        onOpenChange={() => {}}
+        onSelect={onSelect}
+        open
+        options={OPTIONS}
+        renderOption={(option) => (
+          <span>
+            {option.label}
+            <span>{option.value.toUpperCase()}</span>
+          </span>
+        )}
+        selected={[]}
+        testId="cb"
+        trigger={<span>Open</span>}
+      />,
+    );
+
+    const red = screen.getByRole("option", { name: "Red" });
+    expect(red).toHaveTextContent("RED");
+
+    fireEvent.click(red);
+    expect(onSelect).toHaveBeenCalledWith("red");
+  });
 });

--- a/resources/js/ui/combobox.tsx
+++ b/resources/js/ui/combobox.tsx
@@ -15,7 +15,8 @@ const SEARCH_DEBOUNCE_MS = 250;
  * consumer also owns option fetching. Pass `onSearch` for remote search (the
  * combobox debounces the query and renders `options` as given); omit it to
  * filter the provided `options` locally by label. The combobox closes itself
- * after a single-select.
+ * after a single-select. Pass `renderOption` to render rich option rows; the
+ * option's label stays the accessible name.
  */
 function Combobox({
   contentClassName,
@@ -27,6 +28,7 @@ function Combobox({
   open,
   onOpenChange,
   options,
+  renderOption,
   searchLabel,
   searchPlaceholder,
   selected,
@@ -45,6 +47,7 @@ function Combobox({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   options: Option[];
+  renderOption?: (option: Option) => React.ReactNode;
   searchLabel?: string;
   searchPlaceholder?: string;
   selected: string[];
@@ -129,6 +132,7 @@ function Combobox({
 
               return (
                 <button
+                  aria-label={renderOption ? option.label : undefined}
                   aria-selected={isSelected}
                   className={cn(
                     "flex w-full items-center justify-between gap-2 rounded-lt-sm px-3 py-1.5 text-left text-sm transition-colors hover:bg-lt-accent hover:text-lt-accent-fg",
@@ -142,7 +146,13 @@ function Combobox({
                   role="option"
                   type="button"
                 >
-                  {option.label}
+                  {renderOption ? (
+                    <span className="flex min-w-0 flex-1 items-center gap-2">
+                      {renderOption(option)}
+                    </span>
+                  ) : (
+                    option.label
+                  )}
                   {isSelected && (
                     <Icon name="check" aria-hidden="true" className="size-lt-icon-md shrink-0" />
                   )}

--- a/resources/js/ui/segmented-control.test.tsx
+++ b/resources/js/ui/segmented-control.test.tsx
@@ -12,9 +12,9 @@ describe("SegmentedControl", () => {
         label: "Appearance",
         name: "appearance",
         options: [
-          { label: "Light", value: "light" },
-          { label: "Dark", value: "dark" },
-          { label: "System", value: "system" },
+          { label: "Light", value: "light", data: null },
+          { label: "Dark", value: "dark", data: null },
+          { label: "System", value: "system", data: null },
         ],
         value: "system",
       },
@@ -58,8 +58,8 @@ describe("SegmentedControl", () => {
       props: {
         name: "size",
         options: [
-          { label: "Small", value: "s" },
-          { label: "Large", value: "l" },
+          { label: "Small", value: "s", data: null },
+          { label: "Large", value: "l", data: null },
         ],
       },
     });

--- a/resources/js/ui/segmented-pills.test.tsx
+++ b/resources/js/ui/segmented-pills.test.tsx
@@ -4,8 +4,8 @@ import type { Option } from "@lattice-php/lattice/core/types";
 import { SegmentedPills } from "./segmented-pills";
 
 const options: Option[] = [
-  { label: "Light", value: "light" },
-  { label: "Dark", value: "dark" },
+  { label: "Light", value: "light", data: null },
+  { label: "Dark", value: "dark", data: null },
 ];
 
 describe("SegmentedPills", () => {

--- a/src/Core/EloquentOptions.php
+++ b/src/Core/EloquentOptions.php
@@ -182,12 +182,6 @@ final class EloquentOptions implements OptionSource
             return ($this->data)($model);
         }
 
-        $data = [];
-
-        foreach ($this->data as $column) {
-            $data[$column] = $model->getAttribute($column);
-        }
-
-        return $data;
+        return $model->only($this->data);
     }
 }

--- a/src/Core/EloquentOptions.php
+++ b/src/Core/EloquentOptions.php
@@ -24,6 +24,9 @@ final class EloquentOptions implements OptionSource
 
     private int $limit = 50;
 
+    /** @var list<string>|Closure(Model): array<string, mixed>|null */
+    private array|Closure|null $data = null;
+
     private ?string $resolvedValueKey = null;
 
     /**
@@ -89,6 +92,19 @@ final class EloquentOptions implements OptionSource
         return $this;
     }
 
+    /**
+     * Attach a per-option data record for the select's option schema: the
+     * columns to include, or a closure receiving the model for computed values.
+     *
+     * @param  list<string>|Closure(Model): array<string, mixed>  $data
+     */
+    public function data(array|Closure $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
     public function search(string $query): array
     {
         $builder = $this->query();
@@ -147,8 +163,31 @@ final class EloquentOptions implements OptionSource
             ->map(fn (Model $model): Option => new Option(
                 (string) $model->getAttribute($this->labelKey),
                 (string) $model->getAttribute($this->valueColumn()),
+                $this->optionData($model),
             ))
             ->values()
             ->all();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function optionData(Model $model): ?array
+    {
+        if ($this->data === null) {
+            return null;
+        }
+
+        if ($this->data instanceof Closure) {
+            return ($this->data)($model);
+        }
+
+        $data = [];
+
+        foreach ($this->data as $column) {
+            $data[$column] = $model->getAttribute($column);
+        }
+
+        return $data;
     }
 }

--- a/src/Core/Option.php
+++ b/src/Core/Option.php
@@ -11,15 +11,20 @@ use UnitEnum;
 
 /**
  * A `{ label, value }` pair backing every option-driven control (choice, select,
- * segmented control). Generated to TypeScript so the client shares one `Option`
+ * segmented control), optionally carrying a `data` record that a select's option
+ * schema binds against. Generated to TypeScript so the client shares one `Option`
  * type rather than re-declaring the shape per field.
  */
 #[TypeScript]
 final readonly class Option
 {
+    /**
+     * @param  array<string, mixed>|null  $data
+     */
     public function __construct(
         public string $label,
         public string $value,
+        public ?array $data = null,
     ) {}
 
     /**
@@ -49,7 +54,7 @@ final readonly class Option
     }
 
     /**
-     * @param  Option|array{label: string, value: string}|UnitEnum  $option
+     * @param  Option|array{label: string, value: string, data?: array<string, mixed>|null}|UnitEnum  $option
      */
     private static function from(mixed $option): self
     {
@@ -64,6 +69,6 @@ final readonly class Option
             );
         }
 
-        return new self((string) $option['label'], (string) $option['value']);
+        return new self((string) $option['label'], (string) $option['value'], $option['data'] ?? null);
     }
 }

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -121,7 +121,13 @@ class Select extends Field
             return $data;
         }
 
-        $data['props']['optionSchema'] = $this->renderableComponents($this->optionSchema);
+        $schema = $this->renderableComponents($this->optionSchema);
+
+        if ($schema === []) {
+            return $data;
+        }
+
+        $data['props']['optionSchema'] = $schema;
 
         return $data;
     }

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -6,12 +6,15 @@ namespace Lattice\Lattice\Forms\Components;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Core\Contracts\OptionSource;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Facades\Evaluate;
 use Lattice\Lattice\Forms\Attributes\AsField;
 use Lattice\Lattice\Forms\Enums\FieldType;
 use Lattice\Lattice\Forms\FormData;
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Concerns\FiltersRenderableComponents;
 use Lattice\Lattice\Ui\Concerns\HasAutoFocus;
 use Lattice\Lattice\Ui\Concerns\HasOptions;
 use Lattice\Lattice\Ui\Concerns\HasPlaceholder;
@@ -20,6 +23,7 @@ use Lattice\Lattice\Ui\Concerns\HasTabIndex;
 #[AsField(FieldType::Select)]
 class Select extends Field
 {
+    use FiltersRenderableComponents;
     use HasAutoFocus;
     use HasOptions;
     use HasPlaceholder;
@@ -30,6 +34,11 @@ class Select extends Field
     private ?Closure $selectedResolver = null;
 
     private ?OptionSource $optionSource = null;
+
+    /**
+     * @var array<int, Component>
+     */
+    protected array $optionSchema = [];
 
     public bool $multiple = false;
 
@@ -84,6 +93,37 @@ class Select extends Field
         $this->searchable = true;
 
         return $this;
+    }
+
+    /**
+     * Render each option through a schema of bound components instead of the
+     * plain label. Components bind option fields with `->dataKey($prop, $key)`;
+     * bindings resolve against the option's `data` record plus its `label` and
+     * `value`. The schema ships once on the wire — options only carry data.
+     *
+     * @param  array<int, Component>  $components
+     */
+    public function optionSchema(array $components): static
+    {
+        $this->optionSchema = $components;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 300)]
+    protected function serialiseOptionSchema(array $data): array
+    {
+        if ($this->optionSchema === []) {
+            return $data;
+        }
+
+        $data['props']['optionSchema'] = $this->renderableComponents($this->optionSchema);
+
+        return $data;
     }
 
     /**
@@ -172,7 +212,7 @@ class Select extends Field
     }
 
     /**
-     * @param  array<int, Option|array{label: string, value: string|int}>|Collection<int, Option|array{label: string, value: string|int}>  $options
+     * @param  array<int, Option|array{label: string, value: string|int, data?: array<string, mixed>|null}>|Collection<int, Option|array{label: string, value: string|int, data?: array<string, mixed>|null}>  $options
      * @return list<Option>
      */
     private function normalizeOptions(array|Collection $options): array
@@ -184,7 +224,7 @@ class Select extends Field
         return array_values(array_map(
             static fn (Option|array $option): Option => $option instanceof Option
                 ? $option
-                : new Option((string) $option['label'], (string) $option['value']),
+                : new Option((string) $option['label'], (string) $option['value'], $option['data'] ?? null),
             $options,
         ));
     }

--- a/src/Ui/Concerns/HasOptions.php
+++ b/src/Ui/Concerns/HasOptions.php
@@ -13,9 +13,12 @@ trait HasOptions
      */
     public array $options = [];
 
-    public static function option(string $label, string $value): Option
+    /**
+     * @param  array<string, mixed>|null  $data
+     */
+    public static function option(string $label, string $value, ?array $data = null): Option
     {
-        return new Option($label, $value);
+        return new Option($label, $value, $data);
     }
 
     /**

--- a/tests/Browser/Fields/SelectTest.php
+++ b/tests/Browser/Fields/SelectTest.php
@@ -36,3 +36,22 @@ it('searches and selects entities in a multiple select', function (): void {
         ->assertPresent('input[type="hidden"][name="related_products[]"]')
         ->assertNoJavaScriptErrors();
 });
+
+it('renders rich option rows in the products search', function (): void {
+    $this->actingAs(workbenchTestUser());
+    Product::factory()->create(['name' => 'Walnut Desk', 'sku' => 'WD-100', 'status' => 'active']);
+
+    $page = visit('/form/fields/select?type=searchable');
+
+    $page->click('Search products…')
+        ->fill('input[aria-label="Search options"]', 'walnut');
+
+    eventually(function () use ($page): void {
+        $page->assertSee('WD-100');
+    });
+
+    $page->click('Walnut Desk')
+        ->assertPresent('button[aria-label="Remove Walnut Desk"]')
+        ->assertPresent('input[type="hidden"][name="related_products[]"]')
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/Forms/EloquentOptionsTest.php
+++ b/tests/Feature/Forms/EloquentOptionsTest.php
@@ -91,7 +91,7 @@ it('attaches per-option data from a closure, on search and selected alike', func
 
     $source = EloquentOptions::make(Product::class)
         ->label('name')
-        ->data(fn ($product): array => ['badge' => mb_strtolower($product->sku)]);
+        ->data(fn ($product): array => ['badge' => mb_strtolower((string) $product->getAttribute('sku'))]);
 
     expect($source->search('beta')[0]->data)->toBe(['badge' => 'sku-2'])
         ->and($source->selected([(string) $product->getKey()])[0]->data)->toBe(['badge' => 'sku-2']);

--- a/tests/Feature/Forms/EloquentOptionsTest.php
+++ b/tests/Feature/Forms/EloquentOptionsTest.php
@@ -74,3 +74,31 @@ it('applies a query scope to both search and selected', function (): void {
     expect($source->search(''))->toHaveCount(1)
         ->and($source->selected([(string) $hidden->getKey()]))->toBe([]);
 });
+
+it('attaches per-option data from columns', function (): void {
+    Product::factory()->create(['name' => 'Alpha Chair', 'sku' => 'SKU-1', 'status' => 'active']);
+
+    $options = EloquentOptions::make(Product::class)
+        ->label('name')
+        ->data(['sku', 'status'])
+        ->search('alpha');
+
+    expect($options[0]->data)->toBe(['sku' => 'SKU-1', 'status' => 'active']);
+});
+
+it('attaches per-option data from a closure, on search and selected alike', function (): void {
+    $product = Product::factory()->create(['name' => 'Beta Table', 'sku' => 'SKU-2']);
+
+    $source = EloquentOptions::make(Product::class)
+        ->label('name')
+        ->data(fn ($product): array => ['badge' => mb_strtolower($product->sku)]);
+
+    expect($source->search('beta')[0]->data)->toBe(['badge' => 'sku-2'])
+        ->and($source->selected([(string) $product->getKey()])[0]->data)->toBe(['badge' => 'sku-2']);
+});
+
+it('omits option data when none is configured', function (): void {
+    Product::factory()->create(['name' => 'Gamma Shelf']);
+
+    expect(EloquentOptions::make(Product::class)->label('name')->search('gamma')[0]->data)->toBeNull();
+});

--- a/tests/Feature/Forms/ProductRelatedProductsTest.php
+++ b/tests/Feature/Forms/ProductRelatedProductsTest.php
@@ -109,5 +109,5 @@ test('the product form resolves related product labels for prefilled ids', funct
         ->fill(['related_products' => [$related->getKey()]]));
 
     expect(json_encode($form))
-        ->toContain('{"label":"Walnut Desk","value":"'.$related->getKey().'"}');
+        ->toContain('{"label":"Walnut Desk","value":"'.$related->getKey().'","data":null}');
 });

--- a/tests/Feature/Forms/SelectPrefillTest.php
+++ b/tests/Feature/Forms/SelectPrefillTest.php
@@ -9,7 +9,7 @@ use Lattice\Lattice\Forms\Components\RowTemplate;
 use Lattice\Lattice\Forms\Components\Select;
 
 /**
- * @return array<int, array{label: string, value: string}>
+ * @return array<int, array{label: string, value: string, data: array<string, mixed>|null}>
  */
 function prefilledOptions(Form $form): array
 {
@@ -17,7 +17,7 @@ function prefilledOptions(Form $form): array
 }
 
 /**
- * @return array<int, array{label: string, value: string}>
+ * @return array<int, array{label: string, value: string, data: array<string, mixed>|null}>
  */
 function repeaterPrefilledOptions(Form $form): array
 {
@@ -25,7 +25,7 @@ function repeaterPrefilledOptions(Form $form): array
 }
 
 /**
- * @return array<int, array{label: string, value: string}>
+ * @return array<int, array{label: string, value: string, data: array<string, mixed>|null}>
  */
 function nestedRepeaterPrefilledOptions(Form $form): array
 {
@@ -33,7 +33,7 @@ function nestedRepeaterPrefilledOptions(Form $form): array
 }
 
 /**
- * @return array<int, array{label: string, value: string}>
+ * @return array<int, array{label: string, value: string, data: array<string, mixed>|null}>
  */
 function builderPrefilledOptions(Form $form): array
 {
@@ -52,7 +52,7 @@ it('resolves the label for a single filled id', function (): void {
         ]);
 
     expect(prefilledOptions($form))->toBe([
-        ['label' => 'User 5', 'value' => '5'],
+        ['label' => 'User 5', 'value' => '5', 'data' => null],
     ]);
 });
 
@@ -69,8 +69,8 @@ it('resolves labels for multiple filled ids', function (): void {
         ]);
 
     expect(prefilledOptions($form))->toBe([
-        ['label' => 'Tag 1', 'value' => '1'],
-        ['label' => 'Tag 2', 'value' => '2'],
+        ['label' => 'Tag 1', 'value' => '1', 'data' => null],
+        ['label' => 'Tag 2', 'value' => '2', 'data' => null],
     ]);
 });
 
@@ -101,7 +101,7 @@ it('does nothing when the field has no resolver', function (): void {
         ]);
 
     expect(prefilledOptions($form))->toBe([
-        ['label' => 'Pro', 'value' => 'pro'],
+        ['label' => 'Pro', 'value' => 'pro', 'data' => null],
     ]);
 });
 
@@ -145,8 +145,8 @@ it('resolves labels for filled ids inside repeater rows', function (): void {
         ]);
 
     expect(repeaterPrefilledOptions($form))->toBe([
-        ['label' => 'Product 5', 'value' => '5'],
-        ['label' => 'Product 8', 'value' => '8'],
+        ['label' => 'Product 5', 'value' => '5', 'data' => null],
+        ['label' => 'Product 8', 'value' => '8', 'data' => null],
     ])->and($received)->toBe(['5', '8']);
 });
 
@@ -174,8 +174,8 @@ it('resolves labels for filled ids inside builder rows', function (): void {
         ]);
 
     expect(builderPrefilledOptions($form))->toBe([
-        ['label' => 'Product 5', 'value' => '5'],
-        ['label' => 'Product 8', 'value' => '8'],
+        ['label' => 'Product 5', 'value' => '5', 'data' => null],
+        ['label' => 'Product 8', 'value' => '8', 'data' => null],
     ])->and($received)->toBe(['5', '8']);
 });
 
@@ -205,7 +205,7 @@ it('resolves labels for filled ids inside nested repeater rows', function (): vo
         ]);
 
     expect(nestedRepeaterPrefilledOptions($form))->toBe([
-        ['label' => 'Product 5', 'value' => '5'],
-        ['label' => 'Product 8', 'value' => '8'],
+        ['label' => 'Product 5', 'value' => '5', 'data' => null],
+        ['label' => 'Product 8', 'value' => '8', 'data' => null],
     ])->and($received)->toBe(['5', '8']);
 });

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -220,7 +220,7 @@ it('aborts with 422 when a row select is not searchable', function (): void {
 it('searches options through the form endpoint with a signed reference', function (): void {
     Lattice::forms([SelectFieldForm::class]);
 
-    Product::factory()->create(['name' => 'Walnut Desk']);
+    $walnutDesk = Product::factory()->create(['name' => 'Walnut Desk']);
     Product::factory()->create(['name' => 'Steel Lamp']);
 
     $ref = wire(Form::use(SelectFieldForm::class))['props']['ref'];
@@ -232,7 +232,11 @@ it('searches options through the form endpoint with a signed reference', functio
         ->assertOk()
         ->assertExactJson([
             'options' => [
-                ['label' => 'Walnut Desk', 'value' => (string) Product::query()->where('name', 'Walnut Desk')->value('id'), 'data' => null],
+                [
+                    'label' => 'Walnut Desk',
+                    'value' => (string) $walnutDesk->id,
+                    'data' => ['sku' => $walnutDesk->sku, 'status' => $walnutDesk->status],
+                ],
             ],
         ]);
 });

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -232,7 +232,7 @@ it('searches options through the form endpoint with a signed reference', functio
         ->assertOk()
         ->assertExactJson([
             'options' => [
-                ['label' => 'Walnut Desk', 'value' => (string) Product::query()->where('name', 'Walnut Desk')->value('id')],
+                ['label' => 'Walnut Desk', 'value' => (string) Product::query()->where('name', 'Walnut Desk')->value('id'), 'data' => null],
             ],
         ]);
 });

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -33,8 +33,8 @@ test('a table serializes its declared filters and starts with no active values',
             'multiple' => false,
             'searchable' => false,
             'options' => [
-                ['label' => 'Draft', 'value' => 'draft'],
-                ['label' => 'Active', 'value' => 'active'],
+                ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+                ['label' => 'Active', 'value' => 'active', 'data' => null],
             ],
             'placeholder' => null,
         ],
@@ -72,7 +72,7 @@ test('a table searches a searchable filter\'s options through the endpoint', fun
 
     $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => 'filter:author.value', 'q' => 'ad'])
         ->assertOk()
-        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
+        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1', 'data' => null]]]);
 });
 
 test('a table searches a searchable column filter through the endpoint', function (): void {
@@ -80,7 +80,7 @@ test('a table searches a searchable column filter through the endpoint', functio
 
     $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => 'column:owner', 'q' => 'ad'])
         ->assertOk()
-        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
+        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1', 'data' => null]]]);
 });
 
 test('a table 404s searching an unknown filter key', function (): void {
@@ -102,7 +102,7 @@ test('a filter key does not shadow a column of the same name', function (): void
 
     $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => 'column:author', 'q' => 'ad'])
         ->assertOk()
-        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1']]]);
+        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1', 'data' => null]]]);
 });
 
 test('a table rejects searching a filter that is not searchable', function (): void {

--- a/tests/Unit/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Unit/Core/Components/CoreTypedPropsTest.php
@@ -60,8 +60,8 @@ it('segmented control serializes name label value emits options', function (): v
                 'value' => 'system',
                 'emits' => 'lattice:appearance-change',
                 'options' => [
-                    ['label' => 'Light', 'value' => 'light'],
-                    ['label' => 'Dark', 'value' => 'dark'],
+                    ['label' => 'Light', 'value' => 'light', 'data' => null],
+                    ['label' => 'Dark', 'value' => 'dark', 'data' => null],
                 ],
             ],
         ]);

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -121,6 +121,14 @@ it('serializes the option schema only when set', function (): void {
         ->and($schema[1]['props']['dataBindings'])->toBe(['label' => 'number']);
 });
 
+it('omits the option schema when every component is hidden', function (): void {
+    $field = Select::make('customer', 'Customer')->optionSchema([
+        Text::make('')->dataKey('text', 'label')->hidden(),
+    ]);
+
+    expect(wire($field)['props'])->not->toHaveKey('optionSchema');
+});
+
 it('keeps per-option data when normalizing resolver options', function (): void {
     $field = Select::make('author_id', 'Author')
         ->searchable(fn (string $search): array => [

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -17,8 +17,8 @@ it('serializes static options without search flags', function (): void {
 
     expect(wire($field)['type'])->toBe('field.select')
         ->and($props['options'])->toBe([
-            ['label' => 'Free', 'value' => 'free'],
-            ['label' => 'Pro', 'value' => 'pro'],
+            ['label' => 'Free', 'value' => 'free', 'data' => null],
+            ['label' => 'Pro', 'value' => 'pro', 'data' => null],
         ])
         ->and($props['searchable'])->toBeFalse()
         ->and($props['multiple'])->toBeFalse()
@@ -73,6 +73,28 @@ it('serializes the shared focus options', function (): void {
     $node = wire(Select::make('country', 'Country')->autoFocus()->tabIndex(1));
 
     expect($node['props'])->toMatchArray(['autoFocus' => true, 'tabIndex' => 1]);
+});
+
+it('serializes per-option data', function (): void {
+    $field = Select::make('customer', 'Customer')->options([
+        Select::option('Acme GmbH', '42', ['email' => 'kontakt@acme.de']),
+        Select::option('Beta AG', '43'),
+    ]);
+
+    expect(wire($field)['props']['options'])->toBe([
+        ['label' => 'Acme GmbH', 'value' => '42', 'data' => ['email' => 'kontakt@acme.de']],
+        ['label' => 'Beta AG', 'value' => '43', 'data' => null],
+    ]);
+});
+
+it('expands array options carrying data', function (): void {
+    $options = Option::expand([
+        ['label' => 'Jane', 'value' => '1', 'data' => ['email' => 'jane@example.com']],
+        ['label' => 'Joe', 'value' => '2'],
+    ]);
+
+    expect($options[0]->data)->toBe(['email' => 'jane@example.com'])
+        ->and($options[1]->data)->toBeNull();
 });
 
 describe('docs fixtures', function (): void {

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -7,7 +7,10 @@ use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Badge;
+use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Color;
+use Lattice\Lattice\Ui\Enums\Size;
 
 it('serializes static options without search flags', function (): void {
     $field = Select::make('plan', 'Plan')->options([
@@ -164,6 +167,22 @@ describe('docs fixtures', function (): void {
                     Select::option('JavaScript', 'js'),
                     Select::option('Go', 'go'),
                     Select::option('Rust', 'rust'),
+                ]),
+        ]))));
+
+        assertFixtureMatches('select.rich', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
+            Select::make('customer', 'Customer')
+                ->placeholder('Pick a customer')
+                ->options([
+                    Select::option('Acme GmbH', '1', ['email' => 'kontakt@acme.de', 'number' => 'K-10021']),
+                    Select::option('Globex AG', '2', ['email' => 'info@globex.de', 'number' => 'K-10022']),
+                ])
+                ->optionSchema([
+                    Stack::make()->schema([
+                        Text::make('')->dataKey('text', 'label'),
+                        Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::Muted),
+                    ]),
+                    Badge::make('')->dataKey('label', 'number'),
                 ]),
         ]))));
     });

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -6,6 +6,8 @@ use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Support\Wire;
+use Lattice\Lattice\Ui\Components\Badge;
+use Lattice\Lattice\Ui\Components\Text;
 
 it('serializes static options without search flags', function (): void {
     $field = Select::make('plan', 'Plan')->options([
@@ -95,6 +97,49 @@ it('expands array options carrying data', function (): void {
 
     expect($options[0]->data)->toBe(['email' => 'jane@example.com'])
         ->and($options[1]->data)->toBeNull();
+});
+
+it('serializes the option schema only when set', function (): void {
+    $plain = Select::make('plan', 'Plan')->options([Select::option('Free', 'free')]);
+
+    expect(wire($plain)['props'])->not->toHaveKey('optionSchema');
+
+    $rich = Select::make('customer', 'Customer')->optionSchema([
+        Text::make('')->dataKey('text', 'label'),
+        Badge::make('')->dataKey('label', 'number'),
+    ]);
+
+    $schema = wire($rich)['props']['optionSchema'];
+
+    expect($schema)->toHaveCount(2)
+        ->and($schema[0]['type'])->toBe('text')
+        ->and($schema[0]['props']['dataBindings'])->toBe(['text' => 'label'])
+        ->and($schema[1]['type'])->toBe('badge')
+        ->and($schema[1]['props']['dataBindings'])->toBe(['label' => 'number']);
+});
+
+it('keeps per-option data when normalizing resolver options', function (): void {
+    $field = Select::make('author_id', 'Author')
+        ->searchable(fn (string $search): array => [
+            ['label' => 'Jane Doe', 'value' => 5, 'data' => ['email' => 'jane@example.com']],
+        ]);
+
+    expect($field->resolveSearch('ja', FormData::make([]), Request::create('/')))
+        ->toEqual([new Option('Jane Doe', '5', ['email' => 'jane@example.com'])]);
+});
+
+it('keeps per-option data when hydrating selected values', function (): void {
+    $field = Select::make('author_id', 'Author')
+        ->searchable(fn (): array => [])
+        ->resolveSelectedUsing(fn (array $values): array => [
+            ['label' => 'Jane Doe', 'value' => $values[0], 'data' => ['email' => 'jane@example.com']],
+        ]);
+
+    $field->hydrateState('5');
+
+    expect(wire($field)['props']['options'])->toBe([
+        ['label' => 'Jane Doe', 'value' => '5', 'data' => ['email' => 'jane@example.com']],
+    ]);
 });
 
 describe('docs fixtures', function (): void {

--- a/tests/Unit/Forms/EnumOptionsTest.php
+++ b/tests/Unit/Forms/EnumOptionsTest.php
@@ -25,8 +25,8 @@ it('builds options from an enum class using humanised names by default', functio
     $options = wire(Choice::make('status', 'Status')->enum(PlainStatus::class))['props']['options'];
 
     expect($options)->toBe([
-        ['label' => 'Draft', 'value' => 'draft'],
-        ['label' => 'In Review', 'value' => 'in_review'],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+        ['label' => 'In Review', 'value' => 'in_review', 'data' => null],
     ]);
 });
 
@@ -40,8 +40,8 @@ it('uses the HasLabel contract for labels and supports translations', function (
     $options = wire(Choice::make('status', 'Status')->enum(LabelledStatus::class))['props']['options'];
 
     expect($options)->toBe([
-        ['label' => 'Aktiv', 'value' => 'active'],
-        ['label' => 'Archiviert', 'value' => 'archived'],
+        ['label' => 'Aktiv', 'value' => 'active', 'data' => null],
+        ['label' => 'Archiviert', 'value' => 'archived', 'data' => null],
     ]);
 });
 
@@ -50,6 +50,6 @@ it('builds options from a subset of enum cases', function (): void {
         ->enum([PlainStatus::Draft]))['props']['options'];
 
     expect($options)->toBe([
-        ['label' => 'Draft', 'value' => 'draft'],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
     ]);
 });

--- a/tests/Unit/Forms/FieldResolutionTest.php
+++ b/tests/Unit/Forms/FieldResolutionTest.php
@@ -51,7 +51,7 @@ it('runs dependsOn closures during resolution', function (): void {
 
     $field->applyResolution(FormData::make(['country' => 'germany']), Request::create('/'));
 
-    expect(wire($field)['props']['options'])->toBe([['label' => 'Germany', 'value' => 'germany']]);
+    expect(wire($field)['props']['options'])->toBe([['label' => 'Germany', 'value' => 'germany', 'data' => null]]);
 });
 
 it('stores an editable computed default without making the field server-authoritative', function (): void {

--- a/tests/Unit/Tables/Columns/ColumnSelectFilterTest.php
+++ b/tests/Unit/Tables/Columns/ColumnSelectFilterTest.php
@@ -19,8 +19,8 @@ test('a column filter accepts an associative value => label array', function ():
     ]))['props']['filter'];
 
     expect($filter['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft'],
-        ['label' => 'Active', 'value' => 'active'],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null],
     ]);
 });
 
@@ -28,8 +28,8 @@ test('a column filter accepts an enum', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions(ColumnFilterStatus::class))['props']['filter'];
 
     expect($filter['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft'],
-        ['label' => 'Active', 'value' => 'active'],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null],
     ]);
 });
 
@@ -43,8 +43,8 @@ test('a column with filter options serializes a select control', function (): vo
         'control' => 'filter.select',
         'multiple' => false,
         'options' => [
-            ['label' => 'Draft', 'value' => 'draft'],
-            ['label' => 'Active', 'value' => 'active'],
+            ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+            ['label' => 'Active', 'value' => 'active', 'data' => null],
         ],
         'operators' => ['eq', 'neq'],
         'defaultOperator' => 'eq',
@@ -90,8 +90,8 @@ test('a column filter resolves options from an option source', function (): void
 
     expect($filter['control'])->toBe('filter.select')
         ->and($filter['options'])->toBe([
-            ['label' => 'Ada', 'value' => '1'],
-            ['label' => 'Linus', 'value' => '2'],
+            ['label' => 'Ada', 'value' => '1', 'data' => null],
+            ['label' => 'Linus', 'value' => '2', 'data' => null],
         ]);
 });
 
@@ -113,9 +113,9 @@ test('a column filter serializes clause options', function (): void {
     expect($filter)->toMatchArray([
         'control' => 'filter.select',
         'options' => [
-            ['label' => 'Yes', 'value' => 'yes'],
-            ['label' => 'No', 'value' => 'no'],
-            ['label' => 'Unset', 'value' => 'unset'],
+            ['label' => 'Yes', 'value' => 'yes', 'data' => null],
+            ['label' => 'No', 'value' => 'no', 'data' => null],
+            ['label' => 'Unset', 'value' => 'unset', 'data' => null],
         ],
         'clauseOptions' => [
             [
@@ -145,7 +145,7 @@ test('a column filter range option serializes date bounds as clauses', function 
 
     expect($filter)->toMatchArray([
         'options' => [
-            ['label' => 'This month', 'value' => 'this-month'],
+            ['label' => 'This month', 'value' => 'this-month', 'data' => null],
         ],
         'clauseOptions' => [
             [

--- a/tests/Unit/Tables/Filters/FilterTypesTest.php
+++ b/tests/Unit/Tables/Filters/FilterTypesTest.php
@@ -30,8 +30,8 @@ test('ternary filter serializes its wire shape', function (): void {
         ->and($filter['schema'][0]['type'])->toBe('field.select')
         ->and($filter['schema'][0]['props']['name'])->toBe('value')
         ->and($filter['schema'][0]['props']['options'])->toBe([
-            ['label' => 'Featured', 'value' => 'true'],
-            ['label' => 'Not featured', 'value' => 'false'],
+            ['label' => 'Featured', 'value' => 'true', 'data' => null],
+            ['label' => 'Not featured', 'value' => 'false', 'data' => null],
         ]);
 });
 
@@ -52,8 +52,8 @@ test('ternary filter serializes its default labels', function (): void {
         ->and($filter['schema'][0]['type'])->toBe('field.select')
         ->and($filter['schema'][0]['props']['name'])->toBe('value')
         ->and($filter['schema'][0]['props']['options'])->toBe([
-            ['label' => 'Yes', 'value' => 'true'],
-            ['label' => 'No', 'value' => 'false'],
+            ['label' => 'Yes', 'value' => 'true', 'data' => null],
+            ['label' => 'No', 'value' => 'false', 'data' => null],
         ]);
 });
 

--- a/tests/Unit/Tables/Filters/SelectFilterTest.php
+++ b/tests/Unit/Tables/Filters/SelectFilterTest.php
@@ -21,8 +21,8 @@ test('select filter serializes its wire shape', function (): void {
             'multiple' => false,
             'searchable' => false,
             'options' => [
-                ['label' => 'Draft', 'value' => 'draft'],
-                ['label' => 'Active', 'value' => 'active'],
+                ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+                ['label' => 'Active', 'value' => 'active', 'data' => null],
             ],
             'placeholder' => null,
         ],
@@ -74,8 +74,8 @@ test('a select filter accepts an associative value => label array', function ():
     $props = wire(SelectFilter::make('status')->options(['draft' => 'Draft', 'active' => 'Active']))['props'];
 
     expect($props['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft'],
-        ['label' => 'Active', 'value' => 'active'],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null],
     ]);
 });
 
@@ -85,7 +85,7 @@ test('a select filter resolves its options from an option source', function (): 
     $props = wire(SelectFilter::make('author_id')->optionsFrom($source))['props'];
 
     expect($props['options'])->toBe([
-        ['label' => 'Ada', 'value' => '1'],
-        ['label' => 'Linus', 'value' => '2'],
+        ['label' => 'Ada', 'value' => '1', 'data' => null],
+        ['label' => 'Linus', 'value' => '2', 'data' => null],
     ]);
 });

--- a/workbench/app/Forms/Fields/SelectFieldForm.php
+++ b/workbench/app/Forms/Fields/SelectFieldForm.php
@@ -62,20 +62,12 @@ class SelectFieldForm extends FormDefinition
                                 ->orderBy('name')
                                 ->limit(10)
                                 ->get()
-                                ->map(fn (Product $product): Option => Select::option(
-                                    $product->name,
-                                    (string) $product->id,
-                                    ['sku' => $product->sku, 'status' => $product->status],
-                                ))
+                                ->map($this->productOption(...))
                                 ->all())
                             ->resolveSelectedUsing(fn (array $values) => Product::query()
                                 ->whereIn('id', $values)
                                 ->get()
-                                ->map(fn (Product $product): Option => Select::option(
-                                    $product->name,
-                                    (string) $product->id,
-                                    ['sku' => $product->sku, 'status' => $product->status],
-                                ))
+                                ->map($this->productOption(...))
                                 ->all())
                             ->optionSchema([
                                 Stack::make()->schema([
@@ -105,5 +97,14 @@ class SelectFieldForm extends FormDefinition
         $this->validate($request);
 
         return redirect('/form/fields/select');
+    }
+
+    private function productOption(Product $product): Option
+    {
+        return Select::option(
+            $product->name,
+            (string) $product->id,
+            ['sku' => $product->sku, 'status' => $product->status],
+        );
     }
 }

--- a/workbench/app/Forms/Fields/SelectFieldForm.php
+++ b/workbench/app/Forms/Fields/SelectFieldForm.php
@@ -10,9 +10,14 @@ use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Ui\Components\Badge;
+use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Orientation;
+use Lattice\Lattice\Ui\Enums\Size;
 use Symfony\Component\HttpFoundation\Response;
 use Workbench\App\Models\Product;
 
@@ -57,13 +62,28 @@ class SelectFieldForm extends FormDefinition
                                 ->orderBy('name')
                                 ->limit(10)
                                 ->get()
-                                ->map(fn (Product $product): Option => Select::option($product->name, (string) $product->id))
+                                ->map(fn (Product $product): Option => Select::option(
+                                    $product->name,
+                                    (string) $product->id,
+                                    ['sku' => $product->sku, 'status' => $product->status],
+                                ))
                                 ->all())
                             ->resolveSelectedUsing(fn (array $values) => Product::query()
                                 ->whereIn('id', $values)
                                 ->get()
-                                ->map(fn (Product $product): Option => Select::option($product->name, (string) $product->id))
+                                ->map(fn (Product $product): Option => Select::option(
+                                    $product->name,
+                                    (string) $product->id,
+                                    ['sku' => $product->sku, 'status' => $product->status],
+                                ))
                                 ->all())
+                            ->optionSchema([
+                                Stack::make()->schema([
+                                    Text::make('')->dataKey('text', 'label'),
+                                    Text::make('')->dataKey('text', 'status')->size(Size::Sm)->color(Color::Muted),
+                                ]),
+                                Badge::make('')->dataKey('label', 'sku'),
+                            ])
                             ->rules(['nullable', 'array']),
                     ]),
                     Tab::make('eloquent', __('workbench.fields.select.eloquent'))->schema([


### PR DESCRIPTION
Select options can now carry structured content — the ERP entity autocomplete pattern (name + number + status + badge per option).

**What changed**
- `Option` gains an optional `data` record; `Select::option($label, $value, $data)` and search/selected resolvers pass it through.
- `Select::optionSchema([...])` declares a schema of bound components (`->dataKey($prop, $key)`, same binding as the stack column) rendered per option; the schema ships once on the wire, options carry only their data. `label`/`value` are reserved binding keys. An option schema whose components all render-gate off is omitted, falling back to plain labels.
- `EloquentOptions::data([...columns])` or `->data(fn ($model) => [...])` feeds the record from models.
- Client: `Combobox` gains a `renderOption` render-prop (`aria-label` keeps the option label as the accessible name); the select field materializes the schema per option via `materializeSchema` + `Renderer`. Trigger and multi-select chips stay label-only.
- Docs: "Rich options" section with a test-generated `select.rich` fixture; workbench select field page demos it, covered by a browser test.

**Before → after (option row)**
`Walnut Desk` → `Walnut Desk` / `active` (muted, stacked) + `WD-100` badge, rendered from `data: {sku, status}` through the option schema.

**Consumer note**
The generated `Option` TS type now includes `data: Record<string, unknown> | null` as a required key — TS consumers constructing `Option[]` literals need to add `data: null`.