### PR TITLE
0.21 drift fixes: ActionResult::failure(), lattice:typescript no-op, skill refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ See [Installation](https://latticephp.com/introduction/installation/) for the fu
 
 Full documentation, guides, and examples live at **[latticephp.com](https://latticephp.com)**.
 
+## Generating types for custom wire classes
+
+If you define your own Lattice components, fields, columns, filters, or effects in PHP, regenerate the matching TypeScript so the React side stays in lockstep:
+
+```bash
+php artisan lattice:typescript
+```
+
+Projects that use only Lattice's bundled components never need this — the command detects it and no-ops. Generating custom types requires the dev dependency `spatie/laravel-typescript-transformer`.
+
 ## License
 
 The MIT License (MIT). See [LICENSE.md](LICENSE.md) for details.

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "spatie/laravel-typescript-transformer": "^3.2"
     },
     "suggest": {
-        "spatie/typescript-transformer": "Required to run `php artisan lattice:typescript` and generate TypeScript types for your custom components"
+        "spatie/laravel-typescript-transformer": "Only needed to run `php artisan lattice:typescript` when your app defines custom PHP wire types (components, fields, columns, filters, effects)"
     },
     "autoload": {
         "psr-4": {

--- a/docs/content/docs/core/artisan-commands.md
+++ b/docs/content/docs/core/artisan-commands.md
@@ -77,8 +77,9 @@ writes the declaration file configured at `config('lattice.typescript.output')`
 (`resources/js/lattice/generated.d.ts` by default). The generated file augments the configured module
 (`@lattice-php/lattice` by default), so `node.props` and `column.props` stay typed on the client.
 
-`lattice:typescript` requires `spatie/typescript-transformer`. Install it as a dev dependency in
-applications that use the generator.
+`lattice:typescript` only needs `spatie/laravel-typescript-transformer` when your app defines custom
+PHP wire types; it no-ops otherwise. Install it as a dev dependency in applications that generate
+types for custom components.
 
 ## Discovery cache
 

--- a/docs/content/docs/introduction/configuration.md
+++ b/docs/content/docs/introduction/configuration.md
@@ -114,7 +114,7 @@ The `'frontend'` block configures the prebuilt-asset path, theme variables, and 
 
 ## TypeScript
 
-Where `php artisan lattice:typescript` writes the generated type definitions, and the module name they are published under (the command requires the suggested dev dependency: `composer require --dev spatie/typescript-transformer`):
+Where `php artisan lattice:typescript` writes the generated type definitions, and the module name they are published under (generating types for custom wire types needs the suggested dev dependency: `composer require --dev spatie/laravel-typescript-transformer`):
 
 ```php
 'typescript' => [

--- a/docs/content/docs/introduction/development-with-ai.md
+++ b/docs/content/docs/introduction/development-with-ai.md
@@ -53,4 +53,4 @@ One Lattice-specific step the core guideline already teaches your agent — wort
 php artisan lattice:typescript
 ```
 
-The command requires the suggested dev dependency: `composer require --dev spatie/typescript-transformer`.
+You only need this when your app defines **custom** PHP wire types — your own components, fields, columns, filters, or effects. Projects that use only Lattice's bundled types never need it, and the command will tell you so. When you do have custom types, install the suggested dev dependency once: `composer require --dev spatie/laravel-typescript-transformer`.

--- a/resources/boost/skills/lattice-actions/SKILL.md
+++ b/resources/boost/skills/lattice-actions/SKILL.md
@@ -37,7 +37,7 @@ class ArchiveProductAction extends ActionDefinition
         $product->update(['status' => 'archived']);
 
         return ActionResult::success()
-            ->toast(Variant::Success, 'Product archived.')
+            ->toast('Product archived.')
             ->reloadComponent('app.products');
     }
 }
@@ -45,15 +45,15 @@ class ArchiveProductAction extends ActionDefinition
 
 ## The result and its effects
 
-`handle()` returns an `ActionResult`. Start from `ActionResult::success($data?)` or `ActionResult::failure($data?)`, then chain effects (each returns a new result, so they read as a pipeline) — the client runs them in order:
+`handle()` returns an `ActionResult`. Start from `ActionResult::success($data?)` for a successful result, or `ActionResult::failure($message?)` to **reject** the action (HTTP 422; a message auto-adds an error toast and any open confirm dialog or modal stays open). Then chain effects (each returns a new result, so they read as a pipeline) — the client runs them in order:
 
 | Effect | What it does |
 | --- | --- |
-| `->toast($message, $variant?)` | Show a toast (`Variant::Success`/`Error`/`Warning`/`Info`; defaults to success; message and variant are order-insensitive). |
-| `->callout($callout)` | Show a persistent in-flow banner in the layout's `Callouts::make()` slot. Pass a `Callout` value object (`Lattice\Lattice\Ui\Values\Callout`). |
+| `->toast($message, $variant?)` | Show a toast. `$message` first, then an optional `Variant` (`Success` default, or `Error`/`Warning`/`Info`). |
+| `->callout($callout)` | Show a persistent in-flow banner in the layout's `Callouts::make()` slot. Pass a `Callout` value object (`Lattice\Lattice\Effects\Builtin\Callout`). |
 | `->reloadComponent($id)` | Re-fetch one component — pass a `#[AsTable]`/component id so only it refreshes. |
 | `->reloadPage()` | Reload the current page's props. |
-| `->redirect($url)` | Navigate to a URL. |
+| `->to($url)` / `->toRoute($name, $params?)` / `->back()` | Navigate to a URL, a named route, or back. |
 | `->download($url)` | Trigger a file download. |
 | `->openModal($id)` / `->closeModal($id?)` | Open/close a modal (`closeModal()` closes the current one). |
 | `->resetForm($id?)` | Reset a form to its initial values (`resetForm()` resets the current form). |
@@ -64,15 +64,15 @@ return ActionResult::success()->toast('Saved.')->reloadComponent('app.products')
 
 ### Callout effect
 
-`Callout::make(Variant $variant, string $message)` builds a persistent banner. Chain `->title()`, `->dismissible()`, `->link()`, or `->action()` to configure it:
+`Callout::make(string $message, Variant $variant = Variant::Info)` builds a persistent banner. Chain `->title()`, `->dismissible()`, `->link()`, or `->action()` to configure it:
 
 ```php
+use Lattice\Lattice\Effects\Builtin\Callout;
 use Lattice\Lattice\Ui\Enums\Variant;
-use Lattice\Lattice\Ui\Values\Callout;
 
 return ActionResult::success()
     ->callout(
-        Callout::make(Variant::Warning, 'Your trial ends in 3 days.')
+        Callout::make('Your trial ends in 3 days.', Variant::Warning)
             ->title('Trial ending')
             ->link('Upgrade', '/billing')
     );
@@ -85,15 +85,13 @@ The callout renders in the layout slot `Callouts::make()` (placed between the he
 `Effects::flash()` (facade `Lattice\Lattice\Facades\Effects`) delivers any effect(s) with the next Inertia response — no `ActionResult` needed. Use from controllers, listeners, middleware, or anywhere a redirect is returned:
 
 ```php
+use Lattice\Lattice\Effects\Builtin\Callout;
 use Lattice\Lattice\Facades\Effects;
 use Lattice\Lattice\Ui\Enums\Variant;
-use Lattice\Lattice\Ui\Values\Callout;
 
 Effects::flash(
-    Effects::toast(Variant::Success, 'Settings saved.'),
-    Effects::callout(
-        Callout::make(Variant::Info, 'Export is being processed.')->title('Export queued')
-    )
+    Effects::toast('Settings saved.', Variant::Success),
+    Callout::make('Export is being processed.', Variant::Info)->title('Export queued')
 );
 
 return redirect('/dashboard');
@@ -154,7 +152,7 @@ class ArchiveSelectedProductsAction extends BulkActionDefinition
         $records->each(fn (Product $product) => $product->update(['status' => 'archived']));
 
         return ActionResult::success(['archived' => $records->count()])
-            ->toast(Variant::Success, "Archived {$records->count()} products.")
+            ->toast("Archived {$records->count()} products.")
             ->reloadComponent('app.products');
     }
 }
@@ -175,3 +173,4 @@ See the **`lattice-tables`** skill for the table wiring.
 - **Reading context off the raw request** — use `$this->context($request, $key)`; it is the signed, trusted copy.
 - **No `#[AsAction('id')]` / `#[AsBulkAction('id')]`** → the action is not discovered and has no endpoint.
 - **Callout not appearing** — the active layout's `schema()` must include `Callouts::make()`; without it the effect is silently dropped.
+- **Signalling failure with a 2xx** — return `ActionResult::failure('…')` (HTTP 422) to reject; a plain `success()` with an error toast still reads as success to the client and closes modals.

--- a/resources/boost/skills/lattice-tables/SKILL.md
+++ b/resources/boost/skills/lattice-tables/SKILL.md
@@ -39,7 +39,7 @@ class ProductsTable extends EloquentTableDefinition
 }
 ```
 
-`builder()` returns the **base query** — your own scoping only (a `select()`, eager loads, tenant constraints, a default order). Lattice applies the request's filters and sorts **on top** of it, driven by the columns' capabilities. The `TableQuery` argument is the read model of the current request (`->filters()`, `->sorts()`, page, size), so the builder can react — e.g. apply a default order only when `$query->sorts() === []`.
+`builder()` returns the **base query** — your own scoping only (a `select()`, eager loads, tenant constraints, a default order). Lattice applies the request's filters and sorts **on top** of it, driven by the columns' capabilities. The `TableQuery` argument is the read model of the current request (public readonly properties `$filters`, `$sorts`, `$page`, `$perPage`), so the builder can react — e.g. apply a default order only when `$query->sorts === []`.
 
 `TableDefinition` hooks beyond `columns()`: `source()`, `perPage()` (default `25`), `pagination()`, `striped()`, `emptyLabel()`, `actionsLabel()`, `actions($row)`, `bulkActions()`.
 
@@ -54,7 +54,7 @@ Columns live in `Lattice\Lattice\Tables\Columns`. `Column::make('key')` reads `$
 - **`BadgeColumn`** — `->colors(['active' => 'green', 'invited' => 'yellow', 'archived' => 'gray'])`. Colors: `gray`, `red`, `green`, `yellow`, `blue`, `purple`, `orange` (unmapped → gray).
 - **`IconColumn`** — `->icon(Icon::Star)` for one icon, or `->icons(['1' => Icon::Check, '0' => Icon::Minus])`; add `->colors([...])` to tint.
 - **`ImageColumn`** — renders the value as an image URL: `->circular()`, `->size(40)`.
-- **`StackColumn`** — group child columns into one cell: `->columns([TextColumn::make('name'), TextColumn::make('email')])`.
+- **`StackColumn`** — group child columns into one cell: `->schema([TextColumn::make('name'), TextColumn::make('email')])`.
 
 ### Sortable & filterable
 

--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -172,6 +172,43 @@ describe("action form modal", () => {
     expect(await screen.findByText("The Reason field is required.")).toBeVisible();
   });
 
+  it("dispatches effects and keeps the modal open on a domain rejection (422 without errors)", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => ({
+        effects: [{ props: { message: "Rejected." }, type: "toast" }],
+      }),
+      ok: false,
+      status: 422,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const toastListener = vi.fn<(event: Event) => void>();
+
+    window.addEventListener("lattice:toast", toastListener);
+
+    const { container } = renderAction(rejectAction());
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+
+    fireEvent.change(await screen.findByRole("textbox", { name: "Reason" }), {
+      target: { value: "spam" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(toastListener).toHaveBeenCalledTimes(1);
+    });
+
+    const [[toastEvent]] = toastListener.mock.calls as [[CustomEvent]];
+
+    expect(toastEvent.detail).toEqual({ message: "Rejected." });
+    expect(screen.getByRole("textbox", { name: "Reason" })).toBeVisible();
+    expect(container.querySelector("p.text-lt-danger")).toBeNull();
+
+    window.removeEventListener("lattice:toast", toastListener);
+  });
+
   it("lazily fetches the schema when the action declares a lazy form", async () => {
     const formNode = {
       id: "test.edit-form",

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -26,8 +26,9 @@ import {
 import type { FieldErrors } from "@lattice-php/lattice/form/embed";
 import { useDebouncedCallback } from "@lattice-php/lattice/lib/use-debounced-callback";
 import { useT } from "@lattice-php/lattice/i18n";
-import { dispatchActionError } from "@lattice-php/lattice/effects/dispatch";
+import { dispatchActionError, getActionEffects } from "@lattice-php/lattice/effects/dispatch";
 import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";
+import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";
 
 type ActionFormProps = {
   cancelLabel: string;
@@ -123,6 +124,7 @@ function ActionFormBody({
     formNode.schema,
   );
 
+  const dispatch = useEffectDispatcher();
   const [errors, setErrors] = useState<FieldErrors>({});
   const [processing, setProcessing] = useState(false);
 
@@ -173,24 +175,27 @@ function ActionFormBody({
 
     void request()
       .then(async (response) => {
-        if (response.status === 422) {
-          const body = (await response.json()) as { errors?: Record<string, string[]> };
+        const body = (await response.json().catch(() => ({}))) as ActionResponse & {
+          errors?: Record<string, string[]>;
+        };
+
+        dispatch(getActionEffects(body.effects));
+
+        if (response.status === 422 && body.errors) {
           setErrors(firstErrors(body.errors));
 
           return;
         }
 
         if (!response.ok) {
-          dispatchActionError(new Error(`Action request failed with status ${response.status}`));
-
           return;
         }
 
-        onSuccess((await response.json()) as ActionResponse);
+        onSuccess(body);
       })
       .catch((error: unknown) => dispatchActionError(error))
       .finally(() => setProcessing(false));
-  }, [onSuccess, request]);
+  }, [dispatch, onSuccess, request]);
 
   const context = useMemo(
     () => ({

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -7,35 +7,23 @@ import type { IconRendererFunction } from "@lattice-php/lattice/icons";
 import { ActionMenuProvider } from "@lattice-php/lattice/ui/action-menu-context";
 import ActionComponent from "./action";
 
-const http = vi.hoisted(() => ({
-  delete: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  patch: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  post: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  processing: false,
-  put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  transform:
-    vi.fn<(callback: (data: Record<string, unknown>) => Record<string, unknown>) => void>(),
-}));
+const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
+
+vi.mock("@lattice-php/lattice/core/api", () => ({ apiFetch }));
 
 vi.mock("@inertiajs/react", async () =>
-  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
 );
 
 describe("Lattice action component", () => {
   beforeEach(() => {
-    http.delete.mockReset();
-    http.patch.mockReset();
-    http.post.mockReset();
-    http.put.mockReset();
-    http.transform.mockReset();
-    http.processing = false;
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(new Response(JSON.stringify({ effects: [] }), { status: 200 }));
     vi.mocked(router.reload).mockReset();
     vi.mocked(router.visit).mockReset();
   });
 
   it("submits the configured action endpoint", async () => {
-    http.post.mockResolvedValue({ ok: true });
-
     const node = fakeNode({
       props: {
         endpoint: "/lattice/actions/send-test-email",
@@ -50,8 +38,10 @@ describe("Lattice action component", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send test email" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith("/lattice/actions/send-test-email", {
-        headers: { "Accept-Language": "en" },
+      expect(apiFetch).toHaveBeenCalledWith("/lattice/actions/send-test-email", {
+        method: "post",
+        ref: "",
+        throwOnError: false,
       });
     });
   });
@@ -74,12 +64,10 @@ describe("Lattice action component", () => {
     expect(router.visit).toHaveBeenCalledWith("/settings/teams/acme", {
       headers: { "Accept-Language": "en" },
     });
-    expect(http.post).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
   });
 
   it("sends action refs with requests", async () => {
-    http.patch.mockResolvedValue({ ok: true });
-
     const node = fakeNode({
       props: {
         endpoint: "/lattice/actions/teams.sync",
@@ -95,8 +83,10 @@ describe("Lattice action component", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sync" }));
 
     await waitFor(() => {
-      expect(http.patch).toHaveBeenCalledWith("/lattice/actions/teams.sync", {
-        headers: { "Accept-Language": "en", "X-Lattice-Ref": "sealed-reference" },
+      expect(apiFetch).toHaveBeenCalledWith("/lattice/actions/teams.sync", {
+        method: "patch",
+        ref: "sealed-reference",
+        throwOnError: false,
       });
     });
   });
@@ -184,8 +174,8 @@ describe("Lattice action component", () => {
     expect(screen.getByTestId("action-icon")).toHaveClass("size-lt-icon-sm");
   });
 
-  it("uses a compact spinner inside action menus", () => {
-    http.processing = true;
+  it("uses a compact spinner inside action menus", async () => {
+    apiFetch.mockReturnValue(new Promise<Response>(() => {}));
 
     const node = fakeNode({
       props: {
@@ -202,12 +192,14 @@ describe("Lattice action component", () => {
       </ActionMenuProvider>,
     );
 
-    expect(screen.getByRole("status", { name: "Loading" })).toHaveClass("size-lt-icon-sm");
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status", { name: "Loading" })).toHaveClass("size-lt-icon-sm");
+    });
   });
 
   it("opens a confirmation modal before submitting destructive actions", async () => {
-    http.delete.mockResolvedValue({ ok: true });
-
     const node = fakeNode({
       props: {
         confirmation: {
@@ -228,7 +220,7 @@ describe("Lattice action component", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
 
-    expect(http.delete).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
     const firstDialog = screen.getByRole("dialog", { name: "Delete account?" });
 
     expect(firstDialog).toBeVisible();
@@ -246,30 +238,36 @@ describe("Lattice action component", () => {
     );
 
     await waitFor(() => {
-      expect(http.delete).toHaveBeenCalledWith("/lattice/actions/delete-account", {
-        headers: { "Accept-Language": "en" },
+      expect(apiFetch).toHaveBeenCalledWith("/lattice/actions/delete-account", {
+        method: "delete",
+        ref: "",
+        throwOnError: false,
       });
     });
   });
 
   it("dispatches event effects and handles page reloads imperatively", async () => {
-    http.patch.mockResolvedValue({
-      effects: [
-        {
-          props: { message: "Profile updated." },
-          type: "toast",
-        },
-        {
-          props: { component: "settings.profile" },
-          type: "reload-component",
-        },
-        {
-          props: {},
-          type: "reload-page",
-        },
-      ],
-      ok: true,
-    });
+    apiFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          effects: [
+            {
+              props: { message: "Profile updated." },
+              type: "toast",
+            },
+            {
+              props: { component: "settings.profile" },
+              type: "reload-component",
+            },
+            {
+              props: {},
+              type: "reload-page",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
 
     const toastListener = vi.fn<(event: Event) => void>();
     const reloadListener = vi.fn<(event: Event) => void>();
@@ -320,7 +318,7 @@ describe("Lattice action component", () => {
   it("dispatches failed responses as action errors", async () => {
     const error = new Error("Request failed");
 
-    http.delete.mockRejectedValue(error);
+    apiFetch.mockRejectedValue(error);
 
     const errorListener = vi.fn<(event: Event) => void>();
 

--- a/resources/js/action/components/action.test.tsx
+++ b/resources/js/action/components/action.test.tsx
@@ -315,6 +315,61 @@ describe("Lattice action component", () => {
     window.removeEventListener("lattice:reload-page", reloadPageListener);
   });
 
+  it("dispatches effects and keeps the confirm dialog open when the action is rejected with 422", async () => {
+    apiFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          effects: [
+            {
+              props: { message: "Cannot delete account." },
+              type: "toast",
+            },
+          ],
+        }),
+        { status: 422 },
+      ),
+    );
+
+    const toastListener = vi.fn<(event: Event) => void>();
+
+    window.addEventListener("lattice:toast", toastListener);
+
+    const node = fakeNode({
+      props: {
+        confirmation: {
+          cancelLabel: "Keep account",
+          confirmLabel: "Delete account",
+          description: "This cannot be undone.",
+          title: "Delete account?",
+        },
+        endpoint: "/lattice/actions/delete-account",
+        label: "Delete account",
+        method: "delete",
+        variant: "destructive",
+      },
+      type: "action",
+    });
+
+    render(<ActionComponent node={node}>{null}</ActionComponent>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Delete account?" });
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete account" }));
+
+    await waitFor(() => {
+      expect(toastListener).toHaveBeenCalledTimes(1);
+    });
+
+    const [[toastEvent]] = toastListener.mock.calls as [[CustomEvent]];
+
+    expect(toastEvent.detail).toEqual({ message: "Cannot delete account." });
+    expect(screen.getByRole("dialog", { name: "Delete account?" })).toBeVisible();
+
+    window.removeEventListener("lattice:toast", toastListener);
+  });
+
   it("dispatches failed responses as action errors", async () => {
     const error = new Error("Request failed");
 

--- a/resources/js/action/hooks/use-action.tsx
+++ b/resources/js/action/hooks/use-action.tsx
@@ -1,12 +1,11 @@
-import { router, useHttp } from "@inertiajs/react";
+import { router } from "@inertiajs/react";
 import type { Method } from "@inertiajs/core";
 import { useState } from "react";
 import type { ReactNode } from "react";
 import { ConfirmDialog } from "@lattice-php/lattice/ui/confirm-dialog";
+import { apiFetch } from "@lattice-php/lattice/core/api";
 import { withHeaders } from "@lattice-php/lattice/core/headers";
 import type { Node } from "@lattice-php/lattice/core/types";
-import { getActionEffects } from "@lattice-php/lattice/effects/dispatch";
-import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";
 import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";
 import { runAction } from "@lattice-php/lattice/action/lib/run-action";
 import { ActionForm, useLazyActionForm } from "@lattice-php/lattice/action/components/action-form";
@@ -37,7 +36,7 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
   const lazyForm = node.props.lazyForm === true;
   const hasForm = Boolean(inlineForm) || lazyForm;
 
-  const http = useHttp<Record<string, never>, ActionResponse>({});
+  const [processing, setProcessing] = useState(false);
   const dispatch = useEffectDispatcher();
   const [isConfirming, setIsConfirming] = useState(false);
   const [isFilling, setIsFilling] = useState(false);
@@ -56,10 +55,14 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
       return;
     }
 
+    setProcessing(true);
+
     const ok = await runAction(
-      () => http[method](endpoint, { headers: withHeaders(componentRef) }),
+      () => apiFetch(endpoint, { method, ref: componentRef, throwOnError: false }),
       dispatch,
     );
+
+    setProcessing(false);
 
     if (ok) {
       setIsConfirming(false);
@@ -95,7 +98,7 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
           confirmLabel={confirmationConfirmLabel}
           cancelLabel={confirmationCancelLabel}
           confirmVariant={variant}
-          processing={http.processing}
+          processing={processing}
           confirmDisabled={!endpoint}
           onConfirm={() => void submit()}
           onCancel={() => setIsConfirming(false)}
@@ -111,8 +114,7 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
           formNode={formNode}
           method={method}
           onClose={() => setIsFilling(false)}
-          onSuccess={(response) => {
-            dispatch(getActionEffects(response.effects));
+          onSuccess={() => {
             setIsFilling(false);
           }}
           placement={node.props.modalSide ?? "center"}
@@ -124,5 +126,5 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
     </>
   );
 
-  return { processing: http.processing, requestSubmit, overlays };
+  return { processing, requestSubmit, overlays };
 }

--- a/resources/js/action/lib/run-action.test.ts
+++ b/resources/js/action/lib/run-action.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ActionEffect, ActionResponse } from "@lattice-php/lattice/effects/dispatch";
+import type { ActionEffect } from "@lattice-php/lattice/effects/dispatch";
 import { dispatchActionError, getActionEffects } from "@lattice-php/lattice/effects/dispatch";
 import { runAction } from "./run-action";
 
@@ -13,31 +13,40 @@ beforeEach(() => {
 });
 
 describe("runAction", () => {
-  it("dispatches normalized effects and reports success", async () => {
+  it("dispatches effects and reports success on a 2xx response", async () => {
     const effect = { type: "toast" } as ActionEffect;
-    const response = { effects: [effect] } satisfies ActionResponse;
-    const request = vi.fn<() => Promise<ActionResponse>>().mockResolvedValue(response);
-    const dispatch = vi.fn<(effects: ActionEffect[]) => void>();
-
     vi.mocked(getActionEffects).mockReturnValue([effect]);
+    const request = (): Promise<Response> =>
+      Promise.resolve(new Response(JSON.stringify({ effects: [effect] }), { status: 200 }));
+    const dispatch = vi.fn<(effects: ActionEffect[]) => void>();
 
     await expect(runAction(request, dispatch)).resolves.toBe(true);
 
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(getActionEffects).toHaveBeenCalledWith(response.effects);
     expect(dispatch).toHaveBeenCalledWith([effect]);
     expect(dispatchActionError).not.toHaveBeenCalled();
   });
 
-  it("routes failures through the action error event and reports failure", async () => {
-    const error = new Error("Action failed");
-    const request = vi.fn<() => Promise<ActionResponse>>().mockRejectedValue(error);
+  it("dispatches effects but reports failure on a non-2xx response", async () => {
+    const effect = { type: "toast" } as ActionEffect;
+    vi.mocked(getActionEffects).mockReturnValue([effect]);
+    const request = (): Promise<Response> =>
+      Promise.resolve(new Response(JSON.stringify({ effects: [effect] }), { status: 422 }));
     const dispatch = vi.fn<(effects: ActionEffect[]) => void>();
 
     await expect(runAction(request, dispatch)).resolves.toBe(false);
 
-    expect(dispatch).not.toHaveBeenCalled();
-    expect(getActionEffects).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith([effect]);
+    expect(dispatchActionError).not.toHaveBeenCalled();
+  });
+
+  it("routes a thrown/network error through the action error event", async () => {
+    const error = new Error("network down");
+    const request = (): Promise<Response> => Promise.reject(error);
+    const dispatch = vi.fn<(effects: ActionEffect[]) => void>();
+
+    await expect(runAction(request, dispatch)).resolves.toBe(false);
+
     expect(dispatchActionError).toHaveBeenCalledWith(error);
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/resources/js/action/lib/run-action.ts
+++ b/resources/js/action/lib/run-action.ts
@@ -6,21 +6,22 @@ import {
 } from "@lattice-php/lattice/effects/dispatch";
 
 /**
- * Runs an action request and dispatches the effects from its response, routing
- * any failure through dispatchActionError. Returns whether the request
- * succeeded so callers run their own post-success cleanup (closing a dialog,
- * reloading a table). Shared by the single action button and the bulk bar so
- * the invocation contract stays in one place.
+ * Runs an action request and dispatches the effects from its response body,
+ * whether the action succeeded or was rejected (non-2xx). Returns whether the
+ * response was ok so callers run their own post-success cleanup (closing a
+ * dialog, reloading a table) only on success; a rejected action leaves the
+ * dialog open. A thrown/network error routes through dispatchActionError.
  */
 export async function runAction(
-  request: () => Promise<ActionResponse>,
+  request: () => Promise<Response>,
   dispatch: (effects: ActionEffect[]) => void,
 ): Promise<boolean> {
   try {
     const response = await request();
-    dispatch(getActionEffects(response.effects));
+    const body = (await response.json().catch(() => ({}))) as ActionResponse;
+    dispatch(getActionEffects(body.effects));
 
-    return true;
+    return response.ok;
   } catch (error) {
     dispatchActionError(error);
 

--- a/resources/js/layout/components/menu-item-action.test.tsx
+++ b/resources/js/layout/components/menu-item-action.test.tsx
@@ -5,17 +5,12 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 import type { Node, ComponentPropsOf } from "@lattice-php/lattice/core/types";
 import MenuItemComponent from "./menu-item";
 
-const http = vi.hoisted(() => ({
-  delete: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  patch: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  post: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  processing: false,
-  put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-}));
+const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
+
+vi.mock("@lattice-php/lattice/core/api", () => ({ apiFetch }));
 
 vi.mock("@inertiajs/react", async () =>
   (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
-    useHttp: () => http,
     usePage: () => ({ url: "/products" }),
   }),
 );
@@ -51,32 +46,30 @@ function renderActionMenuItem(node: Node<"menu-item">) {
 
 describe("menu item action trigger", () => {
   beforeEach(() => {
-    http.delete.mockReset();
-    http.patch.mockReset();
-    http.post.mockReset();
-    http.put.mockReset();
-    http.processing = false;
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(new Response(JSON.stringify({ effects: [] }), { status: 200 }));
   });
 
   it("dispatches the nested action with the ref header", async () => {
-    http.post.mockResolvedValue({ ok: true, effects: [] });
-
     renderActionMenuItem(actionMenuItem());
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith("/lattice/actions/workbench.logout", {
-        headers: { "Accept-Language": "en", "X-Lattice-Ref": "sealed-reference" },
+      expect(apiFetch).toHaveBeenCalledWith("/lattice/actions/workbench.logout", {
+        method: "post",
+        ref: "sealed-reference",
+        throwOnError: false,
       });
     });
   });
 
   it("runs effects from the action response", async () => {
-    http.post.mockResolvedValue({
-      ok: true,
-      effects: [{ message: "Signed out.", type: "toast" }],
-    });
+    apiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ effects: [{ message: "Signed out.", type: "toast" }] }), {
+        status: 200,
+      }),
+    );
 
     const toastListener = vi.fn<(event: Event) => void>();
     window.addEventListener("lattice:toast", toastListener);
@@ -93,8 +86,6 @@ describe("menu item action trigger", () => {
   });
 
   it("confirms before dispatching when the action requires confirmation", async () => {
-    http.post.mockResolvedValue({ ok: true, effects: [] });
-
     const node = actionMenuItem({
       confirmation: {
         cancelLabel: "Stay",
@@ -108,14 +99,14 @@ describe("menu item action trigger", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
-    expect(http.post).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
     const dialog = screen.getByRole("dialog", { name: "Log out?" });
     expect(dialog).toBeVisible();
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Log out" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -128,7 +119,7 @@ describe("menu item action trigger", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
-    expect(http.post).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog")).toBeVisible();
   });
 });

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -8,19 +8,11 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 import { BulkBar } from "./bulk-bar";
 import type { BulkAction } from "@lattice-php/lattice/table/lib/bulk";
 
-const http = vi.hoisted(() => ({
-  processing: false,
-  transformer: (data: Record<string, unknown>): Record<string, unknown> => data,
-  transform(fn: (data: Record<string, unknown>) => Record<string, unknown>): void {
-    this.transformer = fn;
-  },
-  patch: vi.fn<(url: string, options: unknown) => Promise<ActionResponse>>(async () => ({
-    effects: [],
-  })),
-  post: vi.fn<(url: string, options: unknown) => Promise<ActionResponse>>(async () => ({
-    effects: [],
-  })),
-}));
+const apiFetch = vi.hoisted(() =>
+  vi.fn<(url: string, init?: Record<string, unknown>) => Promise<Response>>(),
+);
+
+vi.mock("@lattice-php/lattice/core/api", () => ({ apiFetch }));
 
 const router = vi.hoisted(() => ({
   on: vi.fn<(event: string, listener: (event: Event) => void) => () => void>(() =>
@@ -31,10 +23,7 @@ const router = vi.hoisted(() => ({
 }));
 
 vi.mock("@inertiajs/react", async () =>
-  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
-    router,
-    useHttp: () => http,
-  }),
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ router }),
 );
 
 type ActionFormProps = {
@@ -118,13 +107,11 @@ function renderBar(props: Partial<Parameters<typeof BulkBar>[0]> = {}) {
 
 describe("BulkBar", () => {
   beforeEach(() => {
-    http.processing = false;
-    http.transformer = (data: Record<string, unknown>): Record<string, unknown> => data;
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(new Response(JSON.stringify({ effects: [] }), { status: 200 }));
   });
 
   afterEach(() => {
-    http.patch.mockClear();
-    http.post.mockClear();
     router.on.mockClear();
     router.reload.mockClear();
     router.visit.mockClear();
@@ -174,10 +161,9 @@ describe("BulkBar", () => {
 
     fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
-    await waitFor(() =>
-      expect(http.patch).toHaveBeenCalledWith("/bulk/archive", expect.anything()),
-    );
-    expect(http.transformer({})).toEqual({ selected: ["7"] });
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledWith("/bulk/archive", expect.anything()));
+    const [, options] = apiFetch.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(options.body)).toEqual({ selected: ["7"] });
     await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
   });
 
@@ -190,11 +176,9 @@ describe("BulkBar", () => {
 
     fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
-    await waitFor(() => expect(http.patch).toHaveBeenCalled());
-    const [, options] = http.patch.mock.calls[0] ?? [];
-    expect((options as { headers: Record<string, string> }).headers).not.toHaveProperty(
-      "X-Lattice-Ref",
-    );
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, options] = apiFetch.mock.calls[0] as [string, { ref: string }];
+    expect(options.ref).toBe("");
   });
 
   it("submits all-matching actions with the query payload", async () => {
@@ -206,8 +190,9 @@ describe("BulkBar", () => {
 
     fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
-    await waitFor(() => expect(http.post).toHaveBeenCalled());
-    expect(http.transformer({})).toEqual({
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, options] = apiFetch.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(options.body)).toEqual({
       allMatching: true,
       filter: "status:eq:active",
       tf: { featured: "true" },
@@ -217,7 +202,7 @@ describe("BulkBar", () => {
 
   it("does not complete when the request fails", async () => {
     const actionError = vi.fn<(event: Event) => void>();
-    http.post.mockRejectedValueOnce(new Error("failed"));
+    apiFetch.mockRejectedValueOnce(new Error("failed"));
     window.addEventListener("lattice:action-error", actionError, { once: true });
     const { onCompleted } = renderBar({ actions: [action({ id: "archive" })] });
 
@@ -227,11 +212,15 @@ describe("BulkBar", () => {
     expect(onCompleted).not.toHaveBeenCalled();
   });
 
-  it("disables the action buttons and shows a spinner while processing", () => {
-    http.processing = true;
+  it("disables the action buttons and shows a spinner while processing", async () => {
+    apiFetch.mockReturnValue(new Promise<Response>(() => {}));
     renderBar({ actions: [action({ id: "archive" })] });
 
-    expect(screen.getByTestId("bulk-action-archive")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("bulk-action-archive"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-action-archive")).toBeDisabled();
+    });
   });
 
   describe("confirmation flow", () => {
@@ -376,7 +365,7 @@ describe("BulkBar", () => {
       expect(screen.getByTestId("form-cancel-label")).toHaveTextContent("Cancel");
     });
 
-    it("dispatches effects, closes and completes on form success", async () => {
+    it("closes and completes on form success without re-dispatching effects", async () => {
       const { onCompleted } = renderBar({
         actions: [action({ id: "tag", form: formNode, confirmation: null })],
       });
@@ -384,9 +373,9 @@ describe("BulkBar", () => {
       fireEvent.click(screen.getByTestId("bulk-action-tag"));
       fireEvent.click(screen.getByTestId("form-success"));
 
-      expect(effectHandler).toHaveBeenCalledWith({ type: "test.bulk-success" });
       await waitFor(() => expect(onCompleted).toHaveBeenCalledTimes(1));
       expect(screen.queryByTestId("action-form")).toBeNull();
+      expect(effectHandler).not.toHaveBeenCalled();
     });
 
     it("closes the form without completing on cancel", () => {

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -296,6 +296,36 @@ describe("BulkBar", () => {
       );
     });
 
+    it("dispatches effects, keeps the dialog open, and does not complete when the request is rejected with 422", async () => {
+      apiFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ effects: [{ type: "test.bulk-success" }] }), {
+          status: 422,
+        }),
+      );
+
+      const { onCompleted } = renderBar({
+        actions: [
+          action({
+            id: "archive",
+            confirmation: {
+              title: "Sure?",
+              description: null,
+              confirmLabel: null,
+              cancelLabel: null,
+            },
+          }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-archive"));
+      fireEvent.click(screen.getByTestId("confirm-accept"));
+
+      await waitFor(() => expect(effectHandler).toHaveBeenCalledTimes(1));
+
+      expect(screen.getByRole("dialog", { name: "Sure?" })).toBeVisible();
+      expect(onCompleted).not.toHaveBeenCalled();
+    });
+
     it("closes without submitting when the confirmation is cancelled", () => {
       const { onCompleted } = renderBar({
         actions: [

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -1,21 +1,13 @@
-import { useHttp } from "@inertiajs/react";
 import { useState } from "react";
 import { ActionForm, runAction } from "@lattice-php/lattice/action";
-import { getActionEffects } from "@lattice-php/lattice/effects/dispatch";
-import type { ActionResponse } from "@lattice-php/lattice/effects/dispatch";
+import { apiFetch } from "@lattice-php/lattice/core/api";
 import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";
-import { withHeaders } from "@lattice-php/lattice/core/headers";
 import { Button } from "@lattice-php/lattice/ui/button";
 import { ConfirmDialog } from "@lattice-php/lattice/ui/confirm-dialog";
 import { Spinner } from "@lattice-php/lattice/ui/spinner";
 import { prefixedTestId } from "@lattice-php/lattice/core/test-id";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { BulkAction } from "@lattice-php/lattice/table/lib/bulk";
-
-type BulkData = {
-  allMatching?: boolean;
-  selected?: string[];
-};
 
 export function BulkBar({
   actions,
@@ -37,7 +29,7 @@ export function BulkBar({
   onCompleted: () => void;
 }) {
   const { t } = useT("lattice");
-  const http = useHttp<BulkData, ActionResponse>({});
+  const [processing, setProcessing] = useState(false);
   const dispatch = useEffectDispatcher();
   const [confirming, setConfirming] = useState<BulkAction | null>(null);
   const [filling, setFilling] = useState<BulkAction | null>(null);
@@ -46,12 +38,20 @@ export function BulkBar({
     allMatching ? { allMatching: true, ...query } : { selected: selectedKeys };
 
   async function submit(action: BulkAction): Promise<void> {
-    http.transform((data) => ({ ...data, ...selectionPayload() }));
+    setProcessing(true);
 
     const ok = await runAction(
-      () => http[action.method](action.endpoint, { headers: withHeaders(action.ref ?? "") }),
+      () =>
+        apiFetch(action.endpoint, {
+          method: action.method,
+          ref: action.ref ?? "",
+          body: JSON.stringify(selectionPayload()),
+          throwOnError: false,
+        }),
       dispatch,
     );
+
+    setProcessing(false);
 
     if (ok) {
       setConfirming(null);
@@ -101,10 +101,10 @@ export function BulkBar({
             type="button"
             data-test={prefixedTestId("bulk-action", action.id)}
             variant={action.variant}
-            disabled={http.processing}
+            disabled={processing}
             onClick={() => run(action)}
           >
-            {http.processing && <Spinner />}
+            {processing && <Spinner />}
             {action.label}
           </Button>
         ))}
@@ -117,7 +117,7 @@ export function BulkBar({
           confirmLabel={confirming.confirmation.confirmLabel ?? confirming.label}
           cancelLabel={confirming.confirmation.cancelLabel ?? t("common.cancel", "Cancel")}
           confirmVariant={confirming.variant}
-          processing={http.processing}
+          processing={processing}
           onConfirm={() => void submit(confirming)}
           onCancel={() => setConfirming(null)}
         />
@@ -133,8 +133,7 @@ export function BulkBar({
           formNode={filling.form}
           method={filling.method}
           onClose={() => setFilling(null)}
-          onSuccess={(response) => {
-            dispatch(getActionEffects(response.effects));
+          onSuccess={() => {
             setFilling(null);
             onCompleted();
           }}

--- a/resources/js/table/components/table-bulk.test.tsx
+++ b/resources/js/table/components/table-bulk.test.tsx
@@ -19,17 +19,16 @@ function col(partial: { key: string; label: string }): TableColumn {
   };
 }
 
-const http = vi.hoisted(() => ({
-  processing: false,
-  transformer: (data: Record<string, unknown>): Record<string, unknown> => data,
-  transform(fn: (data: Record<string, unknown>) => Record<string, unknown>): void {
-    this.transformer = fn;
-  },
-  patch: vi.fn<(url: string) => Promise<{ effects: never[] }>>(async () => ({ effects: [] })),
-}));
+const apiFetch = vi.hoisted(() =>
+  vi.fn<(url: string, init?: Record<string, unknown>) => Promise<Response>>(
+    async () => new Response(JSON.stringify({ effects: [] }), { status: 200 }),
+  ),
+);
+
+vi.mock("@lattice-php/lattice/core/api", () => ({ apiFetch }));
 
 vi.mock("@inertiajs/react", async () =>
-  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
 );
 
 const { default: TableComponent } = await import("./table");
@@ -62,7 +61,7 @@ const node = {
 
 describe("table bulk actions", () => {
   afterEach(() => {
-    http.patch.mockClear();
+    apiFetch.mockClear();
   });
 
   it("dispatches the selected rows when a bulk action runs", async () => {
@@ -77,12 +76,13 @@ describe("table bulk actions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Archive selected" }));
 
     await waitFor(() =>
-      expect(http.patch).toHaveBeenCalledWith(
+      expect(apiFetch).toHaveBeenCalledWith(
         "/lattice/bulk-actions/workbench.products.archive-selected",
-        { headers: { "Accept-Language": "en", "X-Lattice-Ref": "sealed-ref" } },
+        expect.objectContaining({ method: "patch", ref: "sealed-ref" }),
       ),
     );
-    expect(http.transformer({})).toEqual({ selected: ["1"] });
+    const [, options] = apiFetch.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(options.body)).toEqual({ selected: ["1"] });
   });
 
   it("selects every row from the header checkbox", () => {
@@ -135,8 +135,9 @@ describe("table bulk actions", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Archive selected" }));
 
-    await waitFor(() => expect(http.patch).toHaveBeenCalled());
-    expect(http.transformer({})).toEqual({
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const [, options] = apiFetch.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(options.body)).toEqual({
       allMatching: true,
       filter: "status:eq:active",
       tf: {

--- a/resources/js/ui/button-action.test.tsx
+++ b/resources/js/ui/button-action.test.tsx
@@ -5,16 +5,12 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 import type { Node, ComponentPropsOf } from "@lattice-php/lattice/core/types";
 import ButtonComponent from "./button";
 
-const http = vi.hoisted(() => ({
-  delete: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  patch: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  post: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  processing: false,
-  put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-}));
+const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
+
+vi.mock("@lattice-php/lattice/core/api", () => ({ apiFetch }));
 
 vi.mock("@inertiajs/react", async () =>
-  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
 );
 
 function actionButton(props: Partial<ComponentPropsOf<"action">> = {}): Node<"button"> {
@@ -49,27 +45,25 @@ function renderActionButton(node: Node<"button">) {
 
 describe("button action trigger", () => {
   beforeEach(() => {
-    http.post.mockReset();
-    http.processing = false;
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(new Response(JSON.stringify({ effects: [] }), { status: 200 }));
   });
 
   it("dispatches its nested action with the ref header on click", async () => {
-    http.post.mockResolvedValue({ ok: true, effects: [] });
-
     renderActionButton(actionButton());
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith("/lattice/actions/workbench.save", {
-        headers: { "Accept-Language": "en", "X-Lattice-Ref": "sealed-reference" },
+      expect(apiFetch).toHaveBeenCalledWith("/lattice/actions/workbench.save", {
+        method: "post",
+        ref: "sealed-reference",
+        throwOnError: false,
       });
     });
   });
 
   it("confirms before dispatching when the action requires confirmation", async () => {
-    http.post.mockResolvedValue({ ok: true, effects: [] });
-
     const node = actionButton({
       confirmation: {
         cancelLabel: "Cancel",
@@ -83,13 +77,13 @@ describe("button action trigger", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(http.post).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
     const dialog = screen.getByRole("dialog", { name: "Save changes?" });
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/resources/js/ui/link-action.test.tsx
+++ b/resources/js/ui/link-action.test.tsx
@@ -5,16 +5,12 @@ import { fakeNode } from "@lattice-php/lattice/test-support";
 import type { Node, ComponentPropsOf } from "@lattice-php/lattice/core/types";
 import LinkComponent from "./link";
 
-const http = vi.hoisted(() => ({
-  delete: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  patch: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  post: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-  processing: false,
-  put: vi.fn<(url: string, data?: Record<string, unknown>) => Promise<unknown>>(),
-}));
+const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
+
+vi.mock("@lattice-php/lattice/core/api", () => ({ apiFetch }));
 
 vi.mock("@inertiajs/react", async () =>
-  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({ useHttp: () => http }),
+  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
 );
 
 function actionLink(props: Partial<ComponentPropsOf<"action">> = {}): Node<"link"> {
@@ -48,30 +44,25 @@ function renderActionLink(node: Node<"link">) {
 
 describe("link action trigger", () => {
   beforeEach(() => {
-    http.delete.mockReset();
-    http.patch.mockReset();
-    http.post.mockReset();
-    http.put.mockReset();
-    http.processing = false;
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(new Response(JSON.stringify({ effects: [] }), { status: 200 }));
   });
 
   it("dispatches the nested action with the ref header", async () => {
-    http.post.mockResolvedValue({ ok: true, effects: [] });
-
     renderActionLink(actionLink());
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledWith("/lattice/actions/workbench.logout", {
-        headers: { "Accept-Language": "en", "X-Lattice-Ref": "sealed-reference" },
+      expect(apiFetch).toHaveBeenCalledWith("/lattice/actions/workbench.logout", {
+        method: "post",
+        ref: "sealed-reference",
+        throwOnError: false,
       });
     });
   });
 
   it("confirms before dispatching when the action requires confirmation", async () => {
-    http.post.mockResolvedValue({ ok: true, effects: [] });
-
     const node = actionLink({
       confirmation: {
         cancelLabel: "Stay",
@@ -85,14 +76,14 @@ describe("link action trigger", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
-    expect(http.post).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
     const dialog = screen.getByRole("dialog", { name: "Log out?" });
     expect(dialog).toBeVisible();
 
     fireEvent.click(within(dialog).getByRole("button", { name: "Log out" }));
 
     await waitFor(() => {
-      expect(http.post).toHaveBeenCalledTimes(1);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -105,7 +96,7 @@ describe("link action trigger", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Log out" }));
 
-    expect(http.post).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog")).toBeVisible();
   });
 });

--- a/src/Actions/ActionResult.php
+++ b/src/Actions/ActionResult.php
@@ -8,7 +8,10 @@ use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Effects\Concerns\QueuesEffects;
 use Lattice\Lattice\Effects\Effect;
 use Lattice\Lattice\Facades\Effects;
+use Lattice\Lattice\I18n\Values\Translatable;
 use Lattice\Lattice\Support\Wire;
+use Lattice\Lattice\Ui\Enums\Variant;
+use Symfony\Component\HttpFoundation\Response;
 
 #[TypeScript]
 final readonly class ActionResult
@@ -22,6 +25,7 @@ final readonly class ActionResult
     private function __construct(
         public array $data = [],
         public array $effects = [],
+        private int $status = Response::HTTP_OK,
     ) {}
 
     /**
@@ -32,12 +36,24 @@ final readonly class ActionResult
         return new self($data);
     }
 
+    public static function failure(string|Translatable|null $message = null): self
+    {
+        $result = new self(status: Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        return $message === null ? $result : $result->toast($message, Variant::Error);
+    }
+
+    public function status(): int
+    {
+        return $this->status;
+    }
+
     public function effect(Effect $effect): static
     {
         return new self($this->data, [
             ...$this->effects,
             $effect,
-        ]);
+        ], $this->status);
     }
 
     public function to(string $url): static

--- a/src/Console/Commands/TypeScriptCommand.php
+++ b/src/Console/Commands/TypeScriptCommand.php
@@ -16,8 +16,19 @@ final class TypeScriptCommand extends Command
 
     public function handle(TypeScriptProfile $profile, TypeScriptGenerator $generator): int
     {
+        $pending = $profile->pendingTypeCount();
+
+        if ($pending === 0) {
+            $this->components->info('No custom Lattice wire types found — the bundled TypeScript types already cover this project. Nothing to generate.');
+
+            return self::SUCCESS;
+        }
+
         if (! class_exists(TypeScriptTransformer::class)) {
-            $this->components->error('lattice:typescript needs spatie/typescript-transformer. Install it with: composer require --dev spatie/typescript-transformer');
+            $this->components->error(sprintf(
+                'Found %d custom Lattice wire type(s) to generate, but spatie/laravel-typescript-transformer is not installed. Install it with: composer require --dev spatie/laravel-typescript-transformer',
+                $pending,
+            ));
 
             return self::FAILURE;
         }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -38,8 +38,8 @@ final readonly class ActionController
 
         $definition->validate($request);
 
-        return response()->json(
-            $definition->handle($request),
-        );
+        $result = $definition->handle($request);
+
+        return response()->json($result, $result->status());
     }
 }

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -49,7 +49,9 @@ final readonly class BulkActionController
 
         $records = $this->resolveRecords($request, $table, $tableKey);
 
-        return response()->json($definition->handle($records, $request));
+        $result = $definition->handle($records, $request);
+
+        return response()->json($result, $result->status());
     }
 
     /**

--- a/src/Support/TypeScript/AugmentProfile.php
+++ b/src/Support/TypeScript/AugmentProfile.php
@@ -16,6 +16,27 @@ final readonly class AugmentProfile implements TypeScriptProfile
 {
     public function __construct(private WireTypeDiscovery $discovery) {}
 
+    public function pendingTypeCount(): int
+    {
+        $entries = [];
+
+        foreach (DiscoveryManifest::configuredPaths() as $path) {
+            $manifest = $this->discovery->discover($path);
+
+            foreach ($manifest->components as $component) {
+                $entries[$component->class] = true;
+            }
+
+            foreach (WireFamily::registryFamilies() as $family) {
+                foreach (array_keys($manifest->family($family->category)) as $class) {
+                    $entries[$class] = true;
+                }
+            }
+        }
+
+        return count($entries);
+    }
+
     public function run(TypeScriptGenerator $generator): string
     {
         $roots = DiscoveryManifest::configuredPaths();

--- a/src/Support/TypeScript/TypeScriptProfile.php
+++ b/src/Support/TypeScript/TypeScriptProfile.php
@@ -9,6 +9,12 @@ namespace Lattice\Lattice\Support\TypeScript;
  */
 interface TypeScriptProfile
 {
+    /**
+     * App-defined wire types this profile would emit. Zero means the bundled
+     * types already cover the project and no transformer is needed.
+     */
+    public function pendingTypeCount(): int;
+
     /** Run a generation pass and return a summary line for the command to print. */
     public function run(TypeScriptGenerator $generator): string;
 }

--- a/tests/Browser/Actions/ActionRejectionTest.php
+++ b/tests/Browser/Actions/ActionRejectionTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use Workbench\App\Models\Product;
+
+it('keeps the confirm dialog open and shows an error toast when an action is rejected', function (): void {
+    $this->actingAs(workbenchTestUser());
+    Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
+
+    $page = visit('/products');
+
+    $page->click('@product-actions')
+        ->click('@action-fail-demo')
+        ->click('@confirm-accept');
+
+    assertSeeEventually($page, 'Could not process the request.');
+
+    $page->assertVisible('@confirm-accept')
+        ->assertSee('Fail demo?')
+        ->assertNoSmoke();
+});

--- a/tests/Feature/Actions/ActionEndpointTest.php
+++ b/tests/Feature/Actions/ActionEndpointTest.php
@@ -6,6 +6,7 @@ use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Facades\Effects;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Tests\Fixtures\Workbench\WorkbenchFailingAction;
 use Lattice\Lattice\Tests\Fixtures\Workbench\WorkbenchPingAction;
 use Lattice\Lattice\Ui\Enums\Variant;
 use Workbench\App\Actions\SetLocaleAction;
@@ -114,6 +115,16 @@ test('toast effects serialize correctly for action results', function (): void {
                 ],
             ],
         ]);
+});
+
+test('a failure result returns 422 and still serializes its effects', function (): void {
+    Lattice::actions([WorkbenchFailingAction::class]);
+
+    $this->callAction(WorkbenchFailingAction::class, [])
+        ->assertStatus(422)
+        ->assertJsonPath('effects.0.type', 'toast')
+        ->assertJsonPath('effects.0.props.variant', 'error')
+        ->assertJsonPath('effects.0.props.message', 'Could not process.');
 });
 
 test('registered action endpoints require a valid component reference', function (): void {

--- a/tests/Feature/Console/TypeScriptCommandTest.php
+++ b/tests/Feature/Console/TypeScriptCommandTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Support\TypeScript\AugmentProfile;
+use Lattice\Lattice\Support\TypeScript\TypeScriptGenerator;
 use Lattice\Lattice\Support\TypeScript\TypeScriptProfile;
 
 use function Pest\Laravel\artisan;
@@ -52,22 +53,35 @@ it('writes an augmentation file for app components, not built-ins', function ():
     });
 });
 
-it('produces a valid augmentation file even when discover config is empty', function (): void {
+it('no-ops with a friendly message when there are no custom wire types', function (): void {
     withScaffoldWorkspace(function (): void {
-        $output = base_path('resources/js/lattice/generated-empty.d.ts');
+        $output = base_path('resources/js/lattice/generated.d.ts');
 
         config()->set('lattice.typescript.output', $output);
-        config()->set('lattice.typescript.module', '@lattice-php/lattice');
         config()->set('lattice.discover', []);
 
-        artisan('lattice:typescript')->assertSuccessful();
+        // The workbench's require-dev fixture package (lattice-php/signature-example)
+        // always contributes a real component via ComponentPackages discovery, so
+        // AugmentProfile::pendingTypeCount() can never hit 0 in this repo's own dev
+        // environment. Stub the profile to isolate the command's no-op branch from
+        // that fixture, exercising the same contract a clean consumer app would hit.
+        app()->instance(TypeScriptProfile::class, new class implements TypeScriptProfile
+        {
+            public function pendingTypeCount(): int
+            {
+                return 0;
+            }
 
-        $contents = file_get_contents($output);
+            public function run(TypeScriptGenerator $generator): string
+            {
+                throw new RuntimeException('run() must not be called when pendingTypeCount() is 0.');
+            }
+        });
 
-        expect($contents)
-            ->toBeString()
-            ->toContain('declare module "@lattice-php/lattice"')
-            ->toContain('interface ComponentProps {')
-            ->toContain('export {};');
+        artisan('lattice:typescript')
+            ->expectsOutputToContain('No custom Lattice wire types found')
+            ->assertSuccessful();
+
+        expect(file_exists($output))->toBeFalse();
     });
 });

--- a/tests/Fixtures/Workbench/WorkbenchFailingAction.php
+++ b/tests/Fixtures/Workbench/WorkbenchFailingAction.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\Workbench;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Attributes\AsAction;
+
+#[AsAction('workbench.failing')]
+final class WorkbenchFailingAction extends ActionDefinition
+{
+    public function definition(Action $action): Action
+    {
+        return $action->label('Fail');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::failure('Could not process.');
+    }
+}

--- a/tests/Unit/Actions/ActionResultFailureTest.php
+++ b/tests/Unit/Actions/ActionResultFailureTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Actions\ActionResult;
+
+test('success results carry a 200 status and no effects', function (): void {
+    $result = ActionResult::success();
+
+    expect($result->status())->toBe(200)
+        ->and($result->effects)->toBe([]);
+});
+
+test('failure without a message is a 422 with no effects', function (): void {
+    $result = ActionResult::failure();
+
+    expect($result->status())->toBe(422)
+        ->and($result->effects)->toBe([]);
+});
+
+test('failure with a message attaches an error toast and stays 422', function (): void {
+    $result = ActionResult::failure('Order already shipped.');
+
+    expect($result->status())->toBe(422)
+        ->and(wire($result)['effects'][0])
+        ->toMatchArray([
+            'type' => 'toast',
+            'props' => [
+                'variant' => 'error',
+                'message' => 'Order already shipped.',
+                'duration' => null,
+                'persistent' => false,
+                'dismissible' => true,
+                'action' => null,
+            ],
+        ]);
+});
+
+test('chaining an effect preserves the failure status', function (): void {
+    $result = ActionResult::failure('Nope.')->reloadComponent('app.products');
+
+    expect($result->status())->toBe(422)
+        ->and($result->effects)->toHaveCount(2);
+});

--- a/workbench/app/Actions/FailingDemoAction.php
+++ b/workbench/app/Actions/FailingDemoAction.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Actions;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Enums\HttpMethod;
+
+#[AsAction('workbench.products.fail-demo')]
+class FailingDemoAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action
+            ->label('Fail demo')
+            ->method(HttpMethod::Patch)
+            ->confirm('Fail demo?', 'This will be rejected.');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::failure('Could not process the request.');
+    }
+}

--- a/workbench/app/Support/TypeScript/BaseProfile.php
+++ b/workbench/app/Support/TypeScript/BaseProfile.php
@@ -26,6 +26,11 @@ use Lattice\Lattice\Tables\Filters\Filter;
  */
 final class BaseProfile implements TypeScriptProfile
 {
+    public function pendingTypeCount(): int
+    {
+        return count(new WireTypeDiscovery()->discover(dirname(__DIR__, 4).'/src')->components);
+    }
+
     public function run(TypeScriptGenerator $generator): string
     {
         $packageRoot = dirname(__DIR__, 4);

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -24,6 +24,7 @@ use Lattice\Lattice\Ui\Components\Link;
 use Workbench\App\Actions\ArchiveProductAction;
 use Workbench\App\Actions\ArchiveSelectedProductsAction;
 use Workbench\App\Actions\EditProductAction;
+use Workbench\App\Actions\FailingDemoAction;
 use Workbench\App\Actions\RejectProductAction;
 use Workbench\App\Actions\RejectSelectedProductsAction;
 use Workbench\App\Models\Product;
@@ -126,6 +127,7 @@ class ProductsTable extends EloquentTableDefinition
                     Action::use(EditProductAction::class, ['product_id' => $row['id']]),
                     Action::use(ArchiveProductAction::class, ['product_id' => $row['id']]),
                     Action::use(RejectProductAction::class, ['product_id' => $row['id']]),
+                    Action::use(FailingDemoAction::class, ['product_id' => $row['id']]),
                 ]),
         ];
     }


### PR DESCRIPTION
Addresses 0.21 drift reported by a consuming app: no canonical way to reject an action, an alarming `lattice:typescript` failure mode, and bundled skills documenting a pre-0.21 API.

## 1. `ActionResult::failure()` — canonical action rejection
`failure()` was removed in 0.21, leaving `abort(4xx)` as the only way to reject an action. Reintroduced with real semantics:

```php
return ActionResult::failure('Order already shipped.'); // HTTP 422 + error toast
```

- Returns **HTTP 422** (status is a private, non-wire prop — the wire body stays `{data, effects}`, no `generated.ts` change); an optional message auto-attaches a `Variant::Error` toast; still chainable.
- Client is unified onto `apiFetch`: a rejected action **dispatches its effects** (the error toast shows) and **leaves confirm dialogs / modals open** — cleanup only runs on a 2xx response. Previously a failed action was silent.

## 2. `lattice:typescript` no longer alarms
It hard-failed asking for the transformer even for projects with no custom wire types.

```
# before (any project, transformer absent)
ERROR  lattice:typescript needs spatie/typescript-transformer. Install it with: ...

# after — no custom wire types
INFO   No custom Lattice wire types found — the bundled TypeScript types already cover
       this project. Nothing to generate.            (exit 0, no file written)

# after — custom types present but transformer missing
ERROR  Found 4 custom Lattice wire type(s) to generate, but spatie/laravel-typescript-
       transformer is not installed. Install it with: composer require --dev ...   (exit 1)
```

Detection is transformer-free (`TypeScriptProfile::pendingTypeCount()`). The correct wrapper package name (`spatie/laravel-typescript-transformer`) is now used consistently across the command, README, docs, and composer `suggest`.

## 3. Bundled skills refreshed to 0.21
`lattice-actions` corrected to the message-first effects API (`->toast(message, variant?)`, `Callout::make(message, variant?)`, `Effects::toast(message, variant?)`) and the new `failure()` rejection pattern. The audit also fixed `->redirect`→`->to`, a wrong `Callout` namespace, a nonexistent `Effects::callout()`, and `lattice-tables` drift (`StackColumn->schema()`, `TableQuery` public readonly props).

## Verification
`composer check` + `npm run check` green (1222 Pest + 4333 assertions, full Vitest, type check, library build). New unit, feature, Vitest, and browser tests cover the rejection contract end to end.
