### PR TITLE
feat: add named extension slots

### DIFF
--- a/docs/content/docs/core/closure-evaluation.md
+++ b/docs/content/docs/core/closure-evaluation.md
@@ -72,6 +72,7 @@ Some callbacks add more named utilities:
 | Repeater and builder row callbacks | `$row` for the current row and `$form` for the whole form. A typed `FormData` parameter is `$row`. |
 | `ToggleFilter::query()`            | A typed Eloquent `Builder` and `$value`, the submitted toggle state.                               |
 | `TernaryFilter::queries()`         | A typed Eloquent `Builder`.                                                                        |
+| `Lattice::extend()`                | Named slot context, typed context objects, `$user`, `$slot`/typed `Slot`, and typed `Request`.     |
 
 ```php
 Select::make('author_id', 'Author')
@@ -90,6 +91,10 @@ Inside row hooks, use the named `$form` utility when you need values outside the
 Repeater::make('lines')
     ->itemLabel(fn (FormData $row, FormData $form) => $row->string('name') ?: $form->string('currency'));
 ```
+
+Named slot factories also resolve any remaining class or interface from Laravel's container. A
+context object is registered under its concrete type and can satisfy a parameter typed as that class,
+a parent class, or an implemented interface.
 
 ## Server-side timing
 

--- a/docs/content/docs/core/layouts.md
+++ b/docs/content/docs/core/layouts.md
@@ -55,6 +55,39 @@ A layout's schema must contain **exactly one** `Outlet`. It carries no markup of
 seam where Lattice drops the active page's component tree. Everything around it — sidebar, breadcrumbs,
 header — is shared chrome rendered once and left in place as the page changes.
 
+## Named layout slots
+
+Named [`Slot` extension points](/core/pages/#named-extension-slots) use the same server-side schema
+mechanism in layouts. They are useful when a module needs to contribute navigation or chrome without
+replacing the application layout:
+
+```php
+use Lattice\Lattice\Ui\Slot;
+
+Stack::make('app-shell')->schema([
+    Sidebar::make('app-sidebar')->items([
+        Menu::make('navigation')->items([
+            MenuItem::fromPage(HomePage::class),
+            Slot::make('app.sidebar.navigation'),
+        ]),
+    ]),
+    Stack::make('app-main')->schema([
+        Outlet::make(),
+    ]),
+]);
+```
+
+`Slot` and `Outlet` can therefore appear in the same layout tree, but they solve different boundaries:
+
+|                     | `Slot`                                                                   | `Outlet`                                                  |
+| ------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------- |
+| Resolved by         | PHP on the server                                                        | The React layout renderer                                 |
+| Filled with         | Components registered through `Lattice::extend()`                        | The active page's complete schema                         |
+| Serialized itself   | No—the registered components replace it before the wire payload is built | Yes—it remains an `outlet` node in the layout wire schema |
+| Allowed occurrences | Any number of named slots                                                | Exactly one per layout                                    |
+
+An empty named slot disappears without affecting the `Outlet` or the page tree inserted there.
+
 ## The header bar
 
 `Topbar` is a horizontal bar for chrome that sits above the page — a logo, search, settings menu, or

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -52,6 +52,52 @@ primitives like `Stack`, content like `Heading` and `Text`, and the interactive
 [forms](/forms/overview/), [tables](/tables/overview/), and [actions](/actions/overview/) that carry
 their own endpoints.
 
+## Named extension slots
+
+A page can expose part of its component tree to other modules without owning their components. Place
+a named `Slot` wherever contributions should appear and pass any context their factories need:
+
+```php
+use Lattice\Lattice\Ui\Components\Tabs;
+use Lattice\Lattice\Ui\Slot;
+
+Tabs::make('project-settings-tabs')->schema([
+    Slot::make('project.settings.tabs')->context([
+        'project' => $project,
+    ]),
+]);
+```
+
+Register each contribution from the module's service provider:
+
+```php
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Ui\Components\Tab;
+
+Lattice::extend(
+    'project.settings.tabs',
+    fn (Project $project, $user): Tab => Tab::make('api-tokens', 'API tokens')
+        ->visible($user?->can('update', $project) ?? false)
+        ->schema([
+            ApiTokensPanel::make($project),
+        ]),
+    priority: 20,
+);
+```
+
+Each factory returns exactly one component. Lower priorities render first; contributions with the same
+priority retain registration order. Return the component with `->visible(false)` when it should not
+render rather than returning `null`.
+
+Slot context is available to the factory by parameter name. Object values also resolve by type, as the
+`Project $project` parameter does above. Factories additionally receive `$user`, `$slot` (or a typed
+`Slot`), a typed `Request`, and services from Laravel's container. See
+[Closure evaluation](/core/closure-evaluation/#hook-specific-utilities) for the complete rules.
+
+An unregistered slot renders nothing. Each rendered slot receives fresh component instances, and the
+`Slot` itself is expanded on the server before component visibility, tab selection, or
+serialization—it never becomes a client-side node.
+
 ## Route parameters
 
 `render()` is dispatched like a controller method, so route parameters and route-model binding resolve

--- a/src/Actions/Components/ActionGroup.php
+++ b/src/Actions/Components/ActionGroup.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Actions\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
-use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
 use Lattice\Lattice\Ui\Components\IsInteractive;
 use Lattice\Lattice\Ui\Concerns\HasLabel;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 use Lattice\Lattice\Ui\Enums\Orientation;
 
 #[AsComponent('action.group')]
@@ -31,7 +31,7 @@ class ActionGroup extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $actions
+     * @param  array<int, SchemaEntry>  $actions
      */
     public function actions(array $actions): static
     {

--- a/src/Core/PageSchema.php
+++ b/src/Core/PageSchema.php
@@ -5,13 +5,16 @@ namespace Lattice\Lattice\Core;
 
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Concerns\FiltersRenderableComponents;
+use Lattice\Lattice\Ui\Concerns\ResolvesSchemaEntries;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 final class PageSchema
 {
     use FiltersRenderableComponents;
+    use ResolvesSchemaEntries;
 
     /**
-     * @var array<int, Component>
+     * @var array<int, SchemaEntry>
      */
     private array $components = [];
 
@@ -21,7 +24,7 @@ final class PageSchema
     }
 
     /**
-     * @param  array<int, Component>  $components
+     * @param  array<int, SchemaEntry>  $components
      */
     public function schema(array $components): static
     {
@@ -42,6 +45,6 @@ final class PageSchema
      */
     public function renderable(): array
     {
-        return $this->renderableComponents($this->components);
+        return $this->renderableComponents($this->resolveSchemaEntries($this->components));
     }
 }

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -19,6 +19,7 @@ use Lattice\Lattice\LatticeRegistry;
  * @method static void remoteSources(class-string<\Lattice\Lattice\Remote\RemoteSourceDefinition>|array<int, class-string<\Lattice\Lattice\Remote\RemoteSourceDefinition>> $remoteSources)
  * @method static void remoteSourceResolver(callable $resolver)
  * @method static \Lattice\Lattice\Remote\RemoteSourceRegistry remoteSourceRegistry()
+ * @method static void extend(string $name, \Closure $factory, int $priority = 0)
  *
  * @see LatticeRegistry
  */

--- a/src/Forms/Components/Repeater.php
+++ b/src/Forms/Components/Repeater.php
@@ -54,7 +54,7 @@ class Repeater extends RowsField
     public function childFields(): array
     {
         return array_values(array_filter(
-            $this->children,
+            $this->resolvedChildren(),
             static fn (Component $child): bool => $child instanceof Field,
         ));
     }

--- a/src/Forms/Components/RowTemplate.php
+++ b/src/Forms/Components/RowTemplate.php
@@ -41,7 +41,7 @@ final class RowTemplate implements JsonSerializable
     public function fields(): array
     {
         return array_values(array_filter(
-            $this->children,
+            $this->resolvedChildren(),
             static fn (Component $child): bool => $child instanceof Field,
         ));
     }

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice;
 
+use Closure;
 use Illuminate\Contracts\Container\Container;
 use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionRegistry;
@@ -20,6 +21,7 @@ use Lattice\Lattice\Remote\RemoteSourceDefinition;
 use Lattice\Lattice\Remote\RemoteSourceRegistry;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableRegistry;
+use Lattice\Lattice\Ui\SlotRegistry;
 
 final readonly class LatticeRegistry
 {
@@ -32,6 +34,7 @@ final readonly class LatticeRegistry
         private PageRegistry $pages,
         private TableRegistry $tables,
         private RemoteSourceRegistry $remoteSources,
+        private SlotRegistry $slots,
     ) {}
 
     /**
@@ -104,6 +107,11 @@ final readonly class LatticeRegistry
     public function remoteSourceResolver(callable $resolver): void
     {
         $this->remoteSources->resolveUsing($resolver);
+    }
+
+    public function extend(string $name, Closure $factory, int $priority = 0): void
+    {
+        $this->slots->extend($name, $factory, $priority);
     }
 
     public function layoutRegistry(): LayoutRegistry

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -59,6 +59,7 @@ use Lattice\Lattice\Support\TypeScript\AugmentProfile;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 use Lattice\Lattice\Tables\TableRegistry;
 use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\SlotRegistry;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -110,6 +111,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
         $this->app->singleton(BulkActionRegistry::class);
         $this->app->singleton(PageRegistry::class);
         $this->app->singleton(RemoteSourceRegistry::class);
+        $this->app->singleton(SlotRegistry::class);
         $this->app->singleton(ResolvesReferenceIdentity::class, RequestReferenceIdentity::class);
         $this->app->singleton(ComponentReferenceSigner::class);
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);

--- a/src/Layouts/Components/Dropdown.php
+++ b/src/Layouts/Components/Dropdown.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Layouts\Components;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 use Lattice\Lattice\Ui\Enums\Placement;
 
 #[AsComponent('dropdown')]
@@ -41,7 +42,7 @@ class Dropdown extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $items
+     * @param  array<int, SchemaEntry>  $items
      */
     public function items(array $items): static
     {

--- a/src/Layouts/Components/Menu.php
+++ b/src/Layouts/Components/Menu.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Layouts\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
-use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 /**
  * A navigation menu composed of MenuItems, rendered inside a layout schema.
@@ -19,7 +19,7 @@ class Menu extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $items
+     * @param  array<int, SchemaEntry>  $items
      */
     public function items(array $items): static
     {

--- a/src/Layouts/Components/MenuItem.php
+++ b/src/Layouts/Components/MenuItem.php
@@ -9,11 +9,11 @@ use InvalidArgumentException;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Core\Contracts\PageContract;
-use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
 use Lattice\Lattice\Ui\Concerns\HasAffixes;
 use Lattice\Lattice\Ui\Concerns\HasIcon;
 use Lattice\Lattice\Ui\Concerns\Triggerable;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 /**
  * A single menu entry. Renders an Inertia link when it has an href, triggers a
@@ -83,7 +83,7 @@ class MenuItem extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $children
+     * @param  array<int, SchemaEntry>  $children
      */
     public function children(array $children): static
     {

--- a/src/Layouts/Components/Sidebar.php
+++ b/src/Layouts/Components/Sidebar.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Layouts\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
-use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 /**
  * A fixed-width navigation column rendered alongside the page content in a
@@ -32,7 +32,7 @@ class Sidebar extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $components
+     * @param  array<int, SchemaEntry>  $components
      */
     public function items(array $components): static
     {

--- a/src/Layouts/Components/Topbar.php
+++ b/src/Layouts/Components/Topbar.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Layouts\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
-use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 /**
  * A horizontal application bar at the top of the page content. Give a child
@@ -29,7 +29,7 @@ class Topbar extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $components
+     * @param  array<int, SchemaEntry>  $components
      */
     public function items(array $components): static
     {

--- a/src/Tables/Columns/StackColumn.php
+++ b/src/Tables/Columns/StackColumn.php
@@ -21,7 +21,7 @@ class StackColumn extends Column
      */
     public function children(): array
     {
-        return $this->children;
+        return $this->resolvedChildren();
     }
 
     /**
@@ -32,11 +32,7 @@ class StackColumn extends Column
     {
         $keys = [];
 
-        foreach ($this->children as $child) {
-            if (! $child->shouldRender()) {
-                continue;
-            }
-
+        foreach ($this->renderableChildren() as $child) {
             array_push($keys, ...$child->boundRowKeys());
         }
 

--- a/src/Ui/Components/Collapsible.php
+++ b/src/Ui/Components/Collapsible.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Ui\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Ui\Concerns\HasTooltip;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 #[AsComponent('collapsible')]
 class Collapsible extends ContainerComponent
@@ -50,7 +51,7 @@ class Collapsible extends ContainerComponent
     }
 
     /**
-     * @param  array<int, Component>  $components
+     * @param  array<int, SchemaEntry>  $components
      */
     public function content(array $components): static
     {

--- a/src/Ui/Components/Component.php
+++ b/src/Ui/Components/Component.php
@@ -9,12 +9,13 @@ use Lattice\Lattice\Ui\Components\Concerns\HasDataBindings;
 use Lattice\Lattice\Ui\Components\Concerns\SerializesWireNode;
 use Lattice\Lattice\Ui\Concerns\GatesRendering;
 use Lattice\Lattice\Ui\Contracts\Renderable;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 /**
  * @phpstan-consistent-constructor
  */
 #[WireEnvelope('Node')]
-abstract class Component implements JsonSerializable, Renderable
+abstract class Component implements JsonSerializable, Renderable, SchemaEntry
 {
     use GatesRendering;
     use HasDataBindings;
@@ -41,6 +42,14 @@ abstract class Component implements JsonSerializable, Renderable
         $this->hideWhenCollapsed = $hide;
 
         return $this;
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    final public function resolveComponents(): array
+    {
+        return [$this];
     }
 
     /**

--- a/src/Ui/Components/Concerns/HasChildSchema.php
+++ b/src/Ui/Components/Concerns/HasChildSchema.php
@@ -6,22 +6,31 @@ namespace Lattice\Lattice\Ui\Components\Concerns;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Concerns\FiltersRenderableComponents;
+use Lattice\Lattice\Ui\Concerns\ResolvesSchemaEntries;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 
 trait HasChildSchema
 {
     use FiltersRenderableComponents;
+    use ResolvesSchemaEntries;
 
     /**
-     * @var array<int, Component>
+     * @var array<int, SchemaEntry>
      */
     protected array $children = [];
 
     /**
-     * @param  array<int, Component>  $components
+     * @var array<int, Component>|null
+     */
+    private ?array $resolvedChildren = null;
+
+    /**
+     * @param  array<int, SchemaEntry>  $components
      */
     public function schema(array $components): static
     {
         $this->children = $components;
+        $this->resolvedChildren = null;
 
         return $this;
     }
@@ -29,9 +38,17 @@ trait HasChildSchema
     /**
      * @return array<int, Component>
      */
+    protected function resolvedChildren(): array
+    {
+        return $this->resolvedChildren ??= $this->resolveSchemaEntries($this->children);
+    }
+
+    /**
+     * @return array<int, Component>
+     */
     protected function renderableChildren(): array
     {
-        return $this->renderableComponents($this->children);
+        return $this->renderableComponents($this->resolvedChildren());
     }
 
     /**

--- a/src/Ui/Components/ContainerComponent.php
+++ b/src/Ui/Components/ContainerComponent.php
@@ -16,7 +16,7 @@ abstract class ContainerComponent extends Component
     {
         $result = [];
 
-        foreach ($this->children as $child) {
+        foreach ($this->resolvedChildren() as $child) {
             $result[] = $child;
 
             if ($child instanceof ContainerComponent) {

--- a/src/Ui/Concerns/ResolvesSchemaEntries.php
+++ b/src/Ui/Concerns/ResolvesSchemaEntries.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Concerns;
+
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
+
+trait ResolvesSchemaEntries
+{
+    /**
+     * @param  array<int, SchemaEntry>  $entries
+     * @return array<int, Component>
+     */
+    protected function resolveSchemaEntries(array $entries): array
+    {
+        $components = [];
+
+        foreach ($entries as $entry) {
+            array_push($components, ...$entry->resolveComponents());
+        }
+
+        return $components;
+    }
+}

--- a/src/Ui/Contracts/SchemaEntry.php
+++ b/src/Ui/Contracts/SchemaEntry.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Contracts;
+
+use Lattice\Lattice\Ui\Components\Component;
+
+interface SchemaEntry
+{
+    /**
+     * @return array<int, Component>
+     */
+    public function resolveComponents(): array;
+}

--- a/src/Ui/Slot.php
+++ b/src/Ui/Slot.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui;
+
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
+
+final class Slot implements SchemaEntry
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $context = [];
+
+    /**
+     * @var array<int, Component>|null
+     */
+    private ?array $resolvedComponents = null;
+
+    private function __construct(private readonly string $name) {}
+
+    public static function make(string $name): self
+    {
+        return new self($name);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function context(array $context): self
+    {
+        $this->context = $context;
+        $this->resolvedComponents = null;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function evaluationContext(): array
+    {
+        return $this->context;
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    public function resolveComponents(): array
+    {
+        return $this->resolvedComponents ??= app(SlotRegistry::class)->resolve($this);
+    }
+}

--- a/src/Ui/SlotRegistry.php
+++ b/src/Ui/SlotRegistry.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui;
+
+use Closure;
+use Illuminate\Http\Request;
+use Lattice\Lattice\Support\Evaluation\EvaluationContext;
+use Lattice\Lattice\Support\Evaluation\Evaluator;
+use Lattice\Lattice\Ui\Components\Component;
+use UnexpectedValueException;
+
+final class SlotRegistry
+{
+    /**
+     * @var array<string, array<int, array{factory: Closure, priority: int, sequence: int}>>
+     */
+    private array $extensions = [];
+
+    private int $sequence = 0;
+
+    public function __construct(private readonly Evaluator $evaluator) {}
+
+    public function extend(string $name, Closure $factory, int $priority = 0): void
+    {
+        $this->extensions[$name][] = [
+            'factory' => $factory,
+            'priority' => $priority,
+            'sequence' => $this->sequence++,
+        ];
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    public function resolve(Slot $slot): array
+    {
+        $extensions = $this->extensions[$slot->name()] ?? [];
+        $context = $this->evaluationContext($slot);
+
+        usort(
+            $extensions,
+            static fn (array $left, array $right): int => [$left['priority'], $left['sequence']] <=> [$right['priority'], $right['sequence']],
+        );
+
+        return array_map(function (array $extension) use ($context, $slot): Component {
+            $component = $this->evaluator->resolve($extension['factory'], $context);
+
+            if (! $component instanceof Component) {
+                throw new UnexpectedValueException(sprintf(
+                    'Slot [%s] extension must return a component; [%s] returned.',
+                    $slot->name(),
+                    get_debug_type($component),
+                ));
+            }
+
+            return clone $component;
+        }, $extensions);
+    }
+
+    private function evaluationContext(Slot $slot): EvaluationContext
+    {
+        $context = $this->evaluator->context();
+
+        foreach ($slot->evaluationContext() as $name => $value) {
+            $context = $context->named($name, $value);
+
+            if (is_object($value)) {
+                $context = $context->typed($value::class, $value);
+            }
+        }
+
+        return $context
+            ->named('user', auth()->user())
+            ->named('slot', $slot)
+            ->typed(Slot::class, $slot)
+            ->typed(Request::class, request());
+    }
+}

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -157,6 +157,7 @@ arch('contracts are interfaces')
         'Lattice\Lattice\Actions\Contracts',
         'Lattice\Lattice\Forms\Contracts',
         'Lattice\Lattice\Tables\Contracts',
+        'Lattice\Lattice\Ui\Contracts',
     ])
     ->toBeInterfaces();
 

--- a/tests/Feature/Http/LatticeLayoutTest.php
+++ b/tests/Feature/Http/LatticeLayoutTest.php
@@ -14,6 +14,7 @@ use Lattice\Lattice\Layouts\LayoutRegistry;
 use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Slot;
 
 #[AsLayout('app')]
 final class WorkbenchAppLayout extends LayoutDefinition
@@ -23,6 +24,7 @@ final class WorkbenchAppLayout extends LayoutDefinition
         return $schema->schema([
             Stack::make('app-shell')->schema([
                 Heading::make('Workbench'),
+                Slot::make('app.layout.header'),
                 Outlet::make(),
             ]),
         ]);
@@ -62,6 +64,18 @@ test('the layout registry resolves a registered layout to its wire schema', func
 test('the layout registry rejects an unregistered layout key', function (): void {
     expect(fn () => app(LayoutRegistry::class)->render('missing', new Request))
         ->toThrow(UnknownComponent::class);
+});
+
+test('a server slot expands beside the client layout outlet', function (): void {
+    Lattice::layouts([WorkbenchAppLayout::class]);
+    Lattice::extend('app.layout.header', fn (): Text => Text::make('Extension', 'extension'));
+
+    $rendered = app(LayoutRegistry::class)->render('app', new Request);
+    $children = wire($rendered['schema'])[0]['schema'];
+
+    expect(array_column($children, 'type'))->toBe(['heading', 'text', 'outlet'])
+        ->and($children[1]['key'])->toBe('extension')
+        ->and($children[2]['type'])->toBe('outlet');
 });
 
 test('a page serializes its layout as key and schema with an outlet', function (): void {

--- a/tests/Feature/Http/PageExtensionSlotTest.php
+++ b/tests/Feature/Http/PageExtensionSlotTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Ui\Components\Tab;
+use Lattice\Lattice\Ui\Components\Tabs;
+use Lattice\Lattice\Ui\Slot;
+
+final readonly class PageExtensionProject
+{
+    public function __construct(public string $slug) {}
+}
+
+final class PageExtensionSlotPage extends Page
+{
+    public function __construct(private readonly PageExtensionProject $project) {}
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Tabs::make('project-settings-tabs')
+                ->defaultValue('general')
+                ->schema([
+                    Slot::make('project.settings.tabs')->context([
+                        'project' => $this->project,
+                    ]),
+                ]),
+        ]);
+    }
+}
+
+it('expands page slots before tab inspection and visibility filtering', function (): void {
+    $project = new PageExtensionProject('lattice');
+
+    Lattice::extend(
+        'project.settings.tabs',
+        fn (PageExtensionProject $project): Tab => Tab::make('api', "API for {$project->slug}"),
+        priority: 20,
+    );
+    Lattice::extend(
+        'project.settings.tabs',
+        fn (): Tab => Tab::make('general', 'General'),
+        priority: 10,
+    );
+    Lattice::extend(
+        'project.settings.tabs',
+        fn (): Tab => Tab::make('hidden', 'Hidden')->visible(false),
+        priority: 15,
+    );
+
+    $page = new PageExtensionSlotPage($project);
+    $payload = wire($page->toArray($page->render(PageSchema::make()), new Request));
+    $tabs = $payload['schema'][0];
+
+    expect($tabs['type'])->toBe('tabs')
+        ->and($tabs['props']['activeValue'])->toBe('general')
+        ->and(array_column(array_column($tabs['schema'], 'props'), 'value'))->toBe(['general', 'api'])
+        ->and($tabs['schema'][1]['props']['label'])->toBe('API for lattice')
+        ->and(wireJson($payload))->not->toContain('"type":"slot"');
+});

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -34,6 +34,7 @@ use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 use Lattice\Lattice\Ui\Enums\ButtonVariant;
 use Lattice\Lattice\Ui\Enums\FloatingPlacement;
 use Lattice\Lattice\Ui\Enums\Gap;
@@ -522,4 +523,29 @@ test('tabs ignore hidden tab children when resolving their active value', functi
     expect($tabs['props']['activeValue'])->toBe('profile')
         ->and($tabs['schema'])->toHaveCount(1)
         ->and($tabs['schema'][0]['props']['value'])->toBe('profile');
+});
+
+test('tabs resolve schema entries once before inspecting their children', function (): void {
+    $entry = new class implements SchemaEntry
+    {
+        public int $resolutions = 0;
+
+        public function resolveComponents(): array
+        {
+            $this->resolutions++;
+
+            return [
+                Tab::make('profile', 'Profile'),
+                Tab::make('security', 'Security'),
+            ];
+        }
+    };
+
+    $tabs = wire(Tabs::make('settings-tabs')
+        ->defaultValue('security')
+        ->schema([$entry]));
+
+    expect($tabs['props']['activeValue'])->toBe('security')
+        ->and(array_column(array_column($tabs['schema'], 'props'), 'value'))->toBe(['profile', 'security'])
+        ->and($entry->resolutions)->toBe(1);
 });

--- a/tests/Unit/Ui/SchemaEntryTest.php
+++ b/tests/Unit/Ui/SchemaEntryTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\RowTemplate;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Tables\Columns\StackColumn;
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Contracts\SchemaEntry;
+
+final class SchemaEntryStub implements SchemaEntry
+{
+    public int $resolutions = 0;
+
+    /**
+     * @param  array<int, Component>  $components
+     */
+    public function __construct(private readonly array $components) {}
+
+    /**
+     * @return array<int, Component>
+     */
+    public function resolveComponents(): array
+    {
+        $this->resolutions++;
+
+        return $this->components;
+    }
+}
+
+it('resolves page schema entries in declaration order before filtering visibility', function (): void {
+    $first = Text::make('First');
+    $second = Text::make('Second');
+    $hidden = Text::make('Hidden')->hidden();
+    $last = Text::make('Last');
+    $entry = new SchemaEntryStub([$second, $hidden]);
+
+    $renderable = PageSchema::make()
+        ->schema([$first, $entry, $last])
+        ->renderable();
+
+    expect($renderable)->toBe([$first, $second, $last])
+        ->and($entry->resolutions)->toBe(1);
+});
+
+it('exposes resolved entries to specialized child readers', function (): void {
+    $repeaterField = TextInput::make('email');
+    $templateField = TextInput::make('title');
+    $shown = Text::make('')->dataKey('text', 'name');
+    $hidden = Text::make('')->dataKey('text', 'secret')->hidden();
+
+    $repeater = Repeater::make('contacts')->schema([
+        new SchemaEntryStub([$repeaterField]),
+    ]);
+    $template = RowTemplate::make('contact')->schema([
+        new SchemaEntryStub([$templateField]),
+    ]);
+    $column = StackColumn::make('identity')->schema([
+        new SchemaEntryStub([$shown, $hidden]),
+    ]);
+
+    expect($repeater->childFields())->toBe([$repeaterField])
+        ->and($template->fields())->toBe([$templateField])
+        ->and($column->children())->toBe([$shown, $hidden])
+        ->and($column->boundRowKeys())->toBe(['name']);
+});
+
+it('resolves container schema entries once for serialization and traversal', function (): void {
+    $content = Text::make('Content', 'content');
+    $nested = Stack::make('nested')->schema([$content]);
+    $entry = new SchemaEntryStub([$nested]);
+
+    $container = Stack::make('outer')->schema([$entry]);
+    $serialized = wire($container);
+
+    expect($serialized['schema'][0]['key'])->toBe('nested')
+        ->and($container->descendants())->toBe([$nested, $content])
+        ->and($entry->resolutions)->toBe(1);
+});

--- a/tests/Unit/Ui/SlotRegistryTest.php
+++ b/tests/Unit/Ui/SlotRegistryTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Slot;
+
+interface SlotContextContract {}
+
+final readonly class SlotContext implements SlotContextContract
+{
+    public function __construct(public string $name) {}
+}
+
+final class SlotContainerService {}
+
+it('resolves slot contributions by priority with stable registration order', function (): void {
+    Lattice::extend('dashboard.cards', fn (): Text => Text::make('Last'), priority: 20);
+    Lattice::extend('dashboard.cards', fn (): Text => Text::make('First'), priority: 10);
+    Lattice::extend('dashboard.cards', fn (): Text => Text::make('Second'), priority: 10);
+
+    $labels = array_map(
+        static fn (Component $component): string => wire($component)['props']['text'],
+        Slot::make('dashboard.cards')->resolveComponents(),
+    );
+
+    expect($labels)->toBe(['First', 'Second', 'Last']);
+});
+
+it('memoizes one slot instance while fresh slots build fresh components', function (): void {
+    $calls = 0;
+    $component = Text::make('Card');
+
+    Lattice::extend('dashboard.cards', function () use (&$calls, $component): Text {
+        $calls++;
+
+        return $component;
+    });
+
+    $slot = Slot::make('dashboard.cards');
+    $first = $slot->resolveComponents();
+    $second = $slot->resolveComponents();
+    $fresh = Slot::make('dashboard.cards')->resolveComponents();
+
+    expect($calls)->toBe(2)
+        ->and($second)->toBe($first)
+        ->and($first[0])->not->toBe($component)
+        ->and($fresh[0])->not->toBe($first[0]);
+});
+
+it('memoizes an empty slot result', function (): void {
+    $slot = Slot::make('dashboard.cards');
+
+    expect($slot->resolveComponents())->toBe([]);
+
+    Lattice::extend('dashboard.cards', fn (): Text => Text::make('Late card'));
+
+    expect($slot->resolveComponents())->toBe([])
+        ->and(Slot::make('dashboard.cards')->resolveComponents())->toHaveCount(1);
+});
+
+it('injects named typed request user slot and container utilities', function (): void {
+    $project = new SlotContext('Lattice');
+    $user = workbenchTestUser();
+    $request = Request::create('/extension-slot');
+    $service = new SlotContainerService;
+    $captured = [];
+
+    $this->actingAs($user);
+    app()->instance('request', $request);
+    app()->instance(SlotContainerService::class, $service);
+
+    Lattice::extend('project.settings.tabs', function (
+        string $label,
+        SlotContext $concrete,
+        SlotContextContract $contract,
+        $user,
+        $slot,
+        Slot $typedSlot,
+        Request $request,
+        SlotContainerService $service,
+    ) use (&$captured): Text {
+        $captured = [
+            'concrete' => $concrete,
+            'contract' => $contract,
+            'user' => $user,
+            'slot' => $slot,
+            'typedSlot' => $typedSlot,
+            'request' => $request,
+            'service' => $service,
+        ];
+
+        return Text::make($label);
+    });
+
+    $slot = Slot::make('project.settings.tabs')->context([
+        'label' => 'Injected tab',
+        'project' => $project,
+    ]);
+    $components = $slot->resolveComponents();
+
+    expect(wire($components[0])['props']['text'])->toBe('Injected tab')
+        ->and($captured['concrete'])->toBe($project)
+        ->and($captured['contract'])->toBe($project)
+        ->and($captured['user'])->toBe($user)
+        ->and($captured['slot'])->toBe($slot)
+        ->and($captured['typedSlot'])->toBe($slot)
+        ->and($captured['request'])->toBe($request)
+        ->and($captured['service'])->toBe($service);
+});
+
+it('clears a memoized result when slot context is replaced', function (): void {
+    $calls = 0;
+
+    Lattice::extend('project.settings.tabs', function (string $label) use (&$calls): Text {
+        $calls++;
+
+        return Text::make($label);
+    });
+
+    $slot = Slot::make('project.settings.tabs')->context(['label' => 'First']);
+    $first = $slot->resolveComponents();
+    $second = $slot->context(['label' => 'Second'])->resolveComponents();
+
+    expect(wire($first[0])['props']['text'])->toBe('First')
+        ->and(wire($second[0])['props']['text'])->toBe('Second')
+        ->and($calls)->toBe(2);
+});
+
+it('rejects a slot factory that does not return a component', function (): void {
+    Lattice::extend('project.settings.tabs', fn (): string => 'invalid');
+
+    expect(fn (): array => Slot::make('project.settings.tabs')->resolveComponents())
+        ->toThrow(
+            UnexpectedValueException::class,
+            'Slot [project.settings.tabs] extension must return a component; [string] returned.',
+        );
+});


### PR DESCRIPTION
## Summary

- Add server-side named `Slot` extension points with stable priorities, evaluator context, visibility filtering, memoization, and fresh component isolation.
- Generalize page and child schemas through `SchemaEntry`, so slots work in pages and layouts while `Outlet` remains the client-side layout seam.
- Document registration, page/layout usage, and closure utilities.

## Verification

- `composer check`
- `npm run check`
- `npm run docs:build`