### PR TITLE
feat(i18n): plugin-declared i18n namespaces

### DIFF
--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -134,4 +134,47 @@ Signature::make('signature')->label('Sign the contract');
   Tailwind content sources.
 </Warning>
 
+## Translations
+
+A package component translates like a built-in one: declare an i18next namespace on the plugin and read keys with `useT`, passing the English default inline at the call site:
+
+```ts
+import { createPlugin, lazyComponent } from "@lattice-php/lattice";
+
+export default createPlugin({
+  name: "acme-signature",
+  components: {
+    signature: lazyComponent(() => import("./signature")),
+  },
+  i18n: {
+    namespace: "acme-signature",
+  },
+});
+```
+
+```tsx
+import { useT } from "@lattice-php/lattice/i18n";
+
+const Signature: RendererComponent<"signature"> = ({ node }) => {
+  const { t } = useT("acme-signature");
+
+  return (
+    <div>
+      {typeof node.props?.label === "string" ? node.props.label : t("placeholder", "Sign here")}
+    </div>
+  );
+};
+```
+
+`createLatticeApp` merges every plugin's namespace into the [i18n bootstrap](/core/i18n/), so when the app enables the translation backend the namespace loads from `/locales/{lng}/acme-signature.json` like any other — serve the package's lang files by registering them on the translation loader in the package's service provider:
+
+```php
+$this->app->make('translation.loader')->addNamespace('acme-signature', __DIR__.'/../lang');
+```
+
+<Info>
+  The inline defaults are the no-backend fallback: apps that never enable the translation backend
+  render them as-is, and a loaded translation for the key always wins.
+</Info>
+
 See [Registry and types](/extending/registry-and-types/) for how the `type` string couples the two sides, and how generated types keep `node.props` sound.

--- a/packages/signature-example/resources/js/plugin.ts
+++ b/packages/signature-example/resources/js/plugin.ts
@@ -5,4 +5,7 @@ export default createPlugin({
   components: {
     signature: lazyComponent(() => import("./signature")),
   },
+  i18n: {
+    namespace: "signature-example",
+  },
 });

--- a/packages/signature-example/resources/js/signature.tsx
+++ b/packages/signature-example/resources/js/signature.tsx
@@ -1,7 +1,10 @@
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { useT } from "@lattice-php/lattice/i18n";
 
 const Signature: RendererComponent<"signature"> = ({ node }) => {
-  const label = typeof node.props?.label === "string" ? node.props.label : "Sign here";
+  const { t } = useT("signature-example");
+  const label =
+    typeof node.props?.label === "string" ? node.props.label : t("placeholder", "Sign here");
 
   return (
     <div

--- a/packages/signature-example/src/Components/Signature.php
+++ b/packages/signature-example/src/Components/Signature.php
@@ -10,7 +10,7 @@ use Lattice\Lattice\Ui\Components\Component;
 #[AsComponent('signature')]
 final class Signature extends Component
 {
-    public string $label = 'Sign here';
+    public ?string $label = null;
 
     public static function make(?string $key = null): static
     {

--- a/resources/js/core/registry.ts
+++ b/resources/js/core/registry.ts
@@ -26,11 +26,17 @@ export type ComponentRegistryFor<TTypes extends keyof ComponentPropsMap & string
   ComponentRegistration
 >;
 
+export type PluginI18n = {
+  /** i18next namespace the plugin's components translate under. */
+  namespace: string;
+};
+
 export type Plugin = {
   name: string;
   components?: ComponentRegistry;
   columns?: ColumnRegistry;
   effects?: EffectHandlerRegistry;
+  i18n?: PluginI18n;
 };
 
 export type Registry = {

--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -11,7 +11,6 @@ const router = vi.hoisted(() => ({
 const configureI18nFromPageProps = vi.hoisted(() =>
   vi.fn<(props: unknown, options?: unknown) => Promise<void>>(() => Promise.resolve()),
 );
-
 vi.mock("@inertiajs/react", async () =>
   (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
     createInertiaApp,
@@ -176,6 +175,48 @@ describe("createLatticeApp", () => {
 
     expect(configureI18nFromPageProps).toHaveBeenCalledWith(i18nProps, {
       namespaces: ["lattice", "app"],
+    });
+  });
+
+  it("merges plugin i18n namespaces into the i18n bootstrap", async () => {
+    createLatticeApp({
+      plugins: [{ name: "tree", i18n: { namespace: "tree" } }],
+    });
+
+    render(
+      captureOptions().withApp(<div data-test="app" />, {
+        ssr: false,
+        page: fakePage(i18nProps),
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+
+    expect(configureI18nFromPageProps).toHaveBeenCalledWith(i18nProps, {
+      namespaces: ["lattice", "tree"],
+    });
+  });
+
+  it("combines caller namespaces with plugin namespaces without duplicates", async () => {
+    createLatticeApp({
+      i18n: { namespaces: ["lattice", "app"] },
+      plugins: [
+        { name: "tree", i18n: { namespace: "tree" } },
+        { name: "dup", i18n: { namespace: "app" } },
+      ],
+    });
+
+    render(
+      captureOptions().withApp(<div data-test="app" />, {
+        ssr: false,
+        page: fakePage(i18nProps),
+      }),
+    );
+
+    await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+
+    expect(configureI18nFromPageProps).toHaveBeenCalledWith(i18nProps, {
+      namespaces: ["lattice", "app", "tree"],
     });
   });
 

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -2,9 +2,10 @@ import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
 import { createInertiaApp } from "@inertiajs/react";
 import { useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { initializeTheme } from "./appearance";
-import { extendRegistry, type Plugin, type Registry } from "./core/registry";
+import { extendRegistry, type Plugin, type PluginI18n, type Registry } from "./core/registry";
 import { setDefaultRegistry } from "./core/registry-context";
 import type { SpriteValue } from "./icons/sprite";
+import { DEFAULT_NAMESPACE } from "./i18n/instance";
 import { LocaleReload } from "./i18n/locale-reload";
 import { i18nConfigFromPageProps } from "./i18n/shared-props";
 import {
@@ -20,7 +21,10 @@ import { registry as defaultRegistry } from "./registry";
 type InertiaAppOptions = NonNullable<Parameters<typeof createInertiaApp>[0]>;
 
 export type CreateLatticeAppI18nOptions = {
-  /** i18next namespaces to load, e.g. `["lattice", "app"]`. Defaults to the package's own. */
+  /**
+   * i18next namespaces to load, e.g. `["lattice", "app"]`. Defaults to the
+   * package's own. Namespaces declared by plugins are merged in on top.
+   */
   namespaces?: string[];
 };
 
@@ -32,7 +36,8 @@ export type CreateLatticeAppOptions = Omit<
   /**
    * Component-package plugins to merge onto the registry — pass the
    * Composer-discovered `virtual:lattice/plugins` here to register vendor
-   * components with no manual `extendRegistry` call.
+   * components with no manual `extendRegistry` call. A plugin's declared
+   * i18n namespace joins the i18n bootstrap automatically.
    */
   plugins?: Plugin[];
   sprite?: SpriteValue;
@@ -60,6 +65,22 @@ export type CreateLatticeAppOptions = Omit<
    */
   wrap?: (app: ReactElement) => ReactElement;
 };
+
+function withPluginNamespaces(
+  options: CreateLatticeAppI18nOptions,
+  entries: PluginI18n[],
+): CreateLatticeAppI18nOptions {
+  if (entries.length === 0) {
+    return options;
+  }
+
+  const namespaces = new Set([
+    ...(options.namespaces ?? [DEFAULT_NAMESPACE]),
+    ...entries.map((entry) => entry.namespace),
+  ]);
+
+  return { ...options, namespaces: [...namespaces] };
+}
 
 // Fail-open: a failed bootstrap renders the app anyway (with fallback strings)
 // rather than a blank page.
@@ -110,6 +131,8 @@ export function createLatticeApp({
   setDefaultRegistry(activeRegistry);
 
   const i18nEnabled = i18n !== false;
+  const pluginI18n = plugins?.flatMap((plugin) => (plugin.i18n ? [plugin.i18n] : [])) ?? [];
+  const i18nOptions = i18nEnabled ? withPluginNamespaces(i18n ?? {}, pluginI18n) : {};
   const userVisitOptions = inertiaOptions.defaults?.visitOptions;
   const defaults = i18nEnabled
     ? {
@@ -134,7 +157,7 @@ export function createLatticeApp({
         if (i18nEnabled && i18nConfigFromPageProps(page.props) !== undefined) {
           pending.push(
             import("./i18n/page-props").then((module) =>
-              module.configureI18nFromPageProps(page.props, i18n ?? {}),
+              module.configureI18nFromPageProps(page.props, i18nOptions),
             ),
           );
         }

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -3,7 +3,7 @@ import { useCallback, useSyncExternalStore } from "react";
 import { useConfig } from "./config";
 import { currentLocale, subscribeLocale, useLocale } from "./locale";
 
-const NAMESPACE = "lattice";
+export const DEFAULT_NAMESPACE = "lattice";
 
 type TranslationFunction = (
   key: string,
@@ -60,8 +60,8 @@ export function ensureI18n(extend?: (base: InitOptions) => InitOptions): Promise
     const base: InitOptions = {
       lng: currentLocale(),
       fallbackLng: "en",
-      ns: [NAMESPACE],
-      defaultNS: NAMESPACE,
+      ns: [DEFAULT_NAMESPACE],
+      defaultNS: DEFAULT_NAMESPACE,
       interpolation: { escapeValue: false },
     };
 

--- a/tests/Browser/Platform/ComponentPackageTest.php
+++ b/tests/Browser/Platform/ComponentPackageTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 it('renders a component contributed by a third-party Composer package', function (): void {
     $this->visitAsWorkbenchUser('/platform/package')
-        ->assertSee('Vendor component rendered')
-        ->assertVisible('[data-test="signature-pad"]')
+        ->assertVisible('[data-test="signature-pad"]:has-text("Vendor component rendered")')
+        ->assertVisible('[data-test="signature-pad"]:has-text("Sign here")')
         ->assertNoSmoke();
 });

--- a/workbench/app/Pages/Platform/PackageComponentPage.php
+++ b/workbench/app/Pages/Platform/PackageComponentPage.php
@@ -30,6 +30,7 @@ final class PackageComponentPage extends WorkbenchPage
                     Heading::make('Signature demo'),
                     Text::make('A component contributed by a third-party Composer package.'),
                     Signature::make('signature')->label('Vendor component rendered'),
+                    Signature::make('signature-default'),
                 ]),
         ]);
     }


### PR DESCRIPTION
Component-package plugins can now declare `i18n: { namespace }` on `createPlugin`. `createLatticeApp` merges every plugin's namespace into the i18n bootstrap, so a package component's translations load from the backend with no manual namespace wiring. Components ship their English defaults inline at the call site (`t(key, default)`), the same pattern core components use.

The signature-example package demonstrates the seam end-to-end: its 'Sign here' fallback moved from hardcoded strings (on both sides of the wire) into the renderer's translation call, covered by the ComponentPackage browser test. The component-packages docs page gained a Translations section.

Groundwork for extracting Tree into its own first-party package, which needs a namespace of its own.