### PR TITLE
More cleanups: i18n consistency, tooling/CI hygiene, test rigor, dead-code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -38,6 +38,10 @@
 /testbench.yaml export-ignore
 /tsconfig.json export-ignore
 /vite.config.ts export-ignore
+/codecov.yml export-ignore
+/renovate.json export-ignore
+/.mcp.json export-ignore
+/solo.yml export-ignore
 /dist-standalone/** linguist-generated=true
 
 # Keep frontend tests out of the Composer distribution

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,19 +6,16 @@ set -e
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
-staged_php=$(git diff --cached --name-only --diff-filter=ACMR -- '*.php')
-staged_js=$(git diff --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx')
-
-if [ -n "$staged_php" ]; then
+if ! git diff --cached --quiet --diff-filter=ACMR -- '*.php'; then
     echo "▶ pint (staged PHP)"
-    echo "$staged_php" | xargs ./vendor/bin/pint
-    echo "$staged_php" | xargs git add
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -0 ./vendor/bin/pint
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -0 git add
 fi
 
-if [ -n "$staged_js" ]; then
+if ! git diff --cached --quiet --diff-filter=ACMR -- '*.ts' '*.tsx'; then
     echo "▶ oxfmt + oxlint (staged JS)"
-    echo "$staged_js" | xargs ./node_modules/.bin/oxfmt --write
-    echo "$staged_js" | xargs ./node_modules/.bin/oxlint --fix
-    echo "$staged_js" | xargs git add
-    echo "$staged_js" | xargs ./node_modules/.bin/oxlint
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' | xargs -0 ./node_modules/.bin/oxfmt --write
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' | xargs -0 ./node_modules/.bin/oxlint --fix
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' | xargs -0 git add
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.ts' '*.tsx' | xargs -0 ./node_modules/.bin/oxlint
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,7 +5,8 @@
 # The generated-types and docs-fixtures diffs are intentionally left to CI: a local run
 # regenerates resources/js/types/generated.ts with a different property ordering than main,
 # so a local diff check would fail spuriously. Pest Browser stays CI-only because it
-# needs the built workbench assets and Playwright browsers.
+# needs the built workbench assets and Playwright browsers. docs:typecheck (docs/tsconfig.json)
+# and the icons-freshness diff also stay CI-only for the same local-drift reasons.
 set -e
 
 root="$(git rev-parse --show-toplevel)"
@@ -14,7 +15,7 @@ cd "$root"
 echo "▶ pre-push: composer check (pint, phpstan, rector, pest)"
 composer check
 
-echo "▶ pre-push: npm run check (lint, format, typecheck, type-coverage, vitest, build:lib)"
+echo "▶ pre-push: npm run check (lint, format, typecheck, type-coverage, vitest, build:lib, check:package)"
 npm run check
 
 echo "✓ pre-push gate passed"

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           use_oidc: true
           files: coverage_phpunit/browser-clover.xml,coverage_phpunit/browser-serial-clover.xml
-          flags: pest
+          flags: pest-browser
           name: pest-browser
           disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,9 @@ jobs:
           CODECOV_BUNDLE: "1"
         run: npm run build
 
+      - name: Icons are up to date
+        run: git diff --exit-code -- resources/icons src/Ui/Enums/Icon.php workbench/resources/js/sprite-icons.ts
+
   php-static:
     name: PHP Static (pint, phpstan, rector)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ AGENTS.md
 CLAUDE.md
 docs/superpowers
 .superpowers
+/sk-*.png

--- a/lang/de/common.php
+++ b/lang/de/common.php
@@ -11,6 +11,8 @@ return [
     'cancel' => 'Abbrechen',
     'yes' => 'Ja',
     'no' => 'Nein',
+    'all' => 'Alle',
+    'dialog' => 'Dialog',
     'breadcrumb' => 'Navigationspfad',
     'copy' => 'Kopieren',
     'copied' => 'Kopiert',
@@ -21,6 +23,9 @@ return [
     ],
     'action-group' => [
         'label' => 'Aktionen',
+    ],
+    'action' => [
+        'run' => 'Aktion ausführen',
     ],
     'tree' => [
         'expand' => ':label ausklappen',

--- a/lang/de/form.php
+++ b/lang/de/form.php
@@ -45,4 +45,10 @@ return [
     'search-options' => 'Optionen durchsuchen',
     'remove-option' => ':label entfernen',
     'create-option' => '":label" erstellen',
+    'select' => [
+        'empty' => 'Keine Optionen',
+        'search' => 'Suchen…',
+    ],
+    'submit' => 'Absenden',
+    'validation-summary' => 'Bitte diese Felder korrigieren:',
 ];

--- a/lang/en/common.php
+++ b/lang/en/common.php
@@ -11,6 +11,8 @@ return [
     'cancel' => 'Cancel',
     'yes' => 'Yes',
     'no' => 'No',
+    'all' => 'All',
+    'dialog' => 'Dialog',
     'breadcrumb' => 'Breadcrumb',
     'copy' => 'Copy',
     'copied' => 'Copied',
@@ -21,6 +23,9 @@ return [
     ],
     'action-group' => [
         'label' => 'Actions',
+    ],
+    'action' => [
+        'run' => 'Run action',
     ],
     'tree' => [
         'expand' => 'Expand :label',

--- a/lang/en/form.php
+++ b/lang/en/form.php
@@ -45,4 +45,10 @@ return [
     'search-options' => 'Search options',
     'remove-option' => 'Remove :label',
     'create-option' => 'Create ":label"',
+    'select' => [
+        'empty' => 'No options',
+        'search' => 'Search…',
+    ],
+    'submit' => 'Submit',
+    'validation-summary' => 'Fix these fields to continue:',
 ];

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "access": "public"
   },
   "scripts": {
-    "postinstall": "test ! -f vendor/bin/testbench || npm run boost:refresh",
+    "postinstall": "[ -n \"$CI\" ] || test ! -f vendor/bin/testbench || npm run boost:refresh",
     "dev": "vite",
     "build": "vite build",
     "build:lib": "vite build --mode lib",
@@ -153,7 +153,7 @@
     "boost:refresh": "php vendor/bin/testbench boost:update --no-interaction",
     "typecheck": "tsc --noEmit",
     "type-coverage": "type-coverage --project tsconfig.json --at-least 99.5",
-    "check": "npm run lint && npm run format:check && npm run typecheck && npm run type-coverage && npm run test && npm run build:lib",
+    "check": "npm run lint && npm run format:check && npm run typecheck && npm run type-coverage && npm run test && npm run build:lib && npm run check:package",
     "check:package": "publint --strict && attw --pack . --profile esm-only --exclude-entrypoints ./css",
     "fix": "npm run lint:fix && npm run format",
     "docs:typecheck": "tsc --noEmit -p docs/tsconfig.json",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,9 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheDirectory=".phpunit.cache">
+         cacheDirectory=".phpunit.cache"
+         failOnRisky="true"
+         failOnWarning="true">
     <testsuites>
         <testsuite name="Arch">
             <file>tests/ArchTest.php</file>

--- a/resources/boost/skills/lattice-actions/SKILL.md
+++ b/resources/boost/skills/lattice-actions/SKILL.md
@@ -111,7 +111,7 @@ Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]);
 
 ## Confirmation and input forms
 
-- `->confirm($title, $description?, $confirmLabel?, $cancelLabel?)` shows a confirmation dialog before the action runs.
+- `->confirm($title?, $description?, $confirmLabel?, $cancelLabel?)` shows a confirmation dialog before the action runs; `$title` defaults to the action's label when omitted.
 - `->form([...])` renders a [form](#) in a modal first; its values post to the action endpoint, validate server-side (precognitive by default), and are read in `handle()` with `$this->validate($request)`. Use the same `Field` builders as any form. Use `->lazyForm()->form([...])` for a per-record form prefilled from the row when the modal opens.
 
 ```php

--- a/resources/js/action/components/action.tsx
+++ b/resources/js/action/components/action.tsx
@@ -8,11 +8,12 @@ import {
   useActionMenu,
 } from "@lattice-php/lattice/ui/action-menu-context";
 import { useAction } from "@lattice-php/lattice/action/hooks/use-action";
+import { actionLabel } from "@lattice-php/lattice/action/lib/action-label";
 
 const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const endpoint = node.props.endpoint ?? "";
   const icon = node.props.icon;
-  const label = node.props.label ?? "Run action";
+  const label = actionLabel(node);
   const isMenuItem = useActionMenu();
   const variant = node.props.variant ?? "default";
   const { processing, requestSubmit, overlays } = useAction(node);

--- a/resources/js/action/hooks/use-action.tsx
+++ b/resources/js/action/hooks/use-action.tsx
@@ -6,9 +6,11 @@ import { ConfirmDialog } from "@lattice-php/lattice/ui/confirm-dialog";
 import { apiFetch } from "@lattice-php/lattice/core/api";
 import { withHeaders } from "@lattice-php/lattice/core/headers";
 import type { Node } from "@lattice-php/lattice/core/types";
+import { translate } from "@lattice-php/lattice/i18n";
 import { useEffectDispatcher } from "@lattice-php/lattice/effects/use-effect-dispatcher";
 import { runAction } from "@lattice-php/lattice/action/lib/run-action";
 import { ActionForm, useLazyActionForm } from "@lattice-php/lattice/action/components/action-form";
+import { actionLabel } from "@lattice-php/lattice/action/lib/action-label";
 
 type UseAction = {
   /** Whether the action request is in flight. */
@@ -29,7 +31,7 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
   const endpoint = node.props.endpoint ?? "";
   const componentRef = node.props.ref ?? "";
   const method: Method = node.props.method ?? "post";
-  const label = node.props.label ?? "Run action";
+  const label = actionLabel(node);
   const variant = node.props.variant ?? "default";
   const confirmation = node.props.confirmation;
   const inlineForm = node.props.form;
@@ -87,7 +89,8 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
 
   const confirmationTitle = confirmation?.title ?? label;
   const confirmationConfirmLabel = confirmation?.confirmLabel ?? label;
-  const confirmationCancelLabel = confirmation?.cancelLabel ?? "Cancel";
+  const confirmationCancelLabel =
+    confirmation?.cancelLabel ?? translate("lattice", "common.cancel", "Cancel");
 
   const overlays = (
     <>

--- a/resources/js/action/lib/action-label.ts
+++ b/resources/js/action/lib/action-label.ts
@@ -1,0 +1,6 @@
+import { translate } from "@lattice-php/lattice/i18n";
+import type { Node } from "@lattice-php/lattice/core/types";
+
+export function actionLabel(node: Node<"action" | "action.bulk">): string {
+  return node.props.label ?? translate("lattice", "common.action.run", "Run action");
+}

--- a/resources/js/effects/custom-effect.test.tsx
+++ b/resources/js/effects/custom-effect.test.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { Provider } from "@lattice-php/lattice/provider";
 import { createPlugin, extendRegistry } from "@lattice-php/lattice/core/registry";
 import { registry as defaultRegistry } from "@lattice-php/lattice/registry";
+import { effect } from "@lattice-php/lattice/test/effect-fixture";
 import { useEffectDispatcher } from "./use-effect-dispatcher";
 
 describe("custom effect end to end", () => {
@@ -25,8 +26,15 @@ describe("custom effect end to end", () => {
     window.addEventListener("lattice:toast", toastListener);
     result.current([
       { type: "confetti", props: { color: "gold" } },
-      { type: "toast", props: { variant: "success", message: "ok" } },
-    ] as never);
+      effect("toast", {
+        action: null,
+        dismissible: true,
+        duration: null,
+        message: "ok",
+        persistent: false,
+        variant: "success",
+      }),
+    ]);
 
     expect(confetti).toHaveBeenCalledOnce();
     expect(toastListener).toHaveBeenCalledOnce();

--- a/resources/js/effects/dispatch.test.ts
+++ b/resources/js/effects/dispatch.test.ts
@@ -7,10 +7,7 @@ describe("dispatchEffects", () => {
     const toast = vi.fn<() => void>();
     const handlers: EffectHandlerRegistry = { toast };
 
-    dispatchEffects(
-      [{ type: "toast", props: { variant: "success", message: "hi" } }] as never,
-      handlers,
-    );
+    dispatchEffects([{ type: "toast", props: { variant: "success", message: "hi" } }], handlers);
 
     expect(toast).toHaveBeenCalledOnce();
   });
@@ -18,7 +15,7 @@ describe("dispatchEffects", () => {
   it("warns and skips an effect with no registered handler", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    dispatchEffects([{ type: "confetti" }] as never, {});
+    dispatchEffects([{ type: "confetti", props: {} }], {});
 
     expect(warn).toHaveBeenCalledOnce();
     warn.mockRestore();

--- a/resources/js/effects/use-effect-dispatcher.test.tsx
+++ b/resources/js/effects/use-effect-dispatcher.test.tsx
@@ -17,7 +17,7 @@ describe("useEffectDispatcher", () => {
     );
 
     const { result } = renderHook(() => useEffectDispatcher(), { wrapper });
-    result.current([{ type: "confetti" }] as never);
+    result.current([{ type: "confetti", props: {} }]);
 
     expect(confetti).toHaveBeenCalledOnce();
   });

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -1,5 +1,7 @@
 import { expect, it, vi, beforeAll, afterAll } from "vitest";
 import { configure, getConfig, fireEvent, render, screen, within } from "@testing-library/react";
+import type { ComponentPropsOf, Node } from "@lattice-php/lattice/core/types";
+import { fakeNode } from "@lattice-php/lattice/test-support";
 
 let prev: string;
 beforeAll(() => {
@@ -18,11 +20,17 @@ import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { renderCounts } from "@lattice-php/lattice/test/form-renderer-probe";
 import { BuilderComponent } from "./builder";
+import type { RowTemplate } from "./row-templates";
 
-const node = {
-  id: "b",
-  type: "field.builder",
-  props: {
+function builderNode(
+  props: Partial<ComponentPropsOf<"field.builder">>,
+  templates: RowTemplate[],
+): Node<"field.builder"> & { templates: RowTemplate[] } {
+  return { ...fakeNode({ type: "field.builder", props }), templates };
+}
+
+const node = builderNode(
+  {
     name: "items",
     reorderable: true,
     defaultItems: 0,
@@ -30,19 +38,19 @@ const node = {
     minItems: 0,
     maxItems: 5,
   },
-  templates: [
+  [
     {
       type: "text",
       label: "Text",
-      schema: [{ id: "t", type: "field.textarea", props: { name: "content" } }],
+      schema: [fakeNode({ id: "t", type: "field.textarea", props: { name: "content" } })],
     },
     {
       type: "product",
       label: "Product line",
-      schema: [{ id: "p", type: "field.text-input", props: { name: "qty" } }],
+      schema: [fakeNode({ id: "p", type: "field.text-input", props: { name: "qty" } })],
     },
   ],
-} as never;
+);
 
 function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
   return render(
@@ -98,10 +106,8 @@ it("can remove an unknown-block row", () => {
 });
 
 it("renders the table layout: primary columns, spanning non-primary rows", () => {
-  const node = {
-    id: "b",
-    type: "field.builder",
-    props: {
+  const node = builderNode(
+    {
       name: "items",
       layout: "table",
       reorderable: true,
@@ -110,22 +116,32 @@ it("renders the table layout: primary columns, spanning non-primary rows", () =>
       minItems: 0,
       maxItems: 9,
     },
-    templates: [
+    [
       {
         type: "product",
         label: "Product",
         schema: [
-          { id: "p", type: "field.text-input", props: { name: "product", label: "Product" } },
-          { id: "q", type: "field.text-input", props: { name: "qty", label: "Qty" } },
+          fakeNode({
+            id: "p",
+            type: "field.text-input",
+            props: { name: "product", label: "Product" },
+          }),
+          fakeNode({ id: "q", type: "field.text-input", props: { name: "qty", label: "Qty" } }),
         ],
       },
       {
         type: "text",
         label: "Text",
-        schema: [{ id: "c", type: "field.textarea", props: { name: "content", label: "Content" } }],
+        schema: [
+          fakeNode({
+            id: "c",
+            type: "field.textarea",
+            props: { name: "content", label: "Content" },
+          }),
+        ],
       },
     ],
-  } as never;
+  );
   wrap(<BuilderComponent node={node}>{null}</BuilderComponent>, {
     items: [
       { type: "product", product: "SKU", qty: "2" },

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -3,6 +3,7 @@ import { withHeaders } from "@lattice-php/lattice/core/headers";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
 import { useWindowEvent } from "@lattice-php/lattice/core/hooks/use-window-event";
 import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
+import { useT } from "@lattice-php/lattice/i18n";
 import { useMemo } from "react";
 import { FormSubmitButton } from "./base/submit-button";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
@@ -67,6 +68,7 @@ function FormBody({
 }
 
 export const FormComponent: RendererComponent<"form"> = ({ children, node }) => {
+  const { t } = useT("lattice");
   const props = node.props;
   const action = props.action ?? "#";
   const errorBag = props.errorBag;
@@ -82,7 +84,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
   );
   const initialValues = useMemo(() => ({ ...fieldValues, ...state }), [fieldValues, state]);
   const shouldRenderSubmitButton = props.submitButton;
-  const submitLabel = props.submitLabel ?? "Submit";
+  const submitLabel = props.submitLabel ?? t("form.submit", "Submit");
   const summaryLabel = props.validationSummaryLabel;
   const validationTimeout = props.validationTimeout ?? undefined;
 

--- a/resources/js/form/rich-editor/registry.test.ts
+++ b/resources/js/form/rich-editor/registry.test.ts
@@ -1,3 +1,4 @@
+import type { AnyExtension } from "@tiptap/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assembleStarterKitOptions,
@@ -124,9 +125,11 @@ describe("assembleToolbar", () => {
 
 describe("assembleTiptapExtensions", () => {
   it("flat-maps the instances of every active extension", () => {
-    const fakeExtension = { name: "fake" };
+    // Stands in for a real Tiptap extension instance; constructing one for real
+    // is unnecessary — assembleTiptapExtensions only flat-maps by reference.
+    const fakeExtension = { name: "fake" } as unknown as AnyExtension;
     registerRichEditorExtension("with-instances", {
-      extensions: () => [fakeExtension as never],
+      extensions: () => [fakeExtension],
     });
     registerRichEditorExtension("without-instances", {});
 

--- a/resources/js/format/number.test.ts
+++ b/resources/js/format/number.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { NumberFormat } from "@lattice-php/lattice/types";
+import type { NumberFormat } from "@lattice-php/lattice/types/generated";
 import { formatNumber } from "./number";
 
 const base: NumberFormat = {

--- a/resources/js/format/number.ts
+++ b/resources/js/format/number.ts
@@ -1,4 +1,4 @@
-import type { NumberFormat } from "@lattice-php/lattice/types";
+import type { NumberFormat } from "@lattice-php/lattice/types/generated";
 import { numericValue } from "./numeric";
 
 export function formatNumber(value: unknown, format: NumberFormat, locale: string): string {

--- a/resources/js/format/value.test.ts
+++ b/resources/js/format/value.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { DateFormat, NumberFormat } from "@lattice-php/lattice/types";
+import type { DateFormat, NumberFormat } from "@lattice-php/lattice/types/generated";
 import { formatValue } from "./value";
 
 const ctx = { locale: "en-US", timezone: "UTC" };

--- a/resources/js/format/value.ts
+++ b/resources/js/format/value.ts
@@ -1,4 +1,4 @@
-import type { DateFormat, NumberFormat } from "@lattice-php/lattice/types";
+import type { DateFormat, NumberFormat } from "@lattice-php/lattice/types/generated";
 import { formatDateValue } from "./date-time";
 import { formatNumber } from "./number";
 

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -47,7 +47,7 @@ vi.mock("@lattice-php/lattice/action/components/action-form", () => ({
       <button
         type="button"
         data-test="form-success"
-        onClick={() => props.onSuccess({ effects: [{ type: "test.bulk-success" } as never] })}
+        onClick={() => props.onSuccess({ effects: [{ type: "test.bulk-success", props: {} }] })}
       >
         success
       </button>
@@ -170,7 +170,15 @@ describe("BulkBar", () => {
   it("sends an empty ref header when the action has no ref", async () => {
     renderBar({
       actions: [
-        action({ id: "archive", method: "patch", endpoint: "/bulk/archive", ref: null as never }),
+        action({
+          id: "archive",
+          method: "patch",
+          endpoint: "/bulk/archive",
+          // BulkAction.ref is non-nullable by contract (getBulkActions always
+          // defaults it); this forces the out-of-contract value the component's
+          // `action.ref ?? ""` defensively guards against.
+          ref: null as unknown as string,
+        }),
       ],
     });
 
@@ -255,11 +263,14 @@ describe("BulkBar", () => {
             id: "archive",
             label: "Archive",
             confirmation: {
-              title: null,
+              // Confirmation.title is non-nullable by contract; this forces the
+              // out-of-contract value the component's `?? label` fallback
+              // defensively guards against.
+              title: null as unknown as string,
               description: null,
               confirmLabel: null,
               cancelLabel: null,
-            } as never,
+            },
           }),
         ],
       });

--- a/resources/js/table/components/bulk-bar.test.tsx
+++ b/resources/js/table/components/bulk-bar.test.tsx
@@ -174,10 +174,9 @@ describe("BulkBar", () => {
           id: "archive",
           method: "patch",
           endpoint: "/bulk/archive",
-          // BulkAction.ref is non-nullable by contract (getBulkActions always
-          // defaults it); this forces the out-of-contract value the component's
-          // `action.ref ?? ""` defensively guards against.
-          ref: null as unknown as string,
+          // "" is the real normalized "no ref" value: getBulkActions always
+          // defaults `props.ref ?? ""`, so this is an in-contract fixture.
+          ref: "",
         }),
       ],
     });
@@ -263,10 +262,9 @@ describe("BulkBar", () => {
             id: "archive",
             label: "Archive",
             confirmation: {
-              // Confirmation.title is non-nullable by contract; this forces the
-              // out-of-contract value the component's `?? label` fallback
-              // defensively guards against.
-              title: null as unknown as string,
+              // Confirmation.title is nullable by contract: a title-less
+              // confirmation falls back to the action's label.
+              title: null,
               description: null,
               confirmLabel: null,
               cancelLabel: null,

--- a/resources/js/table/components/bulk-bar.tsx
+++ b/resources/js/table/components/bulk-bar.tsx
@@ -44,7 +44,7 @@ export function BulkBar({
       () =>
         apiFetch(action.endpoint, {
           method: action.method,
-          ref: action.ref ?? "",
+          ref: action.ref,
           body: JSON.stringify(selectionPayload()),
           throwOnError: false,
         }),

--- a/resources/js/table/components/cells/numeric-cell.tsx
+++ b/resources/js/table/components/cells/numeric-cell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useLocale } from "@lattice-php/lattice/i18n";
-import type { NumberFormat } from "@lattice-php/lattice/types";
+import type { NumberFormat } from "@lattice-php/lattice/types/generated";
 import { formatNumber } from "@lattice-php/lattice/format/number";
 import { numericValue } from "@lattice-php/lattice/format/numeric";
 import { formatCell } from "@lattice-php/lattice/table/lib/format";

--- a/resources/js/table/lib/bulk.ts
+++ b/resources/js/table/lib/bulk.ts
@@ -2,6 +2,7 @@ import type { Method } from "@inertiajs/core";
 import type { Node } from "@lattice-php/lattice/core/types";
 import type { Action, ButtonVariant } from "@lattice-php/lattice/types/generated";
 import type { ActionNode } from "@lattice-php/lattice/table/types";
+import { actionLabel } from "@lattice-php/lattice/action/lib/action-label";
 
 export type BulkAction = {
   id: string;
@@ -31,7 +32,7 @@ export function getBulkActions(actions: ActionNode[] | undefined): BulkAction[] 
     return [
       {
         id: node.id ?? "",
-        label: props.label ?? "Run action",
+        label: actionLabel(node),
         method: props.method ?? "post",
         endpoint: props.endpoint,
         ref: props.ref ?? "",

--- a/resources/js/table/lib/format.test.ts
+++ b/resources/js/table/lib/format.test.ts
@@ -1,12 +1,30 @@
 import { describe, expect, it } from "vitest";
-import type { TableColumn, TableRow } from "@lattice-php/lattice/table/types";
+import type { ColumnNode, ColumnPropsOf, TableRow } from "@lattice-php/lattice/table/types";
 import { formatCell, resolveLink } from "./format";
 
-const dateColumn = {
-  key: "created",
-  label: "Created",
-  props: { date: { dateStyle: "medium", timeStyle: "short" } },
-} as never;
+function textColumn(props: Partial<ColumnPropsOf<"column.text">> = {}): ColumnNode<"column.text"> {
+  return {
+    key: "col",
+    type: "column.text",
+    props: {
+      align: "start",
+      badge: null,
+      copyable: false,
+      date: null,
+      filter: null,
+      hiddenByDefault: false,
+      label: null,
+      link: null,
+      multiple: null,
+      sortable: false,
+      toggleable: false,
+      width: "md",
+      ...props,
+    },
+  };
+}
+
+const dateColumn = textColumn({ date: { dateStyle: "medium", timeStyle: "short" } });
 
 describe("formatCell date rendering", () => {
   it("renders the default date format in the requested timezone", () => {
@@ -46,31 +64,28 @@ describe("formatCell primitives", () => {
 });
 
 describe("resolveLink", () => {
-  const column = (link: unknown): TableColumn =>
-    ({ key: "name", label: "Name", props: { link } }) as never;
+  const column = (href: string | null) => textColumn({ link: { href, external: false } });
   const row: TableRow = { id: 7, name: "Ada" };
 
   it("returns null when the column has no link", () => {
-    expect(resolveLink(column(null), row, "Ada")).toBeNull();
+    expect(resolveLink(textColumn(), row, "Ada")).toBeNull();
   });
 
   it("returns null when the resolved href is empty", () => {
-    expect(resolveLink(column({ href: null }), row, "")).toBeNull();
+    expect(resolveLink(column(null), row, "")).toBeNull();
   });
 
   it("interpolates the value and row tokens into the href", () => {
-    expect(resolveLink(column({ href: "/users/{id}?q={value}" }), row, "Ada & Co")).toBe(
+    expect(resolveLink(column("/users/{id}?q={value}"), row, "Ada & Co")).toBe(
       "/users/7?q=Ada%20%26%20Co",
     );
   });
 
   it("coerces missing row tokens to an empty string", () => {
-    expect(resolveLink(column({ href: "/x/{missing}" }), row, "v")).toBe("/x/");
+    expect(resolveLink(column("/x/{missing}"), row, "v")).toBe("/x/");
   });
 
   it("falls back to the cell value when no explicit href is set", () => {
-    expect(resolveLink(column({ href: null }), row, "https://example.test")).toBe(
-      "https://example.test",
-    );
+    expect(resolveLink(column(null), row, "https://example.test")).toBe("https://example.test");
   });
 });

--- a/resources/js/toast/index.ts
+++ b/resources/js/toast/index.ts
@@ -1,6 +1,6 @@
 export { normalizeCallout, onCallout } from "./callout";
 export type { Callout } from "./callout";
 export { Toaster } from "./toaster";
-export { isVariant, normalizeToastMessage, onToast } from "./toast";
+export { onToast } from "./toast";
 export type { ToastMessage, Variant } from "./toast";
 export { variantStyles } from "./variant-styles";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -545,7 +545,7 @@ export type Confirmation = {
   readonly cancelLabel: string | null;
   readonly confirmLabel: string | null;
   readonly description: string | null;
-  readonly title: string;
+  readonly title: string | null;
 };
 export type DataList = {
   dataEndpoint: string | null;

--- a/resources/js/ui/modal.tsx
+++ b/resources/js/ui/modal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Dialog, DialogContent, DialogHeader } from "@lattice-php/lattice/ui/dialog";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
+import { useT } from "@lattice-php/lattice/i18n";
 
 type ModalEvent = CustomEvent<{
   modal: string | null;
@@ -14,7 +15,8 @@ function matchesModal(event: Event, modal: string): boolean {
 }
 
 const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
-  const title = node.props.title ?? "Dialog";
+  const { t } = useT("lattice");
+  const title = node.props.title ?? t("common.dialog", "Dialog");
   const description = node.props.description;
   const closeLabel = node.props.closeLabel;
   const [isOpen, setIsOpen] = useState(node.props.open === true);

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -66,7 +66,7 @@ class Action extends Component
     }
 
     public function confirm(
-        string $title,
+        ?string $title = null,
         ?string $description = null,
         ?string $confirmLabel = null,
         ?string $cancelLabel = null,

--- a/src/Actions/Confirmation.php
+++ b/src/Actions/Confirmation.php
@@ -15,7 +15,7 @@ use Lattice\Lattice\Attributes\TypeScript;
 final readonly class Confirmation
 {
     public function __construct(
-        public string $title,
+        public ?string $title = null,
         public ?string $description = null,
         public ?string $confirmLabel = null,
         public ?string $cancelLabel = null,

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -28,7 +28,7 @@ class Form extends ContainerComponent
 
     public ?string $submitLabel = null;
 
-    public string $validationSummaryLabel = 'Fix these fields to continue:';
+    public string $validationSummaryLabel;
 
     public bool $precognitive = false;
 
@@ -54,6 +54,13 @@ class Form extends ContainerComponent
      * @var array<string, mixed>
      */
     public array $state = [];
+
+    public function __construct(?string $key = null)
+    {
+        parent::__construct($key);
+
+        $this->validationSummaryLabel = __('lattice::form.validation-summary');
+    }
 
     public static function make(string $id): static
     {

--- a/src/Forms/Components/Select.php
+++ b/src/Forms/Components/Select.php
@@ -49,9 +49,17 @@ class Select extends Field
     /** @var array<int, mixed>|Closure */
     private array|Closure $itemRules = [];
 
-    public string $emptyLabel = 'No options';
+    public string $emptyLabel;
 
-    public string $searchPlaceholder = 'Search…';
+    public string $searchPlaceholder;
+
+    public function __construct(?string $key = null)
+    {
+        parent::__construct($key);
+
+        $this->emptyLabel = __('lattice::form.select.empty');
+        $this->searchPlaceholder = __('lattice::form.select.search');
+    }
 
     public function multiple(bool $multiple = true): static
     {

--- a/src/Support/Testing/InteractsWithLatticeComponents.php
+++ b/src/Support/Testing/InteractsWithLatticeComponents.php
@@ -5,19 +5,32 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Support\Testing;
 
 use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Http\Request;
 use Illuminate\Testing\TestResponse;
 use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\BulkActionRegistry;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Actions\Components\BulkAction;
+use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Attributes\AsBulkAction;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Attributes\AsTable;
+use Lattice\Lattice\Attributes\DefinitionAttribute;
+use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Forms\FormRegistry;
 use Lattice\Lattice\Fragments\Components\Fragment;
 use Lattice\Lattice\Fragments\FragmentDefinition;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Components\Table;
 use Lattice\Lattice\Tables\TableDefinition;
+use Lattice\Lattice\Tables\TableRegistry;
 use RuntimeException;
+use Spatie\Attributes\Attributes;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -127,11 +140,148 @@ trait InteractsWithLatticeComponents
     }
 
     /**
+     * Drive an action whose authorize() denies the current actor. The normal
+     * serialize path refuses to emit a hidden component ({@see Action::use()}
+     * returns it un-signed), so this seals a ref directly against the
+     * definition's registered key and hits the live endpoint — the same
+     * recipe {@see \RenderAuthorizationTest} uses — to observe the 403 a
+     * denied real request gets.
+     *
+     * @param  class-string<ActionDefinition>  $action
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $context
+     * @return LatticeTestResponse<Response>
+     */
+    public function callDeniedAction(string $action, array $data = [], array $context = []): LatticeTestResponse
+    {
+        $key = $this->deniedDefinitionKey($action, AsAction::class);
+
+        return $this->latticeRequest(
+            'post',
+            app(ActionRegistry::class)->endpointFor($key),
+            $data,
+            $this->sealDeniedRef('action', $key, $context),
+        );
+    }
+
+    /**
+     * @param  class-string<FormDefinition>  $form
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $context
+     * @return LatticeTestResponse<Response>
+     */
+    public function submitDeniedForm(string $form, array $data = [], array $context = []): LatticeTestResponse
+    {
+        $key = $this->deniedDefinitionKey($form, AsForm::class);
+
+        return $this->latticeRequest(
+            'post',
+            app(FormRegistry::class)->endpointFor($key),
+            $data,
+            $this->sealDeniedRef('form', $key, $context),
+        );
+    }
+
+    /**
+     * @param  class-string<TableDefinition>  $table
+     * @param  array<string, mixed>  $query
+     * @param  array<string, mixed>  $context
+     * @return LatticeTestResponse<Response>
+     */
+    public function loadDeniedTable(string $table, array $query = [], array $context = []): LatticeTestResponse
+    {
+        $key = $this->deniedDefinitionKey($table, AsTable::class);
+        $url = app(TableRegistry::class)->endpointFor($key);
+
+        if ($query !== []) {
+            $url .= '?'.http_build_query($query);
+        }
+
+        return $this->latticeTestResponse(
+            $this->getJson($url, $this->latticeHeaders($this->sealDeniedRef('table', $key, $context))),
+        );
+    }
+
+    /**
+     * Bulk actions are pinned to their table, so pass the table slug via
+     * context, e.g. `['table' => 'team.members']`.
+     *
+     * @param  class-string<BulkActionDefinition>  $bulkAction
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $context
+     * @return LatticeTestResponse<Response>
+     */
+    public function callDeniedBulkAction(string $bulkAction, array $data = [], array $context = []): LatticeTestResponse
+    {
+        $key = $this->deniedDefinitionKey($bulkAction, AsBulkAction::class);
+
+        return $this->latticeRequest(
+            'post',
+            app(BulkActionRegistry::class)->endpointFor($key),
+            $data,
+            $this->sealDeniedRef('action.bulk', $key, $context),
+        );
+    }
+
+    /**
+     * @param  class-string  $definition
+     * @param  class-string<DefinitionAttribute>  $attributeClass
+     */
+    private function deniedDefinitionKey(string $definition, string $attributeClass): string
+    {
+        $attribute = Attributes::get($definition, $attributeClass);
+
+        if (! $attribute instanceof DefinitionAttribute) {
+            throw new RuntimeException(sprintf(
+                'Lattice definition [%s] is missing the [%s] attribute.',
+                $definition,
+                class_basename($attributeClass),
+            ));
+        }
+
+        return $attribute->key;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function sealDeniedRef(string $type, string $key, array $context): string
+    {
+        $this->refreshLatticeRequestIdentity();
+
+        return app(SignsComponentReferences::class)->seal($type, $key, $context);
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function sealLatticeComponent(mixed $component): array
     {
+        $this->refreshLatticeRequestIdentity();
+
         return Wire::toArray($component);
+    }
+
+    /**
+     * Rebinds a session-less request into the container before sealing a ref.
+     *
+     * Lattice's JSON test helpers (postJson/patchJson/…) don't forward session
+     * cookies between calls, so every dispatched request gets a brand-new
+     * session id. If the container is still holding the request object a
+     * previous helper call left behind (Laravel's kernel leaves the last
+     * dispatched request bound after handling), sealing against it would bake
+     * that earlier session's hash into the new ref — which then never matches
+     * the fresh session the next dispatch actually gets, and the signer 403s.
+     * Rebinding a pristine, session-less request restores the "no session
+     * claim yet" identity {@see ComponentReferenceSigner}
+     * already treats as a wildcard match, so the seal matches whatever session
+     * the next request ends up with. Binding via `app()->instance('request', ...)`
+     * triggers Auth's rebind callback, which reinstalls a user resolver
+     * delegating to the auth manager — so `actingAs()` keeps working.
+     */
+    private function refreshLatticeRequestIdentity(): void
+    {
+        app()->instance('request', Request::create('/'));
     }
 
     /**

--- a/src/Tables/Columns/BadgeColumn.php
+++ b/src/Tables/Columns/BadgeColumn.php
@@ -14,7 +14,7 @@ use Lattice\Lattice\Tables\Contracts\Sortable;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 #[AsColumn(ColumnType::Badge)]
-class BadgeColumn extends Column implements Filterable, Sortable
+final class BadgeColumn extends Column implements Filterable, Sortable
 {
     use IsFilterable;
     use IsSortable;

--- a/src/Tables/Columns/BooleanColumn.php
+++ b/src/Tables/Columns/BooleanColumn.php
@@ -12,7 +12,7 @@ use Lattice\Lattice\Tables\Enums\ColumnType;
 use Lattice\Lattice\Tables\Enums\FilterType;
 
 #[AsColumn(ColumnType::Boolean)]
-class BooleanColumn extends Column implements Filterable, Sortable
+final class BooleanColumn extends Column implements Filterable, Sortable
 {
     use IsFilterable;
     use IsSortable;

--- a/src/Tables/Columns/IconColumn.php
+++ b/src/Tables/Columns/IconColumn.php
@@ -13,7 +13,7 @@ use Lattice\Lattice\Tables\Enums\ColumnType;
 use Lattice\Lattice\Ui\Concerns\HasIcon;
 
 #[AsColumn(ColumnType::Icon)]
-class IconColumn extends Column
+final class IconColumn extends Column
 {
     use HasIcon;
 

--- a/src/Tables/Columns/ImageColumn.php
+++ b/src/Tables/Columns/ImageColumn.php
@@ -7,7 +7,7 @@ use Lattice\Lattice\Tables\Attributes\AsColumn;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 
 #[AsColumn(ColumnType::Image)]
-class ImageColumn extends Column
+final class ImageColumn extends Column
 {
     public bool $circular = false;
 

--- a/src/Tables/Columns/MoneyColumn.php
+++ b/src/Tables/Columns/MoneyColumn.php
@@ -13,7 +13,7 @@ use Lattice\Lattice\Tables\Enums\ColumnType;
  * placement and per-currency decimals follow the active locale.
  */
 #[AsColumn(ColumnType::Money)]
-class MoneyColumn extends NumericColumn
+final class MoneyColumn extends NumericColumn
 {
     public ?string $currency = null;
 

--- a/src/Tables/Columns/NumberColumn.php
+++ b/src/Tables/Columns/NumberColumn.php
@@ -8,7 +8,7 @@ use Lattice\Lattice\Tables\Enums\ColumnType;
 use Lattice\Lattice\Ui\Enums\NumberFormatUnit;
 
 #[AsColumn(ColumnType::Number)]
-class NumberColumn extends NumericColumn
+final class NumberColumn extends NumericColumn
 {
     public ?NumberFormatUnit $unit = null;
 

--- a/src/Tables/Columns/StackColumn.php
+++ b/src/Tables/Columns/StackColumn.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Ui\Components\Concerns\HasChildSchema;
 use Lattice\Lattice\Ui\Enums\ColumnWidth;
 
 #[AsColumn(ColumnType::Stack)]
-class StackColumn extends Column
+final class StackColumn extends Column
 {
     use HasChildSchema;
 

--- a/src/Tables/Columns/TextColumn.php
+++ b/src/Tables/Columns/TextColumn.php
@@ -17,7 +17,7 @@ use Lattice\Lattice\Ui\Concerns\HasCopyable;
 use Lattice\Lattice\Ui\Enums\DateTimeStyle;
 
 #[AsColumn(ColumnType::Text)]
-class TextColumn extends Column implements Filterable, Searchable, Sortable
+final class TextColumn extends Column implements Filterable, Searchable, Sortable
 {
     use HasCopyable;
     use IsFilterable;

--- a/src/Tables/Filters/DateRangeFilter.php
+++ b/src/Tables/Filters/DateRangeFilter.php
@@ -14,7 +14,7 @@ use Lattice\Lattice\Tables\Enums\FilterControl;
  * inclusive `whereDate` comparison against the column.
  */
 #[AsFilter(FilterControl::DateRange)]
-class DateRangeFilter extends Filter
+final class DateRangeFilter extends Filter
 {
     /**
      * @return array<int, DateInput>

--- a/src/Tables/Filters/DateRangeFilter.php
+++ b/src/Tables/Filters/DateRangeFilter.php
@@ -28,11 +28,8 @@ final class DateRangeFilter extends Filter
         ];
     }
 
-    /**
-     * @return string|list<string|FilterIndicator|array{label?: string, value: mixed}>|array<string, mixed>|null
-     */
     #[\Override]
-    public function indicator(FormData $data): string|array|null
+    public function indicator(FormData $data): ?string
     {
         $from = $data->string('from');
         $until = $data->string('until');

--- a/src/Tables/Filters/Filter.php
+++ b/src/Tables/Filters/Filter.php
@@ -171,7 +171,7 @@ abstract class Filter implements JsonSerializable, Renderable
         }
 
         if (is_bool($value)) {
-            return $value ? 'Yes' : 'No';
+            return $value ? __('lattice::common.yes') : __('lattice::common.no');
         }
 
         return (string) $value;

--- a/src/Tables/Filters/SelectFilter.php
+++ b/src/Tables/Filters/SelectFilter.php
@@ -20,7 +20,7 @@ use Lattice\Lattice\Ui\Concerns\HasPlaceholder;
  * fixed list ({@see options}) or come from an {@see OptionSource} via {@see optionsFrom}.
  */
 #[AsFilter(FilterControl::Select)]
-class SelectFilter extends Filter
+final class SelectFilter extends Filter
 {
     use HasOptions;
     use HasPlaceholder;

--- a/src/Tables/Filters/SelectFilter.php
+++ b/src/Tables/Filters/SelectFilter.php
@@ -94,11 +94,8 @@ final class SelectFilter extends Filter
         return [$field->rules($this->multiple ? ['array'] : ['string'])];
     }
 
-    /**
-     * @return string|list<string|FilterIndicator|array{label?: string, value: mixed}>|array<string, mixed>|null
-     */
     #[\Override]
-    public function indicator(FormData $data): string|array|null
+    public function indicator(FormData $data): ?string
     {
         $values = $this->normalizeValues($data->get('value'));
 

--- a/src/Tables/Filters/TernaryFilter.php
+++ b/src/Tables/Filters/TernaryFilter.php
@@ -19,7 +19,7 @@ use Lattice\Lattice\Tables\Enums\FilterControl;
  * null-existence checks). Custom queries receive the `Builder` by type injection.
  */
 #[AsFilter(FilterControl::Ternary)]
-class TernaryFilter extends Filter
+final class TernaryFilter extends Filter
 {
     public string $trueLabel;
 

--- a/src/Tables/Filters/TernaryFilter.php
+++ b/src/Tables/Filters/TernaryFilter.php
@@ -21,15 +21,24 @@ use Lattice\Lattice\Tables\Enums\FilterControl;
 #[AsFilter(FilterControl::Ternary)]
 class TernaryFilter extends Filter
 {
-    public string $trueLabel = 'Yes';
+    public string $trueLabel;
 
-    public string $falseLabel = 'No';
+    public string $falseLabel;
 
-    public string $placeholder = 'All';
+    public string $placeholder;
 
     private ?Closure $trueQuery = null;
 
     private ?Closure $falseQuery = null;
+
+    public function __construct(string $key)
+    {
+        parent::__construct($key);
+
+        $this->trueLabel = __('lattice::common.yes');
+        $this->falseLabel = __('lattice::common.no');
+        $this->placeholder = __('lattice::common.all');
+    }
 
     public function trueLabel(string $label): static
     {

--- a/src/Tables/Filters/TernaryFilter.php
+++ b/src/Tables/Filters/TernaryFilter.php
@@ -90,11 +90,8 @@ final class TernaryFilter extends Filter
         ];
     }
 
-    /**
-     * @return string|list<string|FilterIndicator|array{label?: string, value: mixed}>|array<string, mixed>|null
-     */
     #[\Override]
-    public function indicator(FormData $data): string|array|null
+    public function indicator(FormData $data): ?string
     {
         $state = is_scalar($data->get('value'))
             ? filter_var($data->get('value'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)

--- a/src/Tables/Filters/ToggleFilter.php
+++ b/src/Tables/Filters/ToggleFilter.php
@@ -17,7 +17,7 @@ use Lattice\Lattice\Tables\Enums\FilterControl;
  * filter needs fields; use ToggleFilter when active state alone is enough.
  */
 #[AsFilter(FilterControl::Toggle)]
-class ToggleFilter extends Filter
+final class ToggleFilter extends Filter
 {
     private ?Closure $query = null;
 

--- a/src/Ui/Components/Modal.php
+++ b/src/Ui/Components/Modal.php
@@ -16,13 +16,20 @@ class Modal extends ContainerComponent
 
     public ?string $description = null;
 
-    public string $closeLabel = 'Close';
+    public string $closeLabel;
 
     public bool $open = false;
 
     public ?Side $side = null;
 
     public ModalWidth $width = ModalWidth::Lg;
+
+    public function __construct(?string $key = null)
+    {
+        parent::__construct($key);
+
+        $this->closeLabel = __('lattice::common.close');
+    }
 
     public static function make(string $id): static
     {

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -14,6 +14,12 @@ use Lattice\Lattice\Fragments\FragmentDefinition;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Layouts\LayoutDefinition;
 use Lattice\Lattice\Layouts\LayoutRegistry;
+use Lattice\Lattice\Tables\Columns\Column;
+use Lattice\Lattice\Tables\Columns\Concerns\IsFilterable;
+use Lattice\Lattice\Tables\Columns\Concerns\IsSearchable;
+use Lattice\Lattice\Tables\Columns\Concerns\IsSortable;
+use Lattice\Lattice\Tables\Columns\NumericColumn;
+use Lattice\Lattice\Tables\Filters\Filter;
 use Lattice\Lattice\Tables\Sources\Eloquent\EloquentTableDefinition;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableRegistry;
@@ -235,12 +241,12 @@ arch('table columns, table filters, and built-in effects are final')
     ])
     ->toBeFinal()
     ->ignoring([
-        'Lattice\Lattice\Tables\Columns\Column',
-        'Lattice\Lattice\Tables\Columns\NumericColumn',
-        'Lattice\Lattice\Tables\Columns\Concerns\IsFilterable',
-        'Lattice\Lattice\Tables\Columns\Concerns\IsSearchable',
-        'Lattice\Lattice\Tables\Columns\Concerns\IsSortable',
-        'Lattice\Lattice\Tables\Filters\Filter',
+        Column::class,
+        NumericColumn::class,
+        IsFilterable::class,
+        IsSearchable::class,
+        IsSortable::class,
+        Filter::class,
     ]);
 
 arch('no debug statements ship in the package')

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -108,6 +108,21 @@ arch('feature domains never depend upward on the orchestration or tooling layers
         'Lattice\Lattice\Console',
     ]);
 
+arch('the ui and secondary domains never depend upward on orchestration or tooling')
+    ->expect([
+        'Lattice\Lattice\Ui',
+        'Lattice\Lattice\Chat',
+        'Lattice\Lattice\Notifications',
+        'Lattice\Lattice\Realtime',
+        'Lattice\Lattice\Remote',
+        'Lattice\Lattice\Effects',
+        'Lattice\Lattice\I18n',
+    ])
+    ->not->toUse([
+        'Lattice\Lattice\Http',
+        'Lattice\Lattice\Console',
+    ]);
+
 /*
  * Attributes are a shared base layer of plain markers: they describe domain
  * objects without reaching into the domains. Actions is intentionally omitted
@@ -204,6 +219,29 @@ arch('the lattice facade extends the laravel facade')
 arch('columns never depend on eloquent')
     ->expect('Lattice\Lattice\Tables\Columns')
     ->not->toUse('Illuminate\Database\Eloquent');
+
+/*
+ * Ui\Components is intentionally excluded here: "lattice component factories
+ * stay open for extension" (tests/Unit/Core/ComponentSerializationTest.php)
+ * asserts consumers may subclass a component (e.g. Badge) and keep the
+ * static::make() factory working via late static binding, so those classes
+ * must not be final.
+ */
+arch('table columns, table filters, and built-in effects are final')
+    ->expect([
+        'Lattice\Lattice\Tables\Columns',
+        'Lattice\Lattice\Tables\Filters',
+        'Lattice\Lattice\Effects\Builtin',
+    ])
+    ->toBeFinal()
+    ->ignoring([
+        'Lattice\Lattice\Tables\Columns\Column',
+        'Lattice\Lattice\Tables\Columns\NumericColumn',
+        'Lattice\Lattice\Tables\Columns\Concerns\IsFilterable',
+        'Lattice\Lattice\Tables\Columns\Concerns\IsSearchable',
+        'Lattice\Lattice\Tables\Columns\Concerns\IsSortable',
+        'Lattice\Lattice\Tables\Filters\Filter',
+    ]);
 
 arch('no debug statements ship in the package')
     ->expect(['dd', 'ddd', 'dump', 'ray', 'var_dump', 'print_r'])

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -29,8 +29,9 @@ use Lattice\Lattice\Tables\TableRegistry;
  * only intentional cross-domain couplings are tables -> actions (row and bulk
  * actions), tables -> forms (table filters are form-field schemas), actions ->
  * forms (action forms), and layouts -> actions (menu items that trigger an
- * action). The UI link primitive may likewise trigger an action, the one
- * deliberate UI -> Actions coupling.
+ * action). The UI layer likewise reaches Actions in two deliberate spots — the
+ * Triggerable primitive (links/buttons that trigger an action) and TreeNode
+ * (which can hold a row action).
  *
  * Top: the orchestration and tooling layers — Http (which renders and routes
  * pages, including the page registry, by consuming the feature domains),

--- a/tests/Feature/Support/DeniedComponentHelpersTest.php
+++ b/tests/Feature/Support/DeniedComponentHelpersTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\BulkActionDefinition;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Attributes\AsBulkAction;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Attributes\AsTable;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Tables\CallbackTableSource;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Contracts\TableSource;
+use Lattice\Lattice\Tables\TableDefinition;
+use Lattice\Lattice\Tables\TableQuery;
+use Lattice\Lattice\Tables\TableResult;
+use Symfony\Component\HttpFoundation\Response;
+
+test('a plain callAction cannot even build the request for a denied action', function (): void {
+    Lattice::actions([DeniedHelperAction::class]);
+
+    expect(fn () => $this->callAction(DeniedHelperAction::class))
+        ->toThrow(LogicException::class, 'must not serialize');
+});
+
+test('callDeniedAction seals the ref directly and reaches the endpoint as a 403', function (): void {
+    Lattice::actions([DeniedHelperAction::class]);
+
+    $this->callDeniedAction(DeniedHelperAction::class)->assertForbidden();
+});
+
+test('submitDeniedForm seals the ref directly and reaches the endpoint as a 403', function (): void {
+    Lattice::forms([DeniedHelperForm::class]);
+
+    $this->submitDeniedForm(DeniedHelperForm::class)->assertForbidden();
+});
+
+test('loadDeniedTable seals the ref directly and reaches the endpoint as a 403', function (): void {
+    Lattice::tables([DeniedHelperTable::class]);
+
+    $this->loadDeniedTable(DeniedHelperTable::class)->assertForbidden();
+});
+
+test('callDeniedBulkAction seals the ref directly and reaches the endpoint as a 403', function (): void {
+    Lattice::bulkActions([DeniedHelperBulkAction::class]);
+
+    $this->callDeniedBulkAction(DeniedHelperBulkAction::class, [], ['table' => 'helper.denied-table'])
+        ->assertForbidden();
+});
+
+#[AsAction('helper.denied-action')]
+final class DeniedHelperAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Denied action');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+}
+
+#[AsForm('helper.denied-form')]
+final class DeniedHelperForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form;
+    }
+
+    public function handle(Request $request): Response
+    {
+        return new Response;
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+}
+
+#[AsTable('helper.denied-table')]
+final class DeniedHelperTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([]));
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+}
+
+#[AsBulkAction('helper.denied-bulk-action')]
+final class DeniedHelperBulkAction extends BulkActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Denied bulk action');
+    }
+
+    /**
+     * @param  Collection<int, mixed>  $records
+     */
+    public function handle(Collection $records, Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+}

--- a/tests/Feature/Support/EndpointTestingHelpersTest.php
+++ b/tests/Feature/Support/EndpointTestingHelpersTest.php
@@ -125,6 +125,19 @@ test('loadTable seals the ref and gets the table endpoint with query parameters'
         ->assertJsonPath('query.perPage', 10);
 });
 
+test('submitForm followed by callAction in the same test both succeed', function (): void {
+    Lattice::forms([HelperDemoForm::class]);
+    Lattice::actions([HelperDemoAction::class]);
+
+    $this->submitForm(HelperDemoForm::class, ['name' => 'Taylor'], ['team' => 'lattice-core'])
+        ->assertRedirect('/submitted');
+
+    $this->callAction(HelperDemoAction::class, ['name' => 'Ada'], ['team' => 'trusted-team'])
+        ->assertOk()
+        ->assertJsonPath('data.handled', 'Ada')
+        ->assertJsonPath('data.team', 'trusted-team');
+});
+
 test('loadFragment seals the ref and gets the lazy fragment endpoint', function (): void {
     Lattice::fragments([HelperDemoFragment::class]);
 

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -487,7 +487,7 @@ test('links serialize their icon and affixes', function (): void {
     ]);
 });
 
-it('serializes progress bars and circles', function (): void {
+test('serializes progress bars and circles', function (): void {
     $bar = wire(Progress::bar(72.5)->color(Color::success())->showValue());
 
     expect($bar['type'])->toBe('progress')

--- a/tests/Unit/Notifications/NotificationsComponentTest.php
+++ b/tests/Unit/Notifications/NotificationsComponentTest.php
@@ -36,7 +36,7 @@ test('the bell defaults to popover mode', function (): void {
 });
 
 describe('docs fixtures', function (): void {
-    it('matches the bell example fixture', function (): void {
+    test('matches the bell example fixture', function (): void {
         assertFixtureMatches('notifications.bell', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
             Notifications::make('notifications-bell'),
         ]))));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -405,6 +405,12 @@ export default defineConfig(({ mode }) => {
           "resources/js/test-support.ts",
           "resources/js/types/**",
         ],
+        thresholds: {
+          statements: 95,
+          branches: 87,
+          functions: 93,
+          lines: 95,
+        },
       },
     },
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -405,12 +405,6 @@ export default defineConfig(({ mode }) => {
           "resources/js/test-support.ts",
           "resources/js/types/**",
         ],
-        thresholds: {
-          statements: 95,
-          branches: 87,
-          functions: 93,
-          lines: 95,
-        },
       },
     },
   };


### PR DESCRIPTION
A curated cleanup sweep — almost entirely non-breaking, plus **one deliberate breaking alignment** (see below). Scope came from a fresh 4-agent audit + Solo-todo triage; most prior audit items were already shipped, so this is the genuine remainder.

## i18n consistency
Route hardcoded English UI defaults through the translation layer (`__()` / `translate()` / `useT()`) with en+de keys — 6 PHP sites (Modal, Ternary/Select/Filter labels, form validation summary) + 7 TS sites (`Run action` ×3 via a shared `actionLabel()`, `Submit`, `Dialog`, `Cancel`). Wire value stays a string; default-locale text is byte-for-byte unchanged.

## Tooling / CI hygiene
- CI **icons freshness gate** (diff `resources/icons` + `Icon.php` + `sprite-icons.ts` after build — successor to the lucide-downgrade trap).
- `.gitattributes` export-ignore for `codecov.yml`/`renovate.json`/`.mcp.json`/`solo.yml`; guard `postinstall boost:refresh` with `$CI`; NUL-safe pre-commit `xargs`; `check:package` added to the pre-push gate; codecov browser flag fix; removed stray root screenshots.

## Test rigor
- Arch: layering rules for 7 previously-unconstrained domains (Ui/Chat/Notifications/Realtime/Remote/Effects/I18n) + a scoped `toBeFinal()` (12 leaf column/filter classes; Ui components stay open by design).
- `failOnRisky`/`failOnWarning` in PHPUnit. (Coverage stays gated by Codecov's required project (90%) / patch (80%) checks — no brittle hardcoded Vitest thresholds.)
- Replaced 12 `as never` test fixtures with typed wire fixtures.

## Dead-code / consistency
Dropped dead toast barrel exports, fixed a `types/index` root-barrel round-trip, refreshed a stale ArchTest comment, normalized `it()`/`test()` in two files, and removed a dead `ref ?? ""` guard in the bulk bar (`getBulkActions` already normalizes it).

## Test-DX regression fixes (Solo #189, #191)
Additive, test-only: `callDeniedAction`/`submitDeniedForm`/… helpers so apps can test 403 paths again (broken by 0.18 render-auth), and a session-refresh so `submitForm()` + `callAction()` work in one test. Production signer untouched.

## ⚠️ Breaking change — `Confirmation.title` is now nullable
`Action::confirm()` no longer requires a title: `confirm(?string $title = null, …)`, and the wire type becomes `Confirmation.title: string | null`. This aligns `title` with its already-optional siblings (`description`/`confirmLabel`/`cancelLabel`) — the client already fell back to the action label for all of them. `->confirm()` is now usable without repeating the label. Consumers regenerating types will see `title` widen to `string | null`; existing `->confirm('Title', …)` calls are unaffected.

Also closed Solo #194 (page extension slots — shipped in 0.21).

## Verification
`composer check` + `npm run check` green (1230 Pest, full Vitest, type check, library build). Two `fix(tables)`/`chore(tests)` commits resolve PHPStan/Rector findings that only surfaced once the filter classes became `final`.

