### PR TITLE
feat(js): export component-author helpers from the core subpath

### DIFF
--- a/resources/js/core/index.ts
+++ b/resources/js/core/index.ts
@@ -38,4 +38,8 @@ export {
   useEffectHandlerRegistry,
 } from "./registry-context";
 export { Renderer, RenderNode } from "./renderer";
+export { nodeIdentity } from "./test-id";
+export { usePersistentState } from "@lattice-php/lattice/lib/use-persistent-state";
+export type { PersistentStateOptions } from "@lattice-php/lattice/lib/use-persistent-state";
+export { cn } from "@lattice-php/lattice/lib/utils";
 export type * from "./types";


### PR DESCRIPTION
Re-lands the second commit of #298, which was merged before this commit reached the branch.

Vendor component packages compile against the consumer's node resolution, so they can only reach export-map subpaths. `nodeIdentity`, `cn`, and `usePersistentState` are part of the renderer-author toolkit but were only importable via deep paths — re-export them from `./core` alongside `Renderer`. The lattice-php/tree renderer imports them from there.