### PR TITLE
fix(ui): restore focus after closing an imperatively-opened Modal

### DIFF
--- a/resources/js/ui/modal.test.tsx
+++ b/resources/js/ui/modal.test.tsx
@@ -106,4 +106,34 @@ describe("ModalComponent", () => {
     fire(LATTICE_EVENT.openModal, null);
     expect(screen.queryByText("Dialog")).not.toBeInTheDocument();
   });
+
+  it("restores focus to the opener element after closing", async () => {
+    render(
+      <>
+        <button type="button">Open</button>
+        <ModalComponent node={fakeNode({ type: "modal", id: "info", props: { title: "Info" } })}>
+          <p>Body content</p>
+        </ModalComponent>
+      </>,
+    );
+
+    const opener = screen.getByRole("button", { name: "Open" });
+    opener.focus();
+    expect(opener).toHaveFocus();
+
+    fire(LATTICE_EVENT.openModal, "info");
+    expect(screen.getByText("Info")).toBeInTheDocument();
+    expect(opener).not.toHaveFocus();
+
+    fire(LATTICE_EVENT.closeModal, "info");
+    expect(screen.queryByText("Info")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => {
+        requestAnimationFrame(() => resolve(undefined));
+      });
+    });
+
+    expect(opener).toHaveFocus();
+  });
 });

--- a/resources/js/ui/modal.tsx
+++ b/resources/js/ui/modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Dialog, DialogContent, DialogHeader } from "@lattice-php/lattice/ui/dialog";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { LATTICE_EVENT } from "@lattice-php/lattice/events/event-names";
@@ -18,6 +18,8 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
   const description = node.props.description;
   const closeLabel = node.props.closeLabel;
   const [isOpen, setIsOpen] = useState(node.props.open === true);
+  const openerRef = useRef<HTMLElement | null>(null);
+  const wasOpenRef = useRef(isOpen);
 
   // Honour server-driven open changes across re-renders, not just on mount. One
   // way on purpose: closing stays user/closeModal-driven so it never fights a
@@ -31,6 +33,8 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
   useEffect(() => {
     function open(event: Event): void {
       if (node.id && matchesModal(event, node.id)) {
+        openerRef.current =
+          document.activeElement instanceof HTMLElement ? document.activeElement : null;
         setIsOpen(true);
       }
     }
@@ -49,6 +53,22 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
       window.removeEventListener(LATTICE_EVENT.closeModal, close);
     };
   }, [node.id]);
+
+  // Radix only restores focus to a `DialogTrigger`-registered element, and this
+  // modal is opened imperatively rather than through one. Own the restore
+  // ourselves instead: whatever had focus when the modal opened gets it back
+  // once the closing dialog has finished unmounting.
+  useEffect(() => {
+    if (wasOpenRef.current && !isOpen) {
+      const opener = openerRef.current;
+
+      if (opener) {
+        requestAnimationFrame(() => opener.focus());
+      }
+    }
+
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
Restores keyboard focus to the triggering element after an imperatively-opened `Modal` closes.

## Why

The Lattice `Modal` is always opened imperatively — a server-driven `isOpen` flag / the `OpenModal` effect — never through a Radix `DialogTrigger`. Radix only restores focus to a `DialogTrigger`-registered element, so on close focus was **lost** (dropped to `<body>`) for every Lattice modal. Keyboard and screen-reader users lose their place.

## Fix

`ModalComponent` now captures `document.activeElement` when it opens and restores focus to it on the open→close transition (via `requestAnimationFrame`, after the dialog unmounts). Where there's no meaningful opener (e.g. the server-`open` prop path, or a detached element), it degrades to a safe no-op.

- No `DialogTrigger` exists anywhere in the codebase, so there's no trigger-based restore to regress.
- `confirm-dialog.tsx` / `action-form.tsx` build their own `<Dialog>` and are unaffected.

## Test

`modal.test.tsx` adds a focus-restore case (RED before the fix, GREEN after): focus an opener, open the modal, close it, assert focus returns to the opener.

## Note

This was surfaced by the Tree component work (#281), where an `Enter`-opens-info-`Modal` node lost focus on close. #281 currently carries an identical copy of this change so its own tests pass; **merge this PR first**, then #281 rebases cleanly with the modal change dropping out.

Gate green: `npm run check` (typecheck, type-coverage, Vitest, library build).
