### PR TITLE
fix(vite): stub useEchoNotification for consumers without @laravel/echo-react

### DIFF
--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -97,6 +97,7 @@ describe("lattice Vite helper", () => {
     expect(code).toContain("export const useEcho =");
     expect(code).toContain("export const useEchoPublic =");
     expect(code).toContain("export const useEchoPresence =");
+    expect(code).toContain("export const useEchoNotification =");
   });
 
   it("defers to the real package when the optional Echo peer is installed", async () => {
@@ -189,13 +190,15 @@ describe("lattice Vite helper", () => {
   it("merges a partial dts override over the default file/augment targets", () => {
     const appRoot = path.resolve("/tmp/lattice-app");
 
-    const iconOptions = resolveIconOptions({ appRoot, icons: { dts: { indent: "\t" } } });
+    const iconOptions = resolveIconOptions({
+      appRoot,
+      icons: { dts: { augmentInterface: "MyIcons" } },
+    });
 
     expect(iconOptions?.dts).toEqual({
       file: "resources/js/types/sprite-icons.ts",
       augmentModule: "@lattice-php/lattice",
-      augmentInterface: "KnownIcons",
-      indent: "\t",
+      augmentInterface: "MyIcons",
     });
   });
 

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -209,6 +209,7 @@ const OPTIONAL_PEER_STUBS: Record<string, string> = {
     "export const useEcho = missing;",
     "export const useEchoPublic = missing;",
     "export const useEchoPresence = missing;",
+    "export const useEchoNotification = missing;",
   ].join("\n"),
 };
 


### PR DESCRIPTION
Two small cleanups found while building lattice-php/tree against 0.23:

- The optional-peer stub for `@laravel/echo-react` exports `useEcho`/`useEchoPublic`/`useEchoPresence` but not `useEchoNotification`, which `notifications-echo.tsx` imports — so any consumer without echo-react installed fails `vite build` with a MISSING_EXPORT. Stub now covers all four hooks core imports; test extended.
- `vite.test.ts` still passed `indent` to the icon `dts` options, an option the current `@lattice-php/vite-svg-sprite` no longer has — `npm run typecheck` was red on main. The partial-override case now uses `augmentInterface`.

(The Tree-removal half of this cleanup was already merged as #302.)