### PR TITLE
feat(ui): icon-button + control primitives, dogfooded across the UI

### DIFF
--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -2,7 +2,7 @@ import { apiFetch } from "@lattice-php/lattice/core/api";
 import { testIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import type { SignedUpload } from "@lattice-php/lattice/types/generated";
-import { Icon } from "@lattice-php/lattice/icons";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 import { useT } from "@lattice-php/lattice/i18n";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { FormFieldFrame } from "@lattice-php/lattice/form/components/base/field";
@@ -324,18 +324,16 @@ export const FileUploadComponent: RendererComponent<"field.file-upload"> = ({ no
                 )}
               </div>
               {(!item.existing || !scope) && (
-                <button
-                  aria-label={t("form.file-upload.remove", "Remove {{name}}", { name: item.name })}
-                  className="inline-flex size-7 shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg disabled:pointer-events-none disabled:opacity-50"
+                <IconButton
+                  size="sm"
+                  icon="x"
+                  label={t("form.file-upload.remove", "Remove {{name}}", { name: item.name })}
                   data-test={testIdentity(
                     item.existing ? `${name}-remove-existing` : `${name}-remove`,
                   )}
                   disabled={locked}
                   onClick={() => removeItem(item.id)}
-                  type="button"
-                >
-                  <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
-                </button>
+                />
               )}
               {signed && !item.existing && item.key && item.status === "ready" && (
                 <input

--- a/resources/js/form/embed.ts
+++ b/resources/js/form/embed.ts
@@ -10,6 +10,7 @@ export { FormProvider } from "./hooks/context";
 export { PrefillProvider } from "./hooks/prefill-context";
 export { ResolvedNodesProvider } from "./hooks/resolved-nodes";
 export { FieldCommitOverrideProvider } from "./hooks/use-field-commit";
+export { TableCellProvider } from "./hooks/row-layout-context";
 export { useFormResolver } from "./hooks/use-form-resolver";
 export { FormValuesProvider, useFormValues, useSetFormValue } from "./hooks/values";
 export { walkFields } from "./lib/field-props";

--- a/resources/js/form/rich-editor/toolbar-button.tsx
+++ b/resources/js/form/rich-editor/toolbar-button.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import { Icon } from "@lattice-php/lattice/icons";
-import { cn } from "@lattice-php/lattice/lib/utils";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 
 /**
- * The shared toolbar trigger: an icon button that keeps focus in the editor
- * (mousedown is prevented so clicks don't blur it, which would otherwise
- * trigger a precognition request).
+ * The shared editor toolbar trigger: an {@link IconButton} that keeps focus in
+ * the editor (mousedown is prevented so clicks don't blur it, which would
+ * otherwise trigger a precognition request).
  */
 export function ToolbarIconButton({
   active = false,
-  className,
   icon,
   label,
   testId,
@@ -21,24 +19,18 @@ export function ToolbarIconButton({
   testId: string;
 }) {
   return (
-    <button
-      aria-label={label}
-      aria-pressed={active}
-      data-test={testId}
+    <IconButton
+      size="sm"
+      icon={icon}
+      label={label}
       title={label}
-      type="button"
+      active={active}
+      data-test={testId}
       {...props}
-      className={cn(
-        "inline-flex size-7 items-center justify-center rounded-lt-sm text-lt-muted-fg transition-colors hover:bg-lt-accent hover:text-lt-accent-fg disabled:pointer-events-none disabled:opacity-40 [&_svg]:size-lt-icon-md",
-        active && "bg-lt-accent text-lt-accent-fg",
-        className,
-      )}
       onMouseDown={(event) => {
         event.preventDefault();
         props.onMouseDown?.(event);
       }}
-    >
-      <Icon name={icon} />
-    </button>
+    />
   );
 }

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -223,6 +223,7 @@ function ColumnSelectFilter({
       filter={data}
       value={{ value }}
       processing={processing}
+      bare
       onChange={change}
       onSearch={onSearch ? (_field, query, signal) => onSearch(query, signal) : undefined}
     />

--- a/resources/js/table/components/column-filter-control.tsx
+++ b/resources/js/table/components/column-filter-control.tsx
@@ -1,8 +1,9 @@
-import { Icon } from "@lattice-php/lattice/icons";
 import { useState } from "react";
+import { Button } from "@lattice-php/lattice/ui/button";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
+import { NativeSelect } from "@lattice-php/lattice/ui/native-select";
 import { Popover, PopoverContent, PopoverTrigger } from "@lattice-php/lattice/ui/popover";
 import { useT } from "@lattice-php/lattice/i18n";
-import { cn } from "@lattice-php/lattice/lib/utils";
 import type {
   ColumnFilterOption,
   FilterType,
@@ -13,7 +14,7 @@ import { filterValue } from "@lattice-php/lattice/table/lib/filter-values";
 import { operatorLabel, VALUELESS_FILTER_OPERATORS } from "@lattice-php/lattice/table/lib/query";
 import type { FilterClause, FilterNode, TableColumn } from "@lattice-php/lattice/table/types";
 import { TableFilterControl } from "./filter-controls";
-import { fieldClass, FilterValueInput } from "./filter-value-input";
+import { FilterValueInput } from "./filter-value-input";
 
 type ColumnClause = { clause: FilterClause; index: number };
 
@@ -94,22 +95,20 @@ export function ColumnFilterControl({
       </div>
       <Popover>
         <PopoverTrigger asChild>
-          <button
-            type="button"
-            aria-label={t("table.filter.columnFilters", "{{label}} filters", {
-              label,
-            })}
+          <IconButton
+            variant="segmented"
+            size="md"
+            icon="filter"
+            label={t("table.filter.columnFilters", "{{label}} filters", { label })}
             data-test={`filter-${column.key}`}
-            className="relative -ml-px inline-flex size-lt-control-md shrink-0 items-center justify-center rounded-r-lt-sm border border-lt-input disabled:opacity-50 data-[state=open]:z-10 data-[state=open]:border-lt-primary"
             disabled={processing}
           >
-            <Icon name="filter" aria-hidden="true" className="size-lt-icon-md" />
             {clauses.length > 0 && (
               <span className="absolute -right-1.5 -top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-lt-primary text-xs font-medium text-lt-primary-fg">
                 {clauses.length}
               </span>
             )}
-          </button>
+          </IconButton>
         </PopoverTrigger>
 
         <PopoverContent align="start" className="w-80 p-4">
@@ -327,16 +326,16 @@ function FilterClauseList({
       )}
 
       <div className="border-t border-lt-border pt-3">
-        <button
-          type="button"
+        <Button
+          variant="secondary"
+          icon="plus"
           data-test={`filter-${column.key}-add`}
-          className="inline-flex w-full items-center justify-center gap-2 rounded-lt-sm bg-lt-muted px-3 py-2 text-sm font-medium hover:bg-lt-muted/70 disabled:opacity-50"
+          className="w-full"
           disabled={processing}
           onClick={() => setAdding(true)}
         >
-          <Icon name="plus" aria-hidden="true" className="size-lt-icon-md" />
           {t("table.filter.add", "Add filter")}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -369,10 +368,11 @@ function FilterClauseRow({
     <div className="grid gap-2">
       <div className="flex items-center gap-2">
         {operators.length > 1 ? (
-          <select
+          <NativeSelect
+            density="compact"
             aria-label={t("table.filter.operator", "{{label}} operator", { label })}
             data-test={`filter-${column.key}-operator`}
-            className={cn(fieldClass, "flex-1")}
+            className="flex-1"
             disabled={processing}
             value={clause.operator}
             onChange={(event) => onOperator(event.target.value as Op)}
@@ -382,20 +382,19 @@ function FilterClauseRow({
                 {operatorLabel(operator)}
               </option>
             ))}
-          </select>
+          </NativeSelect>
         ) : (
           <span className="flex-1 text-sm font-medium">{operatorLabel(clause.operator)}</span>
         )}
-        <button
-          type="button"
+        <Button
+          variant="outline"
+          size="icon"
+          icon="trash-2"
           aria-label={t("table.filter.remove", "Remove {{label}} filter", { label })}
           data-test={`filter-${column.key}-remove`}
-          className="inline-flex size-lt-control-md items-center justify-center rounded-lt-sm border border-lt-border hover:bg-lt-muted disabled:opacity-50"
           disabled={processing}
           onClick={onRemove}
-        >
-          <Icon name="trash-2" aria-hidden="true" className="size-lt-icon-md" />
-        </button>
+        />
       </div>
       {!valueless && (
         <FilterValueInput

--- a/resources/js/table/components/column-select-filter.test.tsx
+++ b/resources/js/table/components/column-select-filter.test.tsx
@@ -202,4 +202,23 @@ describe("column select filter", () => {
 
     expect(screen.queryByRole("button", { name: "Status filters" })).not.toBeInTheDocument();
   });
+
+  it("keeps the select field label screen-reader-only so it does not duplicate the column header", () => {
+    stubFetch();
+
+    const { container } = renderWithRegistry(
+      <TableComponent node={node(selectFilter(false))} />,
+      registry,
+    );
+
+    const fieldLabels = Array.from(container.querySelectorAll("label")).filter(
+      (element) => element.textContent === "Status",
+    );
+
+    expect(fieldLabels.length).toBeGreaterThan(0);
+
+    for (const label of fieldLabels) {
+      expect(label).toHaveClass("sr-only");
+    }
+  });
 });

--- a/resources/js/table/components/column-visibility-menu.tsx
+++ b/resources/js/table/components/column-visibility-menu.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from "@lattice-php/lattice/ui/checkbox";
 import type { ToggleableColumn } from "@lattice-php/lattice/table/hooks/use-column-visibility";
-import { Icon } from "@lattice-php/lattice/icons";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 import { useT } from "@lattice-php/lattice/i18n";
 import { Popover, PopoverContent, PopoverTrigger } from "@lattice-php/lattice/ui/popover";
 
@@ -27,15 +27,13 @@ export function ColumnVisibilityMenu({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={columnsLabel}
+        <IconButton
+          size="sm"
+          icon="columns-3"
+          label={columnsLabel}
           data-test="table-columns-menu"
-          className="relative inline-flex size-7 shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lt-ring/50 data-[state=open]:bg-lt-muted data-[state=open]:text-lt-fg"
           disabled={processing}
-        >
-          <Icon name="columns-3" aria-hidden="true" className="size-lt-icon-md" />
-        </button>
+        />
       </PopoverTrigger>
       <PopoverContent align="end" className="w-64 p-4">
         <div className="grid gap-3">

--- a/resources/js/table/components/filter-bar.tsx
+++ b/resources/js/table/components/filter-bar.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@lattice-php/lattice/icons";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 import { Popover, PopoverContent, PopoverTrigger } from "@lattice-php/lattice/ui/popover";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { Option } from "@lattice-php/lattice/types/generated";
@@ -108,16 +108,14 @@ function FilterChip({
           </>
         )}
       </span>
-      <button
-        type="button"
+      <IconButton
+        size="xs"
+        icon="x"
+        label={removeLabel}
         data-test={removeTestId}
-        className="inline-flex size-5 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-border disabled:opacity-50"
         disabled={processing}
-        aria-label={removeLabel}
         onClick={onRemove}
-      >
-        <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
-      </button>
+      />
     </span>
   );
 }
@@ -142,20 +140,19 @@ export function FilterMenu({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button
-          type="button"
-          aria-label={filtersLabel}
+        <IconButton
+          size="sm"
+          icon="filter"
+          label={filtersLabel}
           data-test="table-filters-menu"
-          className="relative inline-flex size-7 shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lt-ring/50 data-[state=open]:bg-lt-muted data-[state=open]:text-lt-fg"
           disabled={processing}
         >
-          <Icon name="filter" aria-hidden="true" className="size-lt-icon-md" />
           {active.length > 0 && (
             <span className="absolute -right-1 -top-1 inline-flex size-3.5 items-center justify-center rounded-full bg-lt-primary text-[10px] font-medium leading-none text-lt-primary-fg">
               {active.length}
             </span>
           )}
-        </button>
+        </IconButton>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-80 p-4">
         <div className="grid gap-3">

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -11,10 +11,12 @@ import {
   PrefillProvider,
   ResolvedNodesProvider,
   setPath,
+  TableCellProvider,
   useFormValues,
   useSetFormValue,
 } from "@lattice-php/lattice/form/embed";
 import { Icon } from "@lattice-php/lattice/icons";
+import { useT } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { filterValue, isActiveFilterValue } from "@lattice-php/lattice/table/lib/filter-values";
 import type { FilterNode } from "@lattice-php/lattice/table/types";
@@ -31,15 +33,18 @@ export function TableFilterControl({
   filter,
   value,
   processing,
+  bare = false,
   onChange,
   onSearch,
 }: {
   filter: FilterNode;
   value: unknown;
   processing: boolean;
+  bare?: boolean;
   onChange: (value: unknown) => void;
   onSearch?: FilterOptionSearch;
 }) {
+  const { t } = useT("lattice");
   const schema = filter.schema ?? [];
 
   if (schema.length === 0) {
@@ -56,13 +61,16 @@ export function TableFilterControl({
           schema={schema}
           value={value}
           processing={processing}
+          bare={bare}
           onChange={onChange}
           onSearch={onSearch}
         />
       </div>
       {isActiveFilterValue(value) && (
         <button
-          aria-label={`Clear ${filter.props.label} filter`}
+          aria-label={t("table.filter.clear", "Clear {{label}} filter", {
+            label: filter.props.label ?? "",
+          })}
           className="inline-flex size-lt-control-md shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg disabled:opacity-50"
           disabled={processing}
           onClick={() => onChange(undefined)}
@@ -80,6 +88,7 @@ function SchemaControl({
   schema,
   value,
   processing,
+  bare,
   onChange,
   onSearch,
 }: {
@@ -87,6 +96,7 @@ function SchemaControl({
   schema: Node[];
   value: unknown;
   processing: boolean;
+  bare: boolean;
   onChange: (value: unknown) => void;
   onSearch?: FilterOptionSearch;
 }) {
@@ -113,18 +123,22 @@ function SchemaControl({
     [filter.key, onSearch, processing],
   );
 
+  const content = (
+    <div
+      aria-disabled={processing}
+      className={cn("grid gap-3", processing && "pointer-events-none opacity-60")}
+    >
+      <Renderer nodes={schema} />
+    </div>
+  );
+
   return (
     <FormProvider value={form}>
       <PrefillProvider value={{ markUserEdit: () => {} }}>
         <ResolvedNodesProvider nodes={{}}>
           <FormValuesProvider initial={initial}>
             <TableFilterCommitBridge onChange={onChange}>
-              <div
-                aria-disabled={processing}
-                className={cn("grid gap-3", processing && "pointer-events-none opacity-60")}
-              >
-                <Renderer nodes={schema} />
-              </div>
+              {bare ? <TableCellProvider>{content}</TableCellProvider> : content}
             </TableFilterCommitBridge>
           </FormValuesProvider>
         </ResolvedNodesProvider>

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -15,7 +15,7 @@ import {
   useFormValues,
   useSetFormValue,
 } from "@lattice-php/lattice/form/embed";
-import { Icon } from "@lattice-php/lattice/icons";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 import { useT } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { filterValue, isActiveFilterValue } from "@lattice-php/lattice/table/lib/filter-values";
@@ -67,17 +67,15 @@ export function TableFilterControl({
         />
       </div>
       {isActiveFilterValue(value) && (
-        <button
-          aria-label={t("table.filter.clear", "Clear {{label}} filter", {
+        <IconButton
+          size="md"
+          icon="x"
+          label={t("table.filter.clear", "Clear {{label}} filter", {
             label: filter.props.label ?? "",
           })}
-          className="inline-flex size-lt-control-md shrink-0 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg disabled:opacity-50"
           disabled={processing}
           onClick={() => onChange(undefined)}
-          type="button"
-        >
-          <Icon name="x" aria-hidden="true" className="size-lt-icon-md" />
-        </button>
+        />
       )}
     </div>
   );

--- a/resources/js/table/components/filter-value-input.tsx
+++ b/resources/js/table/components/filter-value-input.tsx
@@ -1,10 +1,11 @@
 import { Icon } from "@lattice-php/lattice/icons";
 import { useEffect, useState } from "react";
-import { controlSurface } from "@lattice-php/lattice/ui/control";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
+import { Input } from "@lattice-php/lattice/ui/input";
+import { NativeSelect } from "@lattice-php/lattice/ui/native-select";
+import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { FilterType } from "@lattice-php/lattice/types/generated";
-
-export const fieldClass = controlSurface({ density: "compact" });
 
 export function FilterValueInput({
   type,
@@ -40,10 +41,11 @@ export function FilterValueInput({
 
   if (type === "boolean") {
     return (
-      <select
+      <NativeSelect
+        density="compact"
         aria-label={inputLabel}
         data-test={testId}
-        className={`${fieldClass} ${groupedClass}`}
+        className={groupedClass}
         disabled={processing}
         value={value}
         onChange={(event) => onCommit(event.target.value)}
@@ -51,17 +53,18 @@ export function FilterValueInput({
         <option value="">{t("table.filter.all", "All")}</option>
         <option value="true">{t("table.filter.true", "True")}</option>
         <option value="false">{t("table.filter.false", "False")}</option>
-      </select>
+      </NativeSelect>
     );
   }
 
   if (type === "date") {
     return (
-      <input
+      <Input
         type="date"
+        density="compact"
         aria-label={inputLabel}
         data-test={testId}
-        className={`${fieldClass} ${groupedClass}`}
+        className={groupedClass}
         disabled={processing}
         value={draft}
         onChange={(event) => {
@@ -81,11 +84,12 @@ export function FilterValueInput({
           className="pointer-events-none absolute left-2 size-lt-icon-md text-lt-muted-fg"
         />
       )}
-      <input
+      <Input
         type={type === "number" ? "number" : "text"}
+        density="compact"
         aria-label={inputLabel}
         data-test={testId}
-        className={`${fieldClass} ${groupedClass} ${withSearchIcon ? "pl-8" : ""} ${onClear ? "pr-8" : ""}`}
+        className={cn(groupedClass, withSearchIcon && "pl-8", onClear && "pr-8")}
         disabled={processing}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
@@ -101,16 +105,15 @@ export function FilterValueInput({
         }}
       />
       {onClear && draft !== "" && (
-        <button
-          type="button"
-          aria-label={t("table.filter.clear", "Clear {{label}} filter", { label })}
+        <IconButton
+          size="xs"
+          icon="x"
+          label={t("table.filter.clear", "Clear {{label}} filter", { label })}
           data-test={testId ? `${testId}-clear` : undefined}
-          className="absolute right-1 inline-flex size-6 items-center justify-center rounded-lt-sm hover:bg-lt-muted disabled:opacity-50"
+          className="absolute right-1 size-6"
           disabled={processing}
           onClick={onClear}
-        >
-          <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
-        </button>
+        />
       )}
     </div>
   );

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import { Button } from "@lattice-php/lattice/ui/button";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { PaginationType } from "@lattice-php/lattice/types/generated";
 import type { TablePagination as TablePaginationData } from "@lattice-php/lattice/table/types";
@@ -43,17 +44,16 @@ export function TablePagination({
       {mode === "infinite" ? (
         <div ref={infiniteLoaderRef} className="flex items-center gap-2">
           {pagination.hasMore ? (
-            <button
-              type="button"
+            <Button
+              variant="outline"
               data-test="pagination-load-more"
-              className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
               disabled={processing}
               onClick={onLoadMore}
             >
               {processing
                 ? t("table.pagination.loading", "Loading...")
                 : t("table.pagination.loadMore", "Load more")}
-            </button>
+            </Button>
           ) : (
             <span className="text-lt-muted-fg">
               {t("table.pagination.allLoaded", "All rows loaded")}
@@ -62,59 +62,55 @@ export function TablePagination({
         </div>
       ) : mode === "simple" ? (
         <div className="flex items-center gap-2">
-          <button
-            type="button"
+          <Button
+            variant="outline"
             data-test="pagination-previous"
-            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || currentPage <= 1}
             onClick={() => onPage(currentPage - 1)}
           >
             {t("table.pagination.previous", "Previous")}
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="outline"
             data-test="pagination-next"
-            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || !hasNextPage}
             onClick={() => onPage(currentPage + 1)}
           >
             {t("table.pagination.next", "Next")}
-          </button>
+          </Button>
         </div>
       ) : mode === "table" ? (
         <div className="flex items-center gap-2">
-          <button
-            type="button"
+          <Button
+            variant="outline"
             data-test="pagination-previous"
-            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || currentPage <= 1}
             onClick={() => onPage(currentPage - 1)}
           >
             {t("table.pagination.previous", "Previous")}
-          </button>
+          </Button>
           {visiblePages.map((pageNumber) => (
-            <button
+            <Button
               key={pageNumber}
-              type="button"
+              variant="outline"
+              size="icon"
               data-test={`pagination-page-${pageNumber}`}
-              className="inline-flex size-lt-control-md items-center justify-center rounded-lt-sm border border-lt-border font-medium disabled:opacity-50"
               disabled={processing || pageNumber === currentPage}
               aria-current={pageNumber === currentPage ? "page" : undefined}
               aria-label={t("table.pagination.page", "Page {{page}}", { page: pageNumber })}
               onClick={() => onPage(pageNumber)}
             >
               {pageNumber}
-            </button>
+            </Button>
           ))}
-          <button
-            type="button"
+          <Button
+            variant="outline"
             data-test="pagination-next"
-            className="h-lt-control-md rounded-lt-sm border border-lt-border px-3 font-medium disabled:opacity-50"
             disabled={processing || !hasNextPage}
             onClick={() => onPage(currentPage + 1)}
           >
             {t("table.pagination.next", "Next")}
-          </button>
+          </Button>
         </div>
       ) : null}
     </div>

--- a/resources/js/table/components/sort-bar.tsx
+++ b/resources/js/table/components/sort-bar.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@lattice-php/lattice/icons";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 import { getSortDirectionLabel } from "@lattice-php/lattice/table/lib/query";
 import type { TableColumn, TableSort, TableQuery } from "@lattice-php/lattice/table/types";
 
@@ -30,16 +31,14 @@ export function SortBar({
               aria-label={getSortDirectionLabel(sort.direction)}
               className="size-lt-icon-sm text-lt-muted-fg"
             />
-            <button
-              type="button"
-              className="inline-flex size-5 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted disabled:opacity-50"
-              disabled={processing}
-              aria-label={`Clear ${label} sort`}
+            <IconButton
+              size="xs"
+              icon="x"
+              label={`Clear ${label} sort`}
               data-test={`clear-${sort.key}-sort`}
+              disabled={processing}
               onClick={() => onClear(sort)}
-            >
-              <Icon name="x" className="size-lt-icon-sm" />
-            </button>
+            />
           </span>
         );
       })}

--- a/resources/js/table/components/table-search.tsx
+++ b/resources/js/table/components/table-search.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "@lattice-php/lattice/icons";
+import { IconButton } from "@lattice-php/lattice/ui/icon-button";
 import { Input } from "@lattice-php/lattice/ui/input";
 import { useT } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
@@ -82,15 +83,14 @@ export function TableSearch({
         className={cn("px-8", "[&::-webkit-search-cancel-button]:hidden")}
       />
       {term !== "" && (
-        <button
-          type="button"
+        <IconButton
+          size="xs"
+          icon="x"
+          label={t("table.search.clear", "Clear search")}
           data-test="table-search-clear"
-          aria-label={t("table.search.clear", "Clear search")}
+          className="absolute right-1.5 top-1/2 -translate-y-1/2"
           onClick={clear}
-          className="absolute right-1.5 top-1/2 inline-flex size-5 -translate-y-1/2 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg"
-        >
-          <Icon name="x" aria-hidden="true" className="size-lt-icon-sm" />
-        </button>
+        />
       )}
     </div>
   );

--- a/resources/js/ui/button.tsx
+++ b/resources/js/ui/button.tsx
@@ -3,7 +3,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "@lattice-php/lattice/lib/utils";
-import { IconRenderer } from "@lattice-php/lattice/icons";
+import { Icon, IconRenderer } from "@lattice-php/lattice/icons";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { ActionTrigger, type TriggerState, useClickBehavior } from "./click-behavior";
@@ -49,19 +49,34 @@ function Button({
   variant,
   size,
   asChild = false,
+  icon,
+  children,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
+    /** Leading icon glyph. Ignored with `asChild` (Slot needs a single child). */
+    icon?: string;
   }) {
   const Comp = asChild ? Slot : "button";
+  const content =
+    icon && !asChild ? (
+      <>
+        <Icon name={icon} aria-hidden="true" />
+        {children}
+      </>
+    ) : (
+      children
+    );
 
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
-    />
+    >
+      {content}
+    </Comp>
   );
 }
 

--- a/resources/js/ui/control-extensions.test.tsx
+++ b/resources/js/ui/control-extensions.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "./button";
+import { Input } from "./input";
+import { NativeSelect } from "./native-select";
+
+describe("Input density", () => {
+  it("wears compact chrome when asked and comfortable by default", () => {
+    const { rerender } = render(<Input aria-label="q" density="compact" />);
+    expect(screen.getByLabelText("q")).toHaveClass("text-sm");
+
+    rerender(<Input aria-label="q" />);
+    expect(screen.getByLabelText("q")).toHaveClass("text-base");
+  });
+});
+
+describe("NativeSelect", () => {
+  it("renders a styled native select with its options", () => {
+    render(
+      <NativeSelect aria-label="op" density="compact">
+        <option value="a">A</option>
+        <option value="b">B</option>
+      </NativeSelect>,
+    );
+
+    const select = screen.getByRole("combobox", { name: "op" });
+    expect(select.tagName).toBe("SELECT");
+    expect(select).toHaveClass("text-sm");
+    expect(screen.getByRole("option", { name: "A" })).toBeInTheDocument();
+  });
+});
+
+describe("Button icon prop", () => {
+  it("renders a leading icon glyph next to the label", () => {
+    const { container } = render(<Button icon="save">Save</Button>);
+
+    expect(screen.getByRole("button", { name: /Save/ })).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});

--- a/resources/js/ui/icon-button.test.tsx
+++ b/resources/js/ui/icon-button.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IconButton } from "./icon-button";
+
+describe("IconButton", () => {
+  it("renders an accessible icon button and forwards clicks", () => {
+    const onClick = vi.fn();
+    render(<IconButton icon="x" label="Clear" onClick={onClick} />);
+
+    const button = screen.getByRole("button", { name: "Clear" });
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(button).toHaveAttribute("type", "button");
+  });
+
+  it("defaults to the sm ghost variant and resizes via size", () => {
+    const { rerender } = render(<IconButton icon="x" label="A" />);
+    expect(screen.getByRole("button", { name: "A" })).toHaveClass("size-7");
+
+    rerender(<IconButton icon="x" label="A" size="xs" />);
+    expect(screen.getByRole("button", { name: "A" })).toHaveClass("size-5");
+
+    rerender(<IconButton icon="x" label="A" size="md" />);
+    expect(screen.getByRole("button", { name: "A" })).toHaveClass("size-lt-control-md");
+  });
+
+  it("reflects toggle state through aria-pressed", () => {
+    const { rerender } = render(<IconButton icon="star" label="Bold" active={false} />);
+    expect(screen.getByRole("button", { name: "Bold" })).toHaveAttribute("aria-pressed", "false");
+
+    rerender(<IconButton icon="star" label="Bold" active />);
+    expect(screen.getByRole("button", { name: "Bold" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("omits aria-pressed for non-toggle buttons and renders overlay children", () => {
+    render(
+      <IconButton icon="filter" label="Filters">
+        <span>2</span>
+      </IconButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Filters" });
+    expect(button).not.toHaveAttribute("aria-pressed");
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+});

--- a/resources/js/ui/icon-button.tsx
+++ b/resources/js/ui/icon-button.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Icon } from "@lattice-php/lattice/icons";
+import { cn } from "@lattice-php/lattice/lib/utils";
+
+/**
+ * A compact, resizable icon button — the shared affordance behind toolbar
+ * triggers, popover triggers, and inline clear/remove buttons. `ghost` matches
+ * `Button variant="ghost"` (accent hover) and reacts to `aria-pressed` (toggle)
+ * and `data-[state=open]` (a popover trigger). `segmented` joins onto the right
+ * of an adjacent input. Size defaults to `sm`; pass `size` to resize.
+ */
+const iconButtonVariants = cva(
+  cn(
+    "relative inline-flex shrink-0 items-center justify-center rounded-lt-sm transition-colors",
+    "outline-none focus-visible:ring-2 focus-visible:ring-lt-ring/50",
+    "disabled:pointer-events-none disabled:opacity-50",
+  ),
+  {
+    variants: {
+      variant: {
+        ghost: cn(
+          "text-lt-muted-fg hover:bg-lt-accent hover:text-lt-accent-fg",
+          "data-[state=open]:bg-lt-accent data-[state=open]:text-lt-accent-fg",
+          "aria-pressed:bg-lt-accent aria-pressed:text-lt-accent-fg",
+        ),
+        segmented: cn(
+          "-ml-px rounded-l-none border border-lt-input text-lt-muted-fg hover:bg-lt-accent hover:text-lt-accent-fg",
+          "data-[state=open]:z-10 data-[state=open]:border-lt-primary data-[state=open]:text-lt-fg",
+        ),
+      },
+      size: {
+        xs: "size-5 [&_svg]:size-lt-icon-sm",
+        sm: "size-7 [&_svg]:size-lt-icon-md",
+        md: "size-lt-control-md [&_svg]:size-lt-icon-md",
+      },
+    },
+    defaultVariants: { variant: "ghost", size: "sm" },
+  },
+);
+
+export function IconButton({
+  icon,
+  label,
+  active,
+  size,
+  variant,
+  className,
+  children,
+  ref,
+  ...props
+}: Omit<React.ComponentProps<"button">, "aria-pressed"> &
+  VariantProps<typeof iconButtonVariants> & {
+    /** Icon glyph name; omit and pass `children` for custom content. */
+    icon?: string;
+    /** Accessible name (also used when the button shows only an icon). */
+    label: string;
+    /** Toggle state — sets `aria-pressed` and the pressed styling. */
+    active?: boolean;
+  }) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      className={cn(iconButtonVariants({ variant, size }), className)}
+      {...props}
+    >
+      {icon ? <Icon name={icon} aria-hidden="true" /> : null}
+      {children}
+    </button>
+  );
+}
+
+export { iconButtonVariants };

--- a/resources/js/ui/image-preview.tsx
+++ b/resources/js/ui/image-preview.tsx
@@ -1,5 +1,4 @@
 import { useT } from "@lattice-php/lattice/i18n";
-import { Icon } from "@lattice-php/lattice/icons";
 import { type ReactNode, useState } from "react";
 import { Button } from "@lattice-php/lattice/ui/button";
 import { Dialog, DialogClose, DialogContent, DialogTitle } from "./dialog";
@@ -68,14 +67,13 @@ export function PreviewableImage({
           />
           <DialogClose asChild>
             <Button
+              icon="x"
               aria-label={t("common.close", "Close")}
               data-test="lightbox-close"
               size="icon"
               variant="ghost"
               className="absolute top-2 right-2 bg-lt-bg/80 hover:bg-lt-bg"
-            >
-              <Icon name="x" aria-hidden="true" className="size-lt-icon-md" />
-            </Button>
+            />
           </DialogClose>
         </DialogContent>
       </Dialog>

--- a/resources/js/ui/input.tsx
+++ b/resources/js/ui/input.tsx
@@ -1,15 +1,21 @@
 import * as React from "react";
+import type { VariantProps } from "class-variance-authority";
 
 import { controlSurface } from "@lattice-php/lattice/ui/control";
 import { cn } from "@lattice-php/lattice/lib/utils";
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+function Input({
+  className,
+  type,
+  density,
+  ...props
+}: React.ComponentProps<"input"> & VariantProps<typeof controlSurface>) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        controlSurface(),
+        controlSurface({ density }),
         "file:text-lt-fg selection:bg-lt-primary selection:text-lt-primary-fg file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium",
         className,
       )}

--- a/resources/js/ui/native-select.tsx
+++ b/resources/js/ui/native-select.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import type { VariantProps } from "class-variance-authority";
+
+import { controlSurface } from "@lattice-php/lattice/ui/control";
+import { cn } from "@lattice-php/lattice/lib/utils";
+
+/**
+ * A native `<select>` wearing the shared control chrome — for short, fixed
+ * option lists (filter operators, boolean/ternary states) where the full
+ * Combobox is overkill. `density` matches {@link Input}; defaults to comfortable.
+ */
+function NativeSelect({
+  className,
+  density,
+  children,
+  ref,
+  ...props
+}: React.ComponentProps<"select"> & VariantProps<typeof controlSurface>) {
+  return (
+    <select
+      ref={ref}
+      data-slot="native-select"
+      className={cn(controlSurface({ density }), "cursor-pointer", className)}
+      {...props}
+    >
+      {children}
+    </select>
+  );
+}
+
+export { NativeSelect };


### PR DESCRIPTION
Answers the dogfooding audit: the UI hand-rolled the same raw controls in ~14 places. This adds the missing primitives and reuses them.

> Stacked on #277 (both touch the table filter files); rebased cleanly once #277 merges.

## New / extended primitives
- **`IconButton`** (`ui/icon-button.tsx`) — the compact icon affordance behind toolbar/popover triggers and inline clear/remove buttons. Resizable (`xs`/`sm`/`md`), ghost hover unified with `Button variant="ghost"` (accent), `active`→`aria-pressed` for toggles, `data-[state=open]` for popover triggers, plus a `segmented` variant for the input+filter pair. Generalizes the editor's private `ToolbarIconButton`.
- **`NativeSelect`** (`ui/native-select.tsx`) — a `<select>` in the shared control chrome for short fixed lists (filter operators, boolean states).
- **`Input` gains `density`** (`comfortable`|`compact`) → compact table controls reuse the component instead of calling `controlSurface` directly (kills the only direct-call site).
- **React `Button` gains an `icon` prop** for icon-only/leading-icon buttons.

## Reuse (behavior, test-ids, aria preserved)
- Table filters: `FilterMenu`/`ColumnVisibilityMenu` triggers, `FilterChip` remove, filter clear, operator/boolean selects, add-filter, remove-clause, the segmented popover trigger, filter text/number/date inputs.
- Table chrome: **pagination's 6 buttons → `Button`** — they now get the design-system focus ring + hover they were missing (a11y fix); sort-bar + table-search clears → `IconButton`.
- Beyond tables: the rich-editor `ToolbarIconButton` now wraps `IconButton`; file-upload remove → `IconButton`; the lightbox close uses the new `Button icon` prop.

## Tests
Unit tests for `IconButton` (resize, aria-pressed, overlay children) and the Input-density / NativeSelect / Button-icon extensions. Full gate green: typecheck, lint, **1078 vitest**, library build, and **33 browser tests** (filters, pagination, column visibility, lightbox, rich editor, file upload) with no regressions.

## Left as justified hand-rolls
Native `<select>`s now go through `NativeSelect`; the `CopyButton` chip (bespoke compact text+icon), the table reset-columns overlay, and the checkbox-wrapping labels stay as-is (no clean primitive fit). Missed-translation fixes are a separate slice.