### PR TITLE
refactor!: unify color handling behind a tagged Color value object

### DIFF
--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -43,9 +43,10 @@ layout primitives.
 
 ## Text & sizing
 
-`Lattice\Lattice\Ui\Enums` — sizing and color for `Text` and `Icon`.
+Sizing lives in `Lattice\Lattice\Ui\Enums`; the color vocabulary lives in
+`Lattice\Lattice\Core\Enums` and backs the `Color` value object.
 
-<EnumTable enums={["Size", "Color"]} />
+<EnumTable enums={["Size", "ColorName", "ColorKind"]} showNamespace />
 
 The icon names a `Lattice\Lattice\Ui\Enums\Icon` accepts are the enum's own cases — one per bundled
 SVG. The [Icons](/core/icons/) page covers where they come from and how to add your own.

--- a/docs/content/docs/components/charts.mdx
+++ b/docs/content/docs/components/charts.mdx
@@ -210,9 +210,18 @@ the axes have no effect.
 
 Omit a series color and Lattice cycles a palette built on your [theme tokens](/theming/) —
 `--lt-primary`, `--lt-success`, `--lt-info`, `--lt-warning`, `--lt-danger`, `--lt-muted-fg` — so
-charts follow light and dark mode automatically. Pass an explicit `color` to override: a hex value, or a CSS variable like
-`var(--lt-primary)` to stay theme-aware. For pies, gauges, and distribution bars, a per-row `color`
-field wins over the series color.
+charts follow light and dark mode automatically. Pass an explicit `color` to override — a colour
+name (`'success'`, `Color::success()`) resolves to the matching theme token, and any CSS colour
+(`'#2563eb'`, `Color::hex('#2563eb')`) is used as-is. Give a CSS colour a `->dark()` counterpart to
+swap it in dark mode:
+
+```php
+Chart::make('Signups')
+    ->line('total', color: Color::hex('#2563eb')->dark('#60a5fa'));
+```
+
+For pies, gauges, and distribution bars, a per-row `color` data field — the same named colours or
+CSS colours — wins over the series color.
 
 ## Formatting values and categories
 

--- a/docs/content/docs/components/progress.mdx
+++ b/docs/content/docs/components/progress.mdx
@@ -13,10 +13,10 @@ completed import with `Progress::bar(340)->max(340)` fills exactly once.
 <ComponentExample
   php={`Stack::make()->gap(Gap::Small)->schema([
     Progress::bar(65)->showValue(),
-    Progress::bar(80)->color(Color::Success)->size(Size::Lg),
+    Progress::bar(80)->color(Color::success())->size(Size::Lg),
     Stack::make()->direction(StackDirection::Row)->gap(Gap::Medium)->schema([
         Progress::circle(65)->showValue(),
-        Progress::circle(35)->max(50)->color(Color::Warning)->size(Size::Xl)->showValue(),
+        Progress::circle(35)->max(50)->color(Color::warning())->size(Size::Xl)->showValue(),
     ]),
 ]);`}
   fixture="components.progress"
@@ -33,11 +33,12 @@ completed import with `Progress::bar(340)->max(340)` fills exactly once.
 
 ## Color and size
 
-`->color(Color $color)` tints the fill and defaults to the primary color;
-`->size(Size $size)` scales bar height or circle diameter and defaults to `Size::Md`.
+`->color()` tints the fill — a colour name (`Color::danger()`, `'danger'`) or any CSS colour — and
+defaults to the primary color; `->size(Size $size)` scales bar height or circle diameter and
+defaults to `Size::Md`.
 
 ```php
-Progress::circle(90)->color(Color::Danger)->size(Size::Lg);
+Progress::circle(90)->color(Color::danger())->size(Size::Lg);
 ```
 
 <Info>

--- a/docs/content/docs/components/text.mdx
+++ b/docs/content/docs/components/text.mdx
@@ -35,7 +35,8 @@ Heading::make('sk-live-4242', 3)->copyable();
 [enums reference](/advanced/enums/)):
 
 - `->size(Size::…)` — text size (`Md` by default).
-- `->color(Color::…)` — color (`Muted` by default).
+- `->color()` — a colour name (`Color::success()`, `'success'`) or any CSS colour (`muted` by
+  default).
 - `->align(Align::Center)` — alignment.
 - `->copyable()` — render a copy-to-clipboard affordance.
 
@@ -54,11 +55,11 @@ Badge::make('Trialing');
 ## Icon
 
 `Icon::make($name)` renders an icon from your app's SVG sprite by name — a string, or a backed enum
-whose value is the name. Set `->size(Size::…)`, `->color(Color::…)`, or add classes with
-`->class('…')`.
+whose value is the name. Set `->size(Size::…)`, `->color()` (a colour name or any CSS colour), or
+add classes with `->class('…')`.
 
 ```php
-Icon::make('check-circle')->color(Color::Success);
+Icon::make('check-circle')->color(Color::success());
 ```
 
 See [Icons](/core/icons/) for how the sprite is built and how to add or type your own icon names.

--- a/docs/content/docs/components/text.mdx
+++ b/docs/content/docs/components/text.mdx
@@ -35,8 +35,8 @@ Heading::make('sk-live-4242', 3)->copyable();
 [enums reference](/advanced/enums/)):
 
 - `->size(Size::…)` — text size (`Md` by default).
-- `->color()` — a colour name (`Color::success()`, `'success'`) or any CSS colour (`muted` by
-  default).
+- `->color()` — a colour name (`Color::success()`, `'success'`) or any CSS colour; text renders in
+  the `muted` colour when unset.
 - `->align(Align::Center)` — alignment.
 - `->copyable()` — render a copy-to-clipboard affordance.
 

--- a/docs/content/docs/core/icons.md
+++ b/docs/content/docs/core/icons.md
@@ -145,13 +145,13 @@ own), generate an enum — see below.
 same renderer as `->icon()`, with structured `size`/`color` plus a raw `class` escape hatch:
 
 ```php
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Ui\Components\Icon;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Size;
 
 Stack::make()->schema([
     Icon::make('house'),                                       // size defaults to Md
-    Icon::make('circle-check')->size(Size::Lg)->color(Color::Success),
+    Icon::make('circle-check')->size(Size::Lg)->color(Color::success()),
     Icon::make('spark')->class('opacity-70'),
 ]);
 ```

--- a/docs/content/docs/forms/fields/select.mdx
+++ b/docs/content/docs/forms/fields/select.mdx
@@ -139,7 +139,7 @@ options, the dropdown filter matches the option label; text rendered from `data`
     ->optionSchema([
         Stack::make()->schema([
             Text::make('')->dataKey('text', 'label'),
-            Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::Muted),
+            Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::muted()),
         ]),
         Badge::make('')->dataKey('label', 'number'),
     ])`}
@@ -162,7 +162,7 @@ Select::make('customer_id', 'Customer')
     ->optionSchema([
         Stack::make()->schema([
             Text::make('')->dataKey('text', 'label'),
-            Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::Muted),
+            Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::muted()),
         ]),
         Badge::make('')->dataKey('label', 'customer_number'),
     ]);

--- a/docs/content/docs/tables/columns/badge.mdx
+++ b/docs/content/docs/tables/columns/badge.mdx
@@ -16,8 +16,10 @@ BadgeColumn::make('status')->label('Status')
   fixture="table.badge"
 />
 
-`->colors([value => color])` maps cell values to a colour name — `gray`, `red`, `green`, `yellow`,
-`blue`, `purple`, or `orange`. Unmapped values fall back to gray.
+`->colors([value => color])` maps cell values to a colour name — `gray`, `red`, `orange`, `yellow`,
+`green`, `blue`, `purple`, or the semantic `default`, `muted`, `primary`, `success`, `info`,
+`warning`, `danger` — or any CSS colour. `'green'`, `Color::green()`, `Color::hex('#16a34a')`, and
+`Color::hex('#2563eb')->dark('#60a5fa')` are all accepted. Unmapped values fall back to gray.
 
 ```php
 BadgeColumn::make('status')->colors([

--- a/docs/content/docs/tables/columns/icon.mdx
+++ b/docs/content/docs/tables/columns/icon.mdx
@@ -19,8 +19,9 @@ IconColumn::make('verified')->label('Verified')
 - `->icon('star')` shows the same icon for every row.
 - `->icons([value => icon])` picks an icon per value — each key is a cell value, each icon a sprite
   name or a backed enum case (e.g. the built-in `Icon` enum).
-- `->colors([value => color])` tints the icon per value, with the same palette as a
-  [badge](/tables/columns/badge/).
+- `->colors([value => color])` tints the icon per value — a colour name (`gray`, `red`, `orange`,
+  `yellow`, `green`, `blue`, `purple`, or the semantic `default`, `muted`, `primary`, `success`,
+  `info`, `warning`, `danger`) or any CSS colour, same as a [badge](/tables/columns/badge/).
 
 ```php
 use Lattice\Lattice\Ui\Enums\Icon;

--- a/docs/content/docs/tables/columns/icon.mdx
+++ b/docs/content/docs/tables/columns/icon.mdx
@@ -22,6 +22,7 @@ IconColumn::make('verified')->label('Verified')
 - `->colors([value => color])` tints the icon per value — a colour name (`gray`, `red`, `orange`,
   `yellow`, `green`, `blue`, `purple`, or the semantic `default`, `muted`, `primary`, `success`,
   `info`, `warning`, `danger`) or any CSS colour, same as a [badge](/tables/columns/badge/).
+  Unmapped values render in the default icon colour.
 
 ```php
 use Lattice\Lattice\Ui\Enums\Icon;

--- a/docs/content/docs/tables/columns/stack.mdx
+++ b/docs/content/docs/tables/columns/stack.mdx
@@ -11,7 +11,7 @@ showing a name and email together, or a title with a subtitle. Pass a schema of 
 
 <ComponentExample
   php={`StackColumn::make('identity')->label('User')->schema([
-    Text::make('')->dataKey('text', 'name')->color(Color::Default),
+    Text::make('')->dataKey('text', 'name')->color(Color::default()),
     Text::make('')->dataKey('text', 'email')->size(Size::Sm),
 ]);
 

--- a/docs/content/docs/tables/columns/text.mdx
+++ b/docs/content/docs/tables/columns/text.mdx
@@ -48,9 +48,12 @@ TextColumn::make('api_token')->copyable();
 
 ## As a badge
 
-`->badge()` renders the value as a coloured pill. The tone is read from a sibling field on the row —
-`->badge('status_color')` reads the colour from `status_color`, defaulting to the `color` field.
-For a fixed value-to-colour map instead, use a dedicated [Badge column](/tables/columns/badge/).
+`->badge()` renders the value as a coloured pill. The colour is read from a sibling field on the row —
+`->badge('status_color')` reads it from `status_color`, defaulting to the `color` field. That field
+may hold a colour name (`green`, `success`, …) or any CSS colour — a hex value stored by a
+[ColorPicker](/forms/fields/color-picker/) field works as-is — falling back to gray when unset or
+unrecognized. For a fixed value-to-colour map instead, use a dedicated
+[Badge column](/tables/columns/badge/).
 
 ```php
 TextColumn::make('status')->badge('status_color');

--- a/docs/fixtures/components.progress.json
+++ b/docs/fixtures/components.progress.json
@@ -23,7 +23,11 @@
             },
             {
                 "props": {
-                    "color": "success",
+                    "color": {
+                        "dark": null,
+                        "kind": "named",
+                        "value": "success"
+                    },
                     "max": 100,
                     "showValue": false,
                     "size": "lg",
@@ -56,7 +60,11 @@
                     },
                     {
                         "props": {
-                            "color": "warning",
+                            "color": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "warning"
+                            },
                             "max": 50,
                             "showValue": true,
                             "size": "xl",

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -491,40 +491,6 @@
             }
         ]
     },
-    "Lattice\\Lattice\\Ui\\Enums\\Color": {
-        "name": "Color",
-        "namespace": "Lattice\\Lattice\\Ui\\Enums",
-        "cases": [
-            {
-                "name": "Default",
-                "value": "default"
-            },
-            {
-                "name": "Muted",
-                "value": "muted"
-            },
-            {
-                "name": "Primary",
-                "value": "primary"
-            },
-            {
-                "name": "Success",
-                "value": "success"
-            },
-            {
-                "name": "Info",
-                "value": "info"
-            },
-            {
-                "name": "Warning",
-                "value": "warning"
-            },
-            {
-                "name": "Danger",
-                "value": "danger"
-            }
-        ]
-    },
     "Lattice\\Lattice\\Ui\\Enums\\ColumnWidth": {
         "name": "ColumnWidth",
         "namespace": "Lattice\\Lattice\\Ui\\Enums",

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -31,6 +31,82 @@
             }
         ]
     },
+    "Lattice\\Lattice\\Core\\Enums\\ColorKind": {
+        "name": "ColorKind",
+        "namespace": "Lattice\\Lattice\\Core\\Enums",
+        "cases": [
+            {
+                "name": "Named",
+                "value": "named"
+            },
+            {
+                "name": "Css",
+                "value": "css"
+            }
+        ]
+    },
+    "Lattice\\Lattice\\Core\\Enums\\ColorName": {
+        "name": "ColorName",
+        "namespace": "Lattice\\Lattice\\Core\\Enums",
+        "cases": [
+            {
+                "name": "Default",
+                "value": "default"
+            },
+            {
+                "name": "Muted",
+                "value": "muted"
+            },
+            {
+                "name": "Primary",
+                "value": "primary"
+            },
+            {
+                "name": "Success",
+                "value": "success"
+            },
+            {
+                "name": "Info",
+                "value": "info"
+            },
+            {
+                "name": "Warning",
+                "value": "warning"
+            },
+            {
+                "name": "Danger",
+                "value": "danger"
+            },
+            {
+                "name": "Gray",
+                "value": "gray"
+            },
+            {
+                "name": "Red",
+                "value": "red"
+            },
+            {
+                "name": "Orange",
+                "value": "orange"
+            },
+            {
+                "name": "Yellow",
+                "value": "yellow"
+            },
+            {
+                "name": "Green",
+                "value": "green"
+            },
+            {
+                "name": "Blue",
+                "value": "blue"
+            },
+            {
+                "name": "Purple",
+                "value": "purple"
+            }
+        ]
+    },
     "Lattice\\Lattice\\Core\\Enums\\HttpMethod": {
         "name": "HttpMethod",
         "namespace": "Lattice\\Lattice\\Core\\Enums",

--- a/docs/fixtures/select.rich.json
+++ b/docs/fixtures/select.rich.json
@@ -42,7 +42,11 @@
                         {
                             "props": {
                                 "align": null,
-                                "color": "muted",
+                                "color": {
+                                    "dark": null,
+                                    "kind": "named",
+                                    "value": "muted"
+                                },
                                 "copyable": false,
                                 "dataBindings": {
                                     "text": "email"

--- a/docs/fixtures/table.badge.json
+++ b/docs/fixtures/table.badge.json
@@ -28,9 +28,21 @@
                     "props": {
                         "align": "start",
                         "colors": {
-                            "paid": "green",
-                            "pending": "yellow",
-                            "refunded": "gray"
+                            "paid": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "green"
+                            },
+                            "pending": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "yellow"
+                            },
+                            "refunded": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "gray"
+                            }
                         },
                         "filter": {
                             "clauseOptions": [],

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -44,9 +44,21 @@
                     "props": {
                         "align": "start",
                         "colors": {
-                            "active": "green",
-                            "archived": "gray",
-                            "invited": "yellow"
+                            "active": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "green"
+                            },
+                            "archived": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "gray"
+                            },
+                            "invited": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "yellow"
+                            }
                         },
                         "filter": null,
                         "hiddenByDefault": false,
@@ -62,8 +74,16 @@
                     "props": {
                         "align": "start",
                         "colors": {
-                            "0": "gray",
-                            "1": "green"
+                            "0": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "gray"
+                            },
+                            "1": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "green"
+                            }
                         },
                         "filter": null,
                         "hiddenByDefault": false,

--- a/docs/fixtures/table.icon.json
+++ b/docs/fixtures/table.icon.json
@@ -28,8 +28,16 @@
                     "props": {
                         "align": "start",
                         "colors": {
-                            "0": "gray",
-                            "1": "green"
+                            "0": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "gray"
+                            },
+                            "1": {
+                                "dark": null,
+                                "kind": "named",
+                                "value": "green"
+                            }
                         },
                         "filter": null,
                         "hiddenByDefault": false,

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -20,7 +20,11 @@
                         {
                             "props": {
                                 "align": null,
-                                "color": "default",
+                                "color": {
+                                    "dark": null,
+                                    "kind": "named",
+                                    "value": "default"
+                                },
                                 "copyable": false,
                                 "dataBindings": {
                                     "text": "name"

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -284,12 +284,40 @@
 }
 
 /*
- * Status colours for Badge and Icon table cells. Each tone sets a soft
- * background and a readable foreground in oklch; the `.dark` block swaps them.
- * Defined here (not as utility strings in the renderer) so the palette lives
- * with the theme and can be overridden, and so the cells can pick a tone by
- * name without Tailwind needing to see every class. Gray follows the muted token.
+ * Named colours. Semantic names alias the theme tokens; hue names carry their
+ * own oklch values with `.dark` overrides. Renderers resolve a named colour to
+ * `var(--lt-color-<name>)` for paint, or to an `.lt-tone-<name>` class for the
+ * soft-background/strong-foreground pair used by badge and icon cells. Defined
+ * here (not as utility strings in the renderers) so the palette lives with the
+ * theme and can be overridden, and so a colour can be picked by name at
+ * runtime without Tailwind needing to see every class.
  */
+:root {
+  --lt-color-default: var(--lt-fg);
+  --lt-color-muted: var(--lt-muted-fg);
+  --lt-color-primary: var(--lt-primary);
+  --lt-color-success: var(--lt-success);
+  --lt-color-info: var(--lt-info);
+  --lt-color-warning: var(--lt-warning);
+  --lt-color-danger: var(--lt-danger);
+  --lt-color-gray: var(--lt-muted-fg);
+  --lt-color-red: oklch(0.51 0.19 27);
+  --lt-color-orange: oklch(0.55 0.14 55);
+  --lt-color-yellow: oklch(0.52 0.1 85);
+  --lt-color-green: oklch(0.52 0.13 152);
+  --lt-color-blue: oklch(0.54 0.17 252);
+  --lt-color-purple: oklch(0.53 0.19 305);
+}
+
+.dark {
+  --lt-color-red: oklch(0.83 0.11 27);
+  --lt-color-orange: oklch(0.84 0.1 65);
+  --lt-color-yellow: oklch(0.87 0.11 100);
+  --lt-color-green: oklch(0.85 0.13 155);
+  --lt-color-blue: oklch(0.84 0.11 250);
+  --lt-color-purple: oklch(0.85 0.11 305);
+}
+
 .lt-cell-badge {
   display: inline-flex;
   align-items: center;
@@ -299,67 +327,92 @@
   font-size: 0.75rem;
   line-height: 1rem;
   font-weight: 500;
-  background-color: var(--lt-cell-bg, var(--lt-muted));
-  color: var(--lt-cell-fg, var(--lt-muted-fg));
+  background-color: var(--lt-tone-bg, var(--lt-muted));
+  color: var(--lt-tone-fg, var(--lt-muted-fg));
 }
 
 .lt-cell-icon {
   display: inline-flex;
-  color: var(--lt-cell-fg, var(--lt-fg));
+  color: var(--lt-tone-fg, var(--lt-fg));
 }
 
-.lt-cell-tone-gray {
-  --lt-cell-bg: var(--lt-muted);
-  --lt-cell-fg: var(--lt-muted-fg);
+.lt-tone-gray {
+  --lt-tone-bg: var(--lt-muted);
+  --lt-tone-fg: var(--lt-color-gray);
 }
-.lt-cell-tone-red {
-  --lt-cell-bg: oklch(0.94 0.03 25);
-  --lt-cell-fg: oklch(0.51 0.19 27);
+.lt-tone-red {
+  --lt-tone-bg: oklch(0.94 0.03 25);
+  --lt-tone-fg: var(--lt-color-red);
 }
-.lt-cell-tone-orange {
-  --lt-cell-bg: oklch(0.95 0.04 65);
-  --lt-cell-fg: oklch(0.55 0.14 55);
+.lt-tone-orange {
+  --lt-tone-bg: oklch(0.95 0.04 65);
+  --lt-tone-fg: var(--lt-color-orange);
 }
-.lt-cell-tone-yellow {
-  --lt-cell-bg: oklch(0.96 0.05 100);
-  --lt-cell-fg: oklch(0.52 0.1 85);
+.lt-tone-yellow {
+  --lt-tone-bg: oklch(0.96 0.05 100);
+  --lt-tone-fg: var(--lt-color-yellow);
 }
-.lt-cell-tone-green {
-  --lt-cell-bg: oklch(0.95 0.05 155);
-  --lt-cell-fg: oklch(0.52 0.13 152);
+.lt-tone-green {
+  --lt-tone-bg: oklch(0.95 0.05 155);
+  --lt-tone-fg: var(--lt-color-green);
 }
-.lt-cell-tone-blue {
-  --lt-cell-bg: oklch(0.95 0.03 245);
-  --lt-cell-fg: oklch(0.54 0.17 252);
+.lt-tone-blue {
+  --lt-tone-bg: oklch(0.95 0.03 245);
+  --lt-tone-fg: var(--lt-color-blue);
 }
-.lt-cell-tone-purple {
-  --lt-cell-bg: oklch(0.95 0.03 305);
-  --lt-cell-fg: oklch(0.53 0.19 305);
+.lt-tone-purple {
+  --lt-tone-bg: oklch(0.95 0.03 305);
+  --lt-tone-fg: var(--lt-color-purple);
 }
 
-.dark .lt-cell-tone-red {
-  --lt-cell-bg: oklch(0.29 0.08 27);
-  --lt-cell-fg: oklch(0.83 0.11 27);
+.lt-tone-default,
+.lt-tone-primary,
+.lt-tone-success,
+.lt-tone-info,
+.lt-tone-warning,
+.lt-tone-danger {
+  --lt-tone-bg: color-mix(in oklab, var(--lt-tone-fg) 12%, transparent);
 }
-.dark .lt-cell-tone-orange {
-  --lt-cell-bg: oklch(0.3 0.07 65);
-  --lt-cell-fg: oklch(0.84 0.1 65);
+.lt-tone-default {
+  --lt-tone-fg: var(--lt-color-default);
 }
-.dark .lt-cell-tone-yellow {
-  --lt-cell-bg: oklch(0.31 0.06 100);
-  --lt-cell-fg: oklch(0.87 0.11 100);
+.lt-tone-muted {
+  --lt-tone-bg: var(--lt-muted);
+  --lt-tone-fg: var(--lt-color-muted);
 }
-.dark .lt-cell-tone-green {
-  --lt-cell-bg: oklch(0.3 0.07 155);
-  --lt-cell-fg: oklch(0.85 0.13 155);
+.lt-tone-primary {
+  --lt-tone-fg: var(--lt-color-primary);
 }
-.dark .lt-cell-tone-blue {
-  --lt-cell-bg: oklch(0.3 0.07 245);
-  --lt-cell-fg: oklch(0.84 0.11 250);
+.lt-tone-success {
+  --lt-tone-fg: var(--lt-color-success);
 }
-.dark .lt-cell-tone-purple {
-  --lt-cell-bg: oklch(0.3 0.07 305);
-  --lt-cell-fg: oklch(0.85 0.11 305);
+.lt-tone-info {
+  --lt-tone-fg: var(--lt-color-info);
+}
+.lt-tone-warning {
+  --lt-tone-fg: var(--lt-color-warning);
+}
+.lt-tone-danger {
+  --lt-tone-fg: var(--lt-color-danger);
+}
+
+.dark .lt-tone-red {
+  --lt-tone-bg: oklch(0.29 0.08 27);
+}
+.dark .lt-tone-orange {
+  --lt-tone-bg: oklch(0.3 0.07 65);
+}
+.dark .lt-tone-yellow {
+  --lt-tone-bg: oklch(0.31 0.06 100);
+}
+.dark .lt-tone-green {
+  --lt-tone-bg: oklch(0.3 0.07 155);
+}
+.dark .lt-tone-blue {
+  --lt-tone-bg: oklch(0.3 0.07 245);
+}
+.dark .lt-tone-purple {
+  --lt-tone-bg: oklch(0.3 0.07 305);
 }
 
 /*

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -309,6 +309,7 @@
   --lt-color-purple: oklch(0.53 0.19 305);
 }
 
+[data-theme="dark"],
 .dark {
   --lt-color-red: oklch(0.83 0.11 27);
   --lt-color-orange: oklch(0.84 0.1 65);
@@ -396,21 +397,27 @@
   --lt-tone-fg: var(--lt-color-danger);
 }
 
+[data-theme="dark"] .lt-tone-red,
 .dark .lt-tone-red {
   --lt-tone-bg: oklch(0.29 0.08 27);
 }
+[data-theme="dark"] .lt-tone-orange,
 .dark .lt-tone-orange {
   --lt-tone-bg: oklch(0.3 0.07 65);
 }
+[data-theme="dark"] .lt-tone-yellow,
 .dark .lt-tone-yellow {
   --lt-tone-bg: oklch(0.31 0.06 100);
 }
+[data-theme="dark"] .lt-tone-green,
 .dark .lt-tone-green {
   --lt-tone-bg: oklch(0.3 0.07 155);
 }
+[data-theme="dark"] .lt-tone-blue,
 .dark .lt-tone-blue {
   --lt-tone-bg: oklch(0.3 0.07 245);
 }
+[data-theme="dark"] .lt-tone-purple,
 .dark .lt-tone-purple {
   --lt-tone-bg: oklch(0.3 0.07 305);
 }

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@lattice-php/lattice/icons";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Combobox } from "@lattice-php/lattice/ui/combobox";
 import { controlSurface } from "@lattice-php/lattice/ui/control";
+import { coerceColor, colorValue } from "@lattice-php/lattice/lib/color";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
@@ -78,7 +79,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
   }, [staticOptions, results]);
   const labelFor = (value: string) => optionsByValue.get(value)?.label ?? value;
   const colorFor = (value: string) =>
-    (optionsByValue.get(value)?.data as { color?: string } | undefined)?.color;
+    coerceColor((optionsByValue.get(value)?.data as { color?: unknown } | undefined)?.color);
 
   const locked = readOnly || disabled;
 
@@ -211,7 +212,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
                     <span
                       aria-hidden="true"
                       className="size-2 shrink-0 rounded-full"
-                      style={{ background: color }}
+                      style={{ background: colorValue(color) }}
                     />
                   )}
                   {labelFor(value)}

--- a/resources/js/lib/color.test.ts
+++ b/resources/js/lib/color.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { coerceColor, colorValue, namedColor, toneProps } from "./color";
+
+describe("coerceColor", () => {
+  it("coerces known names to named colors", () => {
+    expect(coerceColor("green")).toEqual({ kind: "named", value: "green", dark: null });
+  });
+
+  it("coerces unknown strings to css colors", () => {
+    expect(coerceColor("#dc2626")).toEqual({ kind: "css", value: "#dc2626", dark: null });
+  });
+
+  it("passes tagged colors through", () => {
+    const color = { kind: "css", value: "#2563eb", dark: "#60a5fa" } as const;
+    expect(coerceColor(color)).toBe(color);
+  });
+
+  it("returns undefined for empty and non-color values", () => {
+    expect(coerceColor("")).toBeUndefined();
+    expect(coerceColor(null)).toBeUndefined();
+    expect(coerceColor(undefined)).toBeUndefined();
+    expect(coerceColor(42)).toBeUndefined();
+  });
+});
+
+describe("colorValue", () => {
+  it("resolves named colors to palette vars", () => {
+    expect(colorValue(namedColor("success"))).toBe("var(--lt-color-success)");
+  });
+
+  it("passes css colors through", () => {
+    expect(colorValue({ kind: "css", value: "#2563eb", dark: null })).toBe("#2563eb");
+  });
+
+  it("emits light-dark() for css colors with a dark counterpart", () => {
+    expect(colorValue({ kind: "css", value: "#2563eb", dark: "#60a5fa" })).toBe(
+      "light-dark(#2563eb, #60a5fa)",
+    );
+  });
+});
+
+describe("toneProps", () => {
+  it("resolves named colors to tone classes", () => {
+    expect(toneProps(namedColor("green"))).toEqual({ className: "lt-tone-green" });
+  });
+
+  it("derives an inline tone pair for css colors", () => {
+    expect(toneProps({ kind: "css", value: "#dc2626", dark: null })).toEqual({
+      style: {
+        "--lt-tone-bg": "color-mix(in oklab, #dc2626 12%, transparent)",
+        "--lt-tone-fg": "#dc2626",
+      },
+    });
+  });
+});

--- a/resources/js/lib/color.ts
+++ b/resources/js/lib/color.ts
@@ -1,0 +1,58 @@
+import type { CSSProperties } from "react";
+import type { Color, ColorName } from "@lattice-php/lattice/types/generated";
+
+const names: ReadonlySet<string> = new Set([
+  "default",
+  "muted",
+  "primary",
+  "success",
+  "info",
+  "warning",
+  "danger",
+  "gray",
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "purple",
+] satisfies ColorName[]);
+
+export function namedColor(value: ColorName): Color {
+  return { kind: "named", value, dark: null };
+}
+
+export function coerceColor(value: unknown): Color | undefined {
+  if (typeof value === "string" && value !== "") {
+    return names.has(value) ? namedColor(value as ColorName) : { kind: "css", value, dark: null };
+  }
+
+  if (typeof value === "object" && value !== null && "kind" in value && "value" in value) {
+    return value as Color;
+  }
+
+  return undefined;
+}
+
+export function colorValue(color: Color): string {
+  if (color.kind === "named") {
+    return `var(--lt-color-${color.value})`;
+  }
+
+  return color.dark === null ? color.value : `light-dark(${color.value}, ${color.dark})`;
+}
+
+export function toneProps(color: Color): { className?: string; style?: CSSProperties } {
+  if (color.kind === "named") {
+    return { className: `lt-tone-${color.value}` };
+  }
+
+  const paint = colorValue(color);
+
+  return {
+    style: {
+      "--lt-tone-bg": `color-mix(in oklab, ${paint} 12%, transparent)`,
+      "--lt-tone-fg": paint,
+    } as CSSProperties,
+  };
+}

--- a/resources/js/remote/components/data-list.test.tsx
+++ b/resources/js/remote/components/data-list.test.tsx
@@ -31,7 +31,7 @@ function node(): Node<"remote.data-list"> {
         key: "name",
         props: {
           align: null,
-          color: "default",
+          color: { kind: "named", value: "default", dark: null },
           dataBindings: {
             text: "name",
           },
@@ -44,7 +44,7 @@ function node(): Node<"remote.data-list"> {
         key: "email",
         props: {
           align: null,
-          color: "muted",
+          color: { kind: "named", value: "muted", dark: null },
           dataBindings: {
             text: "email",
           },
@@ -75,7 +75,7 @@ function schemaNode(): Node<"remote.data-list"> {
             key: "email",
             props: {
               align: null,
-              color: "muted",
+              color: { kind: "named", value: "muted", dark: null },
               dataBindings: {
                 text: "email",
               },

--- a/resources/js/table/components/cells/badge-cell.tsx
+++ b/resources/js/table/components/cells/badge-cell.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { coerceColor, namedColor, toneProps } from "@lattice-php/lattice/lib/color";
 import { formatCell } from "@lattice-php/lattice/table/lib/format";
 import type { ColumnCellComponent } from "@lattice-php/lattice/table/registry";
 
@@ -9,7 +10,11 @@ export const BadgeCell: ColumnCellComponent<"column.badge"> = ({ column, props, 
     return null;
   }
 
-  const color = props.colors?.[String(value)] ?? "gray";
+  const tone = toneProps(coerceColor(props.colors?.[String(value)]) ?? namedColor("gray"));
 
-  return <span className={cn("lt-cell-badge", `lt-cell-tone-${color}`)}>{label}</span>;
+  return (
+    <span className={cn("lt-cell-badge", tone.className)} style={tone.style}>
+      {label}
+    </span>
+  );
 };

--- a/resources/js/table/components/cells/icon-cell.tsx
+++ b/resources/js/table/components/cells/icon-cell.tsx
@@ -1,5 +1,6 @@
 import { IconRenderer } from "@lattice-php/lattice/icons";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { coerceColor, toneProps } from "@lattice-php/lattice/lib/color";
 import type { ColumnCellComponent } from "@lattice-php/lattice/table/registry";
 
 export const IconCell: ColumnCellComponent<"column.icon"> = ({ props, value }) => {
@@ -9,12 +10,14 @@ export const IconCell: ColumnCellComponent<"column.icon"> = ({ props, value }) =
     return null;
   }
 
-  const color = props.colors?.[String(value)];
+  const color = coerceColor(props.colors?.[String(value)]);
+  const tone = color ? toneProps(color) : undefined;
 
   return (
     <span
       aria-label={String(value)}
-      className={cn("lt-cell-icon", color && `lt-cell-tone-${color}`)}
+      className={cn("lt-cell-icon", tone?.className)}
+      style={tone?.style}
     >
       <IconRenderer className="size-lt-icon-md" icon={icon} />
     </span>

--- a/resources/js/table/components/cells/text-cell.test.tsx
+++ b/resources/js/table/components/cells/text-cell.test.tsx
@@ -35,8 +35,8 @@ describe("TextCell", () => {
       { value: "Sale", color: "red" },
     ]);
 
-    expect(screen.getByText("New")).toHaveClass("lt-cell-badge", "lt-cell-tone-blue");
-    expect(screen.getByText("Sale")).toHaveClass("lt-cell-badge", "lt-cell-tone-red");
+    expect(screen.getByText("New")).toHaveClass("lt-cell-badge", "lt-tone-blue");
+    expect(screen.getByText("Sale")).toHaveClass("lt-cell-badge", "lt-tone-red");
   });
 
   it("joins a multiple column without a badge", () => {
@@ -48,13 +48,20 @@ describe("TextCell", () => {
   it("reads the badge colour from a sibling row key for a single value", () => {
     renderCell({ badge: { colorKey: "color" } }, "Active", { color: "green" });
 
-    expect(screen.getByText("Active")).toHaveClass("lt-cell-badge", "lt-cell-tone-green");
+    expect(screen.getByText("Active")).toHaveClass("lt-cell-badge", "lt-tone-green");
   });
 
   it("falls back to the gray tone when the sibling colour is missing", () => {
     renderCell({ badge: { colorKey: "color" } }, "Active", {});
 
-    expect(screen.getByText("Active")).toHaveClass("lt-cell-tone-gray");
+    expect(screen.getByText("Active")).toHaveClass("lt-tone-gray");
+  });
+
+  it("renders a css row colour as an inline tone pair", () => {
+    renderCell({ badge: { colorKey: "color" } }, "Active", { color: "#dc2626" });
+
+    const badge = screen.getByText("Active");
+    expect(badge.style.getPropertyValue("--lt-tone-fg")).toBe("#dc2626");
   });
 
   it("renders nothing for an empty multiple column", () => {

--- a/resources/js/table/components/cells/text-cell.tsx
+++ b/resources/js/table/components/cells/text-cell.tsx
@@ -1,5 +1,6 @@
 import { DateTime } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
+import { coerceColor, namedColor, toneProps } from "@lattice-php/lattice/lib/color";
 import { CopyableText } from "@lattice-php/lattice/ui/copyable-text";
 import type { ReactNode } from "react";
 import { formatCell, resolveLink } from "@lattice-php/lattice/table/lib/format";
@@ -25,7 +26,13 @@ function Badge({ label, color }: { label: string; color?: string | null }): Reac
     return null;
   }
 
-  return <span className={cn("lt-cell-badge", `lt-cell-tone-${color || "gray"}`)}>{label}</span>;
+  const tone = toneProps(coerceColor(color) ?? namedColor("gray"));
+
+  return (
+    <span className={cn("lt-cell-badge", tone.className)} style={tone.style}>
+      {label}
+    </span>
+  );
 }
 
 function MultipleCell({ column, props, value }: ColumnCellArgs<"column.text">): ReactNode {

--- a/resources/js/table/registry.test.tsx
+++ b/resources/js/table/registry.test.tsx
@@ -187,14 +187,14 @@ describe("column registry", () => {
         key: "status",
         label: "Status",
         type: "column.badge",
-        props: { colors: { active: "green" } },
+        props: { colors: { active: { kind: "named", value: "green", dark: null } } },
       }),
       { status: "active" },
     );
 
     const badge = screen.getByText("active");
     expect(badge).toBeVisible();
-    expect(badge.className).toContain("lt-cell-tone-green");
+    expect(badge.className).toContain("lt-tone-green");
   });
 
   it("renders an icon cell from the value map", () => {
@@ -266,7 +266,7 @@ describe("column registry", () => {
       { status: "archived" },
     );
 
-    expect(screen.getByText("archived").className).toContain("lt-cell-tone-gray");
+    expect(screen.getByText("archived").className).toContain("lt-tone-gray");
   });
 
   it("renders nothing for a badge cell with an empty value", () => {
@@ -354,7 +354,7 @@ describe("column registry", () => {
       { s: "ok" },
     );
 
-    expect(screen.getByLabelText("ok").className).toContain("lt-cell-tone-green");
+    expect(screen.getByLabelText("ok").className).toContain("lt-tone-green");
   });
 
   it("renders a text cell as an internal link", () => {

--- a/resources/js/table/types.test-d.ts
+++ b/resources/js/table/types.test-d.ts
@@ -34,9 +34,9 @@ type _ColumnProps = ColumnProps;
 // 3. Built-in column type resolves from the generated map, common concerns included.
 const _builtin: ColumnPropsOf<"column.badge"> = {
   ...commonColumnProps,
-  colors: { active: "green" },
+  colors: { active: { kind: "named", value: "green", dark: null } },
 };
-// @ts-expect-error colors must be a record of strings, not a number
+// @ts-expect-error colors must be a record of Color values, not a number
 const _builtinBad: ColumnPropsOf<"column.badge"> = { colors: 1 };
 void _builtin;
 void _builtinBad;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -36,7 +36,7 @@ export type Badge = {
 };
 export type BadgeColumn = {
   align: ColumnAlign;
-  colors: Record<string | number, string> | null;
+  colors: Record<string | number, Color> | null;
   filter: ColumnFilter | null;
   hiddenByDefault: boolean;
   label: string | null;
@@ -151,7 +151,7 @@ export type ChartSeries = {
   readonly type: ChartSeriesType;
   readonly dataKey: string;
   readonly name: string;
-  readonly color: string | null;
+  readonly color: Color | null;
   readonly stackId: string | null;
   readonly nameKey: string | null;
   readonly innerRadius: string;
@@ -220,7 +220,27 @@ export type Collapsible = {
   tooltip: string | null;
   trigger: Node[];
 };
-export type Color = "default" | "muted" | "primary" | "success" | "info" | "warning" | "danger";
+export type Color = {
+  readonly kind: ColorKind;
+  readonly value: string;
+  readonly dark: string | null;
+};
+export type ColorKind = "named" | "css";
+export type ColorName =
+  | "default"
+  | "muted"
+  | "primary"
+  | "success"
+  | "info"
+  | "warning"
+  | "danger"
+  | "gray"
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "purple";
 export type ColorPicker = {
   columnWidth: ColumnWidth;
   conditions: FieldConditions | null;
@@ -665,7 +685,7 @@ export type Icon = {
 };
 export type IconColumn = {
   align: ColumnAlign;
-  colors: Record<string | number, string> | null;
+  colors: Record<string | number, Color> | null;
   filter: ColumnFilter | null;
   hiddenByDefault: boolean;
   icon: string | null;

--- a/resources/js/ui/chart-view.tsx
+++ b/resources/js/ui/chart-view.tsx
@@ -22,6 +22,7 @@ import {
 import type { ComponentType, ReactNode } from "react";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 import type { PropsOf, RendererComponent } from "@lattice-php/lattice/core/types";
+import { coerceColor, colorValue } from "@lattice-php/lattice/lib/color";
 import { useLocale, useTimezone } from "@lattice-php/lattice/i18n";
 import { numericValue } from "@lattice-php/lattice/format/numeric";
 import { formatValue } from "@lattice-php/lattice/format/value";
@@ -78,11 +79,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function datumColor(datum: ChartDatum, series: ChartSeries, index: number): string {
-  if (isRecord(datum) && typeof datum.color === "string") {
-    return datum.color;
+  if (isRecord(datum)) {
+    const color = coerceColor(datum.color);
+
+    if (color) {
+      return colorValue(color);
+    }
   }
 
-  return series.color ?? colorAt(index);
+  return series.color ? colorValue(series.color) : colorAt(index);
 }
 
 function isCartesianSeries(series: ChartSeries): series is CartesianSeries {
@@ -201,7 +206,7 @@ function CartesianChart({ props }: { props: ChartProps }) {
         )}
         {props.legend && <Legend {...compactLegendProps} />}
         {series.map((item, index) => {
-          const color = item.color ?? colorAt(index);
+          const color = item.color ? colorValue(item.color) : colorAt(index);
           const key = `${item.type}:${item.dataKey}`;
 
           if (item.type === "area") {

--- a/resources/js/ui/chart.test.tsx
+++ b/resources/js/ui/chart.test.tsx
@@ -167,7 +167,7 @@ describe("Chart component", () => {
         legend: true,
         series: [
           {
-            color: "#2563eb",
+            color: { kind: "css", value: "#2563eb", dark: null },
             dataKey: "revenue",
             name: "Revenue",
             nameKey: null,
@@ -177,7 +177,7 @@ describe("Chart component", () => {
             type: "line",
           },
           {
-            color: "#16a34a",
+            color: { kind: "css", value: "#16a34a", dark: null },
             dataKey: "orders",
             name: "Orders",
             nameKey: null,
@@ -187,7 +187,7 @@ describe("Chart component", () => {
             type: "bar",
           },
           {
-            color: "#9333ea",
+            color: { kind: "css", value: "#9333ea", dark: null },
             dataKey: "forecast",
             name: "Forecast",
             nameKey: null,
@@ -321,7 +321,7 @@ describe("Chart component", () => {
         legend: true,
         series: [
           {
-            color: "#2563eb",
+            color: { kind: "css", value: "#2563eb", dark: null },
             dataKey: "amount",
             name: "Series",
             nameKey: "channel",
@@ -415,7 +415,7 @@ describe("Chart component", () => {
         legend: true,
         series: [
           {
-            color: "#2563eb",
+            color: { kind: "css", value: "#2563eb", dark: null },
             dataKey: "value",
             name: "value",
             nameKey: "label",
@@ -469,7 +469,7 @@ describe("Chart component", () => {
         legend: true,
         series: [
           {
-            color: "#2563eb",
+            color: { kind: "css", value: "#2563eb", dark: null },
             dataKey: "amount",
             name: "amount",
             nameKey: "channel",
@@ -729,7 +729,7 @@ describe("Chart component", () => {
         legend: true,
         series: [
           {
-            color: "#9333ea",
+            color: { kind: "css", value: "#9333ea", dark: null },
             dataKey: "forecast",
             name: "Forecast",
             nameKey: null,
@@ -763,7 +763,7 @@ describe("Chart component", () => {
         legend: true,
         series: [
           {
-            color: "#16a34a",
+            color: { kind: "css", value: "#16a34a", dark: null },
             dataKey: "orders",
             name: "Orders",
             nameKey: null,
@@ -917,7 +917,7 @@ describe("Chart component", () => {
             legend: false,
             series: [
               {
-                color: "#2563eb",
+                color: { kind: "css", value: "#2563eb", dark: null },
                 dataKey: "revenue",
                 name: "Revenue",
                 nameKey: null,

--- a/resources/js/ui/icon.test.tsx
+++ b/resources/js/ui/icon.test.tsx
@@ -23,16 +23,20 @@ describe("Lattice icon component", () => {
     const { container } = renderIcon({
       name: "house",
       size: "lg",
-      color: "danger",
+      color: { kind: "named", value: "danger", dark: null },
       class: "opacity-80",
     });
 
     const svg = container.querySelector("svg");
 
-    expect(svg).toHaveClass("size-lt-icon-lg", "text-lt-danger", "opacity-80");
+    expect(svg).toHaveClass("size-lt-icon-lg", "opacity-80");
     // The sprite renderer applies size-lt-icon-md as a baseline; an explicit
     // size must override it rather than coexist with it.
     expect(svg).not.toHaveClass("size-lt-icon-md");
+
+    const wrapper = container.querySelector("span.contents");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.style.getPropertyValue("color")).toBe("var(--lt-color-danger)");
   });
 
   it.each(["2xl", "3xl", "4xl"] as const)("supports the %s display size", (size) => {
@@ -48,6 +52,6 @@ describe("Lattice icon component", () => {
     const svg = container.querySelector("svg");
 
     expect(svg).toHaveClass("size-lt-icon-md");
-    expect(svg).not.toHaveClass("text-lt-danger");
+    expect(container.querySelector("span.contents")).toBeNull();
   });
 });

--- a/resources/js/ui/icon.test.tsx
+++ b/resources/js/ui/icon.test.tsx
@@ -34,7 +34,7 @@ describe("Lattice icon component", () => {
     // size must override it rather than coexist with it.
     expect(svg).not.toHaveClass("size-lt-icon-md");
 
-    const wrapper = container.querySelector("span.contents");
+    const wrapper = container.querySelector<HTMLSpanElement>("span.contents");
     expect(wrapper).not.toBeNull();
     expect(wrapper?.style.getPropertyValue("color")).toBe("var(--lt-color-danger)");
   });

--- a/resources/js/ui/icon.tsx
+++ b/resources/js/ui/icon.tsx
@@ -1,7 +1,8 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { IconRenderer } from "@lattice-php/lattice/icons";
+import { coerceColor, colorValue } from "@lattice-php/lattice/lib/color";
 import { cn } from "@lattice-php/lattice/lib/utils";
-import type { Color, Size } from "@lattice-php/lattice/types/generated";
+import type { Size } from "@lattice-php/lattice/types/generated";
 
 const sizeClass: Record<Size, string> = {
   xs: "size-lt-icon-xs",
@@ -14,24 +15,19 @@ const sizeClass: Record<Size, string> = {
   "4xl": "size-lt-icon-4xl",
 };
 
-const colorClass: Record<Color, string> = {
-  default: "text-lt-fg",
-  muted: "text-lt-muted-fg",
-  primary: "text-lt-primary",
-  success: "text-lt-success",
-  info: "text-lt-info",
-  warning: "text-lt-warning",
-  danger: "text-lt-danger",
-};
-
 const IconComponent: RendererComponent<"icon"> = ({ node }) => {
   const { name, size, color, class: className } = node.props;
+  const icon = <IconRenderer icon={name} className={cn(sizeClass[size], className)} />;
+  const coerced = coerceColor(color);
+
+  if (!coerced) {
+    return icon;
+  }
 
   return (
-    <IconRenderer
-      icon={name}
-      className={cn(sizeClass[size], color ? colorClass[color] : undefined, className)}
-    />
+    <span className="contents" style={{ color: colorValue(coerced) }}>
+      {icon}
+    </span>
   );
 };
 

--- a/resources/js/ui/progress.test.tsx
+++ b/resources/js/ui/progress.test.tsx
@@ -57,11 +57,16 @@ describe("ProgressComponent bar", () => {
   });
 
   it("maps color and size onto the fill and track", () => {
-    renderProgress({ value: 40, color: "success", size: "lg" });
+    renderProgress({
+      value: 40,
+      color: { kind: "named", value: "success", dark: null },
+      size: "lg",
+    });
 
     const track = screen.getByRole("progressbar");
     expect(track.className).toContain("h-3");
-    expect((track.firstElementChild as HTMLElement).className).toContain("bg-lt-success");
+    const fill = track.firstElementChild as HTMLElement;
+    expect(fill.style.getPropertyValue("background")).toBe("var(--lt-color-success)");
   });
 });
 
@@ -98,9 +103,13 @@ describe("ProgressComponent circle", () => {
   });
 
   it("colors the ring stroke from the color prop", () => {
-    const { container } = renderProgress({ value: 10, variant: "circle", color: "danger" });
+    const { container } = renderProgress({
+      value: 10,
+      variant: "circle",
+      color: { kind: "named", value: "danger", dark: null },
+    });
 
     const ring = container.querySelectorAll("circle")[1];
-    expect(ring.getAttribute("class")).toContain("text-lt-danger");
+    expect(ring.style.getPropertyValue("color")).toBe("var(--lt-color-danger)");
   });
 });

--- a/resources/js/ui/progress.tsx
+++ b/resources/js/ui/progress.tsx
@@ -1,7 +1,8 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { useLocale } from "@lattice-php/lattice/i18n";
+import { coerceColor, colorValue, namedColor } from "@lattice-php/lattice/lib/color";
 import { cn } from "@lattice-php/lattice/lib/utils";
-import type { Color, Size } from "@lattice-php/lattice/types/generated";
+import type { Size } from "@lattice-php/lattice/types/generated";
 
 const barHeights: Record<Size, string> = {
   xs: "h-1",
@@ -12,26 +13,6 @@ const barHeights: Record<Size, string> = {
   "2xl": "h-5",
   "3xl": "h-6",
   "4xl": "h-8",
-};
-
-const fillColors: Record<Color, string> = {
-  default: "bg-lt-fg",
-  muted: "bg-lt-muted-fg",
-  primary: "bg-lt-primary",
-  success: "bg-lt-success",
-  info: "bg-lt-info",
-  warning: "bg-lt-warning",
-  danger: "bg-lt-danger",
-};
-
-const strokeColors: Record<Color, string> = {
-  default: "text-lt-fg",
-  muted: "text-lt-muted-fg",
-  primary: "text-lt-primary",
-  success: "text-lt-success",
-  info: "text-lt-info",
-  warning: "text-lt-warning",
-  danger: "text-lt-danger",
 };
 
 const circleDiameters: Record<Size, number> = {
@@ -59,6 +40,7 @@ const circleReadouts: Record<Size, string> = {
 const ProgressComponent: RendererComponent<"progress"> = ({ node }) => {
   const { value, max, variant, showValue, color, size } = node.props;
   const { locale } = useLocale();
+  const paint = colorValue(coerceColor(color) ?? namedColor("primary"));
 
   const clamped = max > 0 ? Math.min(Math.max(value, 0), max) : 0;
   const ratio = max > 0 ? clamped / max : 0;
@@ -94,7 +76,6 @@ const ProgressComponent: RendererComponent<"progress"> = ({ node }) => {
             strokeWidth={strokeWidth}
           />
           <circle
-            className={strokeColors[color ?? "primary"]}
             cx={diameter / 2}
             cy={diameter / 2}
             fill="none"
@@ -104,6 +85,7 @@ const ProgressComponent: RendererComponent<"progress"> = ({ node }) => {
             strokeDashoffset={circumference * (1 - ratio)}
             strokeLinecap="round"
             strokeWidth={strokeWidth}
+            style={{ color: paint }}
           />
         </svg>
         {showValue && (
@@ -127,8 +109,8 @@ const ProgressComponent: RendererComponent<"progress"> = ({ node }) => {
         className={cn("w-full overflow-hidden rounded-full bg-lt-muted", barHeights[size])}
       >
         <div
-          className={cn("h-full rounded-full", fillColors[color ?? "primary"])}
-          style={{ width: `${ratio * 100}%` }}
+          className="h-full rounded-full"
+          style={{ background: paint, width: `${ratio * 100}%` }}
         />
       </div>
       {showValue && (

--- a/resources/js/ui/text.test.tsx
+++ b/resources/js/ui/text.test.tsx
@@ -22,7 +22,7 @@ describe("Lattice text component", () => {
     const node = fakeNode({
       props: {
         align: "center",
-        color: "default",
+        color: { kind: "named", value: "default", dark: null },
         size: "sm",
         text: "Manuel Christlieb",
       },
@@ -31,12 +31,9 @@ describe("Lattice text component", () => {
 
     render(<TextComponent node={node}>{null}</TextComponent>);
 
-    expect(screen.getByText("Manuel Christlieb")).toHaveClass(
-      "m-0",
-      "text-center",
-      "text-lt-fg",
-      "text-sm",
-    );
+    const text = screen.getByText("Manuel Christlieb");
+    expect(text).toHaveClass("m-0", "text-center", "text-sm");
+    expect(text.style.getPropertyValue("color")).toBe("var(--lt-color-default)");
   });
 
   it("falls back to muted styling when no color is set", () => {
@@ -50,6 +47,8 @@ describe("Lattice text component", () => {
 
     render(<TextComponent node={node}>{null}</TextComponent>);
 
-    expect(screen.getByText("Helper text")).toHaveClass("text-lt-muted-fg");
+    expect(screen.getByText("Helper text").style.getPropertyValue("color")).toBe(
+      "var(--lt-color-muted)",
+    );
   });
 });

--- a/resources/js/ui/text.tsx
+++ b/resources/js/ui/text.tsx
@@ -1,21 +1,12 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { coerceColor, colorValue, namedColor } from "@lattice-php/lattice/lib/color";
 import { cn } from "@lattice-php/lattice/lib/utils";
-import type { Color, Size } from "@lattice-php/lattice/types/generated";
+import type { Size } from "@lattice-php/lattice/types/generated";
 import { CopyableText } from "./copyable-text";
 
 const textAlignments: Record<string, string> = {
   center: "text-center",
   left: "text-left",
-};
-
-const textColors: Record<Color, string> = {
-  default: "text-lt-fg",
-  muted: "text-lt-muted-fg",
-  primary: "text-lt-primary",
-  success: "text-lt-success",
-  info: "text-lt-info",
-  warning: "text-lt-warning",
-  danger: "text-lt-danger",
 };
 
 const textSizes: Record<Size, string> = {
@@ -31,6 +22,7 @@ const textSizes: Record<Size, string> = {
 
 const TextComponent: RendererComponent<"text"> = ({ node }) => {
   const align = node.props.align ?? "left";
+  const color = colorValue(coerceColor(node.props.color) ?? namedColor("muted"));
 
   const text = (
     <p
@@ -38,9 +30,9 @@ const TextComponent: RendererComponent<"text"> = ({ node }) => {
         "m-0",
         "max-w-2xl",
         textAlignments[align] ?? textAlignments.left,
-        textColors[node.props.color ?? "muted"],
         textSizes[node.props.size],
       )}
+      style={{ color }}
     >
       {node.props.text}
     </p>

--- a/src/Core/Color.php
+++ b/src/Core/Color.php
@@ -5,6 +5,8 @@ namespace Lattice\Lattice\Core;
 
 use InvalidArgumentException;
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Core\Enums\ColorKind;
+use Lattice\Lattice\Core\Enums\ColorName;
 use LogicException;
 
 /**

--- a/src/Core/Color.php
+++ b/src/Core/Color.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core;
+
+use InvalidArgumentException;
+use Lattice\Lattice\Attributes\TypeScript;
+use LogicException;
+
+/**
+ * A display colour carried on the wire as a tagged value: a theme-defined
+ * named colour (semantic tokens and hue tones) or a raw CSS colour with an
+ * optional dark-mode counterpart. `from()` provides the string sugar accepted
+ * by public APIs — a known name becomes a named colour, anything else passes
+ * through as CSS.
+ */
+#[TypeScript]
+final readonly class Color
+{
+    private function __construct(
+        public ColorKind $kind,
+        public string $value,
+        public ?string $dark = null,
+    ) {}
+
+    public static function named(ColorName $name): self
+    {
+        return new self(ColorKind::Named, $name->value);
+    }
+
+    public static function css(string $value): self
+    {
+        return new self(ColorKind::Css, $value);
+    }
+
+    public static function hex(string $value): self
+    {
+        if (preg_match('/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $value) !== 1) {
+            throw new InvalidArgumentException(sprintf('[%s] is not a valid hex colour.', $value));
+        }
+
+        return new self(ColorKind::Css, $value);
+    }
+
+    public function dark(string $value): self
+    {
+        if ($this->kind !== ColorKind::Css) {
+            throw new LogicException('Named colours take their dark value from the theme; dark() applies to css colours only.');
+        }
+
+        return new self($this->kind, $this->value, $value);
+    }
+
+    public static function from(self|ColorName|string $value): self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        if ($value instanceof ColorName) {
+            return self::named($value);
+        }
+
+        $name = ColorName::tryFrom($value);
+
+        return $name === null ? self::css($value) : self::named($name);
+    }
+
+    public static function default(): self
+    {
+        return self::named(ColorName::Default);
+    }
+
+    public static function muted(): self
+    {
+        return self::named(ColorName::Muted);
+    }
+
+    public static function primary(): self
+    {
+        return self::named(ColorName::Primary);
+    }
+
+    public static function success(): self
+    {
+        return self::named(ColorName::Success);
+    }
+
+    public static function info(): self
+    {
+        return self::named(ColorName::Info);
+    }
+
+    public static function warning(): self
+    {
+        return self::named(ColorName::Warning);
+    }
+
+    public static function danger(): self
+    {
+        return self::named(ColorName::Danger);
+    }
+
+    public static function gray(): self
+    {
+        return self::named(ColorName::Gray);
+    }
+
+    public static function red(): self
+    {
+        return self::named(ColorName::Red);
+    }
+
+    public static function orange(): self
+    {
+        return self::named(ColorName::Orange);
+    }
+
+    public static function yellow(): self
+    {
+        return self::named(ColorName::Yellow);
+    }
+
+    public static function green(): self
+    {
+        return self::named(ColorName::Green);
+    }
+
+    public static function blue(): self
+    {
+        return self::named(ColorName::Blue);
+    }
+
+    public static function purple(): self
+    {
+        return self::named(ColorName::Purple);
+    }
+}

--- a/src/Core/ColorKind.php
+++ b/src/Core/ColorKind.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum ColorKind: string
+{
+    case Named = 'named';
+    case Css = 'css';
+}

--- a/src/Core/ColorName.php
+++ b/src/Core/ColorName.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
 
-namespace Lattice\Lattice\Ui\Enums;
+namespace Lattice\Lattice\Core;
 
 use Lattice\Lattice\Attributes\TypeScript;
 
 #[TypeScript]
-enum Color: string
+enum ColorName: string
 {
     case Default = 'default';
     case Muted = 'muted';
@@ -15,4 +15,11 @@ enum Color: string
     case Info = 'info';
     case Warning = 'warning';
     case Danger = 'danger';
+    case Gray = 'gray';
+    case Red = 'red';
+    case Orange = 'orange';
+    case Yellow = 'yellow';
+    case Green = 'green';
+    case Blue = 'blue';
+    case Purple = 'purple';
 }

--- a/src/Core/Enums/ColorKind.php
+++ b/src/Core/Enums/ColorKind.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Lattice\Lattice\Core;
+namespace Lattice\Lattice\Core\Enums;
 
 use Lattice\Lattice\Attributes\TypeScript;
 

--- a/src/Core/Enums/ColorName.php
+++ b/src/Core/Enums/ColorName.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Lattice\Lattice\Core;
+namespace Lattice\Lattice\Core\Enums;
 
 use Lattice\Lattice\Attributes\TypeScript;
 

--- a/src/Tables/Columns/BadgeColumn.php
+++ b/src/Tables/Columns/BadgeColumn.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Tables\Columns;
 
 use Lattice\Lattice\Attributes\WireMap;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\Enums\ColorName;
 use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
 use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
@@ -18,20 +20,21 @@ class BadgeColumn extends Column implements Filterable, Sortable
     use IsSortable;
 
     /**
-     * @var array<array-key, string>|null
+     * @var array<array-key, Color>|null
      */
     #[WireMap]
     public ?array $colors = null;
 
     /**
-     * Map cell values to a colour name (gray, red, green, yellow, blue, purple,
-     * orange). Unmapped values fall back to gray.
+     * Map cell values to a colour — a named colour (`Color::green()`, `'green'`)
+     * or any CSS colour (`Color::hex('#16a34a')`, `'#16a34a'`). Unmapped values
+     * fall back to gray.
      *
-     * @param  array<array-key, string>  $colors
+     * @param  array<array-key, Color|ColorName|string>  $colors
      */
     public function colors(array $colors): static
     {
-        $this->colors = $colors === [] ? null : $colors;
+        $this->colors = $colors === [] ? null : array_map(Color::from(...), $colors);
 
         return $this;
     }

--- a/src/Tables/Columns/IconColumn.php
+++ b/src/Tables/Columns/IconColumn.php
@@ -5,6 +5,8 @@ namespace Lattice\Lattice\Tables\Columns;
 
 use BackedEnum;
 use Lattice\Lattice\Attributes\WireMap;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\Enums\ColorName;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Enums\ColumnType;
@@ -22,7 +24,7 @@ class IconColumn extends Column
     public ?array $icons = null;
 
     /**
-     * @var array<array-key, string>|null
+     * @var array<array-key, Color>|null
      */
     #[WireMap]
     public ?array $colors = null;
@@ -40,14 +42,15 @@ class IconColumn extends Column
     }
 
     /**
-     * Map cell values to a colour name (gray, red, green, yellow, blue, purple,
-     * orange).
+     * Map cell values to a colour — a named colour (`Color::green()`, `'green'`)
+     * or any CSS colour (`Color::hex('#16a34a')`, `'#16a34a'`). Unmapped values
+     * render in the default icon colour.
      *
-     * @param  array<array-key, string>  $colors
+     * @param  array<array-key, Color|ColorName|string>  $colors
      */
     public function colors(array $colors): static
     {
-        $this->colors = $colors === [] ? null : $colors;
+        $this->colors = $colors === [] ? null : array_map(Color::from(...), $colors);
 
         return $this;
     }

--- a/src/Tables/Columns/TextColumn.php
+++ b/src/Tables/Columns/TextColumn.php
@@ -62,10 +62,10 @@ class TextColumn extends Column implements Filterable, Searchable, Sortable
     }
 
     /**
-     * Render the value as a coloured badge. The tone colour is read from the
-     * sibling field named by $colorKey — a key on the row for a scalar column, or
-     * a key on each related row for a {@see multiple()} column. An unset colour
-     * falls back to gray.
+     * Render the value as a coloured badge. The colour is read from the sibling
+     * field named by $colorKey — a colour name (`green`) or any CSS colour
+     * (`#16a34a`); unset falls back to gray. $colorKey is a key on the row for a
+     * scalar column, or a key on each related row for a {@see multiple()} column.
      */
     public function badge(string $colorKey = 'color'): static
     {

--- a/src/Tables/Sources/Eloquent/MultipleRelationColumn.php
+++ b/src/Tables/Sources/Eloquent/MultipleRelationColumn.php
@@ -16,8 +16,9 @@ use Lattice\Lattice\Tables\RelationBinding;
  * The Eloquent resolution of a to-many {@see RelationBinding} (`tags`), reading a
  * label field — and optionally a colour field — from each related row. The
  * relation is eager-loaded once (no N+1) and projected to a list: plain values,
- * or `{value, color}` pairs when a colour field is configured. Filtering matches
- * any related row through `whereHas`; the column is not sortable.
+ * or `{value, color}` pairs when a colour field is configured — colour values
+ * are names or CSS colours, resolved client-side. Filtering matches any related
+ * row through `whereHas`; the column is not sortable.
  */
 final readonly class MultipleRelationColumn implements RelationProjection
 {

--- a/src/Ui/Components/Chart.php
+++ b/src/Ui/Components/Chart.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Ui\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\Enums\ColorName;
 use Lattice\Lattice\Ui\Values\ChartSeries;
 use Lattice\Lattice\Ui\Values\DateFormat;
 use Lattice\Lattice\Ui\Values\NumberFormat;
@@ -131,37 +133,37 @@ class Chart extends Component
         return $this;
     }
 
-    public function line(string $dataKey, ?string $name = null, ?string $color = null): static
+    public function line(string $dataKey, ?string $name = null, Color|ColorName|string|null $color = null): static
     {
         return $this->addSeries(ChartSeries::line($dataKey, $name, $color));
     }
 
-    public function bar(string $dataKey, ?string $name = null, ?string $color = null, ?string $stackId = null): static
+    public function bar(string $dataKey, ?string $name = null, Color|ColorName|string|null $color = null, ?string $stackId = null): static
     {
         return $this->addSeries(ChartSeries::bar($dataKey, $name, $color, $stackId));
     }
 
-    public function area(string $dataKey, ?string $name = null, ?string $color = null, ?string $stackId = null): static
+    public function area(string $dataKey, ?string $name = null, Color|ColorName|string|null $color = null, ?string $stackId = null): static
     {
         return $this->addSeries(ChartSeries::area($dataKey, $name, $color, $stackId));
     }
 
-    public function pie(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null): static
+    public function pie(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null): static
     {
         return $this->addSeries(ChartSeries::pie($dataKey, $nameKey, $name, $color));
     }
 
-    public function doughnut(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null, string $innerRadius = '60%'): static
+    public function doughnut(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null, string $innerRadius = '60%'): static
     {
         return $this->addSeries(ChartSeries::doughnut($dataKey, $nameKey, $name, $color, $innerRadius));
     }
 
-    public function gauge(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null, ?float $maxValue = null, string $innerRadius = '70%'): static
+    public function gauge(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null, ?float $maxValue = null, string $innerRadius = '70%'): static
     {
         return $this->addSeries(ChartSeries::gauge($dataKey, $nameKey, $name, $color, $maxValue, $innerRadius));
     }
 
-    public function distribution(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null): static
+    public function distribution(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null): static
     {
         return $this->addSeries(ChartSeries::distribution($dataKey, $nameKey, $name, $color));
     }

--- a/src/Ui/Concerns/HasColor.php
+++ b/src/Ui/Concerns/HasColor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Ui\Concerns;
 
 use Lattice\Lattice\Core\Color;
-use Lattice\Lattice\Core\ColorName;
+use Lattice\Lattice\Core\Enums\ColorName;
 
 trait HasColor
 {

--- a/src/Ui/Concerns/HasColor.php
+++ b/src/Ui/Concerns/HasColor.php
@@ -3,15 +3,16 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Ui\Concerns;
 
-use Lattice\Lattice\Ui\Enums\Color;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\ColorName;
 
 trait HasColor
 {
     public ?Color $color = null;
 
-    public function color(Color $color): static
+    public function color(Color|ColorName|string $color): static
     {
-        $this->color = $color;
+        $this->color = Color::from($color);
 
         return $this;
     }

--- a/src/Ui/Values/ChartSeries.php
+++ b/src/Ui/Values/ChartSeries.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Ui\Values;
 
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\Enums\ColorName;
 use Lattice\Lattice\Ui\Enums\ChartSeriesType;
 
 #[TypeScript]
@@ -13,45 +15,50 @@ final readonly class ChartSeries
         public ChartSeriesType $type,
         public string $dataKey,
         public string $name,
-        public ?string $color = null,
+        public ?Color $color = null,
         public ?string $stackId = null,
         public ?string $nameKey = null,
         public string $innerRadius = '0%',
         public ?float $maxValue = null,
     ) {}
 
-    public static function line(string $dataKey, ?string $name = null, ?string $color = null): self
+    public static function line(string $dataKey, ?string $name = null, Color|ColorName|string|null $color = null): self
     {
-        return new self(ChartSeriesType::Line, $dataKey, $name ?? $dataKey, $color);
+        return new self(ChartSeriesType::Line, $dataKey, $name ?? $dataKey, self::resolveColor($color));
     }
 
-    public static function bar(string $dataKey, ?string $name = null, ?string $color = null, ?string $stackId = null): self
+    public static function bar(string $dataKey, ?string $name = null, Color|ColorName|string|null $color = null, ?string $stackId = null): self
     {
-        return new self(ChartSeriesType::Bar, $dataKey, $name ?? $dataKey, $color, $stackId);
+        return new self(ChartSeriesType::Bar, $dataKey, $name ?? $dataKey, self::resolveColor($color), $stackId);
     }
 
-    public static function area(string $dataKey, ?string $name = null, ?string $color = null, ?string $stackId = null): self
+    public static function area(string $dataKey, ?string $name = null, Color|ColorName|string|null $color = null, ?string $stackId = null): self
     {
-        return new self(ChartSeriesType::Area, $dataKey, $name ?? $dataKey, $color, $stackId);
+        return new self(ChartSeriesType::Area, $dataKey, $name ?? $dataKey, self::resolveColor($color), $stackId);
     }
 
-    public static function pie(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null): self
+    public static function pie(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null): self
     {
-        return new self(ChartSeriesType::Pie, $dataKey, $name ?? $dataKey, $color, nameKey: $nameKey);
+        return new self(ChartSeriesType::Pie, $dataKey, $name ?? $dataKey, self::resolveColor($color), nameKey: $nameKey);
     }
 
-    public static function doughnut(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null, string $innerRadius = '60%'): self
+    public static function doughnut(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null, string $innerRadius = '60%'): self
     {
-        return new self(ChartSeriesType::Pie, $dataKey, $name ?? $dataKey, $color, nameKey: $nameKey, innerRadius: $innerRadius);
+        return new self(ChartSeriesType::Pie, $dataKey, $name ?? $dataKey, self::resolveColor($color), nameKey: $nameKey, innerRadius: $innerRadius);
     }
 
-    public static function gauge(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null, ?float $maxValue = null, string $innerRadius = '70%'): self
+    public static function gauge(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null, ?float $maxValue = null, string $innerRadius = '70%'): self
     {
-        return new self(ChartSeriesType::Gauge, $dataKey, $name ?? $dataKey, $color, nameKey: $nameKey, innerRadius: $innerRadius, maxValue: $maxValue);
+        return new self(ChartSeriesType::Gauge, $dataKey, $name ?? $dataKey, self::resolveColor($color), nameKey: $nameKey, innerRadius: $innerRadius, maxValue: $maxValue);
     }
 
-    public static function distribution(string $dataKey, ?string $nameKey = null, ?string $name = null, ?string $color = null): self
+    public static function distribution(string $dataKey, ?string $nameKey = null, ?string $name = null, Color|ColorName|string|null $color = null): self
     {
-        return new self(ChartSeriesType::Distribution, $dataKey, $name ?? $dataKey, $color, nameKey: $nameKey);
+        return new self(ChartSeriesType::Distribution, $dataKey, $name ?? $dataKey, self::resolveColor($color), nameKey: $nameKey);
+    }
+
+    private static function resolveColor(Color|ColorName|string|null $color): ?Color
+    {
+        return $color === null ? null : Color::from($color);
     }
 }

--- a/tests/Unit/Core/ChartTest.php
+++ b/tests/Unit/Core/ChartTest.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Ui\Values\ChartSeries;
 use Lattice\Lattice\Ui\Values\DateFormat;
 use Lattice\Lattice\Ui\Values\NumberFormat;
 
-it('coerces series colors to tagged color values', function () {
+it('coerces series colors to tagged color values', function (): void {
     expect(json_decode(json_encode(ChartSeries::line('revenue', color: '#2563eb')), true)['color'])
         ->toBe(['kind' => 'css', 'value' => '#2563eb', 'dark' => null])
         ->and(json_decode(json_encode(ChartSeries::bar('orders', color: 'success')), true)['color'])

--- a/tests/Unit/Core/ChartTest.php
+++ b/tests/Unit/Core/ChartTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Chart;
 use Lattice\Lattice\Ui\Enums\DateTimeStyle;
@@ -8,6 +9,17 @@ use Lattice\Lattice\Ui\Enums\NumberFormatUnit;
 use Lattice\Lattice\Ui\Values\ChartSeries;
 use Lattice\Lattice\Ui\Values\DateFormat;
 use Lattice\Lattice\Ui\Values\NumberFormat;
+
+it('coerces series colors to tagged color values', function () {
+    expect(json_decode(json_encode(ChartSeries::line('revenue', color: '#2563eb')), true)['color'])
+        ->toBe(['kind' => 'css', 'value' => '#2563eb', 'dark' => null])
+        ->and(json_decode(json_encode(ChartSeries::bar('orders', color: 'success')), true)['color'])
+        ->toBe(['kind' => 'named', 'value' => 'success', 'dark' => null])
+        ->and(json_decode(json_encode(ChartSeries::line('plain')), true)['color'])
+        ->toBeNull()
+        ->and(json_decode(json_encode(ChartSeries::area('forecast', color: Color::hex('#8b5cf6')->dark('#a78bfa'))), true)['color'])
+        ->toBe(['kind' => 'css', 'value' => '#8b5cf6', 'dark' => '#a78bfa']);
+});
 
 it('serializes a cartesian chart with fluent series helpers', function (): void {
     $node = wire(
@@ -44,7 +56,7 @@ it('serializes a cartesian chart with fluent series helpers', function (): void 
             'type' => 'line',
             'dataKey' => 'revenue',
             'name' => 'Revenue',
-            'color' => '#2563eb',
+            'color' => ['kind' => 'css', 'value' => '#2563eb', 'dark' => null],
             'stackId' => null,
             'nameKey' => null,
         ])
@@ -52,7 +64,7 @@ it('serializes a cartesian chart with fluent series helpers', function (): void 
             'type' => 'bar',
             'dataKey' => 'orders',
             'name' => 'Orders',
-            'color' => '#16a34a',
+            'color' => ['kind' => 'css', 'value' => '#16a34a', 'dark' => null],
             'stackId' => 'volume',
             'nameKey' => null,
         ])
@@ -60,7 +72,7 @@ it('serializes a cartesian chart with fluent series helpers', function (): void 
             'type' => 'area',
             'dataKey' => 'forecast',
             'name' => 'Forecast',
-            'color' => '#9333ea',
+            'color' => ['kind' => 'css', 'value' => '#9333ea', 'dark' => null],
             'stackId' => 'projection',
             'nameKey' => null,
         ]);

--- a/tests/Unit/Core/ColorTest.php
+++ b/tests/Unit/Core/ColorTest.php
@@ -5,7 +5,7 @@ use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Core\Enums\ColorKind;
 use Lattice\Lattice\Core\Enums\ColorName;
 
-it('builds named colors from shortcuts', function () {
+it('builds named colors from shortcuts', function (): void {
     $color = Color::success();
 
     expect($color->kind)->toBe(ColorKind::Named)
@@ -13,7 +13,7 @@ it('builds named colors from shortcuts', function () {
         ->and($color->dark)->toBeNull();
 });
 
-it('coerces names, enum cases, css strings, and instances', function () {
+it('coerces names, enum cases, css strings, and instances', function (): void {
     expect(Color::from('green'))->toEqual(Color::green())
         ->and(Color::from(ColorName::Danger))->toEqual(Color::danger())
         ->and(Color::from('#16a34a'))->toEqual(Color::css('#16a34a'))
@@ -21,27 +21,27 @@ it('coerces names, enum cases, css strings, and instances', function () {
         ->and(Color::from(Color::blue()))->toEqual(Color::blue());
 });
 
-it('accepts valid hex colors', function (string $hex) {
+it('accepts valid hex colors', function (string $hex): void {
     expect(Color::hex($hex)->value)->toBe($hex)
         ->and(Color::hex($hex)->kind)->toBe(ColorKind::Css);
 })->with(['#fff', '#ffff', '#16a34a', '#16a34aff']);
 
-it('rejects invalid hex colors', function (string $hex) {
+it('rejects invalid hex colors', function (string $hex): void {
     Color::hex($hex);
 })->with(['16a34a', '#16a34', '#zzz', 'red'])->throws(InvalidArgumentException::class);
 
-it('carries a dark counterpart for css colors', function () {
+it('carries a dark counterpart for css colors', function (): void {
     $color = Color::hex('#2563eb')->dark('#60a5fa');
 
     expect($color->value)->toBe('#2563eb')
         ->and($color->dark)->toBe('#60a5fa');
 });
 
-it('rejects dark() on named colors', function () {
+it('rejects dark() on named colors', function (): void {
     Color::green()->dark('#000');
 })->throws(LogicException::class);
 
-it('serializes to the tagged wire shape', function () {
+it('serializes to the tagged wire shape', function (): void {
     expect(json_decode(json_encode(Color::warning()), true))
         ->toBe(['kind' => 'named', 'value' => 'warning', 'dark' => null])
         ->and(json_decode(json_encode(Color::hex('#2563eb')->dark('#60a5fa')), true))

--- a/tests/Unit/Core/ColorTest.php
+++ b/tests/Unit/Core/ColorTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\ColorKind;
+use Lattice\Lattice\Core\ColorName;
+
+it('builds named colors from shortcuts', function () {
+    $color = Color::success();
+
+    expect($color->kind)->toBe(ColorKind::Named)
+        ->and($color->value)->toBe('success')
+        ->and($color->dark)->toBeNull();
+});
+
+it('coerces names, enum cases, css strings, and instances', function () {
+    expect(Color::from('green'))->toEqual(Color::green())
+        ->and(Color::from(ColorName::Danger))->toEqual(Color::danger())
+        ->and(Color::from('#16a34a'))->toEqual(Color::css('#16a34a'))
+        ->and(Color::from('var(--brand)'))->toEqual(Color::css('var(--brand)'))
+        ->and(Color::from(Color::blue()))->toEqual(Color::blue());
+});
+
+it('accepts valid hex colors', function (string $hex) {
+    expect(Color::hex($hex)->value)->toBe($hex)
+        ->and(Color::hex($hex)->kind)->toBe(ColorKind::Css);
+})->with(['#fff', '#ffff', '#16a34a', '#16a34aff']);
+
+it('rejects invalid hex colors', function (string $hex) {
+    Color::hex($hex);
+})->with(['16a34a', '#16a34', '#zzz', 'red'])->throws(InvalidArgumentException::class);
+
+it('carries a dark counterpart for css colors', function () {
+    $color = Color::hex('#2563eb')->dark('#60a5fa');
+
+    expect($color->value)->toBe('#2563eb')
+        ->and($color->dark)->toBe('#60a5fa');
+});
+
+it('rejects dark() on named colors', function () {
+    Color::green()->dark('#000');
+})->throws(LogicException::class);
+
+it('serializes to the tagged wire shape', function () {
+    expect(json_decode(json_encode(Color::warning()), true))
+        ->toBe(['kind' => 'named', 'value' => 'warning', 'dark' => null])
+        ->and(json_decode(json_encode(Color::hex('#2563eb')->dark('#60a5fa')), true))
+        ->toBe(['kind' => 'css', 'value' => '#2563eb', 'dark' => '#60a5fa']);
+});

--- a/tests/Unit/Core/ColorTest.php
+++ b/tests/Unit/Core/ColorTest.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Core\Color;
-use Lattice\Lattice\Core\ColorKind;
-use Lattice\Lattice\Core\ColorName;
+use Lattice\Lattice\Core\Enums\ColorKind;
+use Lattice\Lattice\Core\Enums\ColorName;
 
 it('builds named colors from shortcuts', function () {
     $color = Color::success();

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -6,6 +6,7 @@ use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Actions\Components\ActionGroup;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Chat\Components\ChatBox;
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Core\Enums\HttpMethod;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Facades\Lattice;
@@ -34,7 +35,6 @@ use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Enums\ButtonVariant;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\FloatingPlacement;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Enums\Icon;
@@ -483,7 +483,7 @@ test('links serialize their icon and affixes', function (): void {
 });
 
 it('serializes progress bars and circles', function (): void {
-    $bar = wire(Progress::bar(72.5)->color(Color::Success)->showValue());
+    $bar = wire(Progress::bar(72.5)->color(Color::success())->showValue());
 
     expect($bar['type'])->toBe('progress')
         ->and($bar['props'])->toMatchArray([
@@ -491,7 +491,7 @@ it('serializes progress bars and circles', function (): void {
             'max' => 100.0,
             'variant' => 'bar',
             'showValue' => true,
-            'color' => 'success',
+            'color' => ['kind' => 'named', 'value' => 'success', 'dark' => null],
             'size' => 'md',
         ]);
 

--- a/tests/Unit/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Unit/Core/Components/CoreTypedPropsTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Ui\Components\Icon;
 use Lattice\Lattice\Ui\Components\Modal;
 use Lattice\Lattice\Ui\Components\SegmentedControl;
@@ -9,7 +10,6 @@ use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Enums\Align;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Enums\Icon as IconName;
 use Lattice\Lattice\Ui\Enums\Justify;
@@ -226,7 +226,7 @@ it('serializes text size and color styling', function (): void {
         Text::make('Manuel Christlieb')
             ->align(Align::Center)
             ->size(Size::Sm)
-            ->color(Color::Default),
+            ->color(Color::default()),
     );
 
     expect($data['type'])->toBe('text')
@@ -235,7 +235,7 @@ it('serializes text size and color styling', function (): void {
             'text' => 'Manuel Christlieb',
             'align' => 'center',
             'size' => 'sm',
-            'color' => 'default',
+            'color' => ['kind' => 'named', 'value' => 'default', 'dark' => null],
             'copyable' => false,
         ]);
 });
@@ -246,7 +246,7 @@ it('marks text as copyable', function (): void {
 
 it('serializes an icon with name, size, color and class', function (): void {
     $data = wire(
-        Icon::make('house')->size(Size::Lg)->color(Color::Danger)->class('opacity-80'),
+        Icon::make('house')->size(Size::Lg)->color(Color::danger())->class('opacity-80'),
     );
 
     expect($data['type'])->toBe('icon')
@@ -254,7 +254,7 @@ it('serializes an icon with name, size, color and class', function (): void {
         ->and($data['props'])->toMatchArray([
             'name' => 'house',
             'size' => 'lg',
-            'color' => 'danger',
+            'color' => ['kind' => 'named', 'value' => 'danger', 'dark' => null],
             'class' => 'opacity-80',
         ]);
 });

--- a/tests/Unit/Docs/ComponentDocsTest.php
+++ b/tests/Unit/Docs/ComponentDocsTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Avatar;
 use Lattice\Lattice\Ui\Components\Badge;
@@ -20,7 +21,6 @@ use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Components\Tooltip;
 use Lattice\Lattice\Ui\Enums\ButtonVariant;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Enums\Orientation;
 use Lattice\Lattice\Ui\Enums\Size;
@@ -81,10 +81,10 @@ describe('docs fixtures', function (): void {
         assertFixtureMatches('components.progress', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Stack::make()->gap(Gap::Small)->schema([
                 Progress::bar(65)->showValue(),
-                Progress::bar(80)->color(Color::Success)->size(Size::Lg),
+                Progress::bar(80)->color(Color::success())->size(Size::Lg),
                 Stack::make()->direction(StackDirection::Row)->gap(Gap::Medium)->schema([
                     Progress::circle(65)->showValue(),
-                    Progress::circle(35)->max(50)->color(Color::Warning)->size(Size::Xl)->showValue(),
+                    Progress::circle(35)->max(50)->color(Color::warning())->size(Size::Xl)->showValue(),
                 ]),
             ]),
         ]))));

--- a/tests/Unit/Docs/TableDocsTest.php
+++ b/tests/Unit/Docs/TableDocsTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Columns\BadgeColumn;
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
@@ -14,7 +15,6 @@ use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableResult;
 use Lattice\Lattice\Ui\Components\Text;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Icon;
 use Lattice\Lattice\Ui\Enums\NumberFormatUnit;
 use Lattice\Lattice\Ui\Enums\Size;
@@ -65,7 +65,7 @@ describe('docs fixtures', function (): void {
             Table::make('users')
                 ->columns([
                     StackColumn::make('identity')->label('User')->schema([
-                        Text::make('')->dataKey('text', 'name')->color(Color::Default),
+                        Text::make('')->dataKey('text', 'name')->color(Color::default()),
                         Text::make('')->dataKey('text', 'email')->size(Size::Sm),
                     ]),
                     TextColumn::make('role')->label('Role'),

--- a/tests/Unit/Forms/Components/SelectTest.php
+++ b/tests/Unit/Forms/Components/SelectTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
@@ -9,7 +10,6 @@ use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Badge;
 use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Text;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Size;
 
 it('serializes static options without search flags', function (): void {
@@ -211,7 +211,7 @@ describe('docs fixtures', function (): void {
                 ->optionSchema([
                     Stack::make()->schema([
                         Text::make('')->dataKey('text', 'label'),
-                        Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::Muted),
+                        Text::make('')->dataKey('text', 'email')->size(Size::Sm)->color(Color::muted()),
                     ]),
                     Badge::make('')->dataKey('label', 'number'),
                 ]),

--- a/tests/Unit/Tables/Columns/ColumnTypesTest.php
+++ b/tests/Unit/Tables/Columns/ColumnTypesTest.php
@@ -25,7 +25,7 @@ it('serializes a badge column with its colour map', function (): void {
         ]);
 });
 
-it('normalizes badge colors to tagged color values', function () {
+it('normalizes badge colors to tagged color values', function (): void {
     $column = BadgeColumn::make('status')->colors([
         'active' => 'green',
         'archived' => Color::gray(),

--- a/tests/Unit/Tables/Columns/ColumnTypesTest.php
+++ b/tests/Unit/Tables/Columns/ColumnTypesTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Tables\Columns\BadgeColumn;
 use Lattice\Lattice\Tables\Columns\BooleanColumn;
 use Lattice\Lattice\Tables\Columns\IconColumn;
@@ -18,7 +19,24 @@ it('serializes a badge column with its colour map', function (): void {
     expect($data['type'])->toBe('column.badge')
         ->and($data['props']['sortable'])->toBeTrue()
         ->and($data['props']['filter']['type'])->toBe('text')
-        ->and($data['props']['colors'])->toBe(['active' => 'green', 'archived' => 'red']);
+        ->and($data['props']['colors'])->toBe([
+            'active' => ['kind' => 'named', 'value' => 'green', 'dark' => null],
+            'archived' => ['kind' => 'named', 'value' => 'red', 'dark' => null],
+        ]);
+});
+
+it('normalizes badge colors to tagged color values', function () {
+    $column = BadgeColumn::make('status')->colors([
+        'active' => 'green',
+        'archived' => Color::gray(),
+        'flagged' => '#dc2626',
+    ]);
+
+    expect(json_decode(json_encode($column->colors), true))->toBe([
+        'active' => ['kind' => 'named', 'value' => 'green', 'dark' => null],
+        'archived' => ['kind' => 'named', 'value' => 'gray', 'dark' => null],
+        'flagged' => ['kind' => 'css', 'value' => '#dc2626', 'dark' => null],
+    ]);
 });
 
 it('serializes an icon column with a value map and colours', function (): void {
@@ -30,7 +48,10 @@ it('serializes an icon column with a value map and colours', function (): void {
 
     expect($data['type'])->toBe('column.icon')
         ->and($data['props']['icons'])->toBe(['1' => 'check', '0' => 'x'])
-        ->and($data['props']['colors'])->toBe(['1' => 'green', '0' => 'gray']);
+        ->and($data['props']['colors'])->toBe([
+            '1' => ['kind' => 'named', 'value' => 'green', 'dark' => null],
+            '0' => ['kind' => 'named', 'value' => 'gray', 'dark' => null],
+        ]);
 });
 
 it('serializes a static icon column', function (): void {

--- a/workbench/app/Forms/Fields/SelectFieldForm.php
+++ b/workbench/app/Forms/Fields/SelectFieldForm.php
@@ -5,6 +5,7 @@ namespace Workbench\App\Forms\Fields;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Core\EloquentOptions;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
@@ -15,7 +16,6 @@ use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Orientation;
 use Lattice\Lattice\Ui\Enums\Size;
 use Symfony\Component\HttpFoundation\Response;
@@ -72,7 +72,7 @@ class SelectFieldForm extends FormDefinition
                             ->optionSchema([
                                 Stack::make()->schema([
                                     Text::make('')->dataKey('text', 'label'),
-                                    Text::make('')->dataKey('text', 'status')->size(Size::Sm)->color(Color::Muted),
+                                    Text::make('')->dataKey('text', 'status')->size(Size::Sm)->color(Color::muted()),
                                 ]),
                                 Badge::make('')->dataKey('label', 'sku'),
                             ])

--- a/workbench/app/Pages/Components/ProgressPage.php
+++ b/workbench/app/Pages/Components/ProgressPage.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 namespace Workbench\App\Pages\Components;
 
 use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Color;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Progress;
 use Lattice\Lattice\Ui\Components\Stack;
-use Lattice\Lattice\Ui\Enums\Color;
 use Lattice\Lattice\Ui\Enums\Gap;
 use Lattice\Lattice\Ui\Enums\Size;
 use Lattice\Lattice\Ui\Enums\StackDirection;
@@ -33,8 +33,8 @@ final class ProgressPage extends WorkbenchPage
                         ->gap(Gap::Small)
                         ->schema([
                             Progress::bar(25, 'progress-bar-primary'),
-                            Progress::bar(50, 'progress-bar-success')->color(Color::Success)->showValue(),
-                            Progress::bar(80, 'progress-bar-large')->color(Color::Warning)->size(Size::Lg)->showValue(),
+                            Progress::bar(50, 'progress-bar-success')->color(Color::success())->showValue(),
+                            Progress::bar(80, 'progress-bar-large')->color(Color::warning())->size(Size::Lg)->showValue(),
                         ]),
                     Heading::make(__('workbench.pages.components.progress.circles'), 2),
                     Stack::make('progress-circles')
@@ -42,8 +42,8 @@ final class ProgressPage extends WorkbenchPage
                         ->gap(Gap::Medium)
                         ->schema([
                             Progress::circle(25, 'progress-circle-primary')->showValue(),
-                            Progress::circle(35, 'progress-circle-scaled')->max(50)->color(Color::Success)->size(Size::Xl)->showValue(),
-                            Progress::circle(90, 'progress-circle-danger')->color(Color::Danger)->size(Size::Lg),
+                            Progress::circle(35, 'progress-circle-scaled')->max(50)->color(Color::success())->size(Size::Xl)->showValue(),
+                            Progress::circle(90, 'progress-circle-danger')->color(Color::danger())->size(Size::Lg),
                         ]),
                 ]),
         ]);

--- a/workbench/remote/todo-schema.json
+++ b/workbench/remote/todo-schema.json
@@ -36,7 +36,7 @@
                       "type": "text",
                       "props": {
                         "text": "Each row below is a card generated from remote data. The status badge and button link are bound from row keys.",
-                        "color": "muted",
+                        "color": { "kind": "named", "value": "muted", "dark": null },
                         "size": "sm"
                       }
                     },


### PR DESCRIPTION
Unifies the three color systems (semantic `Color` enum, table tone-name strings, free-form hex) behind one `Lattice\Lattice\Core\Color` value object carried on the wire as `{kind, value, dark}`. Every color-accepting API takes `Color|ColorName|string` — `'green'`, `Color::green()`, `Color::hex('#16a34a')`, and `Color::hex('#2563eb')->dark('#60a5fa')` all work everywhere (component `->color()`, badge/icon column maps, chart series). Row-driven colors (DB values per row) stay strings and are coerced client-side by one resolver (`resources/js/lib/color.ts`) against a theme-overridable palette layer (`--lt-color-<name>` vars + `.lt-tone-<name>` classes), so e.g. a ColorPicker-stored hex renders in badge cells with no glue. Rendered output is visually unchanged for existing named/tone usage; css-kind colors gain dark-mode support via `light-dark()`.

## Breaking changes

1. `Ui\Enums\Color` enum removed → `Core\Color` VO + `Core\Enums\ColorName`/`ColorKind`; `Color::Success` becomes `Color::success()` (or `'success'`).
2. `HasColor::color()` (Text/Icon/Progress): parameter is now `Color|ColorName|string`; import path changes.
3. `ChartSeries::__construct` `$color` is `?Color` (factories and `Chart` builders accept the string sugar).
4. Wire: `text`/`icon`/`progress` `color` prop and `ChartSeries.color` are tagged objects (renderers stay lenient to plain strings for remote payloads).
5. Wire: `BadgeColumn.colors`/`IconColumn.colors` are `Record<string, Color>`.
6. Generated TS: `Color` is now an object type; `ColorKind`/`ColorName` added.
7. CSS: `.lt-cell-tone-*` and `--lt-cell-bg/fg` removed → `.lt-tone-*`, `--lt-tone-bg/fg`, new `--lt-color-*` palette; old theme overrides stop applying.
8. DOM: Text/Icon/Progress emit inline style colors instead of `text-lt-*`/`bg-lt-*` classes; a colored Icon gains a `<span class="contents">` wrapper.
9. Docs enum reference: `Color` table replaced by `ColorName`/`ColorKind`.
10. `->dark()` rendering uses `light-dark()` (Chrome 123+/Safari 17.5+/Firefox 120+); named and single-value css colors unaffected.

Gates: composer check, npm run check (1101 JS tests, type-coverage, lib build), browser suite (99 passed), docs build — all green.
