### PR TITLE
feat(i18n): accept rt() in notification titles/bodies and callout messages

### DIFF
--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -170,6 +170,24 @@ Effects::flash(
 The flashed effects are stored in the `latticeEffects` session bag, drained on the next request, and
 run through the normal client-side effect pipeline in order.
 
+### Deferred translation with `rt()`
+
+Toast and callout messages (and callout titles) also accept `rt()` — a
+[`Translatable`](/core/i18n/) that carries an i18next key plus replacements instead of a finished
+string. The client resolves it in the viewer's locale at display time. Reach for it when the code
+producing the effect can't know that locale — a queued listener flashing a callout, or a
+[realtime toast](/core/realtime/) broadcast to many subscribers:
+
+```php
+Effects::flash(
+    Callout::make(rt('billing:trial-ending.body')->with(['days' => 3]), Variant::Warning)
+        ->title(rt('billing:trial-ending.title'))
+);
+```
+
+Effects built inside a normal request already run in the user's locale, so plain `__()` strings
+remain the default there.
+
 ## How effects reach the client
 
 The result serializes to `{ ok, data, effects }`. Each effect is a `{ type, props }` envelope — the

--- a/docs/content/docs/components/notifications.mdx
+++ b/docs/content/docs/components/notifications.mdx
@@ -99,6 +99,29 @@ Notification::make()
   row instead of breaking the fetch.
 </Info>
 
+## Localized notifications
+
+A plain string bakes the sender's locale into the stored row — fine for content that is already
+user-specific, wrong for UI copy read later by someone whose language you don't know at send time.
+Pass `rt()` (a [`Translatable`](/core/i18n/)) instead and the notification stores the **key plus
+replacements**; the bell resolves it through i18next in the reading user's locale, at render time,
+and re-resolves it live when they switch languages:
+
+```php
+Notification::make()
+    ->title(rt('orders:notification.shipped.title'))
+    ->body(rt('orders:notification.shipped.body')->with(['order' => $order->number]))
+    ->href("/orders/{$order->id}")
+    ->send($order->user);
+```
+
+The key is an i18next key: with [laravel-i18next](/core/i18n/) serving your `lang/` files, each file
+is a namespace, so `lang/en/orders.php` with `'notification' => ['shipped' => ['title' => '…']]` is
+`orders:notification.shipped.title`. Make sure the namespace is in the `namespaces` list your app
+passes to `createLatticeApp` — an unloaded namespace renders the raw key. Laravel's `:placeholder`
+syntax is served as i18next `{{placeholder}}` tokens, so `->with([...])` replacements interpolate as
+usual. Mixing is fine — `title` can be an `rt()` key while `body` stays a plain string.
+
 ## Reusable notification classes
 
 For a notification that also needs other channels — mail, Slack, SMS — don't reach for a Lattice

--- a/resources/js/i18n/translatable.ts
+++ b/resources/js/i18n/translatable.ts
@@ -24,6 +24,10 @@ function readPath(payload: Record<string, unknown>, path: string): unknown {
   }, payload);
 }
 
+export function resolveText(value: string | Translatable | null, t: Translate): string | null {
+  return isTranslatable(value) ? resolveTranslatable(value, {}, t) : value;
+}
+
 export function resolveTranslatable(
   value: Translatable,
   payload: Record<string, unknown>,

--- a/resources/js/layout/components/callouts.test.tsx
+++ b/resources/js/layout/components/callouts.test.tsx
@@ -57,6 +57,29 @@ describe("Callouts slot", () => {
     expect(screen.queryByRole("button", { name: "Dismiss" })).not.toBeInTheDocument();
   });
 
+  it("resolves a translatable message and title to their keys when no catalog is loaded", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(LATTICE_EVENT.callout, {
+          detail: {
+            variant: "warning",
+            title: { key: "billing.trial-ending-title", payload: {}, replacements: {} },
+            message: { key: "billing.trial-ending", payload: {}, replacements: {} },
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByText("billing.trial-ending-title")).toBeInTheDocument();
+    expect(screen.getByText("billing.trial-ending")).toBeInTheDocument();
+  });
+
   it("renders a link action inside the callout", () => {
     render(
       <Provider toaster={false}>

--- a/resources/js/layout/components/callouts.tsx
+++ b/resources/js/layout/components/callouts.tsx
@@ -6,7 +6,7 @@ import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { onCallout } from "@lattice-php/lattice/toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
-import { isTranslatable, resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
+import { resolveText } from "@lattice-php/lattice/i18n/translatable";
 import { variantStyles } from "@lattice-php/lattice/toast";
 
 type CalloutItem = Callout & { id: number };
@@ -48,17 +48,9 @@ const Callouts: RendererComponent<"callouts"> = () => {
           {variantStyles[callout.variant].icon}
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             {callout.title ? (
-              <p className="text-sm font-medium text-lt-fg">
-                {isTranslatable(callout.title)
-                  ? resolveTranslatable(callout.title, {}, t)
-                  : callout.title}
-              </p>
+              <p className="text-sm font-medium text-lt-fg">{resolveText(callout.title, t)}</p>
             ) : null}
-            <p className="text-sm text-lt-fg">
-              {isTranslatable(callout.message)
-                ? resolveTranslatable(callout.message, {}, t)
-                : callout.message}
-            </p>
+            <p className="text-sm text-lt-fg">{resolveText(callout.message, t)}</p>
             {callout.action ? (
               <div className="flex flex-wrap gap-2">
                 <RenderNode node={callout.action} />

--- a/resources/js/layout/components/callouts.tsx
+++ b/resources/js/layout/components/callouts.tsx
@@ -6,6 +6,7 @@ import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import { onCallout } from "@lattice-php/lattice/toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
+import { isTranslatable, resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
 import { variantStyles } from "@lattice-php/lattice/toast";
 
 type CalloutItem = Callout & { id: number };
@@ -47,9 +48,17 @@ const Callouts: RendererComponent<"callouts"> = () => {
           {variantStyles[callout.variant].icon}
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             {callout.title ? (
-              <p className="text-sm font-medium text-lt-fg">{callout.title}</p>
+              <p className="text-sm font-medium text-lt-fg">
+                {isTranslatable(callout.title)
+                  ? resolveTranslatable(callout.title, {}, t)
+                  : callout.title}
+              </p>
             ) : null}
-            <p className="text-sm text-lt-fg">{callout.message}</p>
+            <p className="text-sm text-lt-fg">
+              {isTranslatable(callout.message)
+                ? resolveTranslatable(callout.message, {}, t)
+                : callout.message}
+            </p>
             {callout.action ? (
               <div className="flex flex-wrap gap-2">
                 <RenderNode node={callout.action} />

--- a/resources/js/notifications/components/notification-item.test.tsx
+++ b/resources/js/notifications/components/notification-item.test.tsx
@@ -85,6 +85,24 @@ describe("NotificationItemRow", () => {
     expect(onDismiss).toHaveBeenCalledWith("notice-a");
   });
 
+  it("resolves a translatable title and body to their keys when no catalog is loaded", () => {
+    render(
+      <ul>
+        <NotificationItemRow
+          notification={item({
+            title: { key: "orders.shipped.title", payload: {}, replacements: {} },
+            body: { key: "orders.shipped.body", payload: {}, replacements: {} },
+          })}
+          onDismiss={vi.fn<(id: string) => void>()}
+          onMarkRead={vi.fn<(id: string) => void>()}
+        />
+      </ul>,
+    );
+
+    expect(screen.getByText("orders.shipped.title")).toBeInTheDocument();
+    expect(screen.getByText("orders.shipped.body")).toBeInTheDocument();
+  });
+
   it("marks linked notifications read when the link is opened", () => {
     const onMarkRead = vi.fn<(id: string) => void>();
 

--- a/resources/js/notifications/components/notification-item.tsx
+++ b/resources/js/notifications/components/notification-item.tsx
@@ -2,6 +2,7 @@ import { Link } from "@inertiajs/react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import { IconRenderer } from "@lattice-php/lattice/icons";
 import { useT } from "@lattice-php/lattice/i18n";
+import { isTranslatable, resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import type { NotificationItem } from "@lattice-php/lattice/notifications/types";
 
@@ -23,12 +24,17 @@ export function NotificationItemRow({
 }) {
   const { t } = useT("lattice");
 
+  const title = isTranslatable(notification.title)
+    ? resolveTranslatable(notification.title, {}, t)
+    : notification.title;
+  const body = isTranslatable(notification.body)
+    ? resolveTranslatable(notification.body, {}, t)
+    : notification.body;
+
   const content = (
     <>
-      {notification.title ? (
-        <p className="truncate text-sm font-medium text-lt-fg">{notification.title}</p>
-      ) : null}
-      {notification.body ? <p className="text-sm text-lt-muted-fg">{notification.body}</p> : null}
+      {title ? <p className="truncate text-sm font-medium text-lt-fg">{title}</p> : null}
+      {body ? <p className="text-sm text-lt-muted-fg">{body}</p> : null}
     </>
   );
 

--- a/resources/js/notifications/components/notification-item.tsx
+++ b/resources/js/notifications/components/notification-item.tsx
@@ -2,7 +2,7 @@ import { Link } from "@inertiajs/react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import { IconRenderer } from "@lattice-php/lattice/icons";
 import { useT } from "@lattice-php/lattice/i18n";
-import { isTranslatable, resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
+import { resolveText } from "@lattice-php/lattice/i18n/translatable";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import type { NotificationItem } from "@lattice-php/lattice/notifications/types";
 
@@ -24,12 +24,8 @@ export function NotificationItemRow({
 }) {
   const { t } = useT("lattice");
 
-  const title = isTranslatable(notification.title)
-    ? resolveTranslatable(notification.title, {}, t)
-    : notification.title;
-  const body = isTranslatable(notification.body)
-    ? resolveTranslatable(notification.body, {}, t)
-    : notification.body;
+  const title = resolveText(notification.title, t);
+  const body = resolveText(notification.body, t);
 
   const content = (
     <>

--- a/resources/js/toast/callout.test.ts
+++ b/resources/js/toast/callout.test.ts
@@ -23,6 +23,16 @@ describe("normalizeCallout", () => {
     expect(normalizeCallout({ variant: "info" })).toBeNull();
   });
 
+  it("keeps translatable messages and titles", () => {
+    const message = { key: "billing.trial-ending", payload: {}, replacements: { days: 3 } };
+    const title = { key: "billing.trial-ending-title", payload: {}, replacements: {} };
+
+    const callout = normalizeCallout({ message, title });
+
+    expect(callout?.message).toEqual(message);
+    expect(callout?.title).toEqual(title);
+  });
+
   it("defaults variant and dismissible", () => {
     const callout = normalizeCallout({ message: "Hi" });
     expect(callout?.variant).toBe("info");

--- a/resources/js/toast/callout.ts
+++ b/resources/js/toast/callout.ts
@@ -1,5 +1,6 @@
 import type { Callout } from "@lattice-php/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
+import { isTranslatable } from "@lattice-php/lattice/i18n/translatable";
 import { isVariant } from "./toast";
 
 export type { Callout };
@@ -11,15 +12,20 @@ export function normalizeCallout(detail: unknown): Callout | null {
 
   const callout = detail as Record<string, unknown>;
 
-  if (typeof callout.message !== "string" || callout.message === "") {
+  const rawMessage = callout.message;
+  const message =
+    typeof rawMessage === "string" ? rawMessage : isTranslatable(rawMessage) ? rawMessage : null;
+
+  if (message === null || message === "") {
     return null;
   }
 
   return {
     action: (callout.action as Callout["action"]) ?? null,
     dismissible: callout.dismissible !== false,
-    message: callout.message,
-    title: typeof callout.title === "string" ? callout.title : null,
+    message,
+    title:
+      typeof callout.title === "string" || isTranslatable(callout.title) ? callout.title : null,
     variant: isVariant(callout.variant) ? callout.variant : "info",
   };
 }

--- a/resources/js/toast/toaster.tsx
+++ b/resources/js/toast/toaster.tsx
@@ -7,7 +7,7 @@ import { onToast } from "./toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
 import { variantStyles } from "./variant-styles";
-import { resolveTranslatable } from "@lattice-php/lattice/i18n/translatable";
+import { resolveText } from "@lattice-php/lattice/i18n/translatable";
 
 type ToastItem = ToastMessage & { id: number };
 
@@ -51,9 +51,7 @@ export function Toaster({ duration = 4000 }: { duration?: number }) {
           {variantStyles[toast.variant].icon}
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             <Toast.Title className="text-sm text-lt-fg">
-              {typeof toast.message === "string"
-                ? toast.message
-                : resolveTranslatable(toast.message, {}, t)}
+              {resolveText(toast.message, t)}
             </Toast.Title>
             {toast.action ? (
               <div className="flex flex-wrap gap-2">

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -284,8 +284,8 @@ export type ButtonVariant =
 export type Callout = {
   action: Node | null;
   dismissible: boolean;
-  message: string;
-  title: string | null;
+  message: Translatable | string;
+  title: Translatable | string | null;
   variant: Variant;
 };
 export type Callouts = Record<string, never>;
@@ -1032,13 +1032,13 @@ export type NodeType =
   | "topbar";
 export type NotificationItem = {
   readonly actions: Node[];
-  readonly body: string | null;
+  readonly body: Translatable | string | null;
   readonly createdAt: string | null;
   readonly href: string | null;
   readonly icon: string | null;
   readonly id: string;
   readonly isRead: boolean;
-  readonly title: string | null;
+  readonly title: Translatable | string | null;
   readonly variant: Variant | null;
 };
 export type NotificationList = {

--- a/src/Effects/Builtin/Callout.php
+++ b/src/Effects/Builtin/Callout.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Effects\Builtin;
 
 use Lattice\Lattice\Effects\Attributes\AsEffect;
 use Lattice\Lattice\Effects\Effect;
+use Lattice\Lattice\I18n\Values\Translatable;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\Link;
 use Lattice\Lattice\Ui\Enums\HttpMethod;
@@ -20,18 +21,18 @@ final class Callout extends Effect
 {
     private function __construct(
         public Variant $variant,
-        public string $message,
-        public ?string $title = null,
+        public string|Translatable $message,
+        public string|Translatable|null $title = null,
         public bool $dismissible = true,
         public ?Component $action = null,
     ) {}
 
-    public static function make(string $message, Variant $variant = Variant::Info): self
+    public static function make(string|Translatable $message, Variant $variant = Variant::Info): self
     {
         return new self($variant, $message);
     }
 
-    public function title(string $title): self
+    public function title(string|Translatable $title): self
     {
         $this->title = $title;
 

--- a/src/Http/Controllers/NotificationController.php
+++ b/src/Http/Controllers/NotificationController.php
@@ -89,10 +89,6 @@ final class NotificationController
 
     private function text(mixed $value): string|Translatable|null
     {
-        if (is_array($value) && is_string($value['key'] ?? null)) {
-            return Translatable::fromWire($value);
-        }
-
-        return is_string($value) ? $value : null;
+        return Translatable::tryFromWire($value) ?? (is_string($value) ? $value : null);
     }
 }

--- a/src/Http/Controllers/NotificationController.php
+++ b/src/Http/Controllers/NotificationController.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\DatabaseNotification;
+use Lattice\Lattice\I18n\Values\Translatable;
 use Lattice\Lattice\Notifications\NotificationItem;
 use Lattice\Lattice\Notifications\NotificationList;
 use Lattice\Lattice\Notifications\Support\ActionDescriptor;
@@ -72,8 +73,8 @@ final class NotificationController
 
         return new NotificationItem(
             id: $notification->getAttribute('id'),
-            title: $data['title'] ?? $data['message'] ?? $data['subject'] ?? null,
-            body: $data['body'] ?? (($data['title'] ?? null) ? ($data['message'] ?? null) : null),
+            title: $this->text($data['title'] ?? $data['message'] ?? $data['subject'] ?? null),
+            body: $this->text($data['body'] ?? (($data['title'] ?? null) ? ($data['message'] ?? null) : null)),
             icon: $data['icon'] ?? null,
             variant: is_string($variant) ? Variant::tryFrom($variant) : null,
             href: $data['href'] ?? null,
@@ -84,5 +85,14 @@ final class NotificationController
                 $data['actions'] ?? [],
             ))),
         );
+    }
+
+    private function text(mixed $value): string|Translatable|null
+    {
+        if (is_array($value) && is_string($value['key'] ?? null)) {
+            return Translatable::fromWire($value);
+        }
+
+        return is_string($value) ? $value : null;
     }
 }

--- a/src/I18n/Values/Translatable.php
+++ b/src/I18n/Values/Translatable.php
@@ -31,6 +31,21 @@ final class Translatable implements JsonSerializable
     }
 
     /**
+     * Rehydrate a Translatable from its serialized wire shape, e.g. when it
+     * comes back out of a database notification's stored payload.
+     *
+     * @param  array<string, mixed>  $wire
+     */
+    public static function fromWire(array $wire): self
+    {
+        $translatable = new self((string) $wire['key']);
+        $translatable->payload = (array) ($wire['payload'] ?? []);
+        $translatable->replacements = (array) ($wire['replacements'] ?? []);
+
+        return $translatable;
+    }
+
+    /**
      * @param  array<string, string>  $paths  replacement name => dotted payload path
      */
     public function fromPayload(array $paths): self

--- a/src/I18n/Values/Translatable.php
+++ b/src/I18n/Values/Translatable.php
@@ -31,6 +31,20 @@ final class Translatable implements JsonSerializable
     }
 
     /**
+     * Rehydrate a value that may be a serialized wire shape, e.g. an untyped
+     * database notification payload. Returns null for anything that does not
+     * look like one.
+     */
+    public static function tryFromWire(mixed $value): ?self
+    {
+        if (! is_array($value) || ! is_string($value['key'] ?? null)) {
+            return null;
+        }
+
+        return self::fromWire($value);
+    }
+
+    /**
      * Rehydrate a Translatable from its serialized wire shape, e.g. when it
      * comes back out of a database notification's stored payload.
      *

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -99,8 +99,8 @@ final class Notification
     {
         return [
             'format' => 'lattice',
-            'title' => $this->title instanceof Translatable ? $this->title->jsonSerialize() : $this->title,
-            'body' => $this->body instanceof Translatable ? $this->body->jsonSerialize() : $this->body,
+            'title' => Wire::toWire($this->title),
+            'body' => Wire::toWire($this->body),
             'icon' => $this->icon,
             'variant' => $this->variant->value,
             'href' => $this->href,

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Notifications;
 
 use BackedEnum;
+use Lattice\Lattice\I18n\Values\Translatable;
 use Lattice\Lattice\Notifications\Support\ActionDescriptor;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Enums\Variant;
 
 final class Notification
 {
-    private ?string $title = null;
+    private string|Translatable|null $title = null;
 
-    private ?string $body = null;
+    private string|Translatable|null $body = null;
 
     private ?string $icon = null;
 
@@ -29,14 +30,14 @@ final class Notification
         return new self;
     }
 
-    public function title(string $title): self
+    public function title(string|Translatable $title): self
     {
         $this->title = $title;
 
         return $this;
     }
 
-    public function body(string $body): self
+    public function body(string|Translatable $body): self
     {
         $this->body = $body;
 
@@ -98,8 +99,8 @@ final class Notification
     {
         return [
             'format' => 'lattice',
-            'title' => $this->title,
-            'body' => $this->body,
+            'title' => $this->title instanceof Translatable ? $this->title->jsonSerialize() : $this->title,
+            'body' => $this->body instanceof Translatable ? $this->body->jsonSerialize() : $this->body,
             'icon' => $this->icon,
             'variant' => $this->variant->value,
             'href' => $this->href,

--- a/src/Notifications/NotificationItem.php
+++ b/src/Notifications/NotificationItem.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Notifications;
 
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\I18n\Values\Translatable;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Enums\Variant;
 
@@ -20,8 +21,8 @@ final readonly class NotificationItem
      */
     public function __construct(
         public string $id,
-        public ?string $title,
-        public ?string $body,
+        public string|Translatable|null $title,
+        public string|Translatable|null $body,
         public ?string $icon,
         public ?Variant $variant,
         public ?string $href,

--- a/tests/Feature/Actions/EffectSerializationTest.php
+++ b/tests/Feature/Actions/EffectSerializationTest.php
@@ -96,6 +96,20 @@ test('a callout effect serializes its callout payload', function (): void {
         ->and($wire['props']['action']['props']['label'])->toBe('Upgrade');
 });
 
+test('a callout accepts a translatable message and title', function (): void {
+    $wire = wire(
+        Callout::make(Translatable::make('billing.trial-ending.body')->with(['days' => 3]), Variant::Warning)
+            ->title(Translatable::make('billing.trial-ending.title')),
+    );
+
+    expect($wire['props']['message'])->toBe([
+        'key' => 'billing.trial-ending.body',
+        'payload' => [],
+        'replacements' => ['days' => 3],
+    ])
+        ->and($wire['props']['title']['key'])->toBe('billing.trial-ending.title');
+});
+
 test('action results expose the callout effect', function (): void {
     $result = ActionResult::success()->callout(
         Callout::make('Saved as draft.', Variant::Info),

--- a/tests/Feature/Notifications/NotificationIndexTest.php
+++ b/tests/Feature/Notifications/NotificationIndexTest.php
@@ -30,6 +30,22 @@ test('index returns the users notifications with an unread count', function (): 
         ->assertJsonPath('notifications.0.isRead', false);
 });
 
+test('index returns translatable titles and bodies as their wire shape', function (): void {
+    $user = workbenchTestUser();
+    Notification::make()
+        ->title(rt('orders.shipped.title'))
+        ->body(rt('orders.shipped.body')->with(['order' => 1234]))
+        ->send($user);
+
+    actingAs($user);
+
+    getJson('/lattice/notifications')
+        ->assertOk()
+        ->assertJsonPath('notifications.0.title.key', 'orders.shipped.title')
+        ->assertJsonPath('notifications.0.body.key', 'orders.shipped.body')
+        ->assertJsonPath('notifications.0.body.replacements.order', 1234);
+});
+
 test('index never leaks another users notifications', function (): void {
     $me = workbenchTestUser();
     $other = workbenchTestUser();

--- a/tests/Feature/Notifications/SendNotificationTest.php
+++ b/tests/Feature/Notifications/SendNotificationTest.php
@@ -19,6 +19,20 @@ test('send persists a lattice payload to the native notifications table', functi
     ])->and($row->getAttribute('read_at'))->toBeNull();
 });
 
+test('send persists a translatable title and body as their wire shape', function (): void {
+    $user = workbenchTestUser();
+
+    Notification::make()
+        ->title(rt('orders.shipped.title'))
+        ->body(rt('orders.shipped.body')->with(['order' => 1234]))
+        ->send($user);
+
+    $data = $user->notifications()->first()->getAttribute('data');
+
+    expect($data['title'])->toBe(['key' => 'orders.shipped.title', 'payload' => [], 'replacements' => []])
+        ->and($data['body'])->toBe(['key' => 'orders.shipped.body', 'payload' => [], 'replacements' => ['order' => 1234]]);
+});
+
 test('via includes broadcast for send and omits it for sendToDatabase', function (): void {
     $user = workbenchTestUser();
 

--- a/tests/Unit/Core/Values/TranslatableTest.php
+++ b/tests/Unit/Core/Values/TranslatableTest.php
@@ -32,3 +32,13 @@ test('payload and replacement calls merge instead of replacing', function (): vo
 test('rt() returns a Translatable for the given key', function (): void {
     expect(rt('a.b')->jsonSerialize()['key'])->toBe('a.b');
 });
+
+test('it rehydrates from its wire shape', function (): void {
+    $wire = [
+        'key' => 'orders.shipped-live',
+        'payload' => ['id' => 'order.id'],
+        'replacements' => ['warehouse' => 'Berlin'],
+    ];
+
+    expect(Translatable::fromWire($wire)->jsonSerialize())->toBe($wire);
+});


### PR DESCRIPTION
Notification content used to be plain strings, so translations were baked in the sender's locale at send time — wrong for a persistent inbox read later, and for broadcasts fanned out to users in different locales.

- `Notification::title()` / `->body()` accept `rt()` (`Translatable`): the database payload stores the key + replacements, `NotificationController` rehydrates them (`Translatable::fromWire()`), and the bell resolves through i18next in the reading user's locale — including live re-resolution on locale switch. The broadcast payload carries the same shape, so realtime items resolve identically.
- `Callout::make()` / `->title()` accept `Translatable` too — the same locale-less gap exists for callouts flashed from queued listeners, and Toast already supported it; Callout was the odd one out.
- Generated TS types widened (`NotificationItem`, `Callout`); `normalizeCallout` and the renderers resolve translatables with the established `isTranslatable`/`resolveTranslatable` helpers.
- Docs: first documentation of `rt()` — a "Localized notifications" section on the notifications page and a "Deferred translation" section on the effects page.

Left as strings deliberately: notification action labels (the action definition already builds its label at fetch time in the reader's locale) and toast/callout/notification link labels (labels of materialized components — a component-level concern, not an effect payload one).

Backwards compatible: plain strings behave exactly as before.