### PR TITLE
feat(ui): Tree view component (hierarchies, expand/collapse, keyboard a11y)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -99,6 +99,7 @@ export default defineConfig({
             { label: "Tooltip", link: "/components/tooltip/" },
             { label: "Progress", link: "/components/progress/" },
             { label: "Charts", link: "/components/charts/" },
+            { label: "Tree", link: "/components/tree/" },
             { label: "Notifications", link: "/components/notifications/" },
           ],
         },

--- a/docs/content/docs/components/overview.mdx
+++ b/docs/content/docs/components/overview.mdx
@@ -28,18 +28,19 @@ serialized **Tree** the renderer receives, and the theme **Style** tokens it use
 
 ## Catalog
 
-| Component                                      | Purpose                                                             | Page                                                      |
-| ---------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------- |
-| `Stack`, `Grid`, `Card`                        | Arrange children — vertical/horizontal, columns, bordered panels    | [Layout](/components/layout/)                             |
-| `Section`, `Collapsible`                       | Titled and untitled disclosures that fold open and closed           | [Section & Collapsible](/components/section-collapsible/) |
-| `FloatingPanel`                                | Pin children to a viewport corner                                   | [Floating panel](/components/floating-panel/)             |
-| `Heading`, `Text`, `Badge`, `Icon`, `RawBlock` | Display primitives — headings, prose, pills, sprite icons, raw HTML | [Text & badges](/components/text/)                        |
-| `Button`, `Link`, `SegmentedControl`           | Buttons, navigational links, and standalone segmented controls      | [Buttons & links](/components/buttons/)                   |
-| `Tabs`, `Tab`                                  | A tab strip with URL-synced, lazily rendered panels                 | [Tabs](/components/tabs/)                                 |
-| `Modal`                                        | A dialog opened and closed by action effects                        | [Modals](/components/modals/)                             |
-| `Tooltip`                                      | An ⓘ info popover you can place anywhere                            | [Tooltip](/components/tooltip/)                           |
-| `Chart`                                        | Line, bar, area, and pie charts                                     | [Charts](/components/charts/)                             |
-| `Notifications`                                | A bell listing a user's database notifications, realtime + polling  | [Notifications](/components/notifications/)               |
+| Component                                      | Purpose                                                               | Page                                                      |
+| ---------------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------- |
+| `Stack`, `Grid`, `Card`                        | Arrange children — vertical/horizontal, columns, bordered panels      | [Layout](/components/layout/)                             |
+| `Section`, `Collapsible`                       | Titled and untitled disclosures that fold open and closed             | [Section & Collapsible](/components/section-collapsible/) |
+| `FloatingPanel`                                | Pin children to a viewport corner                                     | [Floating panel](/components/floating-panel/)             |
+| `Heading`, `Text`, `Badge`, `Icon`, `RawBlock` | Display primitives — headings, prose, pills, sprite icons, raw HTML   | [Text & badges](/components/text/)                        |
+| `Button`, `Link`, `SegmentedControl`           | Buttons, navigational links, and standalone segmented controls        | [Buttons & links](/components/buttons/)                   |
+| `Tabs`, `Tab`                                  | A tab strip with URL-synced, lazily rendered panels                   | [Tabs](/components/tabs/)                                 |
+| `Modal`                                        | A dialog opened and closed by action effects                          | [Modals](/components/modals/)                             |
+| `Tooltip`                                      | An ⓘ info popover you can place anywhere                              | [Tooltip](/components/tooltip/)                           |
+| `Chart`                                        | Line, bar, area, and pie charts                                       | [Charts](/components/charts/)                             |
+| `Tree`                                         | A keyboard-navigable hierarchy with icons, badges, links, and actions | [Tree](/components/tree/)                                 |
+| `Notifications`                                | A bell listing a user's database notifications, realtime + polling    | [Notifications](/components/notifications/)               |
 
 ## Where components appear
 

--- a/docs/content/docs/components/tree.mdx
+++ b/docs/content/docs/components/tree.mdx
@@ -47,7 +47,7 @@ siblings.
   — both normalize through the same builder.
 - **`->hasChildren(bool $hasChildren = true)`** — marks a node as expandable without children attached
   yet. A [`TreeSource`](#data-sources) sets it per row so `Tree` knows which nodes to fetch children
-  for, and `Tree` sets it on nodes truncated at the `eagerDepth` boundary (below).
+  for.
 - **`->disabled(bool $disabled = true)`** — grays the row out and blocks its link and activation.
 
 ## Tree
@@ -57,11 +57,6 @@ siblings.
 - **`->source(TreeSource $source)`** — a [data source](#data-sources) for nodes that live elsewhere.
 - **`->activeId($id)`** — marks a node selected (`aria-selected`); nothing is selected by default.
 - **`->defaultExpanded([$id, ...])`** — ids expanded on first render.
-- **`->eagerDepth($depth)`** — nodes at or beyond this depth serialize as a truncation boundary:
-  their children are dropped and `hasChildren` is set instead, so a very deep hierarchy only ships
-  the top slice. Rows beyond the boundary cannot be expanded yet — lazy loading is a planned
-  follow-up — so lower the default (`50`, effectively unlimited) only to cap what an unbounded
-  source ships.
 - **`->rememberState(bool $remember = true)`** — persists the expanded set across reloads, keyed by
   the tree's identity, the same pattern as [`Collapsible`](/components/section-collapsible/#collapsible).
 
@@ -69,9 +64,10 @@ siblings.
 
 Every node ultimately comes from a `TreeSource` — `roots(): iterable<TreeNode>` and
 `children(string $parentId): iterable<TreeNode>`. `Tree` walks the source eagerly at render time:
-`roots()` first, then `children()` for every `hasChildren` row down to `eagerDepth`. `->nodes([...])`
-is the array-backed source; for a database-backed hierarchy, use `EloquentTreeSource` against a
-self-referencing parent column:
+`roots()` first, then `children()` for every `hasChildren` row. Serialization depth is capped at 50
+purely as a safety bound against cyclic adjacency data; lazy loading is the planned path for
+genuinely deep hierarchies. `->nodes([...])` is the array-backed source; for a database-backed
+hierarchy, use `EloquentTreeSource` against a self-referencing parent column:
 
 ```php
 use Illuminate\Database\Eloquent\Builder;

--- a/docs/content/docs/components/tree.mdx
+++ b/docs/content/docs/components/tree.mdx
@@ -46,8 +46,8 @@ siblings.
 - **`->children([...])`** — nested `TreeNode`s, or plain arrays shaped like `['id' => ..., 'label' => ...]`
   — both normalize through the same builder.
 - **`->hasChildren(bool $hasChildren = true)`** — marks a node as expandable without children attached
-  yet. `Tree` sets this for you at the `eagerDepth` boundary (below) and a [`TreeSource`](#data-sources)
-  sets it per row so a folder with unloaded children still shows a chevron.
+  yet. A [`TreeSource`](#data-sources) sets it per row so `Tree` knows which nodes to fetch children
+  for, and `Tree` sets it on nodes truncated at the `eagerDepth` boundary (below).
 - **`->disabled(bool $disabled = true)`** — grays the row out and blocks its link and activation.
 
 ## Tree
@@ -57,17 +57,21 @@ siblings.
 - **`->source(TreeSource $source)`** — a [data source](#data-sources) for nodes that live elsewhere.
 - **`->activeId($id)`** — marks a node selected (`aria-selected`); nothing is selected by default.
 - **`->defaultExpanded([$id, ...])`** — ids expanded on first render.
-- **`->eagerDepth($depth)`** — nodes at or beyond this depth serialize as a lazy boundary: their
-  children are dropped and `hasChildren` is set instead, so a very deep hierarchy only ships the
-  visible slice. The default (`50`) is effectively unlimited for realistic hierarchies.
+- **`->eagerDepth($depth)`** — nodes at or beyond this depth serialize as a truncation boundary:
+  their children are dropped and `hasChildren` is set instead, so a very deep hierarchy only ships
+  the top slice. Rows beyond the boundary cannot be expanded yet — lazy loading is a planned
+  follow-up — so lower the default (`50`, effectively unlimited) only to cap what an unbounded
+  source ships.
 - **`->rememberState(bool $remember = true)`** — persists the expanded set across reloads, keyed by
   the tree's identity, the same pattern as [`Collapsible`](/components/section-collapsible/#collapsible).
 
 ## Data sources
 
 Every node ultimately comes from a `TreeSource` — `roots(): iterable<TreeNode>` and
-`children(string $parentId): iterable<TreeNode>`. `->nodes([...])` is the array-backed source; for a
-database-backed hierarchy, use `EloquentTreeSource` against a self-referencing parent column:
+`children(string $parentId): iterable<TreeNode>`. `Tree` walks the source eagerly at render time:
+`roots()` first, then `children()` for every `hasChildren` row down to `eagerDepth`. `->nodes([...])`
+is the array-backed source; for a database-backed hierarchy, use `EloquentTreeSource` against a
+self-referencing parent column:
 
 ```php
 use Illuminate\Database\Eloquent\Builder;
@@ -103,6 +107,7 @@ one row sits in the tab order at a time — arrow keys move focus without touchi
 - **ArrowRight** — expands a collapsed node, or moves into its first child when already expanded.
 - **ArrowLeft** — collapses an expanded node, or moves focus to its parent.
 - **Home / End** — jump to the first or last visible row.
-- **Enter / Space** — activates the focused node: follows its `href`, or marks it active.
+- **Enter / Space** — activates the focused node: follows its `href`, triggers its attached action,
+  or marks it active.
 - **Typing a letter** — jumps to the next visible row whose label starts with what's typed, wrapping
   around the tree. Keep typing to extend the match; a short pause starts a new search.

--- a/docs/content/docs/components/tree.mdx
+++ b/docs/content/docs/components/tree.mdx
@@ -1,0 +1,108 @@
+---
+title: Tree
+description: A keyboard-navigable hierarchy — expandable nodes with icons, badges, links, and actions, backed by an eager array or a data source.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
+
+`Tree::make()` renders a hierarchy of `TreeNode` rows the user can expand, collapse, and navigate with
+the keyboard. Feed it a `->nodes([...])` array for a hierarchy you already have in hand, or hand it a
+`->source(...)` for one that lives in a database.
+
+<ComponentExample
+  php={`Tree::make('category-tree')
+    ->nodes([
+        TreeNode::make('Electronics', 'electronics')
+            ->icon('cpu')
+            ->children([
+                TreeNode::make('Laptops', 'electronics-laptops'),
+                TreeNode::make('Phones', 'electronics-phones')->href('/products/phones'),
+            ]),
+        TreeNode::make('Clothing', 'clothing')
+            ->badge('New')
+            ->children([
+                TreeNode::make('Men', 'clothing-men'),
+                TreeNode::make('Women', 'clothing-women'),
+            ]),
+    ])
+    ->activeId('electronics-phones')
+    ->defaultExpanded(['electronics']);`}
+  fixture="components.tree"
+/>
+
+## TreeNode
+
+`TreeNode::make($label, $id)` builds one row. `$id` is a stable identifier — it drives `activeId`,
+`defaultExpanded`, and keyboard focus, so keep it unique across the whole tree, not just among
+siblings.
+
+- **`->icon($name)`** — a sprite icon before the label (see [Icons](/core/icons/)).
+- **`->badge($text)`** — a small pill after the label.
+- **`->href($url)`** — turns the label into a link. Clicking it, or activating the focused node with
+  Enter, navigates through Inertia's client-side router.
+- **`->action(Action $action)`** / **`->actions(ActionGroup $group)`** — attaches a single
+  [action](/actions/overview/) or a grouped action menu at the end of the row.
+- **`->children([...])`** — nested `TreeNode`s, or plain arrays shaped like `['id' => ..., 'label' => ...]`
+  — both normalize through the same builder.
+- **`->hasChildren(bool $hasChildren = true)`** — marks a node as expandable without children attached
+  yet. `Tree` sets this for you at the `eagerDepth` boundary (below) and a [`TreeSource`](#data-sources)
+  sets it per row so a folder with unloaded children still shows a chevron.
+- **`->disabled(bool $disabled = true)`** — grays the row out and blocks its link and activation.
+
+## Tree
+
+- **`->nodes([...])`** — an eager array of `TreeNode`s. Internally this wraps the array in a
+  `CallbackTreeSource`, so it's the same mechanism as `->source()` with the roots already in hand.
+- **`->source(TreeSource $source)`** — a [data source](#data-sources) for nodes that live elsewhere.
+- **`->activeId($id)`** — marks a node selected (`aria-selected`); nothing is selected by default.
+- **`->defaultExpanded([$id, ...])`** — ids expanded on first render.
+- **`->eagerDepth($depth)`** — nodes at or beyond this depth serialize as a lazy boundary: their
+  children are dropped and `hasChildren` is set instead, so a very deep hierarchy only ships the
+  visible slice. The default (`50`) is effectively unlimited for realistic hierarchies.
+- **`->rememberState(bool $remember = true)`** — persists the expanded set across reloads, keyed by
+  the tree's identity, the same pattern as [`Collapsible`](/components/section-collapsible/#collapsible).
+
+## Data sources
+
+Every node ultimately comes from a `TreeSource` — `roots(): iterable<TreeNode>` and
+`children(string $parentId): iterable<TreeNode>`. `->nodes([...])` is the array-backed source; for a
+database-backed hierarchy, use `EloquentTreeSource` against a self-referencing parent column:
+
+```php
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Ui\Components\Tree;
+use Lattice\Lattice\Ui\Sources\EloquentTreeSource;
+
+Tree::make('categories')
+    ->source(
+        EloquentTreeSource::make(Category::class)
+            ->label('title')
+            ->parent('parent_category_id')
+            ->scope(fn (Builder $query) => $query->where('team_id', $this->team->id)),
+    );
+```
+
+- **`label($column)`** — the column shown as the node label (default `name`).
+- **`parent($column)`** — the self-referencing foreign key column (default `parent_id`).
+- **`scope($callback)`** — constrains the query; applied to roots, children, and the `hasChildren`
+  check alike, so a scoped-out row never renders an expand chevron for hidden children.
+
+<Info>
+  Implement the `TreeSource` contract directly for any other backing store — the same shape
+  [`TableSource`](/tables/data-sources/) uses for tables.
+</Info>
+
+## Keyboard & accessibility
+
+The tree renders `role="tree"` with `role="treeitem"` rows carrying `aria-level`, `aria-posinset`,
+`aria-setsize`, `aria-expanded` on expandable nodes, and `aria-selected` on the active node. Exactly
+one row sits in the tab order at a time — arrow keys move focus without touching Tab:
+
+- **ArrowDown / ArrowUp** — move to the next or previous visible row, skipping collapsed subtrees.
+- **ArrowRight** — expands a collapsed node, or moves into its first child when already expanded.
+- **ArrowLeft** — collapses an expanded node, or moves focus to its parent.
+- **Home / End** — jump to the first or last visible row.
+- **Enter / Space** — activates the focused node: follows its `href`, or marks it active.
+- **Typing a letter** — jumps to the next visible row whose label starts with what's typed, wrapping
+  around the tree. Keep typing to extend the match; a short pause starts a new search.

--- a/docs/fixtures/components.tree.json
+++ b/docs/fixtures/components.tree.json
@@ -1,0 +1,46 @@
+[
+    {
+        "key": "category-tree",
+        "props": {
+            "activeId": "electronics-phones",
+            "defaultExpanded": [
+                "electronics"
+            ],
+            "nodes": [
+                {
+                    "children": [
+                        {
+                            "id": "electronics-laptops",
+                            "label": "Laptops"
+                        },
+                        {
+                            "href": "/products/phones",
+                            "id": "electronics-phones",
+                            "label": "Phones"
+                        }
+                    ],
+                    "icon": "cpu",
+                    "id": "electronics",
+                    "label": "Electronics"
+                },
+                {
+                    "badge": "New",
+                    "children": [
+                        {
+                            "id": "clothing-men",
+                            "label": "Men"
+                        },
+                        {
+                            "id": "clothing-women",
+                            "label": "Women"
+                        }
+                    ],
+                    "id": "clothing",
+                    "label": "Clothing"
+                }
+            ],
+            "rememberState": false
+        },
+        "type": "tree"
+    }
+]

--- a/lang/de/common.php
+++ b/lang/de/common.php
@@ -22,6 +22,10 @@ return [
     'action-group' => [
         'label' => 'Aktionen',
     ],
+    'tree' => [
+        'expand' => ':label ausklappen',
+        'collapse' => ':label einklappen',
+    ],
     'chat' => [
         'launcher' => 'Chat',
         'title' => 'Chat',

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -22,6 +22,10 @@ return [
     'action-group' => [
         'label' => 'Actions',
     ],
+    'tree' => [
+        'expand' => 'Expand :label',
+        'collapse' => 'Collapse :label',
+    ],
     'chat' => [
         'launcher' => 'Chat',
         'title' => 'Chat',

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1369,6 +1369,17 @@ export type Translatable = {
   replacements: Record<string, string | number | boolean>;
   key: string;
 };
+export type TreeNode = {
+  icon: string | null;
+  badge: string | null;
+  href: string | null;
+  actions: Node<"action"> | Node<"action.group"> | null;
+  children: TreeNode[];
+  hasChildren: boolean;
+  disabled: boolean;
+  readonly label: string;
+  readonly id: string;
+};
 export type UnreadCount = {
   readonly unreadCount: number;
 };

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -341,6 +341,7 @@ export type ComponentPropsMap = {
   text: Text;
   tooltip: Tooltip;
   topbar: Topbar;
+  tree: Tree;
 };
 export type Condition = {
   readonly field: string;
@@ -812,7 +813,8 @@ export type NodeType =
   | "tabs"
   | "text"
   | "tooltip"
-  | "topbar";
+  | "topbar"
+  | "tree";
 export type NotificationItem = {
   readonly id: string;
   readonly title: string | null;
@@ -1368,6 +1370,11 @@ export type Translatable = {
   payload: Record<string, string>;
   replacements: Record<string, string | number | boolean>;
   key: string;
+};
+export type Tree = {
+  activeId: string | null;
+  defaultExpanded: string[];
+  rememberState: boolean;
 };
 export type TreeNode = {
   icon: string | null;

--- a/resources/js/ui/modal.tsx
+++ b/resources/js/ui/modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Dialog, DialogContent, DialogHeader } from "@lattice-php/lattice/ui/dialog";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
@@ -18,6 +18,8 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
   const description = node.props.description;
   const closeLabel = node.props.closeLabel;
   const [isOpen, setIsOpen] = useState(node.props.open === true);
+  const openerRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(isOpen);
 
   // Honour server-driven open changes across re-renders, not just on mount. One
   // way on purpose: closing stays user/closeModal-driven so it never fights a
@@ -31,6 +33,8 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
   useEffect(() => {
     function open(event: Event): void {
       if (node.id && matchesModal(event, node.id)) {
+        openerRef.current =
+          document.activeElement instanceof HTMLElement ? document.activeElement : null;
         setIsOpen(true);
       }
     }
@@ -49,6 +53,22 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
       window.removeEventListener(LATTICE_EVENT.closeModal, close);
     };
   }, [node.id]);
+
+  // Radix only restores focus to a `DialogTrigger`-registered element, and this
+  // modal is opened imperatively rather than through one. Own the restore
+  // ourselves instead: whatever had focus when the modal opened gets it back
+  // once the closing dialog has finished unmounting.
+  useEffect(() => {
+    if (wasOpenRef.current && !isOpen) {
+      const opener = openerRef.current;
+
+      if (opener) {
+        requestAnimationFrame(() => opener.focus());
+      }
+    }
+
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>

--- a/resources/js/ui/plugin.ts
+++ b/resources/js/ui/plugin.ts
@@ -32,6 +32,7 @@ import StackComponent from "./stack";
 import TabComponent, { TabsComponent } from "./tabs";
 import TextComponent from "./text";
 import TooltipComponent from "./tooltip";
+import TreeComponent from "./tree";
 
 type NonUiComponentType =
   | ActionNodeType
@@ -70,6 +71,7 @@ export const uiComponents = createPlugin({
     tabs: eagerComponent(TabsComponent),
     text: eagerComponent(TextComponent),
     tooltip: eagerComponent(TooltipComponent),
+    tree: eagerComponent(TreeComponent),
   } satisfies ComponentRegistryFor<UiComponentType>,
   name: "lattice/ui",
 });

--- a/resources/js/ui/tree-context.tsx
+++ b/resources/js/ui/tree-context.tsx
@@ -4,6 +4,7 @@ import type { RefObject } from "react";
 export type TreeItemRegistration = {
   id: string;
   label: string;
+  orderPath: string;
   parentPath: string | null;
   path: string;
   ref: RefObject<HTMLLIElement | null>;
@@ -66,9 +67,7 @@ function readStoredExpanded(key: string, remember: boolean, fallback: string[]):
 }
 
 function visibleOrder(registry: Map<string, TreeItemRegistration>): TreeItemRegistration[] {
-  return [...registry.values()].sort((a, b) =>
-    a.path.localeCompare(b.path, undefined, { numeric: true }),
-  );
+  return [...registry.values()].sort((a, b) => a.orderPath.localeCompare(b.orderPath));
 }
 
 const TYPEAHEAD_IDLE_MS = 800;

--- a/resources/js/ui/tree-context.tsx
+++ b/resources/js/ui/tree-context.tsx
@@ -1,0 +1,96 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+export type TreeContextValue = {
+  activeId: string | null;
+  expanded: Set<string>;
+  focus: (id: string) => void;
+  focusedId: string | null;
+  register: (id: string) => void;
+  toggle: (id: string) => void;
+  unregister: (id: string) => void;
+};
+
+const defaultTreeContext: TreeContextValue = {
+  activeId: null,
+  expanded: new Set(),
+  focus: () => {},
+  focusedId: null,
+  register: () => {},
+  toggle: () => {},
+  unregister: () => {},
+};
+
+export const TreeContext = createContext<TreeContextValue>(defaultTreeContext);
+
+export function useTreeContext(): TreeContextValue {
+  return useContext(TreeContext);
+}
+
+function readStoredExpanded(key: string, remember: boolean, fallback: string[]): Set<string> {
+  if (!remember || typeof window === "undefined") {
+    return new Set(fallback);
+  }
+
+  const stored = window.localStorage.getItem(key);
+
+  if (stored === null) {
+    return new Set(fallback);
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(stored);
+
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((id): id is string => typeof id === "string"))
+      : new Set(fallback);
+  } catch {
+    return new Set(fallback);
+  }
+}
+
+export function useTreeState({
+  activeId,
+  defaultExpanded,
+  rememberState,
+  storageKey,
+}: {
+  activeId: string | null;
+  defaultExpanded: string[];
+  rememberState: boolean;
+  storageKey: string;
+}): TreeContextValue {
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    readStoredExpanded(storageKey, rememberState, defaultExpanded),
+  );
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+
+  const toggle = useCallback(
+    (id: string) => {
+      setExpanded((current) => {
+        const next = new Set(current);
+
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+
+        if (rememberState && typeof window !== "undefined") {
+          window.localStorage.setItem(storageKey, JSON.stringify([...next]));
+        }
+
+        return next;
+      });
+    },
+    [rememberState, storageKey],
+  );
+
+  const focus = useCallback((id: string) => setFocusedId(id), []);
+  const register = useCallback((): void => {}, []);
+  const unregister = useCallback((): void => {}, []);
+
+  return useMemo(
+    () => ({ activeId, expanded, focus, focusedId, register, toggle, unregister }),
+    [activeId, expanded, focus, focusedId, register, toggle, unregister],
+  );
+}

--- a/resources/js/ui/tree-context.tsx
+++ b/resources/js/ui/tree-context.tsx
@@ -1,22 +1,39 @@
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+export type TreeItemRegistration = {
+  id: string;
+  label: string;
+  parentPath: string | null;
+  path: string;
+  ref: RefObject<HTMLLIElement | null>;
+};
+
+export type TreeFocusDirection = "first" | "firstChild" | "last" | "next" | "parent" | "prev";
 
 export type TreeContextValue = {
+  activate: (id: string) => void;
   activeId: string | null;
   expanded: Set<string>;
   focus: (id: string) => void;
   focusedId: string | null;
-  register: (id: string) => void;
+  moveFocus: (fromId: string, direction: TreeFocusDirection) => void;
+  register: (entry: TreeItemRegistration) => void;
   toggle: (id: string) => void;
-  unregister: (id: string) => void;
+  typeAhead: (fromId: string, character: string) => void;
+  unregister: (path: string) => void;
 };
 
 const defaultTreeContext: TreeContextValue = {
+  activate: () => {},
   activeId: null,
   expanded: new Set(),
   focus: () => {},
   focusedId: null,
+  moveFocus: () => {},
   register: () => {},
   toggle: () => {},
+  typeAhead: () => {},
   unregister: () => {},
 };
 
@@ -48,21 +65,34 @@ function readStoredExpanded(key: string, remember: boolean, fallback: string[]):
   }
 }
 
+function visibleOrder(registry: Map<string, TreeItemRegistration>): TreeItemRegistration[] {
+  return [...registry.values()].sort((a, b) =>
+    a.path.localeCompare(b.path, undefined, { numeric: true }),
+  );
+}
+
+const TYPEAHEAD_IDLE_MS = 800;
+
 export function useTreeState({
-  activeId,
+  activeId: initialActiveId,
   defaultExpanded,
+  nodes,
   rememberState,
   storageKey,
 }: {
   activeId: string | null;
   defaultExpanded: string[];
+  nodes: Array<{ id: string }>;
   rememberState: boolean;
   storageKey: string;
 }): TreeContextValue {
   const [expanded, setExpanded] = useState<Set<string>>(() =>
     readStoredExpanded(storageKey, rememberState, defaultExpanded),
   );
-  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(initialActiveId);
+  const [focusedId, setFocusedId] = useState<string | null>(() => nodes[0]?.id ?? null);
+  const registryRef = useRef<Map<string, TreeItemRegistration>>(new Map());
+  const typeAheadRef = useRef<{ text: string; timestamp: number }>({ text: "", timestamp: 0 });
 
   const toggle = useCallback(
     (id: string) => {
@@ -85,12 +115,116 @@ export function useTreeState({
     [rememberState, storageKey],
   );
 
-  const focus = useCallback((id: string) => setFocusedId(id), []);
-  const register = useCallback((): void => {}, []);
-  const unregister = useCallback((): void => {}, []);
+  const activate = useCallback((id: string) => setActiveId(id), []);
+
+  const focus = useCallback((id: string) => {
+    setFocusedId(id);
+    const entry = [...registryRef.current.values()].find((candidate) => candidate.id === id);
+    entry?.ref.current?.focus();
+  }, []);
+
+  const register = useCallback((entry: TreeItemRegistration) => {
+    registryRef.current.set(entry.path, entry);
+  }, []);
+
+  const unregister = useCallback((path: string) => {
+    registryRef.current.delete(path);
+  }, []);
+
+  const moveFocus = useCallback(
+    (fromId: string, direction: TreeFocusDirection) => {
+      const order = visibleOrder(registryRef.current);
+
+      if (order.length === 0) {
+        return;
+      }
+
+      const index = order.findIndex((entry) => entry.id === fromId);
+      const current = index === -1 ? undefined : order[index];
+
+      let target: TreeItemRegistration | undefined;
+
+      switch (direction) {
+        case "next":
+          target = index === -1 ? undefined : order[index + 1];
+          break;
+        case "prev":
+          target = index === -1 ? undefined : order[index - 1];
+          break;
+        case "first":
+          target = order[0];
+          break;
+        case "last":
+          target = order[order.length - 1];
+          break;
+        case "parent":
+          target = current ? order.find((entry) => entry.path === current.parentPath) : undefined;
+          break;
+        case "firstChild":
+          target = current ? order.find((entry) => entry.parentPath === current.path) : undefined;
+          break;
+      }
+
+      if (target) {
+        focus(target.id);
+      }
+    },
+    [focus],
+  );
+
+  const typeAhead = useCallback(
+    (fromId: string, character: string) => {
+      const order = visibleOrder(registryRef.current);
+
+      if (order.length === 0) {
+        return;
+      }
+
+      const now = Date.now();
+      const buffer = typeAheadRef.current;
+      const text = now - buffer.timestamp > TYPEAHEAD_IDLE_MS ? character : buffer.text + character;
+      typeAheadRef.current = { text, timestamp: now };
+
+      const needle = text.toLowerCase();
+      const startIndex = order.findIndex((entry) => entry.id === fromId);
+      const start = startIndex === -1 ? 0 : startIndex;
+
+      for (let offset = 1; offset <= order.length; offset++) {
+        const candidate = order[(start + offset) % order.length];
+
+        if (candidate.label.toLowerCase().startsWith(needle)) {
+          focus(candidate.id);
+          return;
+        }
+      }
+    },
+    [focus],
+  );
 
   return useMemo(
-    () => ({ activeId, expanded, focus, focusedId, register, toggle, unregister }),
-    [activeId, expanded, focus, focusedId, register, toggle, unregister],
+    () => ({
+      activate,
+      activeId,
+      expanded,
+      focus,
+      focusedId,
+      moveFocus,
+      register,
+      toggle,
+      typeAhead,
+      unregister,
+    }),
+    [
+      activate,
+      activeId,
+      expanded,
+      focus,
+      focusedId,
+      moveFocus,
+      register,
+      toggle,
+      typeAhead,
+      unregister,
+    ],
   );
 }

--- a/resources/js/ui/tree-keyboard.test.tsx
+++ b/resources/js/ui/tree-keyboard.test.tsx
@@ -1,0 +1,243 @@
+import { act, configure, fireEvent, getConfig, screen } from "@testing-library/react";
+import { router } from "@inertiajs/react";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import TreeComponent, { type TreeNodeData } from "./tree";
+
+vi.mock("@inertiajs/react", () => ({
+  router: { visit: vi.fn<(url: string, options?: unknown) => void>() },
+  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
+}));
+
+const registry = createRegistry({
+  components: {
+    tree: eagerComponent(TreeComponent),
+  },
+  name: "test/tree-keyboard",
+});
+
+let previousTestIdAttribute: string;
+
+beforeAll(() => {
+  previousTestIdAttribute = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+
+afterAll(() => {
+  configure({ testIdAttribute: previousTestIdAttribute });
+});
+
+beforeEach(() => {
+  vi.mocked(router.visit).mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderTree(props: Record<string, unknown>, id = "t1") {
+  const node = fakeNode({
+    id,
+    props: { defaultExpanded: [], rememberState: false, ...props },
+    type: "tree",
+  });
+
+  return renderWithRegistry(<TreeComponent node={node}>{null}</TreeComponent>, registry);
+}
+
+const nodes: TreeNodeData[] = [
+  {
+    children: [
+      { href: "/c/2", id: "2", label: "Laptops" },
+      { id: "3", label: "Phones" },
+    ],
+    id: "1",
+    label: "Electronics",
+  },
+  { hasChildren: true, id: "9", label: "Suppliers" },
+];
+
+function item(id: string): HTMLElement {
+  return screen.getByTestId(`tree-node-${id}`);
+}
+
+describe("Tree keyboard navigation", () => {
+  it("focuses the first root by default with a single roving tabindex", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(item("1")).toHaveAttribute("tabindex", "0");
+    expect(item("2")).toHaveAttribute("tabindex", "-1");
+    expect(item("3")).toHaveAttribute("tabindex", "-1");
+    expect(item("9")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("moves focus down and up across visible nodes, skipping collapsed subtrees", () => {
+    renderTree({ defaultExpanded: [], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("9")).toHaveFocus();
+    expect(item("9")).toHaveAttribute("tabindex", "0");
+    expect(item("1")).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.keyDown(item("9"), { key: "ArrowUp" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("does not double-move focus when a keydown bubbles from a nested treeitem", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "ArrowDown" });
+    expect(item("3")).toHaveFocus();
+  });
+
+  it("expands a collapsed parent with ArrowRight, then descends into the first child", () => {
+    renderTree({ defaultExpanded: [], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowRight" });
+    expect(screen.getByText("Laptops")).toBeVisible();
+    expect(item("1")).toHaveFocus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowRight" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "ArrowRight" });
+    expect(item("2")).toHaveFocus();
+  });
+
+  it("collapses an expanded parent with ArrowLeft, then moves focus to the parent", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "ArrowLeft" });
+    expect(item("1")).toHaveFocus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowLeft" });
+    expect(screen.queryByText("Laptops")).not.toBeInTheDocument();
+    expect(item("1")).toHaveFocus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowLeft" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("jumps to the first and last visible node with Home and End", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "End" });
+    expect(item("9")).toHaveFocus();
+
+    fireEvent.keyDown(item("9"), { key: "Home" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("type-ahead focuses the next visible node whose label starts with the typed text", () => {
+    vi.useFakeTimers();
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "p" });
+    expect(item("3")).toHaveFocus();
+
+    act(() => vi.advanceTimersByTime(2000));
+
+    fireEvent.keyDown(item("3"), { key: "s" });
+    expect(item("9")).toHaveFocus();
+  });
+
+  it("accumulates type-ahead characters within the idle window and resets after it elapses", () => {
+    vi.useFakeTimers();
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "l" });
+    fireEvent.keyDown(item("2"), { key: "a" });
+    expect(item("2")).toHaveFocus();
+
+    act(() => vi.advanceTimersByTime(2000));
+
+    fireEvent.keyDown(item("2"), { key: "s" });
+    expect(item("9")).toHaveFocus();
+  });
+
+  it("sets aria-level, aria-setsize and aria-posinset", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(item("1")).toHaveAttribute("aria-level", "1");
+    expect(item("1")).toHaveAttribute("aria-setsize", "2");
+    expect(item("1")).toHaveAttribute("aria-posinset", "1");
+
+    expect(item("9")).toHaveAttribute("aria-level", "1");
+    expect(item("9")).toHaveAttribute("aria-setsize", "2");
+    expect(item("9")).toHaveAttribute("aria-posinset", "2");
+
+    expect(item("2")).toHaveAttribute("aria-level", "2");
+    expect(item("2")).toHaveAttribute("aria-setsize", "2");
+    expect(item("2")).toHaveAttribute("aria-posinset", "1");
+
+    expect(item("3")).toHaveAttribute("aria-level", "2");
+    expect(item("3")).toHaveAttribute("aria-setsize", "2");
+    expect(item("3")).toHaveAttribute("aria-posinset", "2");
+  });
+
+  it("puts aria-expanded on the treeitem instead of the chevron, and leaves leaves without it", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(item("1")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("tree-node-1-toggle")).not.toHaveAttribute("aria-expanded");
+    expect(item("3")).not.toHaveAttribute("aria-expanded");
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+    expect(item("1")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("gives the chevron toggle an accessible name that reflects its state", () => {
+    renderTree({ defaultExpanded: [], nodes });
+
+    expect(screen.getByTestId("tree-node-1-toggle")).toHaveAttribute(
+      "aria-label",
+      "Expand Electronics",
+    );
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+
+    expect(screen.getByTestId("tree-node-1-toggle")).toHaveAttribute(
+      "aria-label",
+      "Collapse Electronics",
+    );
+  });
+
+  it("activates the focused node on Enter by following its href", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "Enter" });
+    expect(router.visit).toHaveBeenCalledWith("/c/2");
+  });
+
+  it("activates the focused node on Space by marking it active when it has no href", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    fireEvent.keyDown(item("2"), { key: "ArrowDown" });
+    expect(item("3")).toHaveFocus();
+
+    fireEvent.keyDown(item("3"), { key: " " });
+    expect(item("3")).toHaveAttribute("aria-selected", "true");
+    expect(router.visit).not.toHaveBeenCalled();
+  });
+});

--- a/resources/js/ui/tree-keyboard.test.tsx
+++ b/resources/js/ui/tree-keyboard.test.tsx
@@ -4,6 +4,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
 import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import { fakeNode } from "@lattice-php/lattice/test-support";
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import TreeComponent, { type TreeNodeData } from "./tree";
 
 vi.mock("@inertiajs/react", () => ({
@@ -11,8 +12,16 @@ vi.mock("@inertiajs/react", () => ({
   Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
 }));
 
+const actionClicks: string[] = [];
+const TestAction: RendererComponent = ({ node }) => (
+  <button onClick={() => actionClicks.push(String(node.props?.label ?? ""))} type="button">
+    {String(node.props?.label ?? "")}
+  </button>
+);
+
 const registry = createRegistry({
   components: {
+    "test.action": eagerComponent(TestAction),
     tree: eagerComponent(TreeComponent),
   },
   name: "test/tree-keyboard",
@@ -31,6 +40,7 @@ afterAll(() => {
 
 beforeEach(() => {
   vi.mocked(router.visit).mockClear();
+  actionClicks.length = 0;
 });
 
 afterEach(() => {
@@ -267,5 +277,73 @@ describe("Tree keyboard navigation", () => {
     fireEvent.keyDown(item("3"), { key: " " });
     expect(item("3")).toHaveAttribute("aria-selected", "true");
     expect(router.visit).not.toHaveBeenCalled();
+  });
+
+  it("excludes a node's action control from the page tab order", () => {
+    const actionNodes: TreeNodeData[] = [
+      {
+        actions: { props: { label: "Delete" }, type: "test.action" },
+        id: "5",
+        label: "Accessories",
+      },
+    ] as unknown as TreeNodeData[];
+
+    renderTree({ nodes: actionNodes });
+
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("triggers the focused node's action control on Enter when it has no href", () => {
+    const actionNodes: TreeNodeData[] = [
+      {
+        actions: { props: { label: "Delete" }, type: "test.action" },
+        id: "5",
+        label: "Accessories",
+      },
+    ] as unknown as TreeNodeData[];
+
+    renderTree({ nodes: actionNodes });
+    item("5").focus();
+
+    fireEvent.keyDown(item("5"), { key: "Enter" });
+
+    expect(actionClicks).toEqual(["Delete"]);
+    expect(router.visit).not.toHaveBeenCalled();
+  });
+
+  it("triggers the focused node's action control on Space when it has no href", () => {
+    const actionNodes: TreeNodeData[] = [
+      {
+        actions: { props: { label: "Delete" }, type: "test.action" },
+        id: "5",
+        label: "Accessories",
+      },
+    ] as unknown as TreeNodeData[];
+
+    renderTree({ nodes: actionNodes });
+    item("5").focus();
+
+    fireEvent.keyDown(item("5"), { key: " " });
+
+    expect(actionClicks).toEqual(["Delete"]);
+  });
+
+  it("prefers href over an action when both are present", () => {
+    const hrefAndActionNodes: TreeNodeData[] = [
+      {
+        actions: { props: { label: "Delete" }, type: "test.action" },
+        href: "/c/5",
+        id: "5",
+        label: "Accessories",
+      },
+    ] as unknown as TreeNodeData[];
+
+    renderTree({ nodes: hrefAndActionNodes });
+    item("5").focus();
+
+    fireEvent.keyDown(item("5"), { key: "Enter" });
+
+    expect(router.visit).toHaveBeenCalledWith("/c/5");
+    expect(actionClicks).toEqual([]);
   });
 });

--- a/resources/js/ui/tree-keyboard.test.tsx
+++ b/resources/js/ui/tree-keyboard.test.tsx
@@ -63,6 +63,18 @@ function item(id: string): HTMLElement {
   return screen.getByTestId(`tree-node-${id}`);
 }
 
+const outOfOrderNodes: TreeNodeData[] = [
+  {
+    children: [
+      { id: "20", label: "Second Child" },
+      { id: "10", label: "First Child" },
+    ],
+    id: "9",
+    label: "First Root",
+  },
+  { id: "1", label: "Second Root" },
+];
+
 describe("Tree keyboard navigation", () => {
   it("focuses the first root by default with a single roving tabindex", () => {
     renderTree({ defaultExpanded: ["1"], nodes });
@@ -84,6 +96,22 @@ describe("Tree keyboard navigation", () => {
 
     fireEvent.keyDown(item("9"), { key: "ArrowUp" });
     expect(item("1")).toHaveFocus();
+  });
+
+  it("moves focus by authored position even when sibling ids are not in ascending order", () => {
+    renderTree({ defaultExpanded: [], nodes: outOfOrderNodes });
+    item("9").focus();
+
+    fireEvent.keyDown(item("9"), { key: "ArrowDown" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("descends to the first authored child even when child ids are not in ascending order", () => {
+    renderTree({ defaultExpanded: ["9"], nodes: outOfOrderNodes });
+    item("9").focus();
+
+    fireEvent.keyDown(item("9"), { key: "ArrowRight" });
+    expect(item("20")).toHaveFocus();
   });
 
   it("does not double-move focus when a keydown bubbles from a nested treeitem", () => {

--- a/resources/js/ui/tree.test.tsx
+++ b/resources/js/ui/tree.test.tsx
@@ -1,0 +1,129 @@
+import { configure, fireEvent, getConfig, screen } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import { fakeNode } from "@lattice-php/lattice/test-support";
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import TreeComponent, { type TreeNodeData } from "./tree";
+
+const TestAction: RendererComponent = ({ node }) => (
+  <button type="button">{String(node.props?.label ?? "")}</button>
+);
+
+const registry = createRegistry({
+  components: {
+    "test.action": eagerComponent(TestAction),
+    tree: eagerComponent(TreeComponent),
+  },
+  name: "test/tree",
+});
+
+let previousTestIdAttribute: string;
+
+beforeAll(() => {
+  previousTestIdAttribute = getConfig().testIdAttribute;
+  configure({ testIdAttribute: "data-test" });
+});
+
+afterAll(() => {
+  configure({ testIdAttribute: previousTestIdAttribute });
+});
+
+function renderTree(props: Record<string, unknown>, id = "t1") {
+  const node = fakeNode({
+    id,
+    props: { defaultExpanded: [], rememberState: false, ...props },
+    type: "tree",
+  });
+
+  return renderWithRegistry(<TreeComponent node={node}>{null}</TreeComponent>, registry);
+}
+
+const nodes: TreeNodeData[] = [
+  {
+    children: [
+      { href: "/c/2", id: "2", label: "Laptops" },
+      { id: "3", label: "Phones" },
+    ],
+    id: "1",
+    label: "Electronics",
+  },
+  { hasChildren: true, id: "9", label: "Suppliers" },
+];
+
+describe("Tree component", () => {
+  it("renders roots and toggles a subtree via the chevron", () => {
+    renderTree({ defaultExpanded: [], nodes });
+
+    expect(screen.getByText("Electronics")).toBeVisible();
+    expect(screen.queryByText("Laptops")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+
+    expect(screen.getByText("Laptops")).toBeVisible();
+  });
+
+  it("shows a chevron for a lazy boundary and none for a leaf", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(screen.getByTestId("tree-node-9-toggle")).toBeInTheDocument();
+    expect(screen.queryByTestId("tree-node-3-toggle")).not.toBeInTheDocument();
+  });
+
+  it("marks the active node aria-selected", () => {
+    renderTree({ activeId: "3", defaultExpanded: ["1"], nodes });
+
+    expect(screen.getByTestId("tree-node-3")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("renders an href label as a link", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(screen.getByRole("link", { name: "Laptops" })).toHaveAttribute("href", "/c/2");
+  });
+
+  it("marks a disabled node aria-disabled and renders its label as plain text", () => {
+    const disabledNodes: TreeNodeData[] = [
+      { disabled: true, href: "/c/4", id: "4", label: "Tablets" },
+    ];
+
+    renderTree({ nodes: disabledNodes });
+
+    expect(screen.getByTestId("tree-node-4")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.queryByRole("link", { name: "Tablets" })).not.toBeInTheDocument();
+  });
+
+  it("renders trailing actions for a node", () => {
+    const actionNodes = [
+      {
+        actions: { props: { label: "Delete" }, type: "test.action" },
+        id: "5",
+        label: "Accessories",
+      },
+    ] as unknown as TreeNodeData[];
+
+    renderTree({ nodes: actionNodes });
+
+    expect(screen.getByRole("button", { name: "Delete" })).toBeVisible();
+  });
+
+  it("persists expanded ids when rememberState is set", () => {
+    window.localStorage.clear();
+
+    renderTree({ nodes, rememberState: true }, "remember-tree");
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+
+    expect(window.localStorage.getItem("lattice:tree:remember-tree")).toBe('["1"]');
+    window.localStorage.clear();
+  });
+
+  it("restores the persisted expanded ids", () => {
+    window.localStorage.setItem("lattice:tree:remember-tree", JSON.stringify(["1"]));
+
+    renderTree({ nodes, rememberState: true }, "remember-tree");
+
+    expect(screen.getByText("Laptops")).toBeVisible();
+    window.localStorage.clear();
+  });
+});

--- a/resources/js/ui/tree.tsx
+++ b/resources/js/ui/tree.tsx
@@ -1,0 +1,115 @@
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { Icon, IconRenderer } from "@lattice-php/lattice/icons";
+import { cn } from "@lattice-php/lattice/lib/utils";
+import type {
+  Tree as TreeProps,
+  TreeNode as GeneratedTreeNode,
+} from "@lattice-php/lattice/types/generated";
+import { Badge } from "./badge";
+import { TextLink } from "./link";
+import { TreeContext, useTreeContext, useTreeState } from "./tree-context";
+
+/**
+ * The actual sparse wire shape a tree node serializes as (see `TreeNode::jsonSerialize()`):
+ * every optional/falsy field is omitted rather than sent as `null`/`false`, unlike the
+ * generated `TreeNode`, which reflects every declared PHP property as required.
+ */
+export type TreeNodeData = Pick<GeneratedTreeNode, "id" | "label"> &
+  Partial<Omit<GeneratedTreeNode, "children" | "id" | "label">> & {
+    children?: TreeNodeData[];
+  };
+
+declare module "@lattice-php/lattice/core/types" {
+  interface ComponentProps {
+    tree: TreeProps & { nodes: TreeNodeData[] };
+  }
+}
+
+function hasExpandableChildren(node: TreeNodeData): boolean {
+  return Boolean(node.children?.length) || node.hasChildren === true;
+}
+
+function TreeItem({ node }: { node: TreeNodeData }) {
+  const { activeId, expanded, toggle } = useTreeContext();
+  const isExpanded = expanded.has(node.id);
+  const isActive = activeId === node.id;
+  const isDisabled = node.disabled === true;
+  const expandable = hasExpandableChildren(node);
+
+  return (
+    <li
+      aria-disabled={isDisabled}
+      aria-selected={isActive}
+      data-test={`tree-node-${node.id}`}
+      role="treeitem"
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-lt-sm px-2 py-1.5 text-sm text-lt-fg",
+          isActive && "bg-lt-muted font-medium",
+          isDisabled && "pointer-events-none opacity-50",
+        )}
+      >
+        {expandable ? (
+          <button
+            aria-expanded={isExpanded}
+            data-test={`tree-node-${node.id}-toggle`}
+            onClick={() => toggle(node.id)}
+            type="button"
+          >
+            <Icon
+              className={cn(
+                "size-lt-icon-md shrink-0 transition-transform",
+                isExpanded && "rotate-90",
+              )}
+              name="chevron-right"
+            />
+          </button>
+        ) : null}
+        {node.icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={node.icon} /> : null}
+        {node.href && !isDisabled ? (
+          <TextLink href={node.href}>{node.label}</TextLink>
+        ) : (
+          <span>{node.label}</span>
+        )}
+        {node.badge ? <Badge variant="secondary">{node.badge}</Badge> : null}
+        {node.actions ? (
+          <span className="ml-auto">
+            <Renderer nodes={[node.actions]} />
+          </span>
+        ) : null}
+      </div>
+      {expandable && isExpanded && node.children && node.children.length > 0 ? (
+        <ul className="pl-6" role="group">
+          {node.children.map((child) => (
+            <TreeItem key={child.id} node={child} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+const TreeComponent: RendererComponent<"tree"> = ({ node }) => {
+  const identity = nodeIdentity(node);
+  const value = useTreeState({
+    activeId: node.props.activeId,
+    defaultExpanded: node.props.defaultExpanded,
+    rememberState: node.props.rememberState,
+    storageKey: `lattice:tree:${identity ?? "default"}`,
+  });
+
+  return (
+    <TreeContext.Provider value={value}>
+      <ul data-lattice-component={identity} role="tree">
+        {node.props.nodes.map((child) => (
+          <TreeItem key={child.id} node={child} />
+        ))}
+      </ul>
+    </TreeContext.Provider>
+  );
+};
+
+export default TreeComponent;

--- a/resources/js/ui/tree.tsx
+++ b/resources/js/ui/tree.tsx
@@ -1,8 +1,12 @@
+import { router } from "@inertiajs/react";
+import { useEffect, useRef } from "react";
+import type { KeyboardEvent } from "react";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { Icon, IconRenderer } from "@lattice-php/lattice/icons";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { useT } from "@lattice-php/lattice/i18n";
 import type {
   Tree as TreeProps,
   TreeNode as GeneratedTreeNode,
@@ -31,19 +35,115 @@ function hasExpandableChildren(node: TreeNodeData): boolean {
   return Boolean(node.children?.length) || node.hasChildren === true;
 }
 
-function TreeItem({ node }: { node: TreeNodeData }) {
-  const { activeId, expanded, toggle } = useTreeContext();
+function TreeItem({
+  depth,
+  node,
+  parentPath,
+  siblingCount,
+  siblingIndex,
+}: {
+  depth: number;
+  node: TreeNodeData;
+  parentPath: string | null;
+  siblingCount: number;
+  siblingIndex: number;
+}) {
+  const {
+    activate,
+    activeId,
+    expanded,
+    focusedId,
+    moveFocus,
+    register,
+    toggle,
+    typeAhead,
+    unregister,
+  } = useTreeContext();
+  const { t } = useT("lattice");
+  const ref = useRef<HTMLLIElement>(null);
+  const path = parentPath ? `${parentPath}/${node.id}` : node.id;
   const isExpanded = expanded.has(node.id);
   const isActive = activeId === node.id;
+  const isFocused = focusedId === node.id;
   const isDisabled = node.disabled === true;
   const expandable = hasExpandableChildren(node);
+
+  useEffect(() => {
+    register({ id: node.id, label: node.label, parentPath, path, ref });
+
+    return () => unregister(path);
+  }, [node.id, node.label, parentPath, path, register, unregister]);
+
+  function onKeyDown(event: KeyboardEvent<HTMLLIElement>): void {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveFocus(node.id, "next");
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        moveFocus(node.id, "prev");
+        return;
+      case "ArrowRight":
+        event.preventDefault();
+        if (expandable && !isExpanded) {
+          toggle(node.id);
+        } else if (expandable) {
+          moveFocus(node.id, "firstChild");
+        }
+        return;
+      case "ArrowLeft":
+        event.preventDefault();
+        if (expandable && isExpanded) {
+          toggle(node.id);
+        } else {
+          moveFocus(node.id, "parent");
+        }
+        return;
+      case "Home":
+        event.preventDefault();
+        moveFocus(node.id, "first");
+        return;
+      case "End":
+        event.preventDefault();
+        moveFocus(node.id, "last");
+        return;
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        if (isDisabled) {
+          return;
+        }
+        if (node.href) {
+          router.visit(node.href);
+        } else {
+          activate(node.id);
+        }
+        return;
+      default:
+        if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+          typeAhead(node.id, event.key);
+        }
+    }
+  }
 
   return (
     <li
       aria-disabled={isDisabled}
+      aria-expanded={expandable ? isExpanded : undefined}
+      aria-level={depth}
+      aria-posinset={siblingIndex}
       aria-selected={isActive}
+      aria-setsize={siblingCount}
       data-test={`tree-node-${node.id}`}
+      onKeyDown={onKeyDown}
+      ref={ref}
       role="treeitem"
+      tabIndex={isFocused ? 0 : -1}
     >
       <div
         className={cn(
@@ -54,9 +154,14 @@ function TreeItem({ node }: { node: TreeNodeData }) {
       >
         {expandable ? (
           <button
-            aria-expanded={isExpanded}
+            aria-label={
+              isExpanded
+                ? t("common.tree.collapse", "Collapse {{label}}", { label: node.label })
+                : t("common.tree.expand", "Expand {{label}}", { label: node.label })
+            }
             data-test={`tree-node-${node.id}-toggle`}
             onClick={() => toggle(node.id)}
+            tabIndex={-1}
             type="button"
           >
             <Icon
@@ -70,7 +175,9 @@ function TreeItem({ node }: { node: TreeNodeData }) {
         ) : null}
         {node.icon ? <IconRenderer className="size-lt-icon-md shrink-0" icon={node.icon} /> : null}
         {node.href && !isDisabled ? (
-          <TextLink href={node.href}>{node.label}</TextLink>
+          <TextLink href={node.href} tabIndex={-1}>
+            {node.label}
+          </TextLink>
         ) : (
           <span>{node.label}</span>
         )}
@@ -83,8 +190,15 @@ function TreeItem({ node }: { node: TreeNodeData }) {
       </div>
       {expandable && isExpanded && node.children && node.children.length > 0 ? (
         <ul className="pl-6" role="group">
-          {node.children.map((child) => (
-            <TreeItem key={child.id} node={child} />
+          {node.children.map((child, index) => (
+            <TreeItem
+              depth={depth + 1}
+              key={child.id}
+              node={child}
+              parentPath={path}
+              siblingCount={node.children?.length ?? 1}
+              siblingIndex={index + 1}
+            />
           ))}
         </ul>
       ) : null}
@@ -97,6 +211,7 @@ const TreeComponent: RendererComponent<"tree"> = ({ node }) => {
   const value = useTreeState({
     activeId: node.props.activeId,
     defaultExpanded: node.props.defaultExpanded,
+    nodes: node.props.nodes,
     rememberState: node.props.rememberState,
     storageKey: `lattice:tree:${identity ?? "default"}`,
   });
@@ -104,8 +219,15 @@ const TreeComponent: RendererComponent<"tree"> = ({ node }) => {
   return (
     <TreeContext.Provider value={value}>
       <ul data-lattice-component={identity} role="tree">
-        {node.props.nodes.map((child) => (
-          <TreeItem key={child.id} node={child} />
+        {node.props.nodes.map((child, index) => (
+          <TreeItem
+            depth={1}
+            key={child.id}
+            node={child}
+            parentPath={null}
+            siblingCount={node.props.nodes.length}
+            siblingIndex={index + 1}
+          />
         ))}
       </ul>
     </TreeContext.Provider>

--- a/resources/js/ui/tree.tsx
+++ b/resources/js/ui/tree.tsx
@@ -75,12 +75,25 @@ function TreeItem({
   const isFocused = focusedId === node.id;
   const isDisabled = node.disabled === true;
   const expandable = hasExpandableChildren(node);
+  const actionsRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
     register({ id: node.id, label: node.label, orderPath, parentPath, path, ref });
 
     return () => unregister(path);
   }, [node.id, node.label, orderPath, parentPath, path, register, unregister]);
+
+  useEffect(() => {
+    const container = actionsRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    container.querySelectorAll<HTMLElement>("button, a[href], [tabindex]").forEach((control) => {
+      control.tabIndex = -1;
+    });
+  });
 
   function onKeyDown(event: KeyboardEvent<HTMLLIElement>): void {
     if (event.target !== event.currentTarget) {
@@ -128,6 +141,9 @@ function TreeItem({
         }
         if (node.href) {
           router.visit(node.href);
+        } else if (node.actions) {
+          actionsRef.current?.querySelector("button")?.click();
+          ref.current?.focus();
         } else {
           activate(node.id);
         }
@@ -191,7 +207,7 @@ function TreeItem({
         )}
         {node.badge ? <Badge variant="secondary">{node.badge}</Badge> : null}
         {node.actions ? (
-          <span className="ml-auto">
+          <span className="ml-auto" ref={actionsRef}>
             <Renderer nodes={[node.actions]} />
           </span>
         ) : null}

--- a/resources/js/ui/tree.tsx
+++ b/resources/js/ui/tree.tsx
@@ -35,15 +35,23 @@ function hasExpandableChildren(node: TreeNodeData): boolean {
   return Boolean(node.children?.length) || node.hasChildren === true;
 }
 
+const ORDER_PATH_SEGMENT_WIDTH = 6;
+
+function orderPathSegment(index: number): string {
+  return String(index).padStart(ORDER_PATH_SEGMENT_WIDTH, "0");
+}
+
 function TreeItem({
   depth,
   node,
+  orderPath,
   parentPath,
   siblingCount,
   siblingIndex,
 }: {
   depth: number;
   node: TreeNodeData;
+  orderPath: string;
   parentPath: string | null;
   siblingCount: number;
   siblingIndex: number;
@@ -69,10 +77,10 @@ function TreeItem({
   const expandable = hasExpandableChildren(node);
 
   useEffect(() => {
-    register({ id: node.id, label: node.label, parentPath, path, ref });
+    register({ id: node.id, label: node.label, orderPath, parentPath, path, ref });
 
     return () => unregister(path);
-  }, [node.id, node.label, parentPath, path, register, unregister]);
+  }, [node.id, node.label, orderPath, parentPath, path, register, unregister]);
 
   function onKeyDown(event: KeyboardEvent<HTMLLIElement>): void {
     if (event.target !== event.currentTarget) {
@@ -195,6 +203,7 @@ function TreeItem({
               depth={depth + 1}
               key={child.id}
               node={child}
+              orderPath={`${orderPath}.${orderPathSegment(index)}`}
               parentPath={path}
               siblingCount={node.children?.length ?? 1}
               siblingIndex={index + 1}
@@ -224,6 +233,7 @@ const TreeComponent: RendererComponent<"tree"> = ({ node }) => {
             depth={1}
             key={child.id}
             node={child}
+            orderPath={orderPathSegment(index)}
             parentPath={null}
             siblingCount={node.props.nodes.length}
             siblingIndex={index + 1}

--- a/src/Ui/Components/Tree.php
+++ b/src/Ui/Components/Tree.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Components;
+
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Ui\Contracts\TreeSource;
+use Lattice\Lattice\Ui\Sources\CallbackTreeSource;
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+#[AsComponent('tree')]
+class Tree extends Component
+{
+    private ?TreeSource $source = null;
+
+    public ?string $activeId = null;
+
+    /** @var list<string> */
+    public array $defaultExpanded = [];
+
+    public bool $rememberState = false;
+
+    protected int $eagerDepth = 50;
+
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+
+    /**
+     * @param  list<TreeNode|array<string, mixed>>  $nodes
+     */
+    public function nodes(array $nodes): static
+    {
+        $expanded = TreeNode::expand($nodes);
+        $this->source = new CallbackTreeSource(roots: static fn (): array => $expanded);
+
+        return $this;
+    }
+
+    public function source(TreeSource $source): static
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function activeId(?string $id): static
+    {
+        $this->activeId = $id;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<string>  $ids
+     */
+    public function defaultExpanded(array $ids): static
+    {
+        $this->defaultExpanded = $ids;
+
+        return $this;
+    }
+
+    public function eagerDepth(int $depth): static
+    {
+        $this->eagerDepth = $depth;
+
+        return $this;
+    }
+
+    public function rememberState(bool $remember = true): static
+    {
+        $this->rememberState = $remember;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 300)]
+    protected function serialiseNodes(array $data): array
+    {
+        $roots = $this->source instanceof TreeSource ? $this->source->roots() : [];
+
+        $data['props']['nodes'] = array_map(
+            fn (TreeNode $node): array => $this->serialiseNode($node, 0),
+            is_array($roots) ? $roots : iterator_to_array($roots),
+        );
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialiseNode(TreeNode $node, int $depth): array
+    {
+        $data = $node->jsonSerialize();
+
+        if (! isset($data['children'])) {
+            return $data;
+        }
+
+        if ($depth >= $this->eagerDepth) {
+            unset($data['children']);
+            $data['hasChildren'] = true;
+
+            return $data;
+        }
+
+        $children = $node->childNodes();
+        $data['children'] = array_map(fn (TreeNode $child): array => $this->serialiseNode($child, $depth + 1), $children);
+
+        return $data;
+    }
+}

--- a/src/Ui/Components/Tree.php
+++ b/src/Ui/Components/Tree.php
@@ -84,11 +84,11 @@ class Tree extends Component
     #[SerializationHook(priority: 300)]
     protected function serialiseNodes(array $data): array
     {
-        $roots = $this->source instanceof TreeSource ? $this->source->roots() : [];
+        $roots = $this->source instanceof TreeSource ? $this->nodeList($this->source->roots()) : [];
 
         $data['props']['nodes'] = array_map(
             fn (TreeNode $node): array => $this->serialiseNode($node, 0),
-            is_array($roots) ? $roots : iterator_to_array($roots),
+            $roots,
         );
 
         return $data;
@@ -99,22 +99,47 @@ class Tree extends Component
      */
     private function serialiseNode(TreeNode $node, int $depth): array
     {
-        $data = $node->jsonSerialize();
-
-        if (! isset($data['children'])) {
-            return $data;
-        }
+        $data = $node->serialiseShallow();
 
         if ($depth >= $this->eagerDepth) {
-            unset($data['children']);
-            $data['hasChildren'] = true;
+            if ($node->children !== []) {
+                $data['hasChildren'] = true;
+            }
 
             return $data;
         }
 
-        $children = $node->childNodes();
-        $data['children'] = array_map(fn (TreeNode $child): array => $this->serialiseNode($child, $depth + 1), $children);
+        $children = $this->resolveChildren($node);
+
+        if ($children !== []) {
+            $data['children'] = array_map(fn (TreeNode $child): array => $this->serialiseNode($child, $depth + 1), $children);
+        }
 
         return $data;
+    }
+
+    /**
+     * @return list<TreeNode>
+     */
+    private function resolveChildren(TreeNode $node): array
+    {
+        if ($node->children !== []) {
+            return $node->children;
+        }
+
+        if ($node->hasChildren && $this->source instanceof TreeSource) {
+            return $this->nodeList($this->source->children($node->id));
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  iterable<int, TreeNode>  $nodes
+     * @return list<TreeNode>
+     */
+    private function nodeList(iterable $nodes): array
+    {
+        return is_array($nodes) ? array_values($nodes) : iterator_to_array($nodes, false);
     }
 }

--- a/src/Ui/Components/Tree.php
+++ b/src/Ui/Components/Tree.php
@@ -21,7 +21,12 @@ class Tree extends Component
 
     public bool $rememberState = false;
 
-    protected int $eagerDepth = 50;
+    /**
+     * Serialization depth cap: the termination guarantee for source-backed
+     * trees whose adjacency data contains a cycle. Not a feature knob — lazy
+     * loading is the planned path for genuinely deep hierarchies.
+     */
+    private const int MAX_DEPTH = 50;
 
     public static function make(?string $key = null): static
     {
@@ -63,13 +68,6 @@ class Tree extends Component
         return $this;
     }
 
-    public function eagerDepth(int $depth): static
-    {
-        $this->eagerDepth = $depth;
-
-        return $this;
-    }
-
     public function rememberState(bool $remember = true): static
     {
         $this->rememberState = $remember;
@@ -101,7 +99,7 @@ class Tree extends Component
     {
         $data = $node->serialiseShallow();
 
-        if ($depth >= $this->eagerDepth) {
+        if ($depth >= self::MAX_DEPTH) {
             if ($node->children !== []) {
                 $data['hasChildren'] = true;
             }

--- a/src/Ui/Contracts/TreeSource.php
+++ b/src/Ui/Contracts/TreeSource.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Contracts;
+
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+/**
+ * Where a tree's nodes come from. Lattice ships a callback and an Eloquent
+ * source; implement this for any other backing store. Keeps the Tree component
+ * free of persistence concerns, mirroring TableSource.
+ */
+interface TreeSource
+{
+    /** @return iterable<int, TreeNode> */
+    public function roots(): iterable;
+
+    /** @return iterable<int, TreeNode> */
+    public function children(string $parentId): iterable;
+}

--- a/src/Ui/Sources/CallbackTreeSource.php
+++ b/src/Ui/Sources/CallbackTreeSource.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Sources;
+
+use Closure;
+use Lattice\Lattice\Ui\Contracts\TreeSource;
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+final readonly class CallbackTreeSource implements TreeSource
+{
+    /**
+     * @param  Closure(): iterable<int, TreeNode>  $roots
+     * @param  (Closure(string): iterable<int, TreeNode>)|null  $children
+     */
+    public function __construct(
+        private Closure $roots,
+        private ?Closure $children = null,
+    ) {}
+
+    public function roots(): iterable
+    {
+        return ($this->roots)();
+    }
+
+    public function children(string $parentId): iterable
+    {
+        return $this->children instanceof Closure ? ($this->children)($parentId) : [];
+    }
+}

--- a/src/Ui/Sources/EloquentTreeSource.php
+++ b/src/Ui/Sources/EloquentTreeSource.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Sources;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Core\EloquentOptions;
+use Lattice\Lattice\Ui\Contracts\TreeSource;
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+/**
+ * A {@see TreeSource} backed by an Eloquent adjacency-list hierarchy (a
+ * self-referencing parent column), mirroring how {@see EloquentOptions}
+ * bridges Eloquent into the option contract.
+ */
+final class EloquentTreeSource implements TreeSource
+{
+    /** @var Closure(Builder<Model>): mixed|null */
+    private ?Closure $scope = null;
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    private function __construct(
+        private readonly string $model,
+        private string $labelKey = 'name',
+        private string $parentKey = 'parent_id',
+    ) {}
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    public static function make(string $model): self
+    {
+        return new self($model);
+    }
+
+    public function label(string $column): self
+    {
+        $this->labelKey = $column;
+
+        return $this;
+    }
+
+    public function parent(string $column): self
+    {
+        $this->parentKey = $column;
+
+        return $this;
+    }
+
+    /**
+     * Constrain the query (e.g. only active rows). Applied to roots, children,
+     * and the hasChildren existence check alike.
+     *
+     * @param  Closure(Builder<Model>): mixed  $scope
+     */
+    public function scope(Closure $scope): self
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function roots(): iterable
+    {
+        return $this->toNodes($this->query()->whereNull($this->parentKey)->orderBy($this->labelKey)->get());
+    }
+
+    public function children(string $parentId): iterable
+    {
+        return $this->toNodes($this->query()->where($this->parentKey, $parentId)->orderBy($this->labelKey)->get());
+    }
+
+    /**
+     * @return Builder<Model>
+     */
+    private function query(): Builder
+    {
+        $builder = $this->model::query();
+
+        if ($this->scope instanceof Closure) {
+            $scoped = ($this->scope)($builder);
+
+            if ($scoped instanceof Builder) {
+                $builder = $scoped;
+            }
+        }
+
+        return $builder;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $models
+     * @return list<TreeNode>
+     */
+    private function toNodes(Collection $models): array
+    {
+        return $models
+            ->map(fn (Model $model): TreeNode => TreeNode::make(
+                (string) $model->getAttribute($this->labelKey),
+                (string) $model->getKey(),
+            )->hasChildren($this->hasChildren($model)))
+            ->values()
+            ->all();
+    }
+
+    private function hasChildren(Model $model): bool
+    {
+        return $this->query()->where($this->parentKey, $model->getKey())->exists();
+    }
+}

--- a/src/Ui/Sources/EloquentTreeSource.php
+++ b/src/Ui/Sources/EloquentTreeSource.php
@@ -99,17 +99,35 @@ final class EloquentTreeSource implements TreeSource
      */
     private function toNodes(Collection $models): array
     {
+        $parentIds = $this->parentIdsAmong($models);
+
         return $models
             ->map(fn (Model $model): TreeNode => TreeNode::make(
                 (string) $model->getAttribute($this->labelKey),
                 (string) $model->getKey(),
-            )->hasChildren($this->hasChildren($model)))
+            )->hasChildren(in_array((string) $model->getKey(), $parentIds, true)))
             ->values()
             ->all();
     }
 
-    private function hasChildren(Model $model): bool
+    /**
+     * The subset of the given models' keys that are referenced as a parent by
+     * at least one (scoped) row — one query instead of an exists() per model.
+     *
+     * @param  Collection<int, Model>  $models
+     * @return list<string>
+     */
+    private function parentIdsAmong(Collection $models): array
     {
-        return $this->query()->where($this->parentKey, $model->getKey())->exists();
+        if ($models->isEmpty()) {
+            return [];
+        }
+
+        return $this->query()
+            ->whereIn($this->parentKey, $models->map(fn (Model $model): mixed => $model->getKey()))
+            ->distinct()
+            ->pluck($this->parentKey)
+            ->map(fn (mixed $id): string => (string) $id)
+            ->all();
     }
 }

--- a/src/Ui/Values/TreeNode.php
+++ b/src/Ui/Values/TreeNode.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Values;
+
+use JsonSerializable;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Components\ActionGroup;
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+final class TreeNode implements JsonSerializable
+{
+    public ?string $icon = null;
+
+    public ?string $badge = null;
+
+    public ?string $href = null;
+
+    public Action|ActionGroup|null $actions = null;
+
+    /** @var list<TreeNode> */
+    public array $children = [];
+
+    public bool $hasChildren = false;
+
+    public bool $disabled = false;
+
+    private function __construct(
+        public readonly string $label,
+        public readonly string $id,
+    ) {}
+
+    public static function make(string $label, string $id): self
+    {
+        return new self($label, $id);
+    }
+
+    public function icon(string $icon): self
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function badge(string $badge): self
+    {
+        $this->badge = $badge;
+
+        return $this;
+    }
+
+    public function href(string $href): self
+    {
+        $this->href = $href;
+
+        return $this;
+    }
+
+    public function action(Action $action): self
+    {
+        $this->actions = $action;
+
+        return $this;
+    }
+
+    public function actions(ActionGroup $group): self
+    {
+        $this->actions = $group;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<TreeNode|array<string, mixed>>  $children
+     */
+    public function children(array $children): self
+    {
+        $this->children = self::expand($children);
+
+        return $this;
+    }
+
+    public function hasChildren(bool $hasChildren = true): self
+    {
+        $this->hasChildren = $hasChildren;
+
+        return $this;
+    }
+
+    public function disabled(bool $disabled = true): self
+    {
+        $this->disabled = $disabled;
+
+        return $this;
+    }
+
+    /**
+     * The eager child nodes (used by Tree for depth-aware serialization).
+     *
+     * @return list<TreeNode>
+     */
+    public function childNodes(): array
+    {
+        return $this->children;
+    }
+
+    /**
+     * @param  list<TreeNode|array<string, mixed>>  $nodes
+     * @return list<TreeNode>
+     */
+    public static function expand(array $nodes): array
+    {
+        return array_map(
+            static fn (TreeNode|array $node): TreeNode => $node instanceof self ? $node : self::fromArray($node),
+            $nodes,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private static function fromArray(array $node): self
+    {
+        $tree = self::make((string) $node['label'], (string) $node['id']);
+
+        foreach (['icon', 'badge', 'href'] as $key) {
+            if (isset($node[$key])) {
+                $tree->{$key} = (string) $node[$key];
+            }
+        }
+
+        if (! empty($node['children'])) {
+            $tree->children($node['children']);
+        }
+
+        if (! empty($node['hasChildren'])) {
+            $tree->hasChildren(true);
+        }
+
+        if (! empty($node['disabled'])) {
+            $tree->disabled(true);
+        }
+
+        return $tree;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = ['id' => $this->id, 'label' => $this->label];
+
+        foreach (['icon' => $this->icon, 'badge' => $this->badge, 'href' => $this->href] as $key => $value) {
+            if ($value !== null) {
+                $data[$key] = $value;
+            }
+        }
+
+        if ($this->disabled) {
+            $data['disabled'] = true;
+        }
+
+        if ($this->hasChildren) {
+            $data['hasChildren'] = true;
+        }
+
+        if ($this->actions !== null) {
+            $data['actions'] = $this->actions->jsonSerialize();
+        }
+
+        if ($this->children !== []) {
+            $data['children'] = array_map(static fn (TreeNode $child): array => $child->jsonSerialize(), $this->children);
+        }
+
+        return $data;
+    }
+}

--- a/src/Ui/Values/TreeNode.php
+++ b/src/Ui/Values/TreeNode.php
@@ -96,16 +96,6 @@ final class TreeNode implements JsonSerializable
     }
 
     /**
-     * The eager child nodes (used by Tree for depth-aware serialization).
-     *
-     * @return list<TreeNode>
-     */
-    public function childNodes(): array
-    {
-        return $this->children;
-    }
-
-    /**
      * @param  list<TreeNode|array<string, mixed>>  $nodes
      * @return list<TreeNode>
      */
@@ -150,6 +140,23 @@ final class TreeNode implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
+        $data = $this->serialiseShallow();
+
+        if ($this->children !== []) {
+            $data['children'] = array_map(static fn (TreeNode $child): array => $child->jsonSerialize(), $this->children);
+        }
+
+        return $data;
+    }
+
+    /**
+     * This node's own fields without its children, so a depth-aware walk (see
+     * Tree) can serialize each level exactly once.
+     *
+     * @return array<string, mixed>
+     */
+    public function serialiseShallow(): array
+    {
         $data = ['id' => $this->id, 'label' => $this->label];
 
         foreach (['icon' => $this->icon, 'badge' => $this->badge, 'href' => $this->href] as $key => $value) {
@@ -168,10 +175,6 @@ final class TreeNode implements JsonSerializable
 
         if ($this->actions !== null) {
             $data['actions'] = $this->actions->jsonSerialize();
-        }
-
-        if ($this->children !== []) {
-            $data['children'] = array_map(static fn (TreeNode $child): array => $child->jsonSerialize(), $this->children);
         }
 
         return $data;

--- a/tests/Browser/Components/TreeTest.php
+++ b/tests/Browser/Components/TreeTest.php
@@ -10,6 +10,10 @@ it('renders the tree demo with categories, active state, and row actions', funct
         ->assertSee('Phones')
         ->assertSee('Clothing')
         ->assertSee('Documents')
+        ->assertSee('Furniture')
+        ->assertSee('Groceries')
+        ->assertSee('Automotive')
+        ->assertSee('Help')
         ->assertNotPresent('[data-test="tree-node-clothing-men"]')
         ->assertAriaAttribute('[data-test="tree-node-electronics-phones"]', 'selected', 'true')
         ->click('[data-test="tree-documents-actions"]')
@@ -81,4 +85,55 @@ it('navigates when an href node link is clicked', function (): void {
     $page
         ->assertSee('Team settings')
         ->assertNoJavaScriptErrors();
+});
+
+it('keeps row action controls out of the page tab order so Tab exits the tree cleanly', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    $page = visit('/components/tree')
+        ->assertAttribute('[data-test="tree-documents-actions"]', 'tabindex', '-1')
+        ->keys('[data-test="tree-node-electronics"]', ['Tab']);
+
+    $focusedInsideTree = $page->script(<<<'JS'
+        () => document.activeElement != null && document.activeElement.closest('[role="tree"]') != null
+    JS);
+
+    expect($focusedInsideTree)->toBeFalsy();
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('opens the info modal with Enter on the modal-action node and returns focus on close', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    $page = visit('/components/tree')
+        ->keys('[data-test="tree-node-electronics"]', ['End']);
+
+    eventually(function () use ($page): void {
+        $page->assertAttribute('[data-test="tree-node-help"]', 'tabindex', '0');
+    });
+
+    $page->keys('[data-test="tree-node-help"]', ['Enter']);
+
+    eventually(function () use ($page): void {
+        $page->assertSee('Keyboard navigation');
+    });
+
+    $page
+        ->assertSee('Arrow keys move focus between rows')
+        ->click('[data-test="dialog-close"]');
+
+    eventually(function () use ($page): void {
+        $page->assertDontSee('Keyboard navigation');
+    });
+
+    eventually(function () use ($page): void {
+        $focusedTestId = $page->script(<<<'JS'
+            () => document.activeElement?.getAttribute('data-test') ?? null
+        JS);
+
+        expect($focusedTestId)->toBe('tree-node-help');
+    });
+
+    $page->assertNoJavaScriptErrors();
 });

--- a/tests/Browser/Components/TreeTest.php
+++ b/tests/Browser/Components/TreeTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+it('renders the tree demo with categories, active state, and row actions', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    visit('/components/tree')
+        ->assertSee('Electronics')
+        ->assertSee('Laptops')
+        ->assertSee('Phones')
+        ->assertSee('Clothing')
+        ->assertSee('Documents')
+        ->assertNotPresent('[data-test="tree-node-clothing-men"]')
+        ->assertAriaAttribute('[data-test="tree-node-electronics-phones"]', 'selected', 'true')
+        ->click('[data-test="tree-documents-actions"]')
+        ->assertPresent('[data-test="action-tree-documents-rename"]')
+        ->assertPresent('[data-test="action-tree-documents-archive"]')
+        ->assertSee('Rename')
+        ->assertSee('Archive')
+        ->assertNoJavaScriptErrors();
+});
+
+it('expands a collapsed subtree and reveals its children when the chevron is clicked', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    $page = visit('/components/tree')
+        ->assertNotPresent('[data-test="tree-node-clothing-men"]')
+        ->click('[data-test="tree-node-clothing-toggle"]');
+
+    eventually(function () use ($page): void {
+        $page->assertPresent('[data-test="tree-node-clothing-men"]');
+    });
+
+    $page
+        ->assertSee('Men')
+        ->assertSee('Women')
+        ->assertAriaAttribute('[data-test="tree-node-clothing"]', 'expanded', 'true')
+        ->assertNoJavaScriptErrors();
+});
+
+it('moves focus with ArrowDown and expands a node with ArrowRight', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    $page = visit('/components/tree')
+        ->keys('[data-test="tree-node-electronics"]', ['ArrowDown']);
+
+    eventually(function () use ($page): void {
+        $page->assertAttribute('[data-test="tree-node-electronics-laptops"]', 'tabindex', '0');
+    });
+
+    $page
+        ->assertAttribute('[data-test="tree-node-electronics"]', 'tabindex', '-1')
+        ->assertNotPresent('[data-test="tree-node-clothing-men"]')
+        ->keys('[data-test="tree-node-clothing"]', ['ArrowRight']);
+
+    eventually(function () use ($page): void {
+        $page->assertPresent('[data-test="tree-node-clothing-men"]');
+    });
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('navigates when an href node link is clicked', function (): void {
+    $this->actingAs(workbenchTestUser());
+
+    $page = visit('/components/tree')
+        ->click('[data-test="tree-node-clothing-toggle"]');
+
+    eventually(function () use ($page): void {
+        $page->assertPresent('[data-test="tree-node-clothing-women"]');
+    });
+
+    $page
+        ->assertAttribute('[data-test="tree-node-clothing-women"] a', 'href', '/components/containers')
+        ->click('[data-test="tree-node-clothing-women"] a');
+
+    eventually(function () use ($page): void {
+        $page->assertPathIs('/components/containers');
+    });
+
+    $page
+        ->assertSee('Team settings')
+        ->assertNoJavaScriptErrors();
+});

--- a/tests/Feature/Ui/EloquentTreeSourceTest.php
+++ b/tests/Feature/Ui/EloquentTreeSourceTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Ui\Sources\EloquentTreeSource;
+use Lattice\Lattice\Ui\Values\TreeNode;
+use Workbench\App\Models\Category;
+
+it('resolves root categories ordered by label, flagging hasChildren for parents only', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->create(['name' => 'Books']);
+
+    $roots = EloquentTreeSource::make(Category::class)->roots();
+
+    expect(array_map(fn (TreeNode $node): array => [$node->label, $node->id, $node->hasChildren], $roots))->toBe([
+        ['Books', (string) Category::query()->where('name', 'Books')->value('id'), false],
+        ['Electronics', (string) $electronics->getKey(), true],
+    ]);
+});
+
+it('resolves a category\'s immediate children ordered by label, flagging hasChildren for grandparents', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($electronics)->create(['name' => 'Cameras']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+
+    $children = EloquentTreeSource::make(Category::class)->children((string) $electronics->getKey());
+
+    expect(array_map(fn (TreeNode $node): array => [$node->label, $node->id, $node->hasChildren], $children))->toBe([
+        ['Cameras', (string) Category::query()->where('name', 'Cameras')->value('id'), false],
+        ['Laptops', (string) $laptops->getKey(), true],
+    ]);
+});
+
+it('applies a query scope to both roots and children', function (): void {
+    $hidden = Category::factory()->create(['name' => 'Hidden Root']);
+    $visible = Category::factory()->create(['name' => 'Visible Root']);
+    Category::factory()->childOf($visible)->create(['name' => 'Hidden Child']);
+    Category::factory()->childOf($visible)->create(['name' => 'Visible Child']);
+
+    $source = EloquentTreeSource::make(Category::class)->scope(fn ($query) => $query->where('name', 'like', 'Visible%'));
+
+    expect(array_map(fn (TreeNode $node): string => $node->label, $source->roots()))->toBe(['Visible Root'])
+        ->and(array_map(fn (TreeNode $node): string => $node->label, $source->children((string) $visible->getKey())))->toBe(['Visible Child']);
+
+    expect($hidden)->not->toBeNull();
+});

--- a/tests/Feature/Ui/EloquentTreeSourceTest.php
+++ b/tests/Feature/Ui/EloquentTreeSourceTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Ui\Components\Tree;
 use Lattice\Lattice\Ui\Sources\EloquentTreeSource;
 use Lattice\Lattice\Ui\Values\TreeNode;
 use Workbench\App\Models\Category;
@@ -30,6 +31,20 @@ it('resolves a category\'s immediate children ordered by label, flagging hasChil
         ['Cameras', (string) Category::query()->where('name', 'Cameras')->value('id'), false],
         ['Laptops', (string) $laptops->getKey(), true],
     ]);
+});
+
+it('serializes the whole hierarchy when wired through the Tree component', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+
+    $node = wire(Tree::make()->source(EloquentTreeSource::make(Category::class)));
+
+    $root = $node['props']['nodes'][0];
+    expect($root)->toMatchArray(['label' => 'Electronics', 'hasChildren' => true])
+        ->and($root['children'][0])->toMatchArray(['label' => 'Laptops', 'hasChildren' => true])
+        ->and($root['children'][0]['children'][0])->toMatchArray(['label' => 'Ultrabooks'])
+        ->and($root['children'][0]['children'][0])->not->toHaveKey('children');
 });
 
 it('applies a query scope to both roots and children', function (): void {

--- a/tests/Feature/Ui/EloquentTreeSourceTest.php
+++ b/tests/Feature/Ui/EloquentTreeSourceTest.php
@@ -48,7 +48,7 @@ it('serializes the whole hierarchy when wired through the Tree component', funct
 });
 
 it('applies a query scope to both roots and children', function (): void {
-    $hidden = Category::factory()->create(['name' => 'Hidden Root']);
+    Category::factory()->create(['name' => 'Hidden Root']);
     $visible = Category::factory()->create(['name' => 'Visible Root']);
     Category::factory()->childOf($visible)->create(['name' => 'Hidden Child']);
     Category::factory()->childOf($visible)->create(['name' => 'Visible Child']);
@@ -57,6 +57,4 @@ it('applies a query scope to both roots and children', function (): void {
 
     expect(array_map(fn (TreeNode $node): string => $node->label, $source->roots()))->toBe(['Visible Root'])
         ->and(array_map(fn (TreeNode $node): string => $node->label, $source->children((string) $visible->getKey())))->toBe(['Visible Child']);
-
-    expect($hidden)->not->toBeNull();
 });

--- a/tests/Unit/Core/Components/TreeTest.php
+++ b/tests/Unit/Core/Components/TreeTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Ui\Components\Tree;
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+it('serializes an eager node tree with defaults', function (): void {
+    $node = wire(
+        Tree::make()->nodes([
+            TreeNode::make('Electronics', '1')->children([TreeNode::make('Laptops', '2')]),
+        ]),
+    );
+
+    expect($node['type'])->toBe('tree')
+        ->and($node['props']['nodes'][0])->toMatchArray(['id' => '1', 'label' => 'Electronics'])
+        ->and($node['props']['nodes'][0]['children'][0])->toMatchArray(['id' => '2', 'label' => 'Laptops'])
+        ->and($node['props']['rememberState'])->toBeFalse()
+        ->and($node['props']['defaultExpanded'])->toBe([]);
+});
+
+it('serializes activeId, defaultExpanded, and rememberState', function (): void {
+    $node = wire(
+        Tree::make()->nodes([TreeNode::make('A', '1')])->activeId('1')->defaultExpanded(['1'])->rememberState(),
+    );
+
+    expect($node['props'])->toMatchArray([
+        'activeId' => '1', 'defaultExpanded' => ['1'], 'rememberState' => true,
+    ]);
+});
+
+it('truncates children beyond eagerDepth to a lazy boundary', function (): void {
+    $node = wire(
+        Tree::make()->eagerDepth(1)->nodes([
+            TreeNode::make('L0', 'a')->children([
+                TreeNode::make('L1', 'b')->children([TreeNode::make('L2', 'c')]),
+            ]),
+        ]),
+    );
+
+    $l1 = $node['props']['nodes'][0]['children'][0];
+    expect($l1)->toMatchArray(['id' => 'b', 'hasChildren' => true])
+        ->and($l1)->not->toHaveKey('children');
+});

--- a/tests/Unit/Core/Components/TreeTest.php
+++ b/tests/Unit/Core/Components/TreeTest.php
@@ -49,38 +49,43 @@ it('serializes source children recursively for hasChildren nodes', function (): 
         ->and($root['children'][0]['children'][0])->toMatchArray(['id' => 'grandchild', 'label' => 'Grandchild']);
 });
 
-it('stops fetching source children at the eagerDepth boundary', function (): void {
-    $fetched = [];
+it('stops fetching source children at the depth cap so cyclic data terminates', function (): void {
+    $fetches = 0;
 
     $node = wire(
-        Tree::make()->eagerDepth(1)->source(new CallbackTreeSource(
-            roots: fn (): array => [TreeNode::make('Root', 'root')->hasChildren()],
-            children: function (string $parentId) use (&$fetched): array {
-                $fetched[] = $parentId;
+        Tree::make()->source(new CallbackTreeSource(
+            roots: fn (): array => [TreeNode::make('Root', 'n0')->hasChildren()],
+            children: function (string $parentId) use (&$fetches): array {
+                $fetches++;
 
-                return [TreeNode::make("Child of {$parentId}", "{$parentId}.child")->hasChildren()];
+                return [TreeNode::make('Child', "n{$fetches}")->hasChildren()];
             },
         )),
     );
 
-    $boundary = $node['props']['nodes'][0]['children'][0];
-    expect($boundary)->toMatchArray(['id' => 'root.child', 'hasChildren' => true])
-        ->and($boundary)->not->toHaveKey('children')
-        ->and($fetched)->toBe(['root']);
+    $boundary = $node['props']['nodes'][0];
+    while (isset($boundary['children'])) {
+        $boundary = $boundary['children'][0];
+    }
+
+    expect($fetches)->toBe(50)
+        ->and($boundary)->toMatchArray(['id' => 'n50', 'hasChildren' => true]);
 });
 
-it('truncates children beyond eagerDepth to a lazy boundary', function (): void {
-    $node = wire(
-        Tree::make()->eagerDepth(1)->nodes([
-            TreeNode::make('L0', 'a')->children([
-                TreeNode::make('L1', 'b')->children([TreeNode::make('L2', 'c')]),
-            ]),
-        ]),
-    );
+it('truncates eager children at the depth cap with a hasChildren marker', function (): void {
+    $subtree = TreeNode::make('Leaf', 'leaf');
+    foreach (range(51, 0) as $level) {
+        $subtree = TreeNode::make("Level {$level}", "n{$level}")->children([$subtree]);
+    }
 
-    $l1 = $node['props']['nodes'][0]['children'][0];
-    expect($l1)->toMatchArray(['id' => 'b', 'hasChildren' => true])
-        ->and($l1)->not->toHaveKey('children');
+    $node = wire(Tree::make()->nodes([$subtree]));
+
+    $boundary = $node['props']['nodes'][0];
+    while (isset($boundary['children'])) {
+        $boundary = $boundary['children'][0];
+    }
+
+    expect($boundary)->toMatchArray(['id' => 'n50', 'hasChildren' => true]);
 });
 
 describe('docs fixtures', function (): void {

--- a/tests/Unit/Core/Components/TreeTest.php
+++ b/tests/Unit/Core/Components/TreeTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Tree;
+use Lattice\Lattice\Ui\Sources\CallbackTreeSource;
 use Lattice\Lattice\Ui\Values\TreeNode;
 
 it('serializes an eager node tree with defaults', function (): void {
@@ -27,6 +28,45 @@ it('serializes activeId, defaultExpanded, and rememberState', function (): void 
     expect($node['props'])->toMatchArray([
         'activeId' => '1', 'defaultExpanded' => ['1'], 'rememberState' => true,
     ]);
+});
+
+it('serializes source children recursively for hasChildren nodes', function (): void {
+    $childrenByParent = [
+        'root' => [TreeNode::make('Child', 'child')->hasChildren()],
+        'child' => [TreeNode::make('Grandchild', 'grandchild')],
+    ];
+
+    $node = wire(
+        Tree::make()->source(new CallbackTreeSource(
+            roots: fn (): array => [TreeNode::make('Root', 'root')->hasChildren()],
+            children: fn (string $parentId): array => $childrenByParent[$parentId] ?? [],
+        )),
+    );
+
+    $root = $node['props']['nodes'][0];
+    expect($root)->toMatchArray(['id' => 'root', 'hasChildren' => true])
+        ->and($root['children'][0])->toMatchArray(['id' => 'child'])
+        ->and($root['children'][0]['children'][0])->toMatchArray(['id' => 'grandchild', 'label' => 'Grandchild']);
+});
+
+it('stops fetching source children at the eagerDepth boundary', function (): void {
+    $fetched = [];
+
+    $node = wire(
+        Tree::make()->eagerDepth(1)->source(new CallbackTreeSource(
+            roots: fn (): array => [TreeNode::make('Root', 'root')->hasChildren()],
+            children: function (string $parentId) use (&$fetched): array {
+                $fetched[] = $parentId;
+
+                return [TreeNode::make("Child of {$parentId}", "{$parentId}.child")->hasChildren()];
+            },
+        )),
+    );
+
+    $boundary = $node['props']['nodes'][0]['children'][0];
+    expect($boundary)->toMatchArray(['id' => 'root.child', 'hasChildren' => true])
+        ->and($boundary)->not->toHaveKey('children')
+        ->and($fetched)->toBe(['root']);
 });
 
 it('truncates children beyond eagerDepth to a lazy boundary', function (): void {

--- a/tests/Unit/Core/Components/TreeTest.php
+++ b/tests/Unit/Core/Components/TreeTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Tree;
 use Lattice\Lattice\Ui\Values\TreeNode;
 
@@ -40,4 +41,28 @@ it('truncates children beyond eagerDepth to a lazy boundary', function (): void 
     $l1 = $node['props']['nodes'][0]['children'][0];
     expect($l1)->toMatchArray(['id' => 'b', 'hasChildren' => true])
         ->and($l1)->not->toHaveKey('children');
+});
+
+describe('docs fixtures', function (): void {
+    it('matches the tree example fixture', function (): void {
+        assertFixtureMatches('components.tree', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
+            Tree::make('category-tree')
+                ->nodes([
+                    TreeNode::make('Electronics', 'electronics')
+                        ->icon('cpu')
+                        ->children([
+                            TreeNode::make('Laptops', 'electronics-laptops'),
+                            TreeNode::make('Phones', 'electronics-phones')->href('/products/phones'),
+                        ]),
+                    TreeNode::make('Clothing', 'clothing')
+                        ->badge('New')
+                        ->children([
+                            TreeNode::make('Men', 'clothing-men'),
+                            TreeNode::make('Women', 'clothing-women'),
+                        ]),
+                ])
+                ->activeId('electronics-phones')
+                ->defaultExpanded(['electronics']),
+        ]))));
+    });
 });

--- a/tests/Unit/Core/Values/TreeNodeTest.php
+++ b/tests/Unit/Core/Values/TreeNodeTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+it('serializes a leaf node with its scalar props', function (): void {
+    $node = TreeNode::make('Laptops', '2')->icon('cpu')->badge('42')->href('/c/2');
+
+    expect($node->jsonSerialize())->toMatchArray([
+        'id' => '2', 'label' => 'Laptops', 'icon' => 'cpu', 'badge' => '42', 'href' => '/c/2',
+    ]);
+});
+
+it('serializes children recursively and marks a lazy boundary', function (): void {
+    $node = TreeNode::make('Electronics', '1')->children([
+        TreeNode::make('Laptops', '2'),
+    ]);
+    $lazy = TreeNode::make('Suppliers', '9')->hasChildren();
+
+    expect($node->jsonSerialize()['children'][0])->toMatchArray(['id' => '2', 'label' => 'Laptops'])
+        ->and($lazy->jsonSerialize())->toMatchArray(['hasChildren' => true])
+        ->and($lazy->jsonSerialize())->not->toHaveKey('children');
+});
+
+it('omits absent optional keys', function (): void {
+    expect(TreeNode::make('Plain', '5')->jsonSerialize())
+        ->toBe(['id' => '5', 'label' => 'Plain']);
+});
+
+it('normalizes an array of nodes and arrays via expand', function (): void {
+    $nodes = TreeNode::expand([
+        TreeNode::make('A', '1'),
+        ['id' => '2', 'label' => 'B'],
+    ]);
+
+    expect($nodes)->toHaveCount(2)
+        ->and($nodes[1]->jsonSerialize())->toMatchArray(['id' => '2', 'label' => 'B']);
+});
+
+it('serializes an attached action under the actions key as a wire node', function (): void {
+    $node = TreeNode::make('Laptops', '2')->action(Action::make('archive')->label('Archive'));
+
+    expect($node->jsonSerialize()['actions'])->toHaveKey('type');
+});

--- a/tests/Unit/Ui/CallbackTreeSourceTest.php
+++ b/tests/Unit/Ui/CallbackTreeSourceTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Ui\Sources\CallbackTreeSource;
+use Lattice\Lattice\Ui\Values\TreeNode;
+
+it('resolves roots and children from closures', function (): void {
+    $source = new CallbackTreeSource(
+        roots: fn (): array => [TreeNode::make('Root', '1')->hasChildren()],
+        children: fn (string $parentId): array => [TreeNode::make("Child of {$parentId}", "{$parentId}.1")],
+    );
+
+    expect($source->roots()[0]->jsonSerialize())->toMatchArray(['id' => '1', 'hasChildren' => true])
+        ->and($source->children('1')[0]->jsonSerialize())->toMatchArray(['id' => '1.1', 'label' => 'Child of 1']);
+});
+
+it('returns no children when no children closure is given', function (): void {
+    $source = new CallbackTreeSource(roots: fn (): array => []);
+
+    expect($source->children('1'))->toBe([]);
+});

--- a/workbench/app/Actions/ShowTreeNodeInfoAction.php
+++ b/workbench/app/Actions/ShowTreeNodeInfoAction.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Actions;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+
+#[AsAction('workbench.tree.show-node-info')]
+class ShowTreeNodeInfoAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action
+            ->label(__('workbench.actions.tree-node-info.label'))
+            ->icon('info');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success()->openModal('tree-node-info');
+    }
+}

--- a/workbench/app/Factories/CategoryFactory.php
+++ b/workbench/app/Factories/CategoryFactory.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Category;
+
+/** @extends Factory<Category> */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->words(2, true),
+            'parent_id' => null,
+        ];
+    }
+
+    public function childOf(Category $parent): static
+    {
+        return $this->state(['parent_id' => $parent->getKey()]);
+    }
+}

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -45,6 +45,7 @@ use Workbench\App\Pages\Components\ContainersPage;
 use Workbench\App\Pages\Components\NotificationsPage;
 use Workbench\App\Pages\Components\ProgressPage;
 use Workbench\App\Pages\Components\TabsPage;
+use Workbench\App\Pages\Components\TreePage;
 use Workbench\App\Pages\DependentFieldsPage;
 use Workbench\App\Pages\Fields\BooleanFieldsPage;
 use Workbench\App\Pages\Fields\BuilderPage;
@@ -156,6 +157,7 @@ class AppLayout extends LayoutDefinition
                     MenuItem::fromPage(ChartsPage::class)->key('charts')->label(__('workbench.navigation.charts')),
                     MenuItem::fromPage(ProgressPage::class)->key('progress')->label(__('workbench.navigation.progress')),
                     MenuItem::fromPage(ContainersPage::class)->key('containers')->label(__('workbench.navigation.containers')),
+                    MenuItem::fromPage(TreePage::class)->key('tree')->label(__('workbench.navigation.tree')),
                     MenuItem::fromPage(NotificationsPage::class)->key('notifications')->label(__('workbench.navigation.notifications')),
                     MenuItem::fromPage(ChatPage::class)->key('chat')->label(__('workbench.navigation.chat')),
                 ]),

--- a/workbench/app/Models/Category.php
+++ b/workbench/app/Models/Category.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workbench\App\Factories\CategoryFactory;
+
+/**
+ * @property string $name
+ * @property-read Category|null $parent
+ * @property-read Collection<int, Category> $children
+ */
+class Category extends Model
+{
+    /** @use HasFactory<CategoryFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = ['name', 'parent_id'];
+
+    /** @return BelongsTo<Category, $this> */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    /** @return HasMany<Category, $this> */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    protected static function newFactory(): CategoryFactory
+    {
+        return CategoryFactory::new();
+    }
+}

--- a/workbench/app/Pages/Components/TreePage.php
+++ b/workbench/app/Pages/Components/TreePage.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages\Components;
+
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Components\ActionGroup;
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Components\Tree;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Lattice\Ui\Values\TreeNode;
+use Workbench\App\Pages\WorkbenchPage;
+
+#[AsPage(route: '/components/tree')]
+final class TreePage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return __('workbench.pages.components.tree.title');
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('tree-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make($this->title()),
+                    Text::make(__('workbench.pages.components.tree.intro')),
+                    Tree::make('demo-tree')
+                        ->nodes([
+                            TreeNode::make(__('workbench.pages.components.tree.categories.electronics.label'), 'electronics')
+                                ->children([
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.electronics.laptops'), 'electronics-laptops'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.electronics.phones'), 'electronics-phones'),
+                                ]),
+                            TreeNode::make(__('workbench.pages.components.tree.categories.clothing.label'), 'clothing')
+                                ->children([
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.clothing.men'), 'clothing-men'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.clothing.women'), 'clothing-women')
+                                        ->href('/components/containers'),
+                                ]),
+                            TreeNode::make(__('workbench.pages.components.tree.categories.documents.label'), 'documents')
+                                ->actions(
+                                    ActionGroup::make('tree-documents-actions')
+                                        ->actions([
+                                            Action::make('tree-documents-rename')->label(__('workbench.pages.components.tree.categories.documents.rename')),
+                                            Action::make('tree-documents-archive')->label(__('workbench.pages.components.tree.categories.documents.archive')),
+                                        ]),
+                                ),
+                        ])
+                        ->activeId('electronics-phones')
+                        ->defaultExpanded(['electronics'])
+                        ->rememberState(),
+                ]),
+        ]);
+    }
+}

--- a/workbench/app/Pages/Components/TreePage.php
+++ b/workbench/app/Pages/Components/TreePage.php
@@ -8,11 +8,13 @@ use Lattice\Lattice\Actions\Components\ActionGroup;
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Modal;
 use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Components\Tree;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Values\TreeNode;
+use Workbench\App\Actions\ShowTreeNodeInfoAction;
 use Workbench\App\Pages\WorkbenchPage;
 
 #[AsPage(route: '/components/tree')]
@@ -37,12 +39,24 @@ final class TreePage extends WorkbenchPage
                                 ->children([
                                     TreeNode::make(__('workbench.pages.components.tree.categories.electronics.laptops'), 'electronics-laptops'),
                                     TreeNode::make(__('workbench.pages.components.tree.categories.electronics.phones'), 'electronics-phones'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.electronics.tablets'), 'electronics-tablets'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.electronics.accessories.label'), 'electronics-accessories')
+                                        ->children([
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.electronics.accessories.cases'), 'electronics-accessories-cases'),
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.electronics.accessories.chargers'), 'electronics-accessories-chargers'),
+                                        ]),
                                 ]),
                             TreeNode::make(__('workbench.pages.components.tree.categories.clothing.label'), 'clothing')
                                 ->children([
                                     TreeNode::make(__('workbench.pages.components.tree.categories.clothing.men'), 'clothing-men'),
                                     TreeNode::make(__('workbench.pages.components.tree.categories.clothing.women'), 'clothing-women')
                                         ->href('/components/containers'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.clothing.kids'), 'clothing-kids'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.clothing.accessories.label'), 'clothing-accessories')
+                                        ->children([
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.clothing.accessories.belts'), 'clothing-accessories-belts'),
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.clothing.accessories.hats'), 'clothing-accessories-hats'),
+                                        ]),
                                 ]),
                             TreeNode::make(__('workbench.pages.components.tree.categories.documents.label'), 'documents')
                                 ->actions(
@@ -52,10 +66,51 @@ final class TreePage extends WorkbenchPage
                                             Action::make('tree-documents-archive')->label(__('workbench.pages.components.tree.categories.documents.archive')),
                                         ]),
                                 ),
+                            TreeNode::make(__('workbench.pages.components.tree.categories.furniture.label'), 'furniture')
+                                ->children([
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.furniture.living-room.label'), 'furniture-living-room')
+                                        ->children([
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.furniture.living-room.sofas'), 'furniture-living-room-sofas'),
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.furniture.living-room.coffee-tables'), 'furniture-living-room-coffee-tables'),
+                                        ]),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.furniture.bedroom.label'), 'furniture-bedroom')
+                                        ->children([
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.furniture.bedroom.beds'), 'furniture-bedroom-beds'),
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.furniture.bedroom.wardrobes'), 'furniture-bedroom-wardrobes'),
+                                        ]),
+                                ]),
+                            TreeNode::make(__('workbench.pages.components.tree.categories.groceries.label'), 'groceries')
+                                ->children([
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.groceries.produce'), 'groceries-produce'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.groceries.dairy'), 'groceries-dairy'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.groceries.bakery'), 'groceries-bakery'),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.groceries.frozen'), 'groceries-frozen'),
+                                ]),
+                            TreeNode::make(__('workbench.pages.components.tree.categories.automotive.label'), 'automotive')
+                                ->children([
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.automotive.parts.label'), 'automotive-parts')
+                                        ->children([
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.automotive.parts.engine'), 'automotive-parts-engine'),
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.automotive.parts.brakes'), 'automotive-parts-brakes'),
+                                        ]),
+                                    TreeNode::make(__('workbench.pages.components.tree.categories.automotive.accessories.label'), 'automotive-accessories')
+                                        ->children([
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.automotive.accessories.seat-covers'), 'automotive-accessories-seat-covers'),
+                                            TreeNode::make(__('workbench.pages.components.tree.categories.automotive.accessories.floor-mats'), 'automotive-accessories-floor-mats'),
+                                        ]),
+                                ]),
+                            TreeNode::make(__('workbench.pages.components.tree.categories.help.label'), 'help')
+                                ->action(Action::use(ShowTreeNodeInfoAction::class)),
                         ])
                         ->activeId('electronics-phones')
-                        ->defaultExpanded(['electronics'])
+                        ->defaultExpanded(['electronics', 'furniture'])
                         ->rememberState(),
+                    Modal::make('tree-node-info')
+                        ->title(__('workbench.pages.components.tree.info-modal.title'))
+                        ->description(__('workbench.pages.components.tree.info-modal.description'))
+                        ->schema([
+                            Text::make(__('workbench.pages.components.tree.info-modal.body')),
+                        ]),
                 ]),
         ]);
     }

--- a/workbench/database/migrations/2026_07_15_000001_create_categories_table.php
+++ b/workbench/database/migrations/2026_07_15_000001_create_categories_table.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -185,6 +185,9 @@ return [
             'label' => 'Auswahl ablehnen',
             'toast' => ':count Produkte abgelehnt: :reason',
         ],
+        'tree-node-info' => [
+            'label' => 'Über diese Baumstruktur',
+        ],
     ],
     'auth' => [
         'login' => [
@@ -541,7 +544,26 @@ return [
             ],
             'tree' => [
                 'categories' => [
+                    'automotive' => [
+                        'accessories' => [
+                            'floor-mats' => 'Fußmatten',
+                            'label' => 'Zubehör',
+                            'seat-covers' => 'Sitzbezüge',
+                        ],
+                        'label' => 'Kfz-Zubehör',
+                        'parts' => [
+                            'brakes' => 'Bremsen',
+                            'engine' => 'Motor',
+                            'label' => 'Teile',
+                        ],
+                    ],
                     'clothing' => [
+                        'accessories' => [
+                            'belts' => 'Gürtel',
+                            'hats' => 'Hüte',
+                            'label' => 'Zubehör',
+                        ],
+                        'kids' => 'Kinder',
                         'label' => 'Kleidung',
                         'men' => 'Herren',
                         'women' => 'Damen',
@@ -552,12 +574,46 @@ return [
                         'rename' => 'Umbenennen',
                     ],
                     'electronics' => [
+                        'accessories' => [
+                            'cases' => 'Hüllen',
+                            'chargers' => 'Ladegeräte',
+                            'label' => 'Zubehör',
+                        ],
                         'label' => 'Elektronik',
                         'laptops' => 'Laptops',
                         'phones' => 'Smartphones',
+                        'tablets' => 'Tablets',
+                    ],
+                    'furniture' => [
+                        'bedroom' => [
+                            'beds' => 'Betten',
+                            'label' => 'Schlafzimmer',
+                            'wardrobes' => 'Kleiderschränke',
+                        ],
+                        'label' => 'Möbel',
+                        'living-room' => [
+                            'coffee-tables' => 'Couchtische',
+                            'label' => 'Wohnzimmer',
+                            'sofas' => 'Sofas',
+                        ],
+                    ],
+                    'groceries' => [
+                        'bakery' => 'Bäckerei',
+                        'dairy' => 'Milchprodukte',
+                        'frozen' => 'Tiefkühlkost',
+                        'label' => 'Lebensmittel',
+                        'produce' => 'Obst & Gemüse',
+                    ],
+                    'help' => [
+                        'label' => 'Hilfe',
                     ],
                 ],
-                'intro' => 'Eine per Tastatur navigierbare Hierarchie mit aktivem Zustand, einem verlinkten Knoten und Zeilenaktionen.',
+                'info-modal' => [
+                    'body' => 'Die Pfeiltasten bewegen den Fokus zwischen den Zeilen, ohne die Tab-Reihenfolge der Seite zu verlassen. Enter oder Leertaste aktiviert die fokussierte Zeile: sie folgt einem Link, führt eine Aktion aus oder markiert die Zeile als aktiv.',
+                    'description' => 'So funktioniert die Tastaturnavigation in dieser Komponente.',
+                    'title' => 'Tastaturnavigation',
+                ],
+                'intro' => 'Eine per Tastatur navigierbare Hierarchie mit aktivem Zustand, einem verlinkten Knoten, Zeilenaktionen und einer Aktion, die ein Modal öffnet.',
                 'title' => 'Baumstruktur',
             ],
         ],

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -417,6 +417,7 @@ return [
         'tables' => 'Tabellen',
         'tabs' => 'Tabs',
         'toggle-sidebar' => 'Seitenleiste umschalten',
+        'tree' => 'Baumstruktur',
     ],
     'pages' => [
         'charts' => [
@@ -537,6 +538,27 @@ return [
                 'bars' => 'Fortschrittsbalken',
                 'circles' => 'Fortschrittskreise',
                 'title' => 'Fortschritt',
+            ],
+            'tree' => [
+                'categories' => [
+                    'clothing' => [
+                        'label' => 'Kleidung',
+                        'men' => 'Herren',
+                        'women' => 'Damen',
+                    ],
+                    'documents' => [
+                        'archive' => 'Archivieren',
+                        'label' => 'Dokumente',
+                        'rename' => 'Umbenennen',
+                    ],
+                    'electronics' => [
+                        'label' => 'Elektronik',
+                        'laptops' => 'Laptops',
+                        'phones' => 'Smartphones',
+                    ],
+                ],
+                'intro' => 'Eine per Tastatur navigierbare Hierarchie mit aktivem Zustand, einem verlinkten Knoten und Zeilenaktionen.',
+                'title' => 'Baumstruktur',
             ],
         ],
         'dependent' => [

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -185,6 +185,9 @@ return [
             'label' => 'Reject selected',
             'toast' => 'Rejected :count products: :reason',
         ],
+        'tree-node-info' => [
+            'label' => 'About this tree',
+        ],
     ],
     'auth' => [
         'login' => [
@@ -541,7 +544,26 @@ return [
             ],
             'tree' => [
                 'categories' => [
+                    'automotive' => [
+                        'accessories' => [
+                            'floor-mats' => 'Floor mats',
+                            'label' => 'Accessories',
+                            'seat-covers' => 'Seat covers',
+                        ],
+                        'label' => 'Automotive',
+                        'parts' => [
+                            'brakes' => 'Brakes',
+                            'engine' => 'Engine',
+                            'label' => 'Parts',
+                        ],
+                    ],
                     'clothing' => [
+                        'accessories' => [
+                            'belts' => 'Belts',
+                            'hats' => 'Hats',
+                            'label' => 'Accessories',
+                        ],
+                        'kids' => 'Kids',
                         'label' => 'Clothing',
                         'men' => 'Men',
                         'women' => 'Women',
@@ -552,12 +574,46 @@ return [
                         'rename' => 'Rename',
                     ],
                     'electronics' => [
+                        'accessories' => [
+                            'cases' => 'Cases',
+                            'chargers' => 'Chargers',
+                            'label' => 'Accessories',
+                        ],
                         'label' => 'Electronics',
                         'laptops' => 'Laptops',
                         'phones' => 'Phones',
+                        'tablets' => 'Tablets',
+                    ],
+                    'furniture' => [
+                        'bedroom' => [
+                            'beds' => 'Beds',
+                            'label' => 'Bedroom',
+                            'wardrobes' => 'Wardrobes',
+                        ],
+                        'label' => 'Furniture',
+                        'living-room' => [
+                            'coffee-tables' => 'Coffee tables',
+                            'label' => 'Living room',
+                            'sofas' => 'Sofas',
+                        ],
+                    ],
+                    'groceries' => [
+                        'bakery' => 'Bakery',
+                        'dairy' => 'Dairy',
+                        'frozen' => 'Frozen',
+                        'label' => 'Groceries',
+                        'produce' => 'Produce',
+                    ],
+                    'help' => [
+                        'label' => 'Help',
                     ],
                 ],
-                'intro' => 'A keyboard-navigable hierarchy with active state, a linked node, and row actions.',
+                'info-modal' => [
+                    'body' => 'Arrow keys move focus between rows without leaving the page tab order. Enter or Space activates the focused row: it follows a link, runs an action, or marks the row active.',
+                    'description' => 'How keyboard navigation works in this component.',
+                    'title' => 'Keyboard navigation',
+                ],
+                'intro' => 'A keyboard-navigable hierarchy with active state, a linked node, row actions, and a modal-opening action.',
                 'title' => 'Tree',
             ],
         ],

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -417,6 +417,7 @@ return [
         'tables' => 'Tables',
         'tabs' => 'Tabs',
         'toggle-sidebar' => 'Toggle sidebar',
+        'tree' => 'Tree',
     ],
     'pages' => [
         'charts' => [
@@ -537,6 +538,27 @@ return [
                 'bars' => 'Progress bars',
                 'circles' => 'Progress circles',
                 'title' => 'Progress',
+            ],
+            'tree' => [
+                'categories' => [
+                    'clothing' => [
+                        'label' => 'Clothing',
+                        'men' => 'Men',
+                        'women' => 'Women',
+                    ],
+                    'documents' => [
+                        'archive' => 'Archive',
+                        'label' => 'Documents',
+                        'rename' => 'Rename',
+                    ],
+                    'electronics' => [
+                        'label' => 'Electronics',
+                        'laptops' => 'Laptops',
+                        'phones' => 'Phones',
+                    ],
+                ],
+                'intro' => 'A keyboard-navigable hierarchy with active state, a linked node, and row actions.',
+                'title' => 'Tree',
             ],
         ],
         'dependent' => [


### PR DESCRIPTION
Adds a display `Tree` UI component for hierarchies (categories, org structures) — Solo #25. Recursive nodes, expand/collapse, active-node highlight, per-node link/actions, and full keyboard accessibility.

## What

```php
// eager, in-memory
Tree::make()
    ->nodes([
        TreeNode::make('Electronics', 'electronics')->icon('cpu')->badge('42')->children([
            TreeNode::make('Laptops', 'laptops')->href('/catalog/laptops'),
            TreeNode::make('Phones', 'phones'),
        ]),
        TreeNode::make('Documents', 'documents')->actions(ActionGroup::make([...])),
    ])
    ->activeId('phones')
    ->defaultExpanded(['electronics'])
    ->rememberState();

// data-backed via a TreeSource (mirrors the table source architecture)
Tree::make()->source(
    EloquentTreeSource::make(Category::class)->label('name')->parent('parent_id'),
);
```

- **`TreeNode`** value object: `icon`, `badge`, `href` (renders a link), `action`/`actions` (single or `ActionGroup`), `children`, `hasChildren`, `disabled`. A node shows a chevron only when it has children.
- **`TreeSource`** contract + **`CallbackTreeSource`** + **`EloquentTreeSource`** (adjacency list) — keeps the component storage-agnostic, exactly mirroring `TableSource`/`EloquentTableSource`. The component owns no persistence.
- **Frontend:** recursive `TreeItem` + a shared `TreeContext` — expand/collapse (optional `rememberState`), active highlight, and full **ARIA tree** keyboard navigation: ↑/↓, →/← (expand/collapse/descend/ascend), Home/End, Enter/Space, and type-ahead, with a single roving tabindex.

## Try it

Workbench: `/components/tree`. Docs: Components → Tree.

## Notes

- No new endpoint/route: the component is stateless and fully eager in v1. Lazy children (via the Fragment API), reorder, and a `TreeSelect` form field are reserved as non-breaking, namespace-free seams (`hasChildren` marker, `TreeNode.id` as the value key, positional keyboard traversal). See Solo backlog for the follow-ons.
- `EloquentTreeSource` is the basic adjacency-list source (`hasChildren` resolved with one batched query per level) — sufficient for typical category/org trees; a nested-set/optimized source is a future source implementation behind the same contract. Serialization depth is capped internally at 50 as a termination guard against cyclic adjacency data.
- Gate green: `composer check`, `npm run check`, `composer test:browser`, docs build.

