### PR TITLE
feat: progress component (bar + circle)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -97,6 +97,7 @@ export default defineConfig({
             { label: "Tabs", link: "/components/tabs/" },
             { label: "Modals", link: "/components/modals/" },
             { label: "Tooltip", link: "/components/tooltip/" },
+            { label: "Progress", link: "/components/progress/" },
             { label: "Charts", link: "/components/charts/" },
             { label: "Notifications", link: "/components/notifications/" },
           ],

--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -107,6 +107,13 @@ tables.
 
 <EnumTable enums={["ChartSeriesType"]} />
 
+## Progress
+
+`Lattice\Lattice\Ui\Enums` — the bar and circle variants of the
+[progress component](/components/progress/).
+
+<EnumTable enums={["ProgressVariant"]} />
+
 ## Chat
 
 `Lattice\Lattice\Chat\Enums` — the message roles and part kinds used by the chat components.

--- a/docs/content/docs/components/progress.mdx
+++ b/docs/content/docs/components/progress.mdx
@@ -1,0 +1,47 @@
+---
+title: Progress
+description: Linear bars and radial circles for determinate progress.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
+
+`Progress::bar($value)` renders a linear progress bar and `Progress::circle($value)` a radial
+ring. Values count against `->max()` (default `100`) and are clamped into that range, so a
+completed import with `Progress::bar(340)->max(340)` fills exactly once.
+
+<ComponentExample
+  php={`Stack::make()->gap(Gap::Small)->schema([
+    Progress::bar(65)->showValue(),
+    Progress::bar(80)->color(Color::Success)->size(Size::Lg),
+    Stack::make()->direction(StackDirection::Row)->gap(Gap::Medium)->schema([
+        Progress::circle(65)->showValue(),
+        Progress::circle(35)->max(50)->color(Color::Warning)->size(Size::Xl)->showValue(),
+    ]),
+]);`}
+  fixture="components.progress"
+/>
+
+## Value and readout
+
+- `->value($value)` and the constructor argument set the current value; `->max($max)` sets the
+  scale. Values clamp into `0..max`.
+- `->showValue()` adds a percent readout — right of the bar, centered in the circle. The
+  percentage is formatted for the active locale.
+- Screen readers get the same state through `role="progressbar"` with
+  `aria-valuenow`/`aria-valuemax` and the formatted percent as `aria-valuetext`.
+
+## Color and size
+
+`->color(Color $color)` tints the fill and defaults to the primary color;
+`->size(Size $size)` scales bar height or circle diameter and defaults to `Size::Md`.
+
+```php
+Progress::circle(90)->color(Color::Danger)->size(Size::Lg);
+```
+
+<Info>
+  Progress is bindable like any component: `Progress::bar()->dataKey('value', 'completion')`
+  fills it per row in a [stack column](/tables/columns/stack/) or per option in a select's
+  [option schema](/forms/fields/select/).
+</Info>

--- a/docs/fixtures/components.progress.json
+++ b/docs/fixtures/components.progress.json
@@ -1,0 +1,74 @@
+[
+    {
+        "props": {
+            "align": null,
+            "direction": null,
+            "float": null,
+            "gap": "sm",
+            "height": null,
+            "justify": null,
+            "width": null
+        },
+        "schema": [
+            {
+                "props": {
+                    "color": null,
+                    "max": 100,
+                    "showValue": true,
+                    "size": "md",
+                    "value": 65,
+                    "variant": "bar"
+                },
+                "type": "progress"
+            },
+            {
+                "props": {
+                    "color": "success",
+                    "max": 100,
+                    "showValue": false,
+                    "size": "lg",
+                    "value": 80,
+                    "variant": "bar"
+                },
+                "type": "progress"
+            },
+            {
+                "props": {
+                    "align": null,
+                    "direction": "row",
+                    "float": null,
+                    "gap": "md",
+                    "height": null,
+                    "justify": null,
+                    "width": null
+                },
+                "schema": [
+                    {
+                        "props": {
+                            "color": null,
+                            "max": 100,
+                            "showValue": true,
+                            "size": "md",
+                            "value": 65,
+                            "variant": "circle"
+                        },
+                        "type": "progress"
+                    },
+                    {
+                        "props": {
+                            "color": "warning",
+                            "max": 50,
+                            "showValue": true,
+                            "size": "xl",
+                            "value": 35,
+                            "variant": "circle"
+                        },
+                        "type": "progress"
+                    }
+                ],
+                "type": "stack"
+            }
+        ],
+        "type": "stack"
+    }
+]

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -795,6 +795,20 @@
             }
         ]
     },
+    "Lattice\\Lattice\\Ui\\Enums\\ProgressVariant": {
+        "name": "ProgressVariant",
+        "namespace": "Lattice\\Lattice\\Ui\\Enums",
+        "cases": [
+            {
+                "name": "Bar",
+                "value": "bar"
+            },
+            {
+                "name": "Circle",
+                "value": "circle"
+            }
+        ]
+    },
     "Lattice\\Lattice\\Ui\\Enums\\Side": {
         "name": "Side",
         "namespace": "Lattice\\Lattice\\Ui\\Enums",

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -307,6 +307,7 @@ export type ComponentPropsMap = {
   modal: Modal;
   notifications: Notifications;
   outlet: Outlet;
+  progress: Progress;
   "raw-block": RawBlock;
   "remote.data-list": DataList;
   section: Section;
@@ -775,6 +776,7 @@ export type NodeType =
   | "modal"
   | "notifications"
   | "outlet"
+  | "progress"
   | "raw-block"
   | "remote.data-list"
   | "section"
@@ -953,6 +955,15 @@ export type PasswordInput = {
   value: unknown;
 };
 export type Placement = "top" | "bottom" | "right";
+export type Progress = {
+  color: Color | null;
+  max: number;
+  showValue: boolean;
+  size: Size;
+  value: number;
+  variant: ProgressVariant;
+};
+export type ProgressVariant = "bar" | "circle";
 export type RawBlock = {
   html: string;
 };

--- a/resources/js/ui/plugin.ts
+++ b/resources/js/ui/plugin.ts
@@ -23,6 +23,7 @@ import IconComponent from "./icon";
 import ImageComponent from "./image";
 import LinkComponent from "./link";
 import ModalComponent from "./modal";
+import ProgressComponent from "./progress";
 import RawBlockComponent from "./raw-block";
 import SectionComponent from "./section";
 import SegmentedControlComponent from "./segmented-control";
@@ -59,6 +60,7 @@ export const uiComponents = createPlugin({
     image: eagerComponent(ImageComponent),
     link: eagerComponent(LinkComponent),
     modal: eagerComponent(ModalComponent),
+    progress: eagerComponent(ProgressComponent),
     "raw-block": eagerComponent(RawBlockComponent),
     section: eagerComponent(SectionComponent),
     "segmented-control": eagerComponent(SegmentedControlComponent),

--- a/resources/js/ui/progress.test.tsx
+++ b/resources/js/ui/progress.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import type { Progress } from "@lattice-php/lattice/types/generated";
+import ProgressComponent from "./progress";
+
+function renderProgress(props: Partial<Progress>) {
+  const node = {
+    type: "progress",
+    props: {
+      value: 0,
+      max: 100,
+      variant: "bar",
+      showValue: false,
+      color: null,
+      size: "md",
+      ...props,
+    },
+  } as Node<"progress">;
+  return render(<ProgressComponent node={node}>{null}</ProgressComponent>);
+}
+
+describe("ProgressComponent bar", () => {
+  it("renders the fill width from value and max with aria state", () => {
+    const { container } = renderProgress({ value: 72.5 });
+
+    const track = screen.getByRole("progressbar");
+    expect(track).toHaveAttribute("aria-valuemin", "0");
+    expect(track).toHaveAttribute("aria-valuemax", "100");
+    expect(track).toHaveAttribute("aria-valuenow", "72.5");
+    expect(track).toHaveAttribute("aria-valuetext", "73%");
+    expect(container.querySelector('[data-lattice-progress="bar"]')).not.toBeNull();
+
+    const fill = track.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("72.5%");
+  });
+
+  it("clamps the value into the 0..max range", () => {
+    renderProgress({ value: 150 });
+
+    const track = screen.getByRole("progressbar");
+    expect(track).toHaveAttribute("aria-valuenow", "100");
+    expect((track.firstElementChild as HTMLElement).style.width).toBe("100%");
+  });
+
+  it("renders an empty fill when max is not positive", () => {
+    renderProgress({ value: 10, max: 0 });
+
+    const track = screen.getByRole("progressbar");
+    expect((track.firstElementChild as HTMLElement).style.width).toBe("0%");
+  });
+
+  it("shows the percent readout when showValue is set", () => {
+    renderProgress({ value: 50, showValue: true });
+
+    expect(screen.getByText("50%")).toBeInTheDocument();
+  });
+
+  it("maps color and size onto the fill and track", () => {
+    renderProgress({ value: 40, color: "success", size: "lg" });
+
+    const track = screen.getByRole("progressbar");
+    expect(track.className).toContain("h-3");
+    expect((track.firstElementChild as HTMLElement).className).toContain("bg-lt-success");
+  });
+});
+
+describe("ProgressComponent circle", () => {
+  it("renders the ring offset from value and max", () => {
+    const { container } = renderProgress({ value: 25, variant: "circle" });
+
+    const circumference = 2 * Math.PI * 18;
+    const circles = container.querySelectorAll("circle");
+    expect(circles).toHaveLength(2);
+    const ring = circles[1];
+    expect(Number.parseFloat(ring.getAttribute("stroke-dasharray") ?? "")).toBeCloseTo(
+      circumference,
+      2,
+    );
+    expect(Number.parseFloat(ring.getAttribute("stroke-dashoffset") ?? "")).toBeCloseTo(
+      circumference * 0.75,
+      2,
+    );
+    expect(container.querySelector('[data-lattice-progress="circle"]')).not.toBeNull();
+  });
+
+  it("scales the ring with size and centers the readout", () => {
+    const { container } = renderProgress({
+      value: 35,
+      max: 50,
+      variant: "circle",
+      size: "xl",
+      showValue: true,
+    });
+
+    expect(container.querySelector("svg")).toHaveAttribute("width", "64");
+    expect(screen.getByText("70%")).toBeInTheDocument();
+  });
+
+  it("colors the ring stroke from the color prop", () => {
+    const { container } = renderProgress({ value: 10, variant: "circle", color: "danger" });
+
+    const ring = container.querySelectorAll("circle")[1];
+    expect(ring.getAttribute("class")).toContain("text-lt-danger");
+  });
+});

--- a/resources/js/ui/progress.tsx
+++ b/resources/js/ui/progress.tsx
@@ -1,0 +1,141 @@
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { useLocale } from "@lattice-php/lattice/i18n";
+import { cn } from "@lattice-php/lattice/lib/utils";
+import type { Color, Size } from "@lattice-php/lattice/types/generated";
+
+const barHeights: Record<Size, string> = {
+  xs: "h-1",
+  sm: "h-1.5",
+  md: "h-2.5",
+  lg: "h-3",
+  xl: "h-4",
+  "2xl": "h-5",
+  "3xl": "h-6",
+  "4xl": "h-8",
+};
+
+const fillColors: Record<Color, string> = {
+  default: "bg-lt-fg",
+  muted: "bg-lt-muted-fg",
+  primary: "bg-lt-primary",
+  success: "bg-lt-success",
+  info: "bg-lt-info",
+  warning: "bg-lt-warning",
+  danger: "bg-lt-danger",
+};
+
+const strokeColors: Record<Color, string> = {
+  default: "text-lt-fg",
+  muted: "text-lt-muted-fg",
+  primary: "text-lt-primary",
+  success: "text-lt-success",
+  info: "text-lt-info",
+  warning: "text-lt-warning",
+  danger: "text-lt-danger",
+};
+
+const circleDiameters: Record<Size, number> = {
+  xs: 24,
+  sm: 32,
+  md: 40,
+  lg: 48,
+  xl: 64,
+  "2xl": 80,
+  "3xl": 96,
+  "4xl": 128,
+};
+
+const circleReadouts: Record<Size, string> = {
+  xs: "text-[0.5rem]",
+  sm: "text-[0.625rem]",
+  md: "text-xs",
+  lg: "text-sm",
+  xl: "text-base",
+  "2xl": "text-lg",
+  "3xl": "text-xl",
+  "4xl": "text-2xl",
+};
+
+const ProgressComponent: RendererComponent<"progress"> = ({ node }) => {
+  const { value, max, variant, showValue, color, size } = node.props;
+  const { locale } = useLocale();
+
+  const clamped = max > 0 ? Math.min(Math.max(value, 0), max) : 0;
+  const ratio = max > 0 ? clamped / max : 0;
+  const percent = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 0,
+    style: "percent",
+  }).format(ratio);
+
+  const aria = {
+    "aria-valuemax": max,
+    "aria-valuemin": 0,
+    "aria-valuenow": clamped,
+    "aria-valuetext": percent,
+    role: "progressbar",
+  } as const;
+
+  if (variant === "circle") {
+    const diameter = circleDiameters[size];
+    const strokeWidth = Math.max(3, diameter / 10);
+    const radius = (diameter - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+
+    return (
+      <div {...aria} className="relative inline-flex" data-lattice-progress="circle">
+        <svg className="-rotate-90" height={diameter} width={diameter}>
+          <circle
+            className="text-lt-muted"
+            cx={diameter / 2}
+            cy={diameter / 2}
+            fill="none"
+            r={radius}
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+          />
+          <circle
+            className={strokeColors[color ?? "primary"]}
+            cx={diameter / 2}
+            cy={diameter / 2}
+            fill="none"
+            r={radius}
+            stroke="currentColor"
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference * (1 - ratio)}
+            strokeLinecap="round"
+            strokeWidth={strokeWidth}
+          />
+        </svg>
+        {showValue && (
+          <span
+            className={cn(
+              "absolute inset-0 flex items-center justify-center font-medium text-lt-fg tabular-nums",
+              circleReadouts[size],
+            )}
+          >
+            {percent}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full items-center gap-2" data-lattice-progress="bar">
+      <div
+        {...aria}
+        className={cn("w-full overflow-hidden rounded-full bg-lt-muted", barHeights[size])}
+      >
+        <div
+          className={cn("h-full rounded-full", fillColors[color ?? "primary"])}
+          style={{ width: `${ratio * 100}%` }}
+        />
+      </div>
+      {showValue && (
+        <span className="shrink-0 text-lt-muted-fg text-sm tabular-nums">{percent}</span>
+      )}
+    </div>
+  );
+};
+
+export default ProgressComponent;

--- a/src/Ui/Components/Progress.php
+++ b/src/Ui/Components/Progress.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Components;
+
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Ui\Concerns\HasColor;
+use Lattice\Lattice\Ui\Concerns\HasSize;
+use Lattice\Lattice\Ui\Enums\ProgressVariant;
+
+#[AsComponent('progress')]
+class Progress extends Component
+{
+    use HasColor;
+    use HasSize;
+
+    public float $value = 0.0;
+
+    public float $max = 100.0;
+
+    public ProgressVariant $variant = ProgressVariant::Bar;
+
+    public bool $showValue = false;
+
+    public static function bar(float $value = 0.0, ?string $key = null): static
+    {
+        $component = new static($key);
+        $component->value = $value;
+
+        return $component;
+    }
+
+    public static function circle(float $value = 0.0, ?string $key = null): static
+    {
+        $component = new static($key);
+        $component->value = $value;
+        $component->variant = ProgressVariant::Circle;
+
+        return $component;
+    }
+
+    public function value(float $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function max(float $max): static
+    {
+        $this->max = $max;
+
+        return $this;
+    }
+
+    public function showValue(bool $show = true): static
+    {
+        $this->showValue = $show;
+
+        return $this;
+    }
+}

--- a/src/Ui/Enums/ProgressVariant.php
+++ b/src/Ui/Enums/ProgressVariant.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Enums;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum ProgressVariant: string
+{
+    case Bar = 'bar';
+    case Circle = 'circle';
+}

--- a/tests/Browser/Components/ProgressTest.php
+++ b/tests/Browser/Components/ProgressTest.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+it('renders progress bars and circles', function (): void {
+    $this->actingAs(workbenchTestUser());
+    visit('/components/progress')
+        ->assertSee('Progress bars')
+        ->assertSee('Progress circles')
+        ->assertPresent('[data-lattice-progress="bar"]')
+        ->assertPresent('[data-lattice-progress="circle"] svg')
+        ->assertSee('50%')
+        ->assertNoSmoke();
+});

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -27,12 +27,14 @@ use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Image;
 use Lattice\Lattice\Ui\Components\Link;
 use Lattice\Lattice\Ui\Components\Modal;
+use Lattice\Lattice\Ui\Components\Progress;
 use Lattice\Lattice\Ui\Components\Separator;
 use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Enums\ButtonVariant;
+use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\FloatingPlacement;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Enums\Icon;
@@ -477,6 +479,31 @@ test('links serialize their icon and affixes', function (): void {
         'label' => 'Docs',
         'prefix' => ['icon' => 'book-open', 'text' => null],
         'suffix' => ['icon' => null, 'text' => 'new'],
+    ]);
+});
+
+it('serializes progress bars and circles', function (): void {
+    $bar = wire(Progress::bar(72.5)->color(Color::Success)->showValue());
+
+    expect($bar['type'])->toBe('progress')
+        ->and($bar['props'])->toMatchArray([
+            'value' => 72.5,
+            'max' => 100.0,
+            'variant' => 'bar',
+            'showValue' => true,
+            'color' => 'success',
+            'size' => 'md',
+        ]);
+
+    $circle = wire(Progress::circle(35)->max(50)->size(Size::Lg));
+
+    expect($circle['props'])->toMatchArray([
+        'value' => 35.0,
+        'max' => 50.0,
+        'variant' => 'circle',
+        'showValue' => false,
+        'color' => null,
+        'size' => 'lg',
     ]);
 });
 

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Ui\Components\Card;
 use Lattice\Lattice\Ui\Components\Grid;
 use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Image;
+use Lattice\Lattice\Ui\Components\Progress;
 use Lattice\Lattice\Ui\Components\RawBlock;
 use Lattice\Lattice\Ui\Components\Section;
 use Lattice\Lattice\Ui\Components\SegmentedControl;
@@ -19,6 +20,7 @@ use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Components\Tooltip;
 use Lattice\Lattice\Ui\Enums\ButtonVariant;
+use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Enums\Orientation;
 use Lattice\Lattice\Ui\Enums\Size;
@@ -72,6 +74,19 @@ describe('docs fixtures', function (): void {
                     Text::make('Three people have access to this team.'),
                     Badge::make('3 active'),
                 ]),
+        ]))));
+    });
+
+    it('matches the progress example fixture', function (): void {
+        assertFixtureMatches('components.progress', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
+            Stack::make()->gap(Gap::Small)->schema([
+                Progress::bar(65)->showValue(),
+                Progress::bar(80)->color(Color::Success)->size(Size::Lg),
+                Stack::make()->direction(StackDirection::Row)->gap(Gap::Medium)->schema([
+                    Progress::circle(65)->showValue(),
+                    Progress::circle(35)->max(50)->color(Color::Warning)->size(Size::Xl)->showValue(),
+                ]),
+            ]),
         ]))));
     });
 

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -43,6 +43,7 @@ use Workbench\App\Pages\Components\ChartsPage;
 use Workbench\App\Pages\Components\ChatPage;
 use Workbench\App\Pages\Components\ContainersPage;
 use Workbench\App\Pages\Components\NotificationsPage;
+use Workbench\App\Pages\Components\ProgressPage;
 use Workbench\App\Pages\Components\TabsPage;
 use Workbench\App\Pages\DependentFieldsPage;
 use Workbench\App\Pages\Fields\BooleanFieldsPage;
@@ -151,6 +152,7 @@ class AppLayout extends LayoutDefinition
                     MenuItem::fromPage(ButtonsPage::class)->key('buttons')->label(__('workbench.navigation.buttons')),
                     MenuItem::fromPage(TabsPage::class)->key('tabs')->label(__('workbench.navigation.tabs')),
                     MenuItem::fromPage(ChartsPage::class)->key('charts')->label(__('workbench.navigation.charts')),
+                    MenuItem::fromPage(ProgressPage::class)->key('progress')->label(__('workbench.navigation.progress')),
                     MenuItem::fromPage(ContainersPage::class)->key('containers')->label(__('workbench.navigation.containers')),
                     MenuItem::fromPage(NotificationsPage::class)->key('notifications')->label(__('workbench.navigation.notifications')),
                     MenuItem::fromPage(ChatPage::class)->key('chat')->label(__('workbench.navigation.chat')),

--- a/workbench/app/Pages/Components/ProgressPage.php
+++ b/workbench/app/Pages/Components/ProgressPage.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages\Components;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Progress;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Enums\Color;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Lattice\Ui\Enums\Size;
+use Lattice\Lattice\Ui\Enums\StackDirection;
+use Workbench\App\Pages\WorkbenchPage;
+
+#[AsPage(route: '/components/progress')]
+final class ProgressPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return __('workbench.pages.components.progress.title');
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('progress-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make(__('workbench.pages.components.progress.bars')),
+                    Stack::make('progress-bars')
+                        ->gap(Gap::Small)
+                        ->schema([
+                            Progress::bar(25, 'progress-bar-primary'),
+                            Progress::bar(50, 'progress-bar-success')->color(Color::Success)->showValue(),
+                            Progress::bar(80, 'progress-bar-large')->color(Color::Warning)->size(Size::Lg)->showValue(),
+                        ]),
+                    Heading::make(__('workbench.pages.components.progress.circles'), 2),
+                    Stack::make('progress-circles')
+                        ->direction(StackDirection::Row)
+                        ->gap(Gap::Medium)
+                        ->schema([
+                            Progress::circle(25, 'progress-circle-primary')->showValue(),
+                            Progress::circle(35, 'progress-circle-scaled')->max(50)->color(Color::Success)->size(Size::Xl)->showValue(),
+                            Progress::circle(90, 'progress-circle-danger')->color(Color::Danger)->size(Size::Lg),
+                        ]),
+                ]),
+        ]);
+    }
+}

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -395,6 +395,7 @@ return [
         'pagination-modes' => 'Paginierung',
         'platform' => 'Plattform',
         'products' => 'Produkte',
+        'progress' => 'Fortschritt',
         'realtime' => 'Echtzeit',
         'remote-schema' => 'Remote-Schema',
         'sales-orders' => 'Aufträge',
@@ -517,6 +518,11 @@ return [
                 'popover' => 'Die Glocke öffnet Benachrichtigungen in einem Popover.',
                 'slide-out' => 'Die Glocke öffnet Benachrichtigungen in einem Slide-out-Panel.',
                 'title' => 'Benachrichtigungen',
+            ],
+            'progress' => [
+                'bars' => 'Fortschrittsbalken',
+                'circles' => 'Fortschrittskreise',
+                'title' => 'Fortschritt',
             ],
         ],
         'dependent' => [

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -395,6 +395,7 @@ return [
         'pagination-modes' => 'Pagination',
         'platform' => 'Platform',
         'products' => 'Products',
+        'progress' => 'Progress',
         'realtime' => 'Realtime',
         'remote-schema' => 'Remote Schema',
         'sales-orders' => 'Sales orders',
@@ -517,6 +518,11 @@ return [
                 'popover' => 'The bell opens notifications in a popover.',
                 'slide-out' => 'The bell opens notifications in a slide-out panel.',
                 'title' => 'Notifications',
+            ],
+            'progress' => [
+                'bars' => 'Progress bars',
+                'circles' => 'Progress circles',
+                'title' => 'Progress',
             ],
         ],
         'dependent' => [


### PR DESCRIPTION
Server-addressable determinate progress for the Ui layer (solo todo #17).

**What changed**
- `Progress` Ui component: `Progress::bar($value)` / `Progress::circle($value)` named constructors on one `progress` wire type, `->max()` (default 100, values clamp into range), `->showValue()` for a locale-formatted percent readout, plus the shared `->color()` / `->size()` concerns — and `->dataKey()` bindability like any component.
- Client: one renderer — track/fill divs for the bar (mirrors the distribution-bar styling), a plain SVG ring for the circle (no recharts). `role="progressbar"` with `aria-valuenow`/`aria-valuemax` and the percent as `aria-valuetext`.
- Docs: `/components/progress/` page backed by a test-generated `components.progress` fixture; `ProgressVariant` added to the enums reference.
- Workbench: `/components/progress` demo page (en/de) with browser coverage.

**Example (workbench demo)**
`Progress::bar(50)->color(Color::Success)->showValue()` → muted track with a green fill at 50% and a "50%" readout beside it. `Progress::circle(35)->max(50)->size(Size::Xl)->showValue()` → 64px ring filled to 70% with the readout centered.