### PR TITLE
refactor(php): dedup the make-commands, enum prefix, date/time setters, and enum unwraps

### DIFF
--- a/src/Chat/Attributes/AsChatPart.php
+++ b/src/Chat/Attributes/AsChatPart.php
@@ -7,6 +7,7 @@ namespace Lattice\Lattice\Chat\Attributes;
 use Attribute;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Chat\Enums\ChatPartType;
+use Lattice\Lattice\Support\Wire;
 
 /**
  * Marks a chat-part component and declares its wire type — the PHP↔JS
@@ -20,6 +21,6 @@ final readonly class AsChatPart extends AsComponent
 {
     public function __construct(ChatPartType|string $type)
     {
-        parent::__construct($type instanceof ChatPartType ? $type->value : $type);
+        parent::__construct(Wire::scalar($type));
     }
 }

--- a/src/Core/Enums/Concerns/HasPrefixedWireType.php
+++ b/src/Core/Enums/Concerns/HasPrefixedWireType.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Enums\Concerns;
+
+/**
+ * Shared wire-type conversions for a string-backed enum whose cases all carry a
+ * common `Prefix` (e.g. `field.` or `column.`). The using enum declares only the
+ * `Prefix` constant; this trait adds prefix-aware {@see wireType()}/{@see localType()}.
+ */
+trait HasPrefixedWireType
+{
+    public static function wireType(self|string $type): string
+    {
+        if ($type instanceof self) {
+            return $type->value;
+        }
+
+        return str_starts_with($type, self::Prefix) ? $type : self::Prefix.$type;
+    }
+
+    public static function localType(self|string $type): string
+    {
+        $value = $type instanceof self ? $type->value : $type;
+
+        return str_starts_with($value, self::Prefix) ? substr($value, strlen(self::Prefix)) : $value;
+    }
+}

--- a/src/Forms/Components/Concerns/HasMinMax.php
+++ b/src/Forms/Components/Concerns/HasMinMax.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components\Concerns;
+
+trait HasMinMax
+{
+    public ?string $min = null;
+
+    public ?string $max = null;
+
+    public function min(string $min): static
+    {
+        $this->min = $min;
+
+        return $this;
+    }
+
+    public function max(string $max): static
+    {
+        $this->max = $max;
+
+        return $this;
+    }
+}

--- a/src/Forms/Components/Concerns/HasStep.php
+++ b/src/Forms/Components/Concerns/HasStep.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components\Concerns;
+
+trait HasStep
+{
+    public ?int $step = null;
+
+    public function step(int $step): static
+    {
+        $this->step = $step;
+
+        return $this;
+    }
+}

--- a/src/Forms/Components/DateInput.php
+++ b/src/Forms/Components/DateInput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Forms\Components;
 
 use Lattice\Lattice\Forms\Attributes\AsField;
+use Lattice\Lattice\Forms\Components\Concerns\HasMinMax;
 use Lattice\Lattice\Forms\Enums\FieldType;
 use Lattice\Lattice\Ui\Concerns\HasAutoFocus;
 use Lattice\Lattice\Ui\Concerns\HasTabIndex;
@@ -12,23 +13,6 @@ use Lattice\Lattice\Ui\Concerns\HasTabIndex;
 class DateInput extends Field
 {
     use HasAutoFocus;
+    use HasMinMax;
     use HasTabIndex;
-
-    public ?string $min = null;
-
-    public ?string $max = null;
-
-    public function min(string $min): static
-    {
-        $this->min = $min;
-
-        return $this;
-    }
-
-    public function max(string $max): static
-    {
-        $this->max = $max;
-
-        return $this;
-    }
 }

--- a/src/Forms/Components/DateTimeInput.php
+++ b/src/Forms/Components/DateTimeInput.php
@@ -7,6 +7,8 @@ use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Forms\Attributes\AsField;
+use Lattice\Lattice\Forms\Components\Concerns\HasMinMax;
+use Lattice\Lattice\Forms\Components\Concerns\HasStep;
 use Lattice\Lattice\Forms\Enums\FieldType;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\Rules\DateTimeWithTimezone;
@@ -17,38 +19,13 @@ use Lattice\Lattice\Ui\Concerns\HasTabIndex;
 class DateTimeInput extends Field
 {
     use HasAutoFocus;
+    use HasMinMax;
+    use HasStep;
     use HasTabIndex;
-
-    public ?string $min = null;
-
-    public ?string $max = null;
-
-    public ?int $step = null;
 
     public bool $convertTimezone = false;
 
     public ?string $timezone = null;
-
-    public function min(string $min): static
-    {
-        $this->min = $min;
-
-        return $this;
-    }
-
-    public function max(string $max): static
-    {
-        $this->max = $max;
-
-        return $this;
-    }
-
-    public function step(int $step): static
-    {
-        $this->step = $step;
-
-        return $this;
-    }
 
     public function convertTimeZone(?string $timezone = null): static
     {

--- a/src/Forms/Components/TimeInput.php
+++ b/src/Forms/Components/TimeInput.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Forms\Components;
 
 use Lattice\Lattice\Forms\Attributes\AsField;
+use Lattice\Lattice\Forms\Components\Concerns\HasMinMax;
+use Lattice\Lattice\Forms\Components\Concerns\HasStep;
 use Lattice\Lattice\Forms\Enums\FieldType;
 use Lattice\Lattice\Forms\Rules\TimeString;
 use Lattice\Lattice\Ui\Concerns\HasAutoFocus;
@@ -13,34 +15,9 @@ use Lattice\Lattice\Ui\Concerns\HasTabIndex;
 class TimeInput extends Field
 {
     use HasAutoFocus;
+    use HasMinMax;
+    use HasStep;
     use HasTabIndex;
-
-    public ?string $min = null;
-
-    public ?string $max = null;
-
-    public ?int $step = null;
-
-    public function min(string $min): static
-    {
-        $this->min = $min;
-
-        return $this;
-    }
-
-    public function max(string $max): static
-    {
-        $this->max = $max;
-
-        return $this;
-    }
-
-    public function step(int $step): static
-    {
-        $this->step = $step;
-
-        return $this;
-    }
 
     /**
      * @return array<int, mixed>

--- a/src/Forms/Enums/FieldType.php
+++ b/src/Forms/Enums/FieldType.php
@@ -3,8 +3,12 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Forms\Enums;
 
+use Lattice\Lattice\Core\Enums\Concerns\HasPrefixedWireType;
+
 enum FieldType: string
 {
+    use HasPrefixedWireType;
+
     private const string Prefix = 'field.';
 
     case Builder = 'field.builder';
@@ -25,20 +29,4 @@ enum FieldType: string
     case TextInput = 'field.text-input';
     case TimeInput = 'field.time-input';
     case Toggle = 'field.toggle';
-
-    public static function wireType(self|string $type): string
-    {
-        if ($type instanceof self) {
-            return $type->value;
-        }
-
-        return str_starts_with($type, self::Prefix) ? $type : self::Prefix.$type;
-    }
-
-    public static function localType(self|string $type): string
-    {
-        $value = $type instanceof self ? $type->value : $type;
-
-        return str_starts_with($value, self::Prefix) ? substr($value, strlen(self::Prefix)) : $value;
-    }
 }

--- a/src/Forms/FormSchemaWalker.php
+++ b/src/Forms/FormSchemaWalker.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Forms;
 
+use Generator;
 use Illuminate\Support\Arr;
 use Lattice\Lattice\Forms\Components\Field;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
@@ -15,13 +16,7 @@ final class FormSchemaWalker
      */
     public function instances(iterable $fields, FormData $form): array
     {
-        $instances = [];
-
-        foreach ($fields as $field) {
-            $this->walkField($instances, $field, $field->name(), $form, $form);
-        }
-
-        return $instances;
+        return iterator_to_array($this->walk($fields, $form), false);
     }
 
     /**
@@ -29,7 +24,7 @@ final class FormSchemaWalker
      */
     public function find(iterable $fields, string $path, FormData $form): ?FormFieldInstance
     {
-        foreach ($this->instances($fields, $form) as $instance) {
+        foreach ($this->walk($fields, $form) as $instance) {
             if ($instance->path === $path) {
                 return $instance;
             }
@@ -39,13 +34,24 @@ final class FormSchemaWalker
     }
 
     /**
-     * @param  array<int, FormFieldInstance>  $instances
+     * @param  iterable<int, Field>  $fields
+     * @return Generator<int, FormFieldInstance>
      */
-    private function walkField(array &$instances, Field $template, string $path, FormData $scope, FormData $form): void
+    private function walk(iterable $fields, FormData $form): Generator
+    {
+        foreach ($fields as $field) {
+            yield from $this->walkField($field, $field->name(), $form, $form);
+        }
+    }
+
+    /**
+     * @return Generator<int, FormFieldInstance>
+     */
+    private function walkField(Field $template, string $path, FormData $scope, FormData $form): Generator
     {
         $field = clone $template;
 
-        $instances[] = new FormFieldInstance($field, $path, $scope, $form);
+        yield new FormFieldInstance($field, $path, $scope, $form);
 
         if (! $field instanceof ProvidesRowFields) {
             return;
@@ -62,8 +68,7 @@ final class FormSchemaWalker
             $rowScope = FormData::make([...$scope->all(), ...$row]);
 
             foreach ($field->rowFields($row) as $child) {
-                $this->walkField(
-                    $instances,
+                yield from $this->walkField(
                     $child,
                     "{$path}.{$index}.{$child->name()}",
                     $rowScope,

--- a/src/Tables/Attributes/AsFilter.php
+++ b/src/Tables/Attributes/AsFilter.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Tables\Attributes;
 
 use Attribute;
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Enums\FilterControl;
 
 /**
@@ -19,6 +20,6 @@ readonly class AsFilter extends AsComponent
 {
     public function __construct(FilterControl|string $control)
     {
-        parent::__construct($control instanceof FilterControl ? $control->value : $control);
+        parent::__construct(Wire::scalar($control));
     }
 }

--- a/src/Tables/Enums/ColumnType.php
+++ b/src/Tables/Enums/ColumnType.php
@@ -3,8 +3,12 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Enums;
 
+use Lattice\Lattice\Core\Enums\Concerns\HasPrefixedWireType;
+
 enum ColumnType: string
 {
+    use HasPrefixedWireType;
+
     private const string Prefix = 'column.';
 
     case Text = 'column.text';
@@ -15,20 +19,4 @@ enum ColumnType: string
     case Badge = 'column.badge';
     case Icon = 'column.icon';
     case Image = 'column.image';
-
-    public static function wireType(self|string $type): string
-    {
-        if ($type instanceof self) {
-            return $type->value;
-        }
-
-        return str_starts_with($type, self::Prefix) ? $type : self::Prefix.$type;
-    }
-
-    public static function localType(self|string $type): string
-    {
-        $value = $type instanceof self ? $type->value : $type;
-
-        return str_starts_with($value, self::Prefix) ? substr($value, strlen(self::Prefix)) : $value;
-    }
 }


### PR DESCRIPTION
Phase 3 — PHP deduplication bundle (non-breaking). Net −10 LOC.

- **enum prefix**: `HasPrefixedWireType` trait replaces the byte-identical prefix logic in `FieldType`/`ColumnType` (each keeps only its `Prefix` const).
- **enum unwraps**: `AsChatPart`/`AsFilter` route through `Wire::scalar()` instead of hand-rolling `->value`.
- **FormSchemaWalker::find**: rewritten as a lazy generator that short-circuits at the matched path — a perf win on the hot `_search`/`_upload` autocomplete path, identical results.
- **date/time inputs**: `HasMinMax`/`HasStep` concerns replace the copy-pasted setters in DateInput/TimeInput/DateTimeInput (net −21 on that task; NumberInput excluded — int|float semantics differ).

Dropped from the original bundle after review: a `MakeComponentPairCommand` base for the three make-generators. It was net +46 to replace a stable, linear 8-step scaffolding recipe (the complex parts already live in the `GeneratesComponentPair` trait), trading readable inline recipes for a template-method + config-prop indirection — not worth it.

Full `composer check` + `npm run check` green (pre-push gate).