### PR TITLE
feat(tables): expandable rows with lazy fragment detail

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -157,6 +157,7 @@ export default defineConfig({
             },
             { label: "Filtering", link: "/tables/filtering/" },
             { label: "Searching", link: "/tables/searching/" },
+            { label: "Row detail", link: "/tables/row-detail/" },
             { label: "Sorting & pagination", link: "/tables/sorting-and-pagination/" },
             { label: "Actions", link: "/tables/actions/" },
           ],

--- a/docs/content/docs/tables/row-detail.md
+++ b/docs/content/docs/tables/row-detail.md
@@ -1,0 +1,58 @@
+---
+title: Row detail
+description: Expandable rows that fold open a lazy Fragment detail, loaded over AJAX when the row opens.
+---
+
+Override `rowDetail()` to make a row expandable. Each expandable row gets a chevron that folds a detail
+panel open beneath it. The detail is a [`Fragment`](/core/fragments/) loaded over AJAX **when the row
+opens** — nothing is fetched for collapsed rows — so the detail can be as rich as you like without
+weighing down the table payload.
+
+```php
+use Lattice\Lattice\Fragments\Components\Fragment;
+
+public function rowDetail(array $row): ?Fragment
+{
+    return Fragment::lazy(OrderLinesFragment::class, ['orderId' => $row['id']]);
+}
+```
+
+Return `null` for rows that should not expand — those rows simply show no chevron.
+
+## The detail fragment
+
+The detail lives in its own [`#[AsFragment]`](/core/fragments/) class, authored and tested
+independently of the table. It reads the row context you passed to `Fragment::lazy()`:
+
+```php
+use Lattice\Lattice\Attributes\AsFragment;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Fragments\FragmentDefinition;
+
+#[AsFragment('order-lines')]
+final class OrderLinesFragment extends FragmentDefinition
+{
+    public function schema(PageSchema $schema): PageSchema
+    {
+        $order = Order::with('lines')->findOrFail($this->context('orderId'));
+
+        return $schema->component(/* … the order's lines … */);
+    }
+}
+```
+
+Because it is a real fragment, the detail inherits the whole [Fragment](/core/fragments/) pipeline: a
+signed per-row endpoint, authorization, the loading skeleton, and per-fragment reload events.
+
+## Behavior
+
+- The chevron toggles the row; the rest of the row stays free for [row actions](/tables/actions/) and
+  links.
+- Several rows can be open at once.
+- Expansion is client-side and resets when the table reloads, re-sorts, re-filters, or paginates; the
+  detail re-fetches each time a row opens.
+
+:::note
+`rowDetail()` returns a `Fragment` and nothing else — the detail always loads over AJAX. This keeps
+large or expensive detail off the initial table response.
+:::

--- a/lang/de/table.php
+++ b/lang/de/table.php
@@ -29,6 +29,9 @@ return [
         'placeholder' => 'Suchen',
         'clear' => 'Suche löschen',
     ],
+    'rowDetail' => [
+        'toggle' => 'Details ein-/ausklappen',
+    ],
     'filter' => [
         'all' => 'Alle',
         'true' => 'Ja',

--- a/lang/en/table.php
+++ b/lang/en/table.php
@@ -29,6 +29,9 @@ return [
         'placeholder' => 'Search',
         'clear' => 'Clear search',
     ],
+    'rowDetail' => [
+        'toggle' => 'Toggle detail',
+    ],
     'filter' => [
         'all' => 'All',
         'true' => 'True',

--- a/resources/js/table/components/table-row-detail.test.tsx
+++ b/resources/js/table/components/table-row-detail.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registry } from "@lattice-php/lattice/registry";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import type { TableColumn, TableNode, TableRow } from "@lattice-php/lattice/table/types";
+import TableComponent from "./table";
+
+function col(): TableColumn {
+  return {
+    key: "name",
+    type: "column.text",
+    props: {
+      label: "Name",
+      width: "md",
+      align: "start",
+      sortable: false,
+      toggleable: false,
+      hiddenByDefault: false,
+      filter: null,
+    },
+  };
+}
+
+function detailNode(id: string) {
+  return {
+    type: "fragment",
+    id: `detail-${id}`,
+    props: { lazy: true, endpoint: `/lattice/fragments/detail-${id}`, ref: "sig", size: "md" },
+  };
+}
+
+function node(rows: TableRow[]): TableNode {
+  return {
+    id: "workbench.orders",
+    type: "table",
+    props: {
+      columns: [col()],
+      data: rows,
+      endpoint: "/lattice/tables/workbench.orders",
+      query: {
+        filters: [],
+        page: 1,
+        perPage: 25,
+        sorts: [],
+        tableFilters: {},
+        tableFilterIndicators: [],
+        search: "",
+      },
+    },
+  };
+}
+
+function stubFetch(text: string) {
+  const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+    Response.json({ schema: [{ type: "text", props: { text } }] }),
+  );
+
+  vi.stubGlobal("fetch", fetch);
+
+  return fetch;
+}
+
+describe("expandable table rows", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders an expander only for rows that carry a detail", () => {
+    renderWithRegistry(
+      <TableComponent
+        node={node([
+          { id: "1", name: "Order 1", detail: detailNode("1") },
+          { id: "2", name: "Order 2" },
+        ])}
+      />,
+      registry,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Toggle detail" })).toHaveLength(1);
+  });
+
+  it("loads the detail fragment over AJAX on expand and hides it on collapse", async () => {
+    const fetch = stubFetch("Line items loaded");
+
+    renderWithRegistry(
+      <TableComponent node={node([{ id: "1", name: "Order 1", detail: detailNode("1") }])} />,
+      registry,
+    );
+
+    expect(screen.queryByText("Line items loaded")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle detail" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Line items loaded")).toBeInTheDocument();
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/lattice/fragments/detail-1"),
+      expect.anything(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle detail" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Line items loaded")).toBeNull();
+    });
+  });
+});

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -1,15 +1,17 @@
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, Fragment, useMemo } from "react";
 import { useT } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
 import { useColumnResizing } from "@lattice-php/lattice/core/hooks/use-column-resizing";
 import { useColumnVisibility } from "@lattice-php/lattice/table/hooks/use-column-visibility";
+import { useExpandedRows } from "@lattice-php/lattice/table/hooks/use-expanded-rows";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import { Checkbox } from "@lattice-php/lattice/ui/checkbox";
 import { Icon } from "@lattice-php/lattice/icons";
 import { alignJustifyItems, alignText } from "@lattice-php/lattice/table/lib/align";
 import type { TableNode } from "@lattice-php/lattice/table/types";
 import { getBulkActions } from "@lattice-php/lattice/table/lib/bulk";
-import { getRowActions, getRowKey } from "@lattice-php/lattice/table/lib/payload";
+import { getRowActions, getRowDetail, getRowKey } from "@lattice-php/lattice/table/lib/payload";
 import {
   getQueryParams,
   getTableSizingColumns,
@@ -63,10 +65,17 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   const hasBulkActions = bulkActions.length > 0;
   const rowEntries = useMemo(
     () =>
-      rows.map((row, index) => ({ row, actions: getRowActions(row), key: getRowKey(row, index) })),
+      rows.map((row, index) => ({
+        row,
+        actions: getRowActions(row),
+        detail: getRowDetail(row),
+        key: getRowKey(row, index),
+      })),
     [rows],
   );
   const selection = useTableSelection(rowEntries.map((entry) => entry.key));
+  const { isExpanded, toggle: toggleRow } = useExpandedRows();
+  const hasExpandable = rowEntries.some((entry) => entry.detail != null);
 
   const columnsByKey = useMemo(
     () => new Map(columns.map((column) => [column.key, column])),
@@ -104,8 +113,8 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   const hasTrailingUtility = hasActions || hasDedicatedFilters || hasToggleableColumns;
   const sizingColumns = useMemo(() => getTableSizingColumns(visibleColumns), [visibleColumns]);
   const utilityTracks = useMemo(
-    () => getTableUtilityTracks(hasTrailingUtility, hasBulkActions),
-    [hasTrailingUtility, hasBulkActions],
+    () => getTableUtilityTracks(hasTrailingUtility, hasBulkActions, hasExpandable),
+    [hasTrailingUtility, hasBulkActions, hasExpandable],
   );
   const resizingEnabled = node.props?.resizableColumns === true;
   const resizeStorageIdentity = nodeIdentity(node);
@@ -197,6 +206,9 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
               className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
               role="row"
             >
+              {hasExpandable && (
+                <div className="px-2 py-3" role="columnheader" aria-hidden="true" />
+              )}
               {hasBulkActions && (
                 <div className="flex items-center px-4 py-3" role="columnheader">
                   <Checkbox
@@ -253,6 +265,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                 className="hidden min-w-full border-t border-lt-border md:grid md:grid-cols-[var(--lattice-table-columns)]"
                 role="row"
               >
+                {hasExpandable && <div className="px-2 py-2" role="cell" />}
                 {hasBulkActions && <div className="px-4 py-2" role="cell" />}
                 {visibleColumns.map((column) => (
                   <div key={column.key} className="min-w-0 px-2 py-2" role="cell">
@@ -286,68 +299,106 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
                 <div role="cell">{node.props?.emptyLabel}</div>
               </div>
             ) : (
-              rowEntries.map(({ row, actions, key }) => {
+              rowEntries.map(({ row, actions, detail, key }) => {
+                const expanded = detail != null && isExpanded(key);
+                const detailId = `${nodeIdentity(node) ?? "table"}-row-detail-${key}`;
+
                 return (
-                  <div
-                    key={key}
-                    data-slot="table-row"
-                    className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
-                      striped ? "odd:bg-lt-muted/30" : ""
-                    }`}
-                    role="row"
-                  >
-                    {hasBulkActions && (
-                      <div className="flex items-center px-lt-cell-x py-lt-cell-y" role="cell">
-                        <Checkbox
-                          aria-label={t("table.selectRow", "Select row {{key}}", { key })}
-                          data-test={`select-row-${key}`}
-                          checked={selection.isSelected(key)}
-                          onCheckedChange={() => selection.toggle(key)}
-                        />
-                      </div>
-                    )}
-                    {visibleColumns.map((column) => (
-                      <div
-                        key={column.key}
-                        data-slot="table-cell"
-                        className={cn(
-                          "grid min-w-0 gap-1 overflow-hidden px-lt-cell-x py-lt-cell-y align-middle",
-                          alignText(column.props.align),
-                          alignJustifyItems(column.props.align),
-                        )}
-                        role="cell"
-                      >
-                        <span
-                          aria-hidden="true"
-                          className="text-xs font-medium text-lt-muted-fg md:hidden"
-                        >
-                          {column.props.label}
-                        </span>
-                        <div
-                          data-slot="table-cell-content"
-                          className="min-w-0 max-w-full overflow-hidden truncate"
-                        >
-                          <ColumnCell column={column} row={row} />
+                  <Fragment key={key}>
+                    <div
+                      data-slot="table-row"
+                      className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
+                        striped ? "odd:bg-lt-muted/30" : ""
+                      }`}
+                      role="row"
+                    >
+                      {hasExpandable && (
+                        <div className="flex items-center px-2 py-lt-cell-y" role="cell">
+                          {detail && (
+                            <button
+                              type="button"
+                              data-test={`row-expand-${key}`}
+                              aria-expanded={expanded}
+                              aria-controls={detailId}
+                              aria-label={t("table.rowDetail.toggle", "Toggle detail")}
+                              className="inline-flex size-6 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg"
+                              onClick={() => toggleRow(key)}
+                            >
+                              <Icon
+                                name="chevron-down"
+                                aria-hidden="true"
+                                className={cn(
+                                  "size-lt-icon-md transition-transform",
+                                  !expanded && "-rotate-90",
+                                )}
+                              />
+                            </button>
+                          )}
                         </div>
-                      </div>
-                    ))}
-                    {hasTrailingUtility && (
-                      <div
-                        className={cn(
-                          "items-center justify-start gap-2 px-lt-cell-x py-lt-cell-y md:justify-end",
-                          actions.length > 0 ? "flex" : "hidden md:flex",
-                        )}
-                        role="cell"
-                      >
-                        {actions.map((action, actionIndex) => (
-                          <TableActionNode
-                            key={action.key ?? action.id ?? actionIndex}
-                            node={action}
+                      )}
+                      {hasBulkActions && (
+                        <div className="flex items-center px-lt-cell-x py-lt-cell-y" role="cell">
+                          <Checkbox
+                            aria-label={t("table.selectRow", "Select row {{key}}", { key })}
+                            data-test={`select-row-${key}`}
+                            checked={selection.isSelected(key)}
+                            onCheckedChange={() => selection.toggle(key)}
                           />
-                        ))}
+                        </div>
+                      )}
+                      {visibleColumns.map((column) => (
+                        <div
+                          key={column.key}
+                          data-slot="table-cell"
+                          className={cn(
+                            "grid min-w-0 gap-1 overflow-hidden px-lt-cell-x py-lt-cell-y align-middle",
+                            alignText(column.props.align),
+                            alignJustifyItems(column.props.align),
+                          )}
+                          role="cell"
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="text-xs font-medium text-lt-muted-fg md:hidden"
+                          >
+                            {column.props.label}
+                          </span>
+                          <div
+                            data-slot="table-cell-content"
+                            className="min-w-0 max-w-full overflow-hidden truncate"
+                          >
+                            <ColumnCell column={column} row={row} />
+                          </div>
+                        </div>
+                      ))}
+                      {hasTrailingUtility && (
+                        <div
+                          className={cn(
+                            "items-center justify-start gap-2 px-lt-cell-x py-lt-cell-y md:justify-end",
+                            actions.length > 0 ? "flex" : "hidden md:flex",
+                          )}
+                          role="cell"
+                        >
+                          {actions.map((action, actionIndex) => (
+                            <TableActionNode
+                              key={action.key ?? action.id ?? actionIndex}
+                              node={action}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    {expanded && detail && (
+                      <div
+                        id={detailId}
+                        role="region"
+                        data-slot="table-row-detail"
+                        className="border-b border-lt-border bg-lt-muted/20 px-lt-cell-x py-lt-cell-y"
+                      >
+                        <Renderer nodes={[detail]} />
                       </div>
                     )}
-                  </div>
+                  </Fragment>
                 );
               })
             )}

--- a/resources/js/table/hooks/use-expanded-rows.ts
+++ b/resources/js/table/hooks/use-expanded-rows.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Client-side expansion state for expandable table rows, keyed by row key.
+ * In-memory only: expansions reset when the table reloads or refetches.
+ */
+export function useExpandedRows() {
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+
+  const isExpanded = useCallback((key: string): boolean => expanded.has(key), [expanded]);
+
+  const toggle = useCallback((key: string): void => {
+    setExpanded((current) => {
+      const next = new Set(current);
+
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+
+      return next;
+    });
+  }, []);
+
+  return { isExpanded, toggle };
+}

--- a/resources/js/table/lib/payload.ts
+++ b/resources/js/table/lib/payload.ts
@@ -138,3 +138,11 @@ export function getRowKey(row: TableRow, index: number): string {
 export function getRowActions(row: TableRow): Node[] {
   return Array.isArray(row.actions) ? (row.actions as Node[]) : [];
 }
+
+export function getRowDetail(row: TableRow): Node | null {
+  const detail = row.detail;
+
+  return typeof detail === "object" && detail !== null && !Array.isArray(detail)
+    ? (detail as Node)
+    : null;
+}

--- a/resources/js/table/lib/query.ts
+++ b/resources/js/table/lib/query.ts
@@ -229,10 +229,14 @@ function columnWidthOrDefault(column: TableColumn): ColumnWidth {
     (column.type === "column.stack" ? "xl" : DEFAULT_COLUMN_WIDTH)) as ColumnWidth;
 }
 
-export function getTableUtilityTracks(hasActions: boolean, hasSelection: boolean) {
+export function getTableUtilityTracks(
+  hasActions: boolean,
+  hasSelection: boolean,
+  hasExpander = false,
+) {
   // Utility tracks are fixed because the independent header/filter/body grids would drift with content-sized tracks.
   return {
-    leadingTracks: hasSelection ? ["3rem"] : [],
+    leadingTracks: [...(hasExpander ? ["2.5rem"] : []), ...(hasSelection ? ["3rem"] : [])],
     trailingTracks: hasActions ? ["10rem"] : [],
   };
 }

--- a/src/Tables/TableDefinition.php
+++ b/src/Tables/TableDefinition.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Tables;
 
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Core\Definition;
+use Lattice\Lattice\Fragments\Components\Fragment;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Contracts\TableSource;
 use Lattice\Lattice\Tables\Enums\PaginationType;
@@ -82,6 +83,18 @@ abstract class TableDefinition extends Definition
     public function actions(array $row): array
     {
         return [];
+    }
+
+    /**
+     * The lazy detail fragment revealed when this row is expanded, or null when
+     * the row does not expand. Return `Fragment::lazy(...)` so the detail loads
+     * over AJAX on open.
+     *
+     * @param  array<string, mixed>  $row
+     */
+    public function rowDetail(array $row): ?Fragment
+    {
+        return null;
     }
 
     /**

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -227,15 +227,20 @@ final class TableRegistry extends DefinitionRegistry
 
         return $result->decorateRows(function (array $row) use ($definition, $rowKeys): array {
             $actions = $this->renderableComponents($definition->actions($row));
+            $detail = array_values($this->renderableComponents(array_filter([$definition->rowDetail($row)])));
             $projected = array_intersect_key($row, array_flip($rowKeys));
 
-            unset($projected['actions']);
+            unset($projected['actions'], $projected['detail']);
 
-            if ($actions === []) {
-                return $projected;
+            if ($detail !== []) {
+                $projected['detail'] = $detail[0];
             }
 
-            return [...$projected, 'actions' => $actions];
+            if ($actions !== []) {
+                $projected['actions'] = $actions;
+            }
+
+            return $projected;
         });
     }
 

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -54,10 +54,9 @@ arch('actions depend on no feature domain other than forms')
         'Lattice\Lattice\Layouts',
     ]);
 
-arch('tables depend on no feature domain other than actions and forms')
+arch('tables depend on no feature domain other than actions, forms, and fragments')
     ->expect('Lattice\Lattice\Tables')
     ->not->toUse([
-        'Lattice\Lattice\Fragments',
         'Lattice\Lattice\Layouts',
     ]);
 

--- a/tests/Browser/Tables/RowDetailTest.php
+++ b/tests/Browser/Tables/RowDetailTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use Workbench\App\Models\BusinessPartner;
+use Workbench\App\Models\Product;
+use Workbench\App\Models\SalesOrder;
+
+it('expands a sales-order row to load its line items over ajax and collapses again', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    $partner = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $product = Product::factory()->create(['name' => 'Gizmo']);
+    $order = SalesOrder::factory()->create(['business_partner_id' => $partner->getKey(), 'number' => 'SO-77']);
+    $order->lines()->create(['product_id' => $product->getKey(), 'quantity' => 2, 'unit_price' => '15.00']);
+
+    $page = visit('/sales-orders');
+
+    $page->assertSee('SO-77')
+        ->assertDontSee('Gizmo')
+        ->click('@row-expand-'.$order->getKey());
+
+    eventually(function () use ($page): void {
+        $page->assertSee('Gizmo');
+    });
+
+    $page->click('@row-expand-'.$order->getKey());
+
+    eventually(function () use ($page): void {
+        $page->assertDontSee('Gizmo');
+    });
+
+    $page->assertNoSmoke();
+});

--- a/tests/Feature/Tables/RowDetailTest.php
+++ b/tests/Feature/Tables/RowDetailTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Tables\Components\Table;
+use Workbench\App\Fragments\SalesOrderLinesFragment;
+use Workbench\App\Models\BusinessPartner;
+use Workbench\App\Models\Product;
+use Workbench\App\Models\SalesOrder;
+use Workbench\App\Models\User;
+use Workbench\App\Tables\SalesOrdersTable;
+use Workbench\App\Tables\UsersTable;
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function salesOrdersTableRows(): array
+{
+    Lattice::tables([SalesOrdersTable::class]);
+    Lattice::fragments([SalesOrderLinesFragment::class]);
+
+    return wire(Table::use(SalesOrdersTable::class))['props']['data'];
+}
+
+it('attaches a lazy detail fragment node to each row', function (): void {
+    $partner = BusinessPartner::factory()->create();
+    SalesOrder::factory()->create(['business_partner_id' => $partner->getKey(), 'number' => 'SO-1']);
+
+    $rows = salesOrdersTableRows();
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0])->toHaveKey('detail')
+        ->and($rows[0]['detail']['type'])->toBe('fragment')
+        ->and($rows[0]['detail']['props']['lazy'])->toBeTrue()
+        ->and($rows[0]['detail']['props']['endpoint'])->not->toBeNull();
+});
+
+it('omits detail when a table declares no row detail', function (): void {
+    Lattice::tables([UsersTable::class]);
+    User::query()->forceCreate([
+        'name' => 'Ada', 'email' => 'ada@example.com', 'password' => bcrypt('secret'),
+    ]);
+
+    $rows = wire(Table::use(UsersTable::class))['props']['data'];
+
+    expect($rows[0])->not->toHaveKey('detail');
+});
+
+it('renders the order line items in the detail fragment', function (): void {
+    $partner = BusinessPartner::factory()->create();
+    $product = Product::factory()->create(['name' => 'Widget']);
+    $order = SalesOrder::factory()->create(['business_partner_id' => $partner->getKey()]);
+    $order->lines()->create(['product_id' => $product->getKey(), 'quantity' => 3, 'unit_price' => '10.00']);
+
+    $fragment = (new SalesOrderLinesFragment)->withContext(['orderId' => $order->getKey()]);
+    $json = json_encode($fragment->schema(PageSchema::make())->renderable(), JSON_UNESCAPED_UNICODE);
+
+    expect($json)->toContain('3 × Widget — 30.00');
+});

--- a/workbench/app/Fragments/SalesOrderLinesFragment.php
+++ b/workbench/app/Fragments/SalesOrderLinesFragment.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Fragments;
+
+use Lattice\Lattice\Attributes\AsFragment;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Fragments\FragmentDefinition;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Workbench\App\Models\SalesOrder;
+use Workbench\App\Models\SalesOrderLine;
+
+/**
+ * The detail revealed when a sales-order row expands: the order's line items,
+ * loaded lazily over AJAX from the row's `orderId` context.
+ */
+#[AsFragment('workbench.sales-order-lines')]
+final class SalesOrderLinesFragment extends FragmentDefinition
+{
+    public function schema(PageSchema $schema): PageSchema
+    {
+        $order = SalesOrder::query()->with('lines.product')->find((int) $this->context('orderId'));
+
+        if ($order === null) {
+            return $schema->component(Text::make(__('workbench.commerce.sales-orders.detail.missing')));
+        }
+
+        $lines = $order->lines
+            ->map(fn (SalesOrderLine $line): Text => Text::make(
+                $line->quantity.' × '.$line->product->name.' — '.$line->total(),
+            ))
+            ->all();
+
+        if ($lines === []) {
+            $lines = [Text::make(__('workbench.commerce.sales-orders.detail.empty'))];
+        }
+
+        return $schema->component(
+            Stack::make('sales-order-lines-'.$order->getKey())->gap(Gap::Small)->schema($lines),
+        );
+    }
+}

--- a/workbench/app/Tables/SalesOrdersTable.php
+++ b/workbench/app/Tables/SalesOrdersTable.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Lattice\Lattice\Attributes\AsTable;
 use Lattice\Lattice\Core\Enums\Op;
+use Lattice\Lattice\Fragments\Components\Fragment;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
@@ -14,6 +15,7 @@ use Lattice\Lattice\Tables\Sources\Eloquent\EloquentTableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\Link;
+use Workbench\App\Fragments\SalesOrderLinesFragment;
 use Workbench\App\Models\SalesOrder;
 use Workbench\App\Models\SalesOrderLine;
 use Workbench\App\Tables\Columns\StatusBadgeColumn;
@@ -72,5 +74,14 @@ class SalesOrdersTable extends EloquentTableDefinition
             Link::make(__('workbench.commerce.sales-orders.actions.edit'), 'sales-order-edit')
                 ->href('/sales-orders/'.$row['id'].'/edit'),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    #[\Override]
+    public function rowDetail(array $row): ?Fragment
+    {
+        return Fragment::lazy(SalesOrderLinesFragment::class, ['orderId' => $row['id']]);
     }
 }

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -74,6 +74,10 @@ return [
                 'status' => 'Status',
                 'total' => 'Gesamt',
             ],
+            'detail' => [
+                'empty' => 'Dieser Auftrag hat keine Positionen.',
+                'missing' => 'Auftrag nicht gefunden.',
+            ],
             'fields' => [
                 'add-line' => 'Position hinzufügen',
                 'billing-address' => 'Rechnungsadresse',

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -74,6 +74,10 @@ return [
                 'status' => 'Status',
                 'total' => 'Total',
             ],
+            'detail' => [
+                'empty' => 'This order has no line items.',
+                'missing' => 'Order not found.',
+            ],
             'fields' => [
                 'add-line' => 'Add line',
                 'billing-address' => 'Billing address',


### PR DESCRIPTION
Adds expandable table rows: a row can fold open a detail panel that loads lazily as a Fragment over AJAX when the row opens.

## What changed
- **Authoring**: override `rowDetail(array $row): ?Fragment` on a `TableDefinition` (beside `actions()`). Return `Fragment::lazy(SomeDetail::class, ['id' => $row['id']])` for expandable rows, `null` otherwise. The detail is authored in a separate `#[AsFragment]` class that reads the row context.
- **Wire**: `TableRegistry::decorateRows` attaches the authorized fragment as the row's lightweight `detail` node (ref/endpoint/context, no content) beside `actions`. Nothing loads for collapsed rows. No component prop / `TableQuery` change → **no generated-types change**.
- **UI**: a leading expander column with a chevron toggle (`useExpandedRows`); expanding mounts the fragment (fetch on open, `Skeleton` while loading) in a full-width detail panel; collapsing unmounts it. Reuses the entire Fragment pipeline (signed per-row endpoint, authorization, reload/locale events).
- **Behavior**: chevron-only toggle, multiple rows open at once, client-side/in-memory expansion.
- **Architecture**: Tables may now use the Fragments domain — the arch layering rule is updated and stays acyclic (Fragments depends on no feature domain).
- Workbench demo: sales-order rows expand to their line items (`SalesOrderLinesFragment`). Docs: a new **Row detail** page.

Distinct from #20 Drawer/Sheet (the overlay presentation), which stays parked for later.

## Tests
Backend feature (`RowDetailTest`: fragment attached per row, omitted when no detail, detail renders line items), vitest (`table-row-detail`: expander only for detail rows, AJAX load on expand, collapse), and a browser test (expand a sales-order row → line items load → collapse). Full gate green.