### PR TITLE
test: extract shared Inertia mock, eventually helpers, wire(); type as-never casts

### DIFF
--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -9,21 +9,9 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 import { actionComponents } from "@lattice-php/lattice/action/plugin";
 import { ActionForm } from "./action-form";
 
-vi.mock("@inertiajs/react", () => ({
-  router: { reload: vi.fn<() => void>(), visit: vi.fn<() => void>() },
-  useHttp: () => ({
-    delete: vi.fn<() => void>(),
-    get: vi.fn<() => void>(),
-    patch: vi.fn<() => void>(),
-    post: vi.fn<() => void>(),
-    processing: false,
-    put: vi.fn<() => void>(),
-  }),
-  Form: ({ children }: { children: ReactNode }) => <form>{children}</form>,
-  Link: ({ children, ...props }: { children: ReactNode; href: string }) => (
-    <a {...props}>{children}</a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 type FetchMock = (input: string, init: RequestInit) => Promise<Response>;
 

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -17,13 +17,9 @@ const http = vi.hoisted(() => ({
     vi.fn<(callback: (data: Record<string, unknown>) => Record<string, unknown>) => void>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  router: {
-    reload: vi.fn<() => void>(),
-    visit: vi.fn<(url: string) => void>(),
-  },
-  useHttp: () => http,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+);
 
 describe("Lattice action component", () => {
   beforeEach(() => {

--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -12,7 +12,12 @@ const configureI18nFromPageProps = vi.hoisted(() =>
   vi.fn<(props: unknown, options?: unknown) => Promise<void>>(() => Promise.resolve()),
 );
 
-vi.mock("@inertiajs/react", () => ({ createInertiaApp, router }));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    createInertiaApp,
+    router,
+  }),
+);
 vi.mock("./i18n/page-props", () => ({ configureI18nFromPageProps }));
 
 import { createLatticeApp } from "./create-app";

--- a/resources/js/effects/registry.test.ts
+++ b/resources/js/effects/registry.test.ts
@@ -8,7 +8,9 @@ const router = vi.hoisted(() => ({
   visit: vi.fn<(url: string) => void>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({ router }));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ router }),
+);
 
 const setLocale = vi.hoisted(() => vi.fn<(locale: string) => void>());
 vi.mock("@lattice-php/lattice/i18n/locale", () => ({ setLocale }));

--- a/resources/js/effects/use-flash-effects.test.tsx
+++ b/resources/js/effects/use-flash-effects.test.tsx
@@ -16,7 +16,9 @@ const router = vi.hoisted(() => ({
   on: vi.fn<(event: string, listener: FlashListener) => () => void>(() => () => undefined),
 }));
 
-vi.mock("@inertiajs/react", () => ({ router }));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ router }),
+);
 
 import { useFlashEffects } from "@lattice-php/lattice/effects/use-flash-effects";
 

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -20,8 +20,9 @@ import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { renderCounts } from "@lattice-php/lattice/test/form-renderer-probe";
 import { RepeaterComponent } from "./repeater";
+import { fakeNode } from "@lattice-php/lattice/test-support";
 
-const repeaterNode = {
+const repeaterNode = fakeNode({
   id: "r",
   type: "field.repeater",
   props: {
@@ -34,7 +35,7 @@ const repeaterNode = {
     label: "Line items",
   },
   schema: [{ id: "c", type: "field.text-input", props: { name: "name", label: "Name" } }],
-} as never;
+});
 
 function wrap(
   ui: React.ReactNode,
@@ -84,7 +85,7 @@ it("removes a row", () => {
 });
 
 it("renders declared row actions in a kebab and duplicates a row", () => {
-  const node = {
+  const node = fakeNode({
     id: "r",
     type: "field.repeater",
     props: {
@@ -100,7 +101,7 @@ it("renders declared row actions in a kebab and duplicates a row", () => {
       ],
     },
     schema: [{ id: "c", type: "field.text-input", props: { name: "name", label: "Name" } }],
-  } as never;
+  });
 
   wrap(<RepeaterComponent node={node}>{null}</RepeaterComponent>, {
     items: [{ name: "a" }],
@@ -125,7 +126,7 @@ it("shows the array-level error for the repeater field", () => {
 });
 
 it("renders the table layout with a header from the schema", () => {
-  const node = {
+  const node = fakeNode({
     id: "r",
     type: "field.repeater",
     props: {
@@ -141,7 +142,7 @@ it("renders the table layout with a header from the schema", () => {
       { id: "q", type: "field.text-input", props: { name: "qty", label: "Qty" } },
       { id: "p", type: "field.text-input", props: { name: "price", label: "Price" } },
     ],
-  } as never;
+  });
   wrap(<RepeaterComponent node={node}>{null}</RepeaterComponent>, {
     items: [{ qty: "1", price: "2" }],
   });

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -23,6 +23,7 @@ import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { renderCounts } from "@lattice-php/lattice/test/form-renderer-probe";
 import { RepeaterComponent } from "./repeater";
 import { TableRows, type TableColumn } from "./table-rows";
+import { fakeNode } from "@lattice-php/lattice/test-support";
 
 const columns: TableColumn[] = [
   { name: "qty", label: "Qty", columnWidth: "md" },
@@ -32,9 +33,9 @@ const sizedColumns: TableColumn[] = [
   { name: "qty", label: "Qty", columnWidth: "xs" },
   { name: "description", label: "Description", columnWidth: "xl" },
 ];
-const qtyNode = { id: "q", type: "field.text-input", props: { name: "qty" } } as never;
-const priceNode = { id: "p", type: "field.text-input", props: { name: "price" } } as never;
-const contentNode = { id: "c", type: "field.textarea", props: { name: "content" } } as never;
+const qtyNode = fakeNode({ id: "q", type: "field.text-input", props: { name: "qty" } });
+const priceNode = fakeNode({ id: "p", type: "field.text-input", props: { name: "price" } });
+const contentNode = fakeNode({ id: "c", type: "field.textarea", props: { name: "content" } });
 
 function noop() {}
 
@@ -279,7 +280,7 @@ function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
   );
 }
 
-const tableNode = {
+const tableNode = fakeNode({
   id: "r",
   type: "field.repeater",
   props: {
@@ -293,7 +294,7 @@ const tableNode = {
   schema: [
     { id: "q", type: "field.text-input", props: { name: "qty", label: "Qty", columnWidth: "md" } },
   ],
-} as never;
+});
 
 it("does not re-render sibling table rows when one row changes", () => {
   wrap(<RepeaterComponent node={tableNode}>{null}</RepeaterComponent>, {

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -19,55 +19,57 @@ const formSlotState = vi.hoisted(() => ({
   validate: vi.fn<(field: string) => void>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  Form: ({
-    children,
-    errorBag: _errorBag,
-    resetOnError: _resetOnError,
-    resetOnSuccess: _resetOnSuccess,
-    headers,
-    validationTimeout,
-    ...props
-  }: {
-    children: (state: {
-      clearErrors: (field: string) => void;
-      errors: Record<string, string>;
-      invalid: (field: string) => boolean;
-      processing: boolean;
-      reset: (...fields: string[]) => void;
-      touch: (field: string) => void;
-      validate: (field: string) => void;
-      validating: boolean;
-      valid: (field: string) => boolean;
-    }) => ReactNode;
-    errorBag?: string;
-    resetOnError?: boolean | string[];
-    resetOnSuccess?: boolean | string[];
-    headers?: Record<string, string>;
-    validationTimeout?: number;
-  }) => (
-    <form
-      {...props}
-      data-headers={JSON.stringify(headers ?? null)}
-      data-validation-timeout={validationTimeout}
-    >
-      {children({
-        clearErrors: formSlotState.clearErrors,
-        errors: {},
-        invalid: () => false,
-        processing: false,
-        reset: formSlotState.reset,
-        touch: formSlotState.touch,
-        validate: formSlotState.validate,
-        validating: false,
-        valid: () => false,
-      })}
-    </form>
-  ),
-  Link: ({ children, ...props }: { children: ReactNode; href: string }) => (
-    <a {...props}>{children}</a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    Form: ({
+      children,
+      errorBag: _errorBag,
+      resetOnError: _resetOnError,
+      resetOnSuccess: _resetOnSuccess,
+      headers,
+      validationTimeout,
+      ...props
+    }: {
+      children: (state: {
+        clearErrors: (field: string) => void;
+        errors: Record<string, string>;
+        invalid: (field: string) => boolean;
+        processing: boolean;
+        reset: (...fields: string[]) => void;
+        touch: (field: string) => void;
+        validate: (field: string) => void;
+        validating: boolean;
+        valid: (field: string) => boolean;
+      }) => ReactNode;
+      errorBag?: string;
+      resetOnError?: boolean | string[];
+      resetOnSuccess?: boolean | string[];
+      headers?: Record<string, string>;
+      validationTimeout?: number;
+    }) => (
+      <form
+        {...props}
+        data-headers={JSON.stringify(headers ?? null)}
+        data-validation-timeout={validationTimeout}
+      >
+        {children({
+          clearErrors: formSlotState.clearErrors,
+          errors: {},
+          invalid: () => false,
+          processing: false,
+          reset: formSlotState.reset,
+          touch: formSlotState.touch,
+          validate: formSlotState.validate,
+          validating: false,
+          valid: () => false,
+        })}
+      </form>
+    ),
+    Link: ({ children, ...props }: { children: ReactNode; href: string }) => (
+      <a {...props}>{children}</a>
+    ),
+  }),
+);
 
 describe("Lattice form schema components", () => {
   beforeEach(() => {

--- a/resources/js/i18n/locale-reload.test.tsx
+++ b/resources/js/i18n/locale-reload.test.tsx
@@ -6,7 +6,9 @@ const router = vi.hoisted(() => ({
   visit: vi.fn<(url: string, options: Record<string, unknown>) => void>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({ router }));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ router }),
+);
 
 describe("LocaleReload", () => {
   beforeEach(() => {

--- a/resources/js/layout/components/breadcrumbs.test.tsx
+++ b/resources/js/layout/components/breadcrumbs.test.tsx
@@ -13,12 +13,11 @@ const usePage = vi.fn<
   }
 >();
 
-vi.mock("@inertiajs/react", () => ({
-  usePage: () => usePage(),
-  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    usePage: () => usePage(),
+  }),
+);
 
 const registry = createRegistry({
   components: { breadcrumbs: eagerComponent(BreadcrumbsComponent) },

--- a/resources/js/layout/components/callouts.test.tsx
+++ b/resources/js/layout/components/callouts.test.tsx
@@ -1,21 +1,14 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { ReactNode } from "react";
 import { vi } from "vitest";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
 import { Provider } from "@lattice-php/lattice/provider";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { fakeNode } from "@lattice-php/lattice/test-support";
 
-vi.mock("@inertiajs/react", () => ({
-  Link: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-  router: {
-    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
-      () => () => undefined,
-    ),
-  },
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 function emitCallout(
   message: string,
@@ -40,7 +33,7 @@ describe("Callouts slot", () => {
   it("renders callouts emitted on the bus and dismisses them", () => {
     render(
       <Provider toaster={false}>
-        <Renderer nodes={[{ type: "callouts", id: "c", props: {} } as never]} />
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
       </Provider>,
     );
 
@@ -54,7 +47,7 @@ describe("Callouts slot", () => {
   it("omits the dismiss button when the callout is not dismissible", () => {
     render(
       <Provider toaster={false}>
-        <Renderer nodes={[{ type: "callouts", id: "c", props: {} } as never]} />
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
       </Provider>,
     );
 
@@ -67,7 +60,7 @@ describe("Callouts slot", () => {
   it("renders a link action inside the callout", () => {
     render(
       <Provider toaster={false}>
-        <Renderer nodes={[{ type: "callouts", id: "c", props: {} } as never]} />
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
       </Provider>,
     );
 

--- a/resources/js/layout/components/dropdown.test.tsx
+++ b/resources/js/layout/components/dropdown.test.tsx
@@ -10,12 +10,9 @@ import { SidebarCollapsedContext } from "@lattice-php/lattice/layout/hooks/conte
 import DropdownComponent from "./dropdown";
 import MenuItemComponent from "./menu-item";
 
-vi.mock("@inertiajs/react", () => ({
-  usePage: vi.fn<() => { url: string }>(() => ({ url: "/" })),
-  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 const registry = createRegistry({
   components: {

--- a/resources/js/layout/components/menu-item-action.test.tsx
+++ b/resources/js/layout/components/menu-item-action.test.tsx
@@ -13,12 +13,12 @@ const http = vi.hoisted(() => ({
   put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  router: { reload: vi.fn<() => void>(), visit: vi.fn<(url: string) => void>() },
-  useHttp: () => http,
-  usePage: vi.fn<() => { url: string }>(() => ({ url: "/products" })),
-  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    useHttp: () => http,
+    usePage: () => ({ url: "/products" }),
+  }),
+);
 
 function actionMenuItem(props: Partial<ComponentPropsOf<"action">> = {}): Node<"menu-item"> {
   return fakeNode({

--- a/resources/js/layout/components/menu.test.tsx
+++ b/resources/js/layout/components/menu.test.tsx
@@ -8,25 +8,27 @@ import { SidebarCollapsedContext } from "@lattice-php/lattice/layout/hooks/conte
 import MenuComponent from "./menu";
 import MenuItemComponent from "./menu-item";
 
-vi.mock("@inertiajs/react", () => ({
-  usePage: vi.fn<() => { url: string }>(() => ({ url: "/products" })),
-  Link: ({
-    children,
-    href,
-    method,
-    as,
-    ...rest
-  }: {
-    children: React.ReactNode;
-    href: string;
-    method?: string;
-    as?: string;
-  }) => (
-    <a data-method={method} data-as={as} href={href} {...rest}>
-      {children}
-    </a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    usePage: vi.fn<() => { url: string }>(() => ({ url: "/products" })),
+    Link: ({
+      children,
+      href,
+      method,
+      as,
+      ...rest
+    }: {
+      children: React.ReactNode;
+      href: string;
+      method?: string;
+      as?: string;
+    }) => (
+      <a data-method={method} data-as={as} href={href} {...rest}>
+        {children}
+      </a>
+    ),
+  }),
+);
 
 const registry = createRegistry({
   components: {

--- a/resources/js/layout/components/popover.test.tsx
+++ b/resources/js/layout/components/popover.test.tsx
@@ -1,5 +1,7 @@
 import { vi } from "vitest";
-vi.mock("@inertiajs/react", () => ({ usePage: () => ({ url: "/" }) }));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";

--- a/resources/js/layout/components/schema-layout.test.tsx
+++ b/resources/js/layout/components/schema-layout.test.tsx
@@ -5,14 +5,9 @@ import { Provider } from "@lattice-php/lattice";
 import type { PagePayload } from "@lattice-php/lattice";
 import SchemaLayout from "./schema-layout";
 
-vi.mock("@inertiajs/react", () => ({
-  usePage: vi.fn<() => unknown>(),
-  router: {
-    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
-      () => () => undefined,
-    ),
-  },
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 const mockedUsePage = vi.mocked(usePage);
 

--- a/resources/js/notifications/components/notification-item.test.tsx
+++ b/resources/js/notifications/components/notification-item.test.tsx
@@ -4,19 +4,21 @@ import type { Node } from "@lattice-php/lattice/core/types";
 import type { NotificationItem } from "@lattice-php/lattice/notifications/types";
 import { NotificationItemRow } from "./notification-item";
 
-vi.mock("@inertiajs/react", () => ({
-  Link: ({ children, onClick, ...props }: React.ComponentProps<"a">) => (
-    <a
-      {...props}
-      onClick={(event) => {
-        event.preventDefault();
-        onClick?.(event);
-      }}
-    >
-      {children}
-    </a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    Link: ({ children, onClick, ...props }: React.ComponentProps<"a">) => (
+      <a
+        {...props}
+        onClick={(event) => {
+          event.preventDefault();
+          onClick?.(event);
+        }}
+      >
+        {children}
+      </a>
+    ),
+  }),
+);
 
 vi.mock("@lattice-php/lattice/icons", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@lattice-php/lattice/icons")>();

--- a/resources/js/notifications/components/notification-list.test.tsx
+++ b/resources/js/notifications/components/notification-list.test.tsx
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import { NotificationList } from "./notification-list";
 import type { NotificationItem } from "@lattice-php/lattice/notifications/types";
 
-vi.mock("@inertiajs/react", () => ({
-  Link: ({ children, ...props }: React.ComponentProps<"a">) => <a {...props}>{children}</a>,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 function item(id: string, title: string): NotificationItem {
   return {

--- a/resources/js/notifications/components/notifications.test.tsx
+++ b/resources/js/notifications/components/notifications.test.tsx
@@ -6,12 +6,9 @@ import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import type { Node } from "@lattice-php/lattice/core/types";
 import NotificationsComponent from "./notifications";
 
-vi.mock("@inertiajs/react", () => ({
-  usePage: () => ({ url: "/" }),
-  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 vi.mock("./notifications-echo", () => ({ NotificationsEcho: () => null }));
 
 const registry = createRegistry({

--- a/resources/js/page.test.tsx
+++ b/resources/js/page.test.tsx
@@ -4,14 +4,9 @@ import { createPlugin, createRegistry, eagerComponent, Provider } from "@lattice
 import type { PagePayload, RendererComponent } from "@lattice-php/lattice";
 import Page from "./page";
 
-vi.mock("@inertiajs/react", () => ({
-  Head: ({ title }: { title?: string }) => <title>{title}</title>,
-  router: {
-    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
-      () => () => undefined,
-    ),
-  },
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 function payload(lattice: Partial<PagePayload> = {}): PagePayload {
   return {

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -30,10 +30,12 @@ const router = vi.hoisted(() => ({
   visit: vi.fn<(url: string) => void>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  router,
-  useHttp: () => http,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
+    router,
+    useHttp: () => http,
+  }),
+);
 
 type ActionFormProps = {
   cancelLabel: string;

--- a/resources/js/table/components/cells/boolean-cell.test.tsx
+++ b/resources/js/table/components/cells/boolean-cell.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { TableColumn } from "@lattice-php/lattice/table/types";
+import type { ColumnPropsOf, TableColumn } from "@lattice-php/lattice/table/types";
 import { BooleanCell } from "./boolean-cell";
 
 const column = {
@@ -19,7 +19,12 @@ const column = {
 
 function renderCell(value: unknown) {
   return render(
-    <BooleanCell column={column} props={column.props as never} row={{}} value={value} />,
+    <BooleanCell
+      column={column}
+      props={column.props as ColumnPropsOf<"column.boolean">}
+      row={{}}
+      value={value}
+    />,
   );
 }
 

--- a/resources/js/table/components/cells/image-cell.test.tsx
+++ b/resources/js/table/components/cells/image-cell.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { TableColumn } from "@lattice-php/lattice/table/types";
+import type { ColumnPropsOf, TableColumn } from "@lattice-php/lattice/table/types";
 import { ImageCell } from "./image-cell";
 
 function column(props: Record<string, unknown> = {}): TableColumn {
@@ -25,7 +25,14 @@ function column(props: Record<string, unknown> = {}): TableColumn {
 
 function renderCell(value: unknown, props: Record<string, unknown> = {}) {
   const col = column(props);
-  return render(<ImageCell column={col} props={col.props as never} row={{}} value={value} />);
+  return render(
+    <ImageCell
+      column={col}
+      props={col.props as ColumnPropsOf<"column.image">}
+      row={{}}
+      value={value}
+    />,
+  );
 }
 
 describe("ImageCell", () => {

--- a/resources/js/table/components/cells/money-cell.test.tsx
+++ b/resources/js/table/components/cells/money-cell.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { TableColumn, TableRow } from "@lattice-php/lattice/table/types";
+import type { ColumnPropsOf, TableColumn, TableRow } from "@lattice-php/lattice/table/types";
 import { MoneyCell } from "./money-cell";
 
 function column(props: Record<string, unknown>): TableColumn {
@@ -22,7 +22,14 @@ function column(props: Record<string, unknown>): TableColumn {
 
 function renderCell(value: unknown, props: Record<string, unknown>, row: TableRow = {}) {
   const col = column(props);
-  return render(<MoneyCell column={col} props={col.props as never} row={row} value={value} />);
+  return render(
+    <MoneyCell
+      column={col}
+      props={col.props as ColumnPropsOf<"column.money">}
+      row={row}
+      value={value}
+    />,
+  );
 }
 
 afterEach(() => {

--- a/resources/js/table/components/cells/number-cell.test.tsx
+++ b/resources/js/table/components/cells/number-cell.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { TableColumn } from "@lattice-php/lattice/table/types";
+import type { ColumnPropsOf, TableColumn } from "@lattice-php/lattice/table/types";
 import { NumberCell } from "./number-cell";
 
 function column(props: Record<string, unknown> = {}): TableColumn {
@@ -22,7 +22,14 @@ function column(props: Record<string, unknown> = {}): TableColumn {
 
 function renderCell(value: unknown, props: Record<string, unknown> = {}) {
   const col = column(props);
-  return render(<NumberCell column={col} props={col.props as never} row={{}} value={value} />);
+  return render(
+    <NumberCell
+      column={col}
+      props={col.props as ColumnPropsOf<"column.number">}
+      row={{}}
+      value={value}
+    />,
+  );
 }
 
 afterEach(() => {

--- a/resources/js/table/components/cells/text-cell.test.tsx
+++ b/resources/js/table/components/cells/text-cell.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import type { TableColumn, TableRow } from "@lattice-php/lattice/table/types";
+import type { ColumnPropsOf, TableColumn, TableRow } from "@lattice-php/lattice/table/types";
 import { TextCell } from "./text-cell";
 
 function renderCell(props: Record<string, unknown>, value: unknown, row: TableRow = {}) {
@@ -19,7 +19,14 @@ function renderCell(props: Record<string, unknown>, value: unknown, row: TableRo
     },
   } as TableColumn;
 
-  return render(<TextCell column={column} props={props as never} row={row} value={value} />);
+  return render(
+    <TextCell
+      column={column}
+      props={column.props as ColumnPropsOf<"column.text">}
+      row={row}
+      value={value}
+    />,
+  );
 }
 
 describe("TextCell", () => {

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -28,10 +28,9 @@ const http = vi.hoisted(() => ({
   patch: vi.fn<(url: string) => Promise<{ effects: never[] }>>(async () => ({ effects: [] })),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  useHttp: () => http,
-  router: { reload: vi.fn<() => void>(), visit: vi.fn<(url: string) => void>() },
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+);
 
 const { default: TableComponent } = await import("./table");
 

--- a/resources/js/table/lib/format.test.ts
+++ b/resources/js/table/lib/format.test.ts
@@ -48,7 +48,7 @@ describe("formatCell primitives", () => {
 describe("resolveLink", () => {
   const column = (link: unknown): TableColumn =>
     ({ key: "name", label: "Name", props: { link } }) as never;
-  const row: TableRow = { id: 7, name: "Ada" } as never;
+  const row: TableRow = { id: 7, name: "Ada" };
 
   it("returns null when the column has no link", () => {
     expect(resolveLink(column(null), row, "Ada")).toBeNull();

--- a/resources/js/test/inertia-mock.tsx
+++ b/resources/js/test/inertia-mock.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+
+/**
+ * The `@inertiajs/react` surface tests replace with `vi.mock`. Call this inside
+ * the mock factory — `vi.mock("@inertiajs/react", () => inertiaMock({ ... }))` —
+ * and pass overrides for the exports a test asserts on (a hoisted `router`, a
+ * component-specific `Link`, …). The mock factory runs lazily, so referencing
+ * this import from inside it is safe under vi.mock hoisting.
+ */
+export function inertiaMock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    Link: ({ children, ...rest }: { children?: ReactNode }) => <a {...rest}>{children}</a>,
+    Head: ({ title }: { title?: string }) => <title>{title}</title>,
+    Form: ({ children }: { children: ReactNode }) => <form>{children}</form>,
+    usePage: vi.fn<() => { url: string }>(() => ({ url: "/" })),
+    useHttp: () => ({
+      delete: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
+      get: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
+      patch: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
+      post: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
+      put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
+      processing: false,
+      transform:
+        vi.fn<(callback: (data: Record<string, unknown>) => Record<string, unknown>) => void>(),
+    }),
+    router: {
+      on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
+        () => () => undefined,
+      ),
+      reload: vi.fn<() => void>(),
+      visit: vi.fn<(url: string, options?: unknown) => void>(),
+    },
+    ...overrides,
+  };
+}

--- a/resources/js/toast/toaster.test.tsx
+++ b/resources/js/toast/toaster.test.tsx
@@ -1,20 +1,12 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ReactNode } from "react";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
 import { Provider } from "@lattice-php/lattice/provider";
 import { Toaster } from "./toaster";
 
-vi.mock("@inertiajs/react", () => ({
-  Link: ({ children, href }: { children: ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-  router: {
-    on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(
-      () => () => undefined,
-    ),
-  },
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 function emit(toast: unknown): void {
   act(() => {

--- a/resources/js/ui/button-action.test.tsx
+++ b/resources/js/ui/button-action.test.tsx
@@ -13,11 +13,9 @@ const http = vi.hoisted(() => ({
   put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  router: { reload: vi.fn<() => void>(), visit: vi.fn<(url: string) => void>() },
-  useHttp: () => http,
-  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+);
 
 function actionButton(props: Partial<ComponentPropsOf<"action">> = {}): Node<"button"> {
   return fakeNode({

--- a/resources/js/ui/link-action.test.tsx
+++ b/resources/js/ui/link-action.test.tsx
@@ -13,11 +13,9 @@ const http = vi.hoisted(() => ({
   put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
 }));
 
-vi.mock("@inertiajs/react", () => ({
-  router: { reload: vi.fn<() => void>(), visit: vi.fn<(url: string) => void>() },
-  useHttp: () => http,
-  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+);
 
 function actionLink(props: Partial<ComponentPropsOf<"action">> = {}): Node<"link"> {
   return fakeNode({

--- a/resources/js/ui/tabs.test.tsx
+++ b/resources/js/ui/tabs.test.tsx
@@ -7,11 +7,9 @@ import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import TabComponent, { TabsComponent } from "./tabs";
 
-vi.mock("@inertiajs/react", () => ({
-  router: {
-    visit: vi.fn<(url: string, options?: unknown) => void>(),
-  },
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 const TextProbe: RendererComponent<"text"> = ({ node }) => <span>{String(node.props?.text)}</span>;
 

--- a/resources/js/ui/tree-keyboard.test.tsx
+++ b/resources/js/ui/tree-keyboard.test.tsx
@@ -7,10 +7,9 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import TreeComponent, { type TreeNodeData } from "./tree";
 
-vi.mock("@inertiajs/react", () => ({
-  router: { visit: vi.fn<(url: string, options?: unknown) => void>() },
-  Link: ({ children, ...rest }: { children: React.ReactNode }) => <a {...rest}>{children}</a>,
-}));
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
+);
 
 const actionClicks: string[] = [];
 const TestAction: RendererComponent = ({ node }) => (

--- a/tests/Browser/App/ToastTest.php
+++ b/tests/Browser/App/ToastTest.php
@@ -13,15 +13,11 @@ it('shows a toast after an action and dismisses it', function (): void {
         ->click('@action-archive')
         ->click('@confirm-accept');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Product archived.');
-    });
+    assertSeeEventually($page, 'Product archived.');
 
     $page->click('@toast-dismiss');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Product archived.');
-    });
+    assertDontSeeEventually($page, 'Product archived.');
 
     $page->assertNoSmoke();
 });
@@ -36,15 +32,11 @@ it('renders a link inside a toast', function (): void {
         ->click('@action-archive')
         ->click('@confirm-accept');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Product archived.');
-    });
+    assertSeeEventually($page, 'Product archived.');
 
     $page->click('@view-products');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Create product');
-    });
+    assertSeeEventually($page, 'Create product');
 
     $page->assertNoSmoke();
 });
@@ -60,16 +52,12 @@ it('opens a modal form from a toast action', function (): void {
         ->assertValue('#name', 'Desk Lamp')
         ->click('@action-form-submit');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Product updated.');
-    });
+    assertSeeEventually($page, 'Product updated.');
 
     $page->click('@product-actions')
         ->click('@action-reject');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Reject product?');
-    });
+    assertSeeEventually($page, 'Reject product?');
 
     $page->fill('@reason', 'Counterfeit listing')
         ->click('@action-form-submit')

--- a/tests/Browser/Components/ChartsTest.php
+++ b/tests/Browser/Components/ChartsTest.php
@@ -23,9 +23,7 @@ it('translates dashboard chart examples in lazy fragments', function (): void {
         ->click('@locale-switcher')
         ->click('@locale-de');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Umsatz');
-    });
+    assertSeeEventually($page, 'Umsatz');
 
     $page
         ->assertSee('Dashboard-Diagramme')

--- a/tests/Browser/Components/FloatingChatTest.php
+++ b/tests/Browser/Components/FloatingChatTest.php
@@ -58,12 +58,8 @@ it('shows an optimistic user bubble when a message is sent', function (): void {
     $page->type('@chat-input', 'Hello from the browser test')
         ->click('@chat-send');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Hello from the browser test');
-    });
-    eventually(function () use ($page): void {
-        $page->assertSee('Stubbed assistant response.');
-    });
+    assertSeeEventually($page, 'Hello from the browser test');
+    assertSeeEventually($page, 'Stubbed assistant response.');
 
     $page->assertNoSmoke()
         ->assertNoJavaScriptErrors();

--- a/tests/Browser/Components/TreeTest.php
+++ b/tests/Browser/Components/TreeTest.php
@@ -31,9 +31,7 @@ it('expands a collapsed subtree and reveals its children when the chevron is cli
         ->assertNotPresent('[data-test="tree-node-clothing-men"]')
         ->click('[data-test="tree-node-clothing-toggle"]');
 
-    eventually(function () use ($page): void {
-        $page->assertPresent('[data-test="tree-node-clothing-men"]');
-    });
+    assertPresentEventually($page, '[data-test="tree-node-clothing-men"]');
 
     $page
         ->assertSee('Men')
@@ -57,9 +55,7 @@ it('moves focus with ArrowDown and expands a node with ArrowRight', function ():
         ->assertNotPresent('[data-test="tree-node-clothing-men"]')
         ->keys('[data-test="tree-node-clothing"]', ['ArrowRight']);
 
-    eventually(function () use ($page): void {
-        $page->assertPresent('[data-test="tree-node-clothing-men"]');
-    });
+    assertPresentEventually($page, '[data-test="tree-node-clothing-men"]');
 
     $page->assertNoJavaScriptErrors();
 });
@@ -70,9 +66,7 @@ it('navigates when an href node link is clicked', function (): void {
     $page = visit('/components/tree')
         ->click('[data-test="tree-node-clothing-toggle"]');
 
-    eventually(function () use ($page): void {
-        $page->assertPresent('[data-test="tree-node-clothing-women"]');
-    });
+    assertPresentEventually($page, '[data-test="tree-node-clothing-women"]');
 
     $page
         ->assertAttribute('[data-test="tree-node-clothing-women"] a', 'href', '/components/containers')
@@ -115,17 +109,13 @@ it('opens the info modal with Enter on the modal-action node and returns focus o
 
     $page->keys('[data-test="tree-node-help"]', ['Enter']);
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Keyboard navigation');
-    });
+    assertSeeEventually($page, 'Keyboard navigation');
 
     $page
         ->assertSee('Arrow keys move focus between rows')
         ->click('[data-test="dialog-close"]');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Keyboard navigation');
-    });
+    assertDontSeeEventually($page, 'Keyboard navigation');
 
     eventually(function () use ($page): void {
         $focusedTestId = $page->script(<<<'JS'

--- a/tests/Browser/Fields/FileUploadTest.php
+++ b/tests/Browser/Fields/FileUploadTest.php
@@ -17,9 +17,7 @@ it('uploads a file through a multipart payload', function (): void {
 
     $page->attach('@avatar-input', __DIR__.'/fixtures/avatar.jpg');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('avatar.jpg');
-    });
+    assertSeeEventually($page, 'avatar.jpg');
 
     $page->click('@form-submit')
         ->assertSee('File upload')
@@ -48,12 +46,8 @@ it('uploads directly to s3 via the signed flow', function (): void {
 
     $page->attach('@document-input', __DIR__.'/fixtures/avatar.jpg');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('avatar.jpg');
-    });
-    eventually(function () use ($page): void {
-        $page->assertPresent('[data-test="document-uploaded"]');
-    });
+    assertSeeEventually($page, 'avatar.jpg');
+    assertPresentEventually($page, '[data-test="document-uploaded"]');
 
     $page->click('@form-submit')
         ->assertNoSmoke();

--- a/tests/Browser/Fields/SelectTest.php
+++ b/tests/Browser/Fields/SelectTest.php
@@ -26,9 +26,7 @@ it('searches and selects entities in a multiple select', function (): void {
         ->click('Search products…')
         ->fill('input[aria-label="Search options"]', 'walnut');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Steel Lamp');
-    });
+    assertDontSeeEventually($page, 'Steel Lamp');
 
     $page->assertSee('Walnut Desk')
         ->click('Walnut Desk')
@@ -46,9 +44,7 @@ it('renders rich option rows in the products search', function (): void {
     $page->click('Search products…')
         ->fill('input[aria-label="Search options"]', 'walnut');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('WD-100');
-    });
+    assertSeeEventually($page, 'WD-100');
 
     $page->click('Walnut Desk')
         ->assertPresent('button[aria-label="Remove Walnut Desk"]')
@@ -75,9 +71,7 @@ it('adds a new tag on the tags tab', function (): void {
         ->fill('[data-test="select-topics-search"]', 'Logistics')
         ->keys('[data-test="select-topics-search"]', ['Enter']);
 
-    eventually(function () use ($page): void {
-        $page->assertPresent('input[type="hidden"][name="topics[]"][value="Logistics"]');
-    });
+    assertPresentEventually($page, 'input[type="hidden"][name="topics[]"][value="Logistics"]');
 
     $page->assertNoJavaScriptErrors();
 });

--- a/tests/Browser/Forms/DependentFieldsTest.php
+++ b/tests/Browser/Forms/DependentFieldsTest.php
@@ -23,9 +23,7 @@ it('requires the company field for business on submit', function (): void {
         ->assertPresent('input[name="company"]')
         ->click('@form-submit');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('The Company field is required.');
-    });
+    assertSeeEventually($page, 'The Company field is required.');
 
     $page->assertNoSmoke();
 });

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -57,9 +57,7 @@ it('opens the sidebar as an off-canvas drawer on mobile', function (): void {
         ->assertMissing('[data-test="sidebar-backdrop"]')
         ->click('@sidebar-toggle');
 
-    eventually(function () use ($page): void {
-        $page->assertPresent('[data-test="sidebar-backdrop"]');
-    });
+    assertPresentEventually($page, '[data-test="sidebar-backdrop"]');
 
     $page
         ->click('@menu-components')

--- a/tests/Browser/Tables/ColumnVisibilityTest.php
+++ b/tests/Browser/Tables/ColumnVisibilityTest.php
@@ -13,17 +13,13 @@ it('hides a column from the menu and remembers it across reloads', function (): 
         ->click('@table-columns-menu')
         ->click('@table-column-toggle-sku');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('LAMP-1');
-    });
+    assertDontSeeEventually($page, 'LAMP-1');
 
     $page->assertSee('Desk Lamp')
         ->assertNoSmoke()
         ->refresh();
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('LAMP-1');
-    });
+    assertDontSeeEventually($page, 'LAMP-1');
 
     $page->assertSee('Desk Lamp')
         ->assertNoSmoke();

--- a/tests/Browser/Tables/FiltersTest.php
+++ b/tests/Browser/Tables/FiltersTest.php
@@ -27,16 +27,12 @@ it('filters by text and clears via the filter chip', function (): void {
     $page->fill('@filter-name-value', 'Ada')
         ->keys('@filter-name-value', 'Enter');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Maya Chen');
-    });
+    assertDontSeeEventually($page, 'Maya Chen');
 
     $page->assertSee('Ada Lovelace')
         ->click('@filter-chip-name-remove');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Maya Chen');
-    });
+    assertSeeEventually($page, 'Maya Chen');
 
     $page->assertNoSmoke();
 });
@@ -52,9 +48,7 @@ it('adds a filter through the column popover', function (): void {
         ->fill('[aria-label="Name filter value"]', 'Grace')
         ->keys('[aria-label="Name filter value"]', 'Enter');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Ada Lovelace');
-    });
+    assertDontSeeEventually($page, 'Ada Lovelace');
 
     $page->assertSee('Grace Hopper')
         ->assertNoSmoke();
@@ -71,9 +65,7 @@ it('filters products by the boolean featured column', function (): void {
         ->assertSee('Plain Item')
         ->select('@filter-featured-value', 'true');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Plain Item');
-    });
+    assertDontSeeEventually($page, 'Plain Item');
 
     $page->assertSee('Featured Item')
         ->assertNoSmoke();
@@ -91,16 +83,12 @@ it('narrows rows with the ternary featured filter and restores them via reset', 
         ->click('#table-filter-featured-value')
         ->click('[data-test="select-value-option-true"]');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Draft Plain');
-    });
+    assertDontSeeEventually($page, 'Draft Plain');
 
     $page->assertSee('Active Featured')
         ->click('@table-filters-reset');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Draft Plain');
-    });
+    assertSeeEventually($page, 'Draft Plain');
 
     $page->assertNoSmoke();
 });
@@ -114,9 +102,7 @@ it('narrows rows with a custom toggle filter', function (): void {
     $page->click('@table-filters-menu')
         ->click('@table-filter-high_value');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Draft Plain');
-    });
+    assertDontSeeEventually($page, 'Draft Plain');
 
     $page->assertSee('Active Featured')
         ->assertNoSmoke();
@@ -131,9 +117,7 @@ it('narrows rows with the status column select filter', function (): void {
     $page->click('#table-filter-status-value')
         ->click('[data-test="select-value-option-active"]');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Draft Plain');
-    });
+    assertDontSeeEventually($page, 'Draft Plain');
 
     $page->assertSee('Active Featured')
         ->assertNoSmoke();

--- a/tests/Browser/Tables/GlobalSearchTest.php
+++ b/tests/Browser/Tables/GlobalSearchTest.php
@@ -11,16 +11,12 @@ it('filters rows through the global search box and restores them on clear', func
         ->assertSee('Maya Chen')
         ->fill('@table-search', 'Ada');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Maya Chen');
-    });
+    assertDontSeeEventually($page, 'Maya Chen');
 
     $page->assertSee('Ada Lovelace')
         ->click('@table-search-clear');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Maya Chen');
-    });
+    assertSeeEventually($page, 'Maya Chen');
 
     $page->assertNoSmoke();
 });
@@ -33,9 +29,7 @@ it('matches against a searchable relation-free email column', function (): void 
 
     $page->fill('@table-search', 'grace@example.com');
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Ada Lovelace');
-    });
+    assertDontSeeEventually($page, 'Ada Lovelace');
 
     $page->assertSee('Grace Hopper')
         ->assertNoSmoke();

--- a/tests/Browser/Tables/PaginationTest.php
+++ b/tests/Browser/Tables/PaginationTest.php
@@ -33,16 +33,12 @@ it('shows pagination modes in lazily loaded tabs', function (): void {
         ->click('@tab-table')
         ->assertSee('Table pagination');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Showing 1-25 of 30');
-    });
+    assertSeeEventually($page, 'Showing 1-25 of 30');
 
     $page->click('@tab-infinite')
         ->assertSee('Infinite pagination');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Load more');
-    });
+    assertSeeEventually($page, 'Load more');
 
     $page->assertNoSmoke();
 });
@@ -54,19 +50,13 @@ it('navigates between pages in table pagination mode', function (): void {
     $page = visit('/tables/pagination');
 
     $page->click('@tab-table');
-    eventually(function () use ($page): void {
-        $page->assertSee('Showing 1-25 of 30');
-    });
+    assertSeeEventually($page, 'Showing 1-25 of 30');
 
     $page->click('@pagination-next');
-    eventually(function () use ($page): void {
-        $page->assertSee('Showing 26-30 of 30');
-    });
+    assertSeeEventually($page, 'Showing 26-30 of 30');
 
     $page->click('@pagination-page-1');
-    eventually(function () use ($page): void {
-        $page->assertSee('Showing 1-25 of 30');
-    });
+    assertSeeEventually($page, 'Showing 1-25 of 30');
 
     $page->assertNoSmoke();
 });
@@ -79,16 +69,12 @@ it('loads more rows in infinite mode', function (): void {
     disableInfiniteScrollAutoLoad($page);
 
     $page->click('@tab-infinite');
-    eventually(function () use ($page): void {
-        $page->assertSee('Load more');
-    });
+    assertSeeEventually($page, 'Load more');
 
     $page->assertDontSee('Browser User 26')
         ->click('@pagination-load-more');
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Browser User 26');
-    });
+    assertSeeEventually($page, 'Browser User 26');
 
     $page->assertNoSmoke();
 });
@@ -101,14 +87,10 @@ it('keeps the topbar user menu visible on infinite pagination pages', function (
     disableInfiniteScrollAutoLoad($page);
 
     $page->click('@tab-infinite');
-    eventually(function () use ($page): void {
-        $page->assertSee('Load more');
-    });
+    assertSeeEventually($page, 'Load more');
 
     $page->click('@pagination-load-more');
-    eventually(function () use ($page): void {
-        $page->assertSee('Browser User 26');
-    });
+    assertSeeEventually($page, 'Browser User 26');
 
     $page->assertVisible('@user-menu');
 

--- a/tests/Browser/Tables/RowDetailTest.php
+++ b/tests/Browser/Tables/RowDetailTest.php
@@ -19,15 +19,11 @@ it('expands a sales-order row to load its line items over ajax and collapses aga
         ->assertDontSee('Gizmo')
         ->click('@row-expand-'.$order->getKey());
 
-    eventually(function () use ($page): void {
-        $page->assertSee('Gizmo');
-    });
+    assertSeeEventually($page, 'Gizmo');
 
     $page->click('@row-expand-'.$order->getKey());
 
-    eventually(function () use ($page): void {
-        $page->assertDontSee('Gizmo');
-    });
+    assertDontSeeEventually($page, 'Gizmo');
 
     $page->assertNoSmoke();
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -18,6 +18,9 @@ use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tests\BrowserTestCase;
 use Lattice\Lattice\Tests\TestCase;
 use Orchestra\Testbench\Factories\UserFactory;
+use Pest\Browser\Api\AwaitableWebpage;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Api\Webpage;
 use Workbench\App\Models\User;
 
 use function Pest\Laravel\getJson;
@@ -59,6 +62,32 @@ function retryUntil(Closure $assert, int $attempts = 20, int $sleepMicroseconds 
 function eventually(Closure $assert, int $attempts = 20, int $sleepMicroseconds = 500_000, ?Closure $between = null): void
 {
     retryUntil($assert, $attempts, $sleepMicroseconds, $between);
+}
+
+/**
+ * Poll {@see eventually()} until the text is present on the page. The polled
+ * closure must be a statement body — an arrow closure returns the page rather
+ * than void and breaks the `Closure(): void` contract.
+ */
+function assertSeeEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $page, string|int|float $text): void
+{
+    eventually(function () use ($page, $text): void {
+        $page->assertSee($text);
+    });
+}
+
+function assertDontSeeEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $page, string|int|float $text): void
+{
+    eventually(function () use ($page, $text): void {
+        $page->assertDontSee($text);
+    });
+}
+
+function assertPresentEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $page, string $selector): void
+{
+    eventually(function () use ($page, $selector): void {
+        $page->assertPresent($selector);
+    });
 }
 
 function rustfsIsReachable(): bool

--- a/tests/Unit/Core/ChartTest.php
+++ b/tests/Unit/Core/ChartTest.php
@@ -11,13 +11,13 @@ use Lattice\Lattice\Ui\Values\DateFormat;
 use Lattice\Lattice\Ui\Values\NumberFormat;
 
 it('coerces series colors to tagged color values', function (): void {
-    expect(json_decode(json_encode(ChartSeries::line('revenue', color: '#2563eb')), true)['color'])
+    expect(wire(ChartSeries::line('revenue', color: '#2563eb'))['color'])
         ->toBe(['kind' => 'css', 'value' => '#2563eb', 'dark' => null])
-        ->and(json_decode(json_encode(ChartSeries::bar('orders', color: 'success')), true)['color'])
+        ->and(wire(ChartSeries::bar('orders', color: 'success'))['color'])
         ->toBe(['kind' => 'named', 'value' => 'success', 'dark' => null])
-        ->and(json_decode(json_encode(ChartSeries::line('plain')), true)['color'])
+        ->and(wire(ChartSeries::line('plain'))['color'])
         ->toBeNull()
-        ->and(json_decode(json_encode(ChartSeries::area('forecast', color: Color::hex('#8b5cf6')->dark('#a78bfa'))), true)['color'])
+        ->and(wire(ChartSeries::area('forecast', color: Color::hex('#8b5cf6')->dark('#a78bfa')))['color'])
         ->toBe(['kind' => 'css', 'value' => '#8b5cf6', 'dark' => '#a78bfa']);
 });
 

--- a/tests/Unit/Core/ColorTest.php
+++ b/tests/Unit/Core/ColorTest.php
@@ -42,8 +42,8 @@ it('rejects dark() on named colors', function (): void {
 })->throws(LogicException::class);
 
 it('serializes to the tagged wire shape', function (): void {
-    expect(json_decode(json_encode(Color::warning()), true))
+    expect(wire(Color::warning()))
         ->toBe(['kind' => 'named', 'value' => 'warning', 'dark' => null])
-        ->and(json_decode(json_encode(Color::hex('#2563eb')->dark('#60a5fa')), true))
+        ->and(wire(Color::hex('#2563eb')->dark('#60a5fa')))
         ->toBe(['kind' => 'css', 'value' => '#2563eb', 'dark' => '#60a5fa']);
 });

--- a/tests/Unit/Http/PageSerializationTest.php
+++ b/tests/Unit/Http/PageSerializationTest.php
@@ -98,7 +98,7 @@ test('pages serialize breadcrumb metadata', function (): void {
 
     $payload = $page->toArray($page->render(PageSchema::make()), new Request);
 
-    expect(json_decode(json_encode($payload['breadcrumbs']), associative: true))
+    expect(wire($payload['breadcrumbs']))
         ->toBe([
             [
                 'title' => 'Dashboard',

--- a/tests/Unit/Tables/Columns/ColumnTypesTest.php
+++ b/tests/Unit/Tables/Columns/ColumnTypesTest.php
@@ -32,7 +32,7 @@ it('normalizes badge colors to tagged color values', function (): void {
         'flagged' => '#dc2626',
     ]);
 
-    expect(json_decode(json_encode($column->colors), true))->toBe([
+    expect(wire($column->colors))->toBe([
         'active' => ['kind' => 'named', 'value' => 'green', 'dark' => null],
         'archived' => ['kind' => 'named', 'value' => 'gray', 'dark' => null],
         'flagged' => ['kind' => 'css', 'value' => '#dc2626', 'dark' => null],


### PR DESCRIPTION
Phase 3 — test-infrastructure deduplication. No production code changes, no coverage change; pure boilerplate removal.

- **Inertia mock factory** (`resources/js/test/inertia-mock.tsx`): all 25 hand-rolled `vi.mock("@inertiajs/react")` blocks now call one factory with per-file overrides. Uses the async-factory + dynamic-import form required to survive vi.mock hoisting (a one-line comment records that footgun).
- **`eventually` browser helpers** (`tests/Pest.php`): `assertSeeEventually`/`assertDontSeeEventually`/`assertPresentEventually` replace 46 of 58 identical statement-body poll closures; the 12 multi-assertion polls stay explicit. The `$page` param is typed `PendingAwaitablePage|Webpage` and the closures stay statement-body/void per the repo's PHPStan constraint.
- **`wire()` helper**: 8 `json_decode(json_encode(...))` round-trip sites (Color/Chart/ColumnTypes/PageSerialization) use the existing helper; WireMaterializeTest keeps its explicit round-trip (it tests materialization itself).
- **`as never` casts**: 15 of 28 typed away (cells via `ColumnPropsOf`, nodes via `fakeNode`, effects via the existing `effect()` fixture); 13 genuinely-dynamic ones (custom/unregistered effects, the builder's non-standard `templates` field) left with a note.

Net −65 LOC. JS suite + typecheck green; PHP helper changes green under the full pre-push gate. **Browser suite** (the `eventually` ports) runs in CI's Browser job — outside the pre-push hook's scope.