### PR TITLE
fix(tables): column select filter printed its field label

### DIFF
--- a/resources/js/form/embed.ts
+++ b/resources/js/form/embed.ts
@@ -10,6 +10,7 @@ export { FormProvider } from "./hooks/context";
 export { PrefillProvider } from "./hooks/prefill-context";
 export { ResolvedNodesProvider } from "./hooks/resolved-nodes";
 export { FieldCommitOverrideProvider } from "./hooks/use-field-commit";
+export { TableCellProvider } from "./hooks/row-layout-context";
 export { useFormResolver } from "./hooks/use-form-resolver";
 export { FormValuesProvider, useFormValues, useSetFormValue } from "./hooks/values";
 export { walkFields } from "./lib/field-props";

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -223,6 +223,7 @@ function ColumnSelectFilter({
       filter={data}
       value={{ value }}
       processing={processing}
+      bare
       onChange={change}
       onSearch={onSearch ? (_field, query, signal) => onSearch(query, signal) : undefined}
     />

--- a/resources/js/table/components/column-select-filter.test.tsx
+++ b/resources/js/table/components/column-select-filter.test.tsx
@@ -202,4 +202,23 @@ describe("column select filter", () => {
 
     expect(screen.queryByRole("button", { name: "Status filters" })).not.toBeInTheDocument();
   });
+
+  it("keeps the select field label screen-reader-only so it does not duplicate the column header", () => {
+    stubFetch();
+
+    const { container } = renderWithRegistry(
+      <TableComponent node={node(selectFilter(false))} />,
+      registry,
+    );
+
+    const fieldLabels = Array.from(container.querySelectorAll("label")).filter(
+      (element) => element.textContent === "Status",
+    );
+
+    expect(fieldLabels.length).toBeGreaterThan(0);
+
+    for (const label of fieldLabels) {
+      expect(label).toHaveClass("sr-only");
+    }
+  });
 });

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -11,10 +11,12 @@ import {
   PrefillProvider,
   ResolvedNodesProvider,
   setPath,
+  TableCellProvider,
   useFormValues,
   useSetFormValue,
 } from "@lattice-php/lattice/form/embed";
 import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { filterValue, isActiveFilterValue } from "@lattice-php/lattice/table/lib/filter-values";
 import type { FilterNode } from "@lattice-php/lattice/table/types";
@@ -31,15 +33,18 @@ export function TableFilterControl({
   filter,
   value,
   processing,
+  bare = false,
   onChange,
   onSearch,
 }: {
   filter: FilterNode;
   value: unknown;
   processing: boolean;
+  bare?: boolean;
   onChange: (value: unknown) => void;
   onSearch?: FilterOptionSearch;
 }) {
+  const { t } = useT("lattice");
   const schema = filter.schema ?? [];
 
   if (schema.length === 0) {
@@ -56,13 +61,16 @@ export function TableFilterControl({
           schema={schema}
           value={value}
           processing={processing}
+          bare={bare}
           onChange={onChange}
           onSearch={onSearch}
         />
       </div>
       {isActiveFilterValue(value) && (
         <button
-          aria-label={`Clear ${filter.props.label} filter`}
+          aria-label={t("table.filter.clear", "Clear {{label}} filter", {
+            label: filter.props.label ?? "",
+          })}
           className="inline-flex size-lt-control-md shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg disabled:opacity-50"
           disabled={processing}
           onClick={() => onChange(undefined)}
@@ -80,6 +88,7 @@ function SchemaControl({
   schema,
   value,
   processing,
+  bare,
   onChange,
   onSearch,
 }: {
@@ -87,6 +96,7 @@ function SchemaControl({
   schema: Node[];
   value: unknown;
   processing: boolean;
+  bare: boolean;
   onChange: (value: unknown) => void;
   onSearch?: FilterOptionSearch;
 }) {
@@ -113,18 +123,22 @@ function SchemaControl({
     [filter.key, onSearch, processing],
   );
 
+  const content = (
+    <div
+      aria-disabled={processing}
+      className={cn("grid gap-3", processing && "pointer-events-none opacity-60")}
+    >
+      <Renderer nodes={schema} />
+    </div>
+  );
+
   return (
     <FormProvider value={form}>
       <PrefillProvider value={{ markUserEdit: () => {} }}>
         <ResolvedNodesProvider nodes={{}}>
           <FormValuesProvider initial={initial}>
             <TableFilterCommitBridge onChange={onChange}>
-              <div
-                aria-disabled={processing}
-                className={cn("grid gap-3", processing && "pointer-events-none opacity-60")}
-              >
-                <Renderer nodes={schema} />
-              </div>
+              {bare ? <TableCellProvider>{content}</TableCellProvider> : content}
             </TableFilterCommitBridge>
           </FormValuesProvider>
         </ResolvedNodesProvider>


### PR DESCRIPTION
## Bug
A table column configured with `->filterOptions()` (e.g. the products **Status** column) rendered its Select field's **visible label** inside the filter row — printing the column label a second time, directly under the column header.

**Root cause:** the column select filter renders a real form field, but not inside `TableCellProvider`. `FormFieldFrame` only makes the label `sr-only` when `useInTableCell()` is true; outside that context it drew the visible `<Label>`. Text/number columns don't hit this because they render a bare `FilterValueInput`, not a form field.

**Fix:** add a `bare` flag to `TableFilterControl` that wraps the field render in `TableCellProvider` (label becomes `sr-only` — visually hidden, accessible name preserved). The column filter path passes `bare`; the dedicated filter **menu** keeps its visible labels (stacked filters need them). `TableCellProvider` is now exposed from the `form/embed` surface, whose doc comment already lists "table filter rows".

## Filter cleanup (requested review)
Translated the clear-button aria-label in `TableFilterControl` — it was the one hardcoded-English string (`Clear ${label} filter`) among the filter controls, now `t("table.filter.clear", …)` like the rest. The remaining column-filter code reviewed clean.

### Adjacent finding (not in this PR)
`column-header.tsx` has a similarly hardcoded `Sort ${label}` aria-label — a sort control, not a filter, so left out to keep this scoped. Happy to fix it in a follow-up.

## Tests
New vitest asserting the column select filter's label renders `sr-only`; all existing filter tests pass; the status-column select filter browser test still passes end-to-end. Full gate green.