### PR TITLE
feat(forms): wizard multi-step form with per-step precognitive validation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -132,6 +132,7 @@ export default defineConfig({
             },
             { label: "Validation", link: "/forms/validation/" },
             { label: "Conditional fields", link: "/forms/conditional-fields/" },
+            { label: "Wizard", link: "/forms/wizard/" },
           ],
         },
         {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 codecov:
   notify:
     after_n_builds: 4
-    wait_for_ci: true
 
 coverage:
   status:

--- a/docs/content/docs/forms/wizard.mdx
+++ b/docs/content/docs/forms/wizard.mdx
@@ -125,6 +125,12 @@ WizardStep::make('review')->schema([
 A step whose fields are all computed still advances through Next without validating anything —
 computed fields carry no rules of their own.
 
+## Wizards in actions
+
+A [form action](/actions/confirmation-and-forms/) can carry a wizard the same way: declare it as the sole root child
+of the action's form schema. The modal then drops its own submit button — Next validates the active
+step against the action endpoint, and Finish submits the action itself.
+
 ## Conditional fields and steps
 
 [`visibleWhen`, `requiredWhen`, `readOnlyWhen`, and `disabledWhen`](/forms/conditional-fields/) work

--- a/docs/content/docs/forms/wizard.mdx
+++ b/docs/content/docs/forms/wizard.mdx
@@ -103,6 +103,28 @@ badges every errored step in the rail, so the user always lands where the proble
   the page restarts the wizard from its first step.
 </Warning>
 
+## Review steps
+
+A closing step summarizes what the user entered with computed, read-only fields: a field whose
+`value()` is a closure recomputes on the server whenever the form changes, so the summary follows
+the earlier steps' input automatically.
+
+```php
+WizardStep::make('review')->schema([
+    TextInput::make('review_name', 'Name')
+        ->readOnly()
+        ->value(fn (FormData $data): string => $data->string('name')),
+    TextInput::make('review_items', 'Items')
+        ->readOnly()
+        ->value(fn (FormData $data): string => collect($data->get('items', []))
+            ->map(fn (array $row): string => $row['qty'].' × '.$row['sku'])
+            ->join(', ')),
+]),
+```
+
+A step whose fields are all computed still advances through Next without validating anything —
+computed fields carry no rules of their own.
+
 ## Conditional fields and steps
 
 [`visibleWhen`, `requiredWhen`, `readOnlyWhen`, and `disabledWhen`](/forms/conditional-fields/) work

--- a/docs/content/docs/forms/wizard.mdx
+++ b/docs/content/docs/forms/wizard.mdx
@@ -108,16 +108,14 @@ badges every errored step in the rail, so the user always lands where the proble
 [`visibleWhen`, `requiredWhen`, `readOnlyWhen`, and `disabledWhen`](/forms/conditional-fields/) work
 the same inside a wizard step as anywhere else — they react to other fields in the form.
 
-<Info>
-  A step carries the same render gate as every other component. `WizardStep::make('two')->hidden()`
-  drops the step from the serialized schema entirely, and `->visible()` is the inverse — both
-  resolved once when the form renders, including the closure form. `visibleWhen` and its siblings
-  stay scoped to fields; reach for `->hidden()` / `->visible()` when the step itself needs to come
-  and go.
+<Info title="Gate fields, not steps">
+  A field hidden by `visibleWhen` or `->hidden()` is skipped by server-side validation too, so
+  conditional behavior inside a wizard stays in sync on both sides when the conditions live on the
+  fields themselves.
 </Info>
 
 ## Common options
 
-`Wizard` and `WizardStep` share label, description, and schema with the rest of the component system.
-For the field types that go inside a step's schema, see [Fields](/forms/fields/overview/); for the
-rules that Next and Finish validate, see [Validation](/forms/validation/).
+`WizardStep` carries its own `name`, `label`, and `description`; `Wizard` carries `orientation`. For
+the field types that go inside a step's schema, see [Fields](/forms/fields/overview/); for the rules
+that Next and Finish validate, see [Validation](/forms/validation/).

--- a/docs/content/docs/forms/wizard.mdx
+++ b/docs/content/docs/forms/wizard.mdx
@@ -1,0 +1,123 @@
+---
+title: Wizard
+description: A multi-step form that validates one step at a time and submits only when every step is complete.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+import Info from "@components/Info.astro";
+import Warning from "@components/Warning.astro";
+
+`Wizard::make([...WizardStep])` splits a form into steps the user moves through one at a time. It
+must be the only root child of the form's schema — placed beside another component, or nested inside
+a layout container, it throws. Declaring one replaces the form's default submit row with its own
+Back / Next / Finish controls.
+
+```php
+use Lattice\Lattice\Forms\Components\Wizard;
+use Lattice\Lattice\Forms\Components\WizardStep;
+
+$form->schema([
+    Wizard::make([
+        WizardStep::make('customer')->schema([
+            TextInput::make('name', 'Name')->required(),
+            TextInput::make('email', 'Email')->rules(['required', 'email']),
+        ]),
+        WizardStep::make('items')->schema([
+            Repeater::make('items', 'Line items')->schema([
+                TextInput::make('sku', 'SKU')->required(),
+                TextInput::make('qty', 'Qty')->rules(['required', 'integer']),
+            ]),
+        ]),
+        WizardStep::make('review')->schema([
+            Text::make('Everything looks good — finish to place the order.'),
+        ]),
+    ]),
+]);
+```
+
+## Steps
+
+Each `WizardStep::make($name)` carries its own `->schema()` of fields, exactly like a form's own
+schema. Its label defaults to a headline-cased version of the name — `shipping-address` becomes
+"Shipping Address" — or pass a second argument to set one explicitly. `->description()` adds a longer
+summary of the step, shown alongside the label when the wizard is [vertical](#orientation).
+
+## Orientation
+
+The default horizontal layout puts the steps in a strip above the active step's fields. Call
+`->vertical()` to move the steps into a sidebar rail instead — the only layout that also shows each
+step's description.
+
+<ComponentExample
+  php={`Wizard::make([
+    WizardStep::make('customer')
+        ->description('Who is this order for?')
+        ->schema([
+            Text::make('Confirm the customer before moving on.'),
+        ]),
+    WizardStep::make('shipping-address')
+        ->description('Where should we send it?')
+        ->schema([
+            Text::make('Add the shipping details.'),
+        ]),
+    WizardStep::make('review')
+        ->description('Check everything before you finish.')
+        ->schema([
+            Text::make('Everything looks good — finish to place the order.'),
+        ]),
+])->vertical();`}
+  fixture="wizard.basic"
+/>
+
+## Advancing with Next
+
+Next validates only the active step's fields, through the same
+[Precognition](/forms/validation/#live-validation) pipeline as the rest of the form — scoped to that
+step's field names, so a later step's rules never block an earlier one. A step with no fields, like
+the review step above, advances immediately with no round trip at all.
+
+<Info>
+  Dynamic rules and rule closures see the whole form, not just the active step. A rule that reads a
+  later step's field still runs during an earlier step's `Next` validation — at that point the later
+  field is empty, so write such rules to tolerate absence there. The [final submit](#finishing)
+  validates the complete data and is where they should actually apply.
+</Info>
+
+## Moving around
+
+Back always moves to the previous step, unvalidated. The step rail lets the user jump back to any
+step already visited, but not ahead — a step becomes reachable only once Next has cleared the one
+before it.
+
+## Finishing
+
+Finish is the form's real submit: it posts to the form's own endpoint and validates every step's rules
+at once, regardless of what Next already cleared client-side. This is the actual gating boundary —
+nothing reaches `handle()` until the whole form passes.
+
+If the submission comes back invalid, the wizard jumps to the first step that owns an error and
+badges every errored step in the rail, so the user always lands where the problem is.
+
+<Warning title="State lives on the client">
+  The wizard keeps the active step, visited steps, and field values in the browser only. Reloading
+  the page restarts the wizard from its first step.
+</Warning>
+
+## Conditional fields and steps
+
+[`visibleWhen`, `requiredWhen`, `readOnlyWhen`, and `disabledWhen`](/forms/conditional-fields/) work
+the same inside a wizard step as anywhere else — they react to other fields in the form.
+
+<Info>
+  A step carries the same render gate as every other component. `WizardStep::make('two')->hidden()`
+  drops the step from the serialized schema entirely, and `->visible()` is the inverse — both
+  resolved once when the form renders, including the closure form. `visibleWhen` and its siblings
+  stay scoped to fields; reach for `->hidden()` / `->visible()` when the step itself needs to come
+  and go.
+</Info>
+
+## Common options
+
+`Wizard` and `WizardStep` share label, description, and schema with the rest of the component system.
+For the field types that go inside a step's schema, see [Fields](/forms/fields/overview/); for the
+rules that Next and Finish validate, see [Validation](/forms/validation/).

--- a/docs/fixtures/wizard.basic.json
+++ b/docs/fixtures/wizard.basic.json
@@ -1,0 +1,70 @@
+[
+    {
+        "props": {
+            "orientation": "vertical"
+        },
+        "schema": [
+            {
+                "props": {
+                    "description": "Who is this order for?",
+                    "label": "Customer",
+                    "name": "customer"
+                },
+                "schema": [
+                    {
+                        "props": {
+                            "align": null,
+                            "color": null,
+                            "copyable": false,
+                            "size": "md",
+                            "text": "Confirm the customer before moving on."
+                        },
+                        "type": "text"
+                    }
+                ],
+                "type": "wizard-step"
+            },
+            {
+                "props": {
+                    "description": "Where should we send it?",
+                    "label": "Shipping Address",
+                    "name": "shipping-address"
+                },
+                "schema": [
+                    {
+                        "props": {
+                            "align": null,
+                            "color": null,
+                            "copyable": false,
+                            "size": "md",
+                            "text": "Add the shipping details."
+                        },
+                        "type": "text"
+                    }
+                ],
+                "type": "wizard-step"
+            },
+            {
+                "props": {
+                    "description": "Check everything before you finish.",
+                    "label": "Review",
+                    "name": "review"
+                },
+                "schema": [
+                    {
+                        "props": {
+                            "align": null,
+                            "color": null,
+                            "copyable": false,
+                            "size": "md",
+                            "text": "Everything looks good — finish to place the order."
+                        },
+                        "type": "text"
+                    }
+                ],
+                "type": "wizard-step"
+            }
+        ],
+        "type": "wizard"
+    }
+]

--- a/lang/de/form.php
+++ b/lang/de/form.php
@@ -51,4 +51,10 @@ return [
     ],
     'submit' => 'Absenden',
     'validation-summary' => 'Bitte diese Felder korrigieren:',
+    'wizard' => [
+        'back' => 'Zurück',
+        'finish' => 'Fertigstellen',
+        'next' => 'Weiter',
+        'steps' => 'Schritte',
+    ],
 ];

--- a/lang/en/form.php
+++ b/lang/en/form.php
@@ -51,4 +51,10 @@ return [
     ],
     'submit' => 'Submit',
     'validation-summary' => 'Fix these fields to continue:',
+    'wizard' => [
+        'back' => 'Back',
+        'finish' => 'Finish',
+        'next' => 'Next',
+        'steps' => 'Steps',
+    ],
 ];

--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -13,9 +13,10 @@ type ValidateFieldsOptions = { onSuccess?: () => void; onValidationError?: () =>
 
 let capturedValidateFields: ((fields: string[], options?: ValidateFieldsOptions) => void) | null =
   null;
+let capturedValidating = false;
 
 function ValidateFieldsProbe() {
-  ({ validateFields: capturedValidateFields } = useFormContext());
+  ({ validateFields: capturedValidateFields, validating: capturedValidating } = useFormContext());
 
   return null;
 }
@@ -45,6 +46,46 @@ function validateFieldsAction(): Node {
         type: "form",
       },
       label: "Validate",
+      method: "post",
+      ref: "sealed-ref",
+    },
+  });
+}
+
+function wizardAction(): Node {
+  return fakeNode({
+    id: "test.wizard",
+    type: "action",
+    props: {
+      confirmation: { confirmLabel: "Save", title: "Checkout wizard" },
+      endpoint: "/lattice/actions/test.wizard",
+      form: {
+        id: "test.wizard-form",
+        props: { submitButton: false },
+        schema: [
+          {
+            key: "wizard",
+            props: { orientation: "horizontal" },
+            schema: [
+              {
+                props: { label: "Customer", name: "customer" },
+                schema: [
+                  {
+                    key: "name",
+                    props: { label: "Name", name: "name" },
+                    type: "field.text-input",
+                  },
+                ],
+                type: "wizard-step",
+              },
+              { props: { label: "Review", name: "review" }, schema: [], type: "wizard-step" },
+            ],
+            type: "wizard",
+          },
+        ],
+        type: "form",
+      },
+      label: "Open wizard",
       method: "post",
       ref: "sealed-ref",
     },
@@ -153,6 +194,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
   capturedValidateFields = null;
+  capturedValidating = false;
 });
 
 describe("action form modal", () => {
@@ -528,6 +570,64 @@ describe("action form modal", () => {
     capturedValidateFields?.(["name"]);
     await waitFor(() => expect(screen.queryByText("Required")).not.toBeInTheDocument());
     expect(screen.getByText("Invalid email")).toBeVisible();
+  });
+
+  it("tracks a validating state across the validation round-trip", async () => {
+    let resolveFetch: (response: Response) => void = () => {};
+    const fetchMock = vi.fn<FetchMock>().mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    expect(capturedValidating).toBe(false);
+
+    capturedValidateFields?.(["name"]);
+    await waitFor(() => expect(capturedValidating).toBe(true));
+
+    resolveFetch({ json: async () => ({}), ok: true, status: 204 } as unknown as Response);
+    await waitFor(() => expect(capturedValidating).toBe(false));
+  });
+
+  it("drops its own save button when the form suppresses the submit row", async () => {
+    renderAction(wizardAction());
+
+    fireEvent.click(screen.getByRole("button", { name: "Open wizard" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Next" })).toBeVisible();
+  });
+
+  it("advances a wizard step once its precognitive validation passes", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => ({}),
+      ok: true,
+      status: 204,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(wizardAction());
+
+    fireEvent.click(screen.getByRole("button", { name: "Open wizard" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(await screen.findByRole("button", { name: "Finish" })).toBeVisible();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Precognition).toBe("true");
+    expect(headers["Precognition-Validate-Only"]).toBe("name,name.*");
   });
 });
 

--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -1,12 +1,55 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createRegistry, Renderer } from "@lattice-php/lattice";
-import type { Node } from "@lattice-php/lattice";
+import { createPlugin, createRegistry, eagerComponent, Renderer } from "@lattice-php/lattice";
+import type { Node, Plugin } from "@lattice-php/lattice";
 import { formComponents } from "@lattice-php/lattice/form";
+import { useFormContext } from "@lattice-php/lattice/form/toolkit";
 import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 import { actionComponents } from "@lattice-php/lattice/action/plugin";
 import { ActionForm } from "./action-form";
+
+type ValidateFieldsOptions = { onSuccess?: () => void; onValidationError?: () => void };
+
+let capturedValidateFields: ((fields: string[], options?: ValidateFieldsOptions) => void) | null =
+  null;
+
+function ValidateFieldsProbe() {
+  ({ validateFields: capturedValidateFields } = useFormContext());
+
+  return null;
+}
+
+const validateFieldsProbePlugin: Plugin = createPlugin({
+  components: {
+    "test.validate-fields-probe": eagerComponent(ValidateFieldsProbe),
+  },
+  name: "test/validate-fields-probe",
+});
+
+function validateFieldsAction(): Node {
+  return fakeNode({
+    id: "test.validate-fields",
+    type: "action",
+    props: {
+      confirmation: { confirmLabel: "Save", title: "Validate fields?" },
+      endpoint: "/lattice/actions/test.validate-fields",
+      form: {
+        id: "test.validate-fields-form",
+        props: {},
+        schema: [
+          { key: "name", props: { label: "Name", name: "name" }, type: "field.text-input" },
+          { key: "email", props: { label: "Email", name: "email" }, type: "field.text-input" },
+          { key: "probe", props: {}, type: "test.validate-fields-probe" },
+        ],
+        type: "form",
+      },
+      label: "Validate",
+      method: "post",
+      ref: "sealed-ref",
+    },
+  });
+}
 
 vi.mock("@inertiajs/react", async () =>
   (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
@@ -99,16 +142,17 @@ function editProductActionWithExistingImage(): Node {
   });
 }
 
-function renderAction(node: Node) {
+function renderAction(node: Node, ...extraPlugins: Plugin[]) {
   return renderWithRegistry(
     <Renderer nodes={[node]} />,
-    createRegistry(actionComponents, formComponents),
+    createRegistry(actionComponents, formComponents, ...extraPlugins),
   );
 }
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
+  capturedValidateFields = null;
 });
 
 describe("action form modal", () => {
@@ -313,6 +357,177 @@ describe("action form modal", () => {
     const headers = init.headers as Record<string, string>;
     expect(headers.Precognition).toBe("true");
     expect(headers["Precognition-Validate-Only"]).toBe("reason");
+  });
+
+  it("validates multiple fields on demand and reports success", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => ({}),
+      ok: true,
+      status: 204,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    expect(capturedValidateFields).not.toBeNull();
+
+    const onSuccess = vi.fn();
+    const onValidationError = vi.fn();
+
+    capturedValidateFields?.(["name", "name.*"], { onSuccess, onValidationError });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+
+    expect(onValidationError).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Precognition).toBe("true");
+    expect(headers["Precognition-Validate-Only"]).toBe("name,name.*");
+  });
+
+  it("sets the field error and reports a validation failure on a 422", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({
+      json: async () => ({ errors: { name: ["Required"] } }),
+      ok: false,
+      status: 422,
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    const onSuccess = vi.fn();
+    const onValidationError = vi.fn();
+
+    capturedValidateFields?.(["name", "name.*"], { onSuccess, onValidationError });
+
+    expect(await screen.findByText("Required")).toBeVisible();
+    expect(onValidationError).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("clears a previously set field error once a later validation call succeeds", async () => {
+    const fetchMock = vi
+      .fn<FetchMock>()
+      .mockResolvedValueOnce({
+        json: async () => ({ errors: { name: ["Required"] } }),
+        ok: false,
+        status: 422,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({}),
+        ok: true,
+        status: 204,
+      } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    capturedValidateFields?.(["name"]);
+    expect(await screen.findByText("Required")).toBeVisible();
+
+    capturedValidateFields?.(["name"]);
+    await waitFor(() => expect(screen.queryByText("Required")).not.toBeInTheDocument());
+  });
+
+  it("reports a validation failure on a non-422 error response without clearing errors", async () => {
+    const fetchMock = vi
+      .fn<FetchMock>()
+      .mockResolvedValueOnce({
+        json: async () => ({ errors: { name: ["Required"] } }),
+        ok: false,
+        status: 422,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({}),
+        ok: false,
+        status: 500,
+      } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    capturedValidateFields?.(["name"]);
+    expect(await screen.findByText("Required")).toBeVisible();
+
+    const onSuccess = vi.fn();
+    const onValidationError = vi.fn();
+
+    capturedValidateFields?.(["name"], { onSuccess, onValidationError });
+
+    await waitFor(() => expect(onValidationError).toHaveBeenCalledTimes(1));
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(screen.getByText("Required")).toBeVisible();
+  });
+
+  it("reports a validation failure when the request itself rejects", async () => {
+    const fetchMock = vi.fn<FetchMock>().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    const onSuccess = vi.fn();
+    const onValidationError = vi.fn();
+
+    capturedValidateFields?.(["name"], { onSuccess, onValidationError });
+
+    await waitFor(() => expect(onValidationError).toHaveBeenCalledTimes(1));
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("keeps an unrelated field's error through another field's 422 merge and success-clear", async () => {
+    const fetchMock = vi
+      .fn<FetchMock>()
+      .mockResolvedValueOnce({
+        json: async () => ({ errors: { email: ["Invalid email"] } }),
+        ok: false,
+        status: 422,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({ errors: { name: ["Required"] } }),
+        ok: false,
+        status: 422,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        json: async () => ({}),
+        ok: true,
+        status: 204,
+      } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAction(validateFieldsAction(), validateFieldsProbePlugin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+    await screen.findByRole("textbox", { name: "Name" });
+
+    capturedValidateFields?.(["email"]);
+    expect(await screen.findByText("Invalid email")).toBeVisible();
+
+    capturedValidateFields?.(["name"]);
+    expect(await screen.findByText("Required")).toBeVisible();
+    expect(screen.getByText("Invalid email")).toBeVisible();
+
+    capturedValidateFields?.(["name"]);
+    await waitFor(() => expect(screen.queryByText("Required")).not.toBeInTheDocument());
+    expect(screen.getByText("Invalid email")).toBeVisible();
   });
 });
 

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -17,6 +17,7 @@ import {
   FORM_DEBOUNCE_MS,
   FormProvider,
   FormValuesProvider,
+  errorKeyBelongsTo,
   firstErrors,
   PrefillProvider,
   ResolvedNodesProvider,
@@ -127,6 +128,7 @@ function ActionFormBody({
   const dispatch = useEffectDispatcher();
   const [errors, setErrors] = useState<FieldErrors>({});
   const [processing, setProcessing] = useState(false);
+  const [validating, setValidating] = useState(false);
 
   const request = useCallback(
     (extraHeaders?: Record<string, string>): Promise<Response> =>
@@ -174,6 +176,8 @@ function ActionFormBody({
 
   const validateFields = useCallback(
     (fields: string[], options?: { onSuccess?: () => void; onValidationError?: () => void }) => {
+      setValidating(true);
+
       void request({ Precognition: "true", "Precognition-Validate-Only": fields.join(",") })
         .then(async (response) => {
           if (response.status === 422) {
@@ -194,13 +198,14 @@ function ActionFormBody({
           setErrors((current) =>
             Object.fromEntries(
               Object.entries(current).filter(
-                ([key]) => !cleared.some((name) => key === name || key.startsWith(`${name}.`)),
+                ([key]) => !cleared.some((name) => errorKeyBelongsTo(key, name)),
               ),
             ),
           );
           options?.onSuccess?.();
         })
-        .catch(() => options?.onValidationError?.());
+        .catch(() => options?.onValidationError?.())
+        .finally(() => setValidating(false));
     },
     [request],
   );
@@ -244,7 +249,7 @@ function ActionFormBody({
       touch,
       validate,
       validateFields,
-      validating: false,
+      validating,
     }),
     [
       clearErrors,
@@ -257,6 +262,7 @@ function ActionFormBody({
       touch,
       validate,
       validateFields,
+      validating,
     ],
   );
 
@@ -286,10 +292,12 @@ function ActionFormBody({
             {cancelLabel}
           </Button>
 
-          <Button data-test="action-form-submit" disabled={processing} type="submit">
-            {processing && <Spinner />}
-            {submitLabel}
-          </Button>
+          {formNode.props?.submitButton !== false && (
+            <Button data-test="action-form-submit" disabled={processing} type="submit">
+              {processing && <Spinner />}
+              {submitLabel}
+            </Button>
+          )}
         </div>
       </form>
     </FormProvider>

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -170,6 +170,41 @@ function ActionFormBody({
     [precognitive, runValidation],
   );
 
+  const touch = useCallback(() => {}, []);
+
+  const validateFields = useCallback(
+    (fields: string[], options?: { onSuccess?: () => void; onValidationError?: () => void }) => {
+      void request({ Precognition: "true", "Precognition-Validate-Only": fields.join(",") })
+        .then(async (response) => {
+          if (response.status === 422) {
+            const body = (await response.json()) as { errors?: Record<string, string[]> };
+            setErrors((current) => ({ ...current, ...firstErrors(body.errors) }));
+            options?.onValidationError?.();
+
+            return;
+          }
+
+          if (!response.ok) {
+            options?.onValidationError?.();
+
+            return;
+          }
+
+          const cleared = fields.filter((field) => !field.includes("*"));
+          setErrors((current) =>
+            Object.fromEntries(
+              Object.entries(current).filter(
+                ([key]) => !cleared.some((name) => key === name || key.startsWith(`${name}.`)),
+              ),
+            ),
+          );
+          options?.onSuccess?.();
+        })
+        .catch(() => options?.onValidationError?.());
+    },
+    [request],
+  );
+
   const submit = useCallback(() => {
     setProcessing(true);
 
@@ -206,9 +241,23 @@ function ActionFormBody({
       fieldLabels,
       precognitive,
       processing,
+      touch,
       validate,
+      validateFields,
+      validating: false,
     }),
-    [clearErrors, componentRef, endpoint, errors, fieldLabels, precognitive, processing, validate],
+    [
+      clearErrors,
+      componentRef,
+      endpoint,
+      errors,
+      fieldLabels,
+      precognitive,
+      processing,
+      touch,
+      validate,
+      validateFields,
+    ],
   );
 
   return (

--- a/resources/js/form/components/base/submit-button.test.tsx
+++ b/resources/js/form/components/base/submit-button.test.tsx
@@ -1,33 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
+import type { FormContextValue } from "@lattice-php/lattice/form/hooks/context";
+import { fakeFormContext } from "@lattice-php/lattice/test-support";
 import { FormSubmitButton } from "./submit-button";
 
-type ContextOverrides = {
-  errors?: Record<string, string | undefined>;
-  fieldLabels?: Record<string, string>;
-  processing?: boolean;
-  componentId?: string;
-};
-
-function renderSubmit(overrides: ContextOverrides = {}) {
+function renderSubmit(overrides: Partial<FormContextValue> = {}) {
   return render(
-    <FormProvider
-      value={{
-        action: "#",
-        clearErrors: () => {},
-        componentId: overrides.componentId,
-        componentRef: "",
-        errors: overrides.errors ?? {},
-        fieldLabels: overrides.fieldLabels ?? {},
-        precognitive: false,
-        processing: overrides.processing ?? false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext(overrides)}>
       <FormSubmitButton label="Save" summaryLabel="Fix these fields" />
     </FormProvider>,
   );

--- a/resources/js/form/components/base/submit-button.test.tsx
+++ b/resources/js/form/components/base/submit-button.test.tsx
@@ -22,7 +22,10 @@ function renderSubmit(overrides: ContextOverrides = {}) {
         fieldLabels: overrides.fieldLabels ?? {},
         precognitive: false,
         processing: overrides.processing ?? false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormSubmitButton label="Save" summaryLabel="Fix these fields" />

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -1,7 +1,7 @@
 import { expect, it, vi } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { ComponentPropsOf, Node } from "@lattice-php/lattice/core/types";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeFormContext, fakeNode } from "@lattice-php/lattice/test-support";
 
 vi.mock("@lattice-php/lattice/core/renderer", async () => {
   const { RenderNode } = await import("@lattice-php/lattice/test/form-renderer-probe");
@@ -47,21 +47,7 @@ const node = builderNode(
 
 function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
   return render(
-    <FormProvider
-      value={{
-        action: "#",
-        clearErrors: () => {},
-        componentRef: "",
-        errors: {},
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext()}>
       <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>
     </FormProvider>,
   );

--- a/resources/js/form/components/fields/builder.test.tsx
+++ b/resources/js/form/components/fields/builder.test.tsx
@@ -56,7 +56,10 @@ function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>

--- a/resources/js/form/components/fields/color-picker-field.test.tsx
+++ b/resources/js/form/components/fields/color-picker-field.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeFormContext, fakeNode } from "@lattice-php/lattice/test-support";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { ColorPickerFieldComponent } from "./color-picker-field";
@@ -18,21 +18,7 @@ function renderField(props: Record<string, unknown>, initial: Record<string, unk
   });
 
   return render(
-    <FormProvider
-      value={{
-        action: "/forms/tags",
-        clearErrors: () => {},
-        componentRef: "ref-1",
-        errors: {},
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext({ action: "/forms/tags", componentRef: "ref-1" })}>
       <FormValuesProvider initial={initial}>
         <ColorPickerFieldComponent node={node}>{null}</ColorPickerFieldComponent>
       </FormValuesProvider>

--- a/resources/js/form/components/fields/color-picker-field.test.tsx
+++ b/resources/js/form/components/fields/color-picker-field.test.tsx
@@ -27,7 +27,10 @@ function renderField(props: Record<string, unknown>, initial: Record<string, unk
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={initial}>

--- a/resources/js/form/components/fields/file-upload.test.tsx
+++ b/resources/js/form/components/fields/file-upload.test.tsx
@@ -62,7 +62,10 @@ function renderUpload({
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={values}>

--- a/resources/js/form/components/fields/file-upload.test.tsx
+++ b/resources/js/form/components/fields/file-upload.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeFormContext, fakeNode } from "@lattice-php/lattice/test-support";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FieldScopeProvider } from "@lattice-php/lattice/form/hooks/field-scope";
 import { FormValuesProvider, useFormValues } from "@lattice-php/lattice/form/hooks/values";
@@ -53,21 +53,7 @@ function renderUpload({
   });
 
   return render(
-    <FormProvider
-      value={{
-        action: "/forms/products",
-        clearErrors: () => {},
-        componentRef: "ref-1",
-        errors: {},
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext({ action: "/forms/products", componentRef: "ref-1" })}>
       <FormValuesProvider initial={values}>
         <ValuesProbe onValues={onValues} />
         {scoped ? (

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -11,7 +11,7 @@ import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { renderCounts } from "@lattice-php/lattice/test/form-renderer-probe";
 import { RepeaterComponent } from "./repeater";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeFormContext, fakeNode } from "@lattice-php/lattice/test-support";
 
 const repeaterNode = fakeNode({
   id: "r",
@@ -34,21 +34,7 @@ function wrap(
   errors: Record<string, string> = {},
 ) {
   return render(
-    <FormProvider
-      value={{
-        action: "#",
-        clearErrors: () => {},
-        componentRef: "",
-        errors,
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext({ errors })}>
       <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>
     </FormProvider>,
   );

--- a/resources/js/form/components/fields/repeater.test.tsx
+++ b/resources/js/form/components/fields/repeater.test.tsx
@@ -43,7 +43,10 @@ function wrap(
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice-php/lattice";
 import { renderWithRegistry } from "@lattice-php/lattice/test/render";
 import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeFormContext, fakeNode } from "@lattice-php/lattice/test-support";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { FieldScopeProvider } from "@lattice-php/lattice/form/hooks/field-scope";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
@@ -61,21 +61,7 @@ function renderSelect({
   );
 
   return render(
-    <FormProvider
-      value={{
-        action: "/forms/products",
-        clearErrors: () => {},
-        componentRef: "ref-1",
-        errors: {},
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext({ action: "/forms/products", componentRef: "ref-1" })}>
       <FormValuesProvider initial={initial}>{scoped}</FormValuesProvider>
     </FormProvider>,
   );
@@ -152,21 +138,7 @@ function renderStaticSelect(props: Record<string, unknown>, initial: Record<stri
   });
 
   return render(
-    <FormProvider
-      value={{
-        action: "/forms/products",
-        clearErrors: () => {},
-        componentRef: "ref-1",
-        errors: {},
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext({ action: "/forms/products", componentRef: "ref-1" })}>
       <FormValuesProvider initial={initial}>
         <SelectComponent node={node}>{null}</SelectComponent>
       </FormValuesProvider>
@@ -425,21 +397,7 @@ describe("SelectComponent option schema", () => {
     ];
 
     renderWithRegistry(
-      <FormProvider
-        value={{
-          action: "/forms/customers",
-          clearErrors: () => {},
-          componentRef: "ref-1",
-          errors: {},
-          fieldLabels: {},
-          precognitive: false,
-          processing: false,
-          touch: () => {},
-          validate: () => {},
-          validateFields: () => {},
-          validating: false,
-        }}
-      >
+      <FormProvider value={fakeFormContext({ action: "/forms/customers", componentRef: "ref-1" })}>
         <FormValuesProvider initial={{}}>
           <SelectComponent node={node}>{null}</SelectComponent>
         </FormValuesProvider>
@@ -467,21 +425,7 @@ describe("SelectComponent option schema", () => {
     (node.props as { optionSchema?: Node[] }).optionSchema = [];
 
     render(
-      <FormProvider
-        value={{
-          action: "/forms/customers",
-          clearErrors: () => {},
-          componentRef: "ref-1",
-          errors: {},
-          fieldLabels: {},
-          precognitive: false,
-          processing: false,
-          touch: () => {},
-          validate: () => {},
-          validateFields: () => {},
-          validating: false,
-        }}
-      >
+      <FormProvider value={fakeFormContext({ action: "/forms/customers", componentRef: "ref-1" })}>
         <FormValuesProvider initial={{}}>
           <SelectComponent node={node}>{null}</SelectComponent>
         </FormValuesProvider>

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -70,7 +70,10 @@ function renderSelect({
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={initial}>{scoped}</FormValuesProvider>
@@ -158,7 +161,10 @@ function renderStaticSelect(props: Record<string, unknown>, initial: Record<stri
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={initial}>
@@ -428,7 +434,10 @@ describe("SelectComponent option schema", () => {
           fieldLabels: {},
           precognitive: false,
           processing: false,
+          touch: () => {},
           validate: () => {},
+          validateFields: () => {},
+          validating: false,
         }}
       >
         <FormValuesProvider initial={{}}>
@@ -467,7 +476,10 @@ describe("SelectComponent option schema", () => {
           fieldLabels: {},
           precognitive: false,
           processing: false,
+          touch: () => {},
           validate: () => {},
+          validateFields: () => {},
+          validating: false,
         }}
       >
         <FormValuesProvider initial={{}}>

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -265,7 +265,10 @@ function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
         fieldLabels: {},
         precognitive: false,
         processing: false,
+        touch: () => {},
         validate: () => {},
+        validateFields: () => {},
+        validating: false,
       }}
     >
       <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>

--- a/resources/js/form/components/fields/table-rows.test.tsx
+++ b/resources/js/form/components/fields/table-rows.test.tsx
@@ -16,7 +16,7 @@ import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
 import { renderCounts } from "@lattice-php/lattice/test/form-renderer-probe";
 import { RepeaterComponent } from "./repeater";
 import { TableRows, type TableColumn } from "./table-rows";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { fakeFormContext, fakeNode } from "@lattice-php/lattice/test-support";
 
 const columns: TableColumn[] = [
   { name: "qty", label: "Qty", columnWidth: "md" },
@@ -256,21 +256,7 @@ it("renders stack rows instead of the horizontal table below the table breakpoin
 
 function wrap(ui: React.ReactNode, initial: Record<string, unknown> = {}) {
   return render(
-    <FormProvider
-      value={{
-        action: "#",
-        clearErrors: () => {},
-        componentRef: "",
-        errors: {},
-        fieldLabels: {},
-        precognitive: false,
-        processing: false,
-        touch: () => {},
-        validate: () => {},
-        validateFields: () => {},
-        validating: false,
-      }}
-    >
+    <FormProvider value={fakeFormContext()}>
       <FormValuesProvider initial={initial}>{ui}</FormValuesProvider>
     </FormProvider>,
   );

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -141,7 +141,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
       headers={withHeaders(componentRef)}
       className="mx-auto flex w-full max-w-2xl flex-col gap-6"
     >
-      {({ clearErrors, errors, processing, reset, validate }) => (
+      {({ clearErrors, errors, processing, reset, touch, validate, validating }) => (
         <FormProvider
           value={{
             action,
@@ -152,7 +152,10 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
             fieldLabels,
             precognitive,
             processing,
+            touch: (fields) => touch(...fields),
             validate: (field) => validate(field),
+            validateFields: (fields, options) => validate({ only: fields, ...options }),
+            validating,
           }}
         >
           <FormResetListener componentId={node.id} reset={reset} />

--- a/resources/js/form/components/index.ts
+++ b/resources/js/form/components/index.ts
@@ -16,3 +16,4 @@ export { TextareaComponent } from "./fields/textarea";
 export { TextInputComponent } from "./fields/text-input";
 export { TimeInputComponent } from "./fields/time-input";
 export { ToggleComponent } from "./fields/toggle";
+export { WizardComponent, WizardStepComponent } from "./wizard";

--- a/resources/js/form/components/wizard.test.tsx
+++ b/resources/js/form/components/wizard.test.tsx
@@ -35,8 +35,8 @@ const formStub = (overrides: Partial<Parameters<typeof FormProvider>[0]["value"]
   ...overrides,
 });
 
-function renderWizard(steps: Node<"wizard-step">[], stub = formStub()) {
-  return render(
+function wizardTree(steps: Node<"wizard-step">[], stub: ReturnType<typeof formStub>) {
+  return (
     <FormProvider value={stub}>
       <FormValuesProvider initial={{}}>
         <WizardComponent node={wizardNode(steps)}>
@@ -49,8 +49,12 @@ function renderWizard(steps: Node<"wizard-step">[], stub = formStub()) {
           </>
         </WizardComponent>
       </FormValuesProvider>
-    </FormProvider>,
+    </FormProvider>
   );
+}
+
+function renderWizard(steps: Node<"wizard-step">[], stub = formStub()) {
+  return render(wizardTree(steps, stub));
 }
 
 describe("WizardComponent", () => {
@@ -99,5 +103,26 @@ describe("WizardComponent", () => {
 
     expect(screen.getByTestId("wizard-finish")).toBeInTheDocument();
     expect(screen.queryByTestId("wizard-next")).not.toBeInTheDocument();
+  });
+
+  it("jumps back to the first errored step and badges it after a failed submit", () => {
+    const validateFields = vi.fn((_fields, options) => options?.onSuccess?.());
+    const steps = [fieldStep, emptyStep];
+    const { rerender } = renderWizard(steps, formStub({ validateFields }));
+
+    fireEvent.click(screen.getByTestId("wizard-next"));
+    expect(screen.getByTestId("content-review")).toBeInTheDocument();
+
+    rerender(wizardTree(steps, formStub({ validateFields, processing: true })));
+    rerender(
+      wizardTree(
+        steps,
+        formStub({ validateFields, processing: false, errors: { name: "Required" } }),
+      ),
+    );
+
+    expect(screen.getByTestId("content-customer").closest("section")).not.toHaveAttribute("hidden");
+    expect(screen.getByTestId("content-review").closest("section")).toHaveAttribute("hidden");
+    expect(screen.getByTestId("wizard-rail-customer")).toHaveAttribute("data-error");
   });
 });

--- a/resources/js/form/components/wizard.test.tsx
+++ b/resources/js/form/components/wizard.test.tsx
@@ -1,0 +1,103 @@
+import { configure, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
+import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
+import { WizardComponent, WizardStepComponent } from "./wizard";
+
+configure({ testIdAttribute: "data-test" });
+
+const node = <TType extends string>(
+  type: TType,
+  props: Record<string, unknown>,
+  schema: Node[] = [],
+): Node<TType> => ({ type, props, schema }) as unknown as Node<TType>;
+
+const fieldStep = node("wizard-step", { name: "customer", label: "Customer" }, [
+  node("field.text-input", { name: "name" }),
+]);
+const emptyStep = node("wizard-step", { name: "review", label: "Review" });
+const wizardNode = (steps: Node<"wizard-step">[]) =>
+  node("wizard", { orientation: "horizontal" }, steps);
+
+const formStub = (overrides: Partial<Parameters<typeof FormProvider>[0]["value"]> = {}) => ({
+  action: "#",
+  clearErrors: () => {},
+  componentRef: "",
+  errors: {},
+  fieldLabels: {},
+  precognitive: false,
+  processing: false,
+  touch: () => {},
+  validate: () => {},
+  validateFields: () => {},
+  validating: false,
+  ...overrides,
+});
+
+function renderWizard(steps: Node<"wizard-step">[], stub = formStub()) {
+  return render(
+    <FormProvider value={stub}>
+      <FormValuesProvider initial={{}}>
+        <WizardComponent node={wizardNode(steps)}>
+          <>
+            {steps.map((step) => (
+              <WizardStepComponent key={step.props.name} node={step}>
+                <div data-test={`content-${step.props.name}`} />
+              </WizardStepComponent>
+            ))}
+          </>
+        </WizardComponent>
+      </FormValuesProvider>
+    </FormProvider>,
+  );
+}
+
+describe("WizardComponent", () => {
+  it("mounts only the first step initially and keeps visited steps mounted", () => {
+    const validateFields = vi.fn((_fields, options) => options?.onSuccess?.());
+    renderWizard([fieldStep, emptyStep], formStub({ validateFields }));
+
+    expect(screen.getByTestId("content-customer")).toBeInTheDocument();
+    expect(screen.queryByTestId("content-review")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("wizard-next"));
+
+    expect(screen.getByTestId("content-review")).toBeInTheDocument();
+    expect(screen.getByTestId("content-customer")).toBeInTheDocument();
+    expect(screen.getByTestId("content-customer").closest("section")).toHaveAttribute("hidden");
+  });
+
+  it("validates the step fields before advancing", () => {
+    const touch = vi.fn();
+    const validateFields = vi.fn();
+    renderWizard([fieldStep, emptyStep], formStub({ touch, validateFields }));
+
+    fireEvent.click(screen.getByTestId("wizard-next"));
+
+    expect(touch).toHaveBeenCalledWith(["name", "name.*"]);
+    expect(validateFields).toHaveBeenCalledWith(["name", "name.*"], expect.any(Object));
+    expect(screen.queryByTestId("content-review")).not.toBeInTheDocument();
+  });
+
+  it("advances a fieldless step without a validation round-trip", () => {
+    const validateFields = vi.fn();
+    renderWizard([emptyStep, fieldStep], formStub({ validateFields }));
+
+    fireEvent.click(screen.getByTestId("wizard-next"));
+
+    expect(validateFields).not.toHaveBeenCalled();
+    expect(screen.getByTestId("content-customer")).toBeInTheDocument();
+  });
+
+  it("shows the finish button only on the last step", () => {
+    renderWizard([emptyStep, fieldStep]);
+
+    expect(screen.queryByTestId("wizard-finish")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("wizard-next"));
+
+    expect(screen.getByTestId("wizard-finish")).toBeInTheDocument();
+    expect(screen.queryByTestId("wizard-next")).not.toBeInTheDocument();
+  });
+});

--- a/resources/js/form/components/wizard.test.tsx
+++ b/resources/js/form/components/wizard.test.tsx
@@ -2,7 +2,9 @@ import { configure, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
+import type { FormContextValue } from "@lattice-php/lattice/form/hooks/context";
 import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
+import { fakeFormContext } from "@lattice-php/lattice/test-support";
 import { WizardComponent, WizardStepComponent } from "./wizard";
 
 configure({ testIdAttribute: "data-test" });
@@ -20,22 +22,7 @@ const emptyStep = node("wizard-step", { name: "review", label: "Review" });
 const wizardNode = (steps: Node<"wizard-step">[]) =>
   node("wizard", { orientation: "horizontal" }, steps);
 
-const formStub = (overrides: Partial<Parameters<typeof FormProvider>[0]["value"]> = {}) => ({
-  action: "#",
-  clearErrors: () => {},
-  componentRef: "",
-  errors: {},
-  fieldLabels: {},
-  precognitive: false,
-  processing: false,
-  touch: () => {},
-  validate: () => {},
-  validateFields: () => {},
-  validating: false,
-  ...overrides,
-});
-
-function wizardTree(steps: Node<"wizard-step">[], stub: ReturnType<typeof formStub>) {
+function wizardTree(steps: Node<"wizard-step">[], stub: FormContextValue) {
   return (
     <FormProvider value={stub}>
       <FormValuesProvider initial={{}}>
@@ -53,14 +40,14 @@ function wizardTree(steps: Node<"wizard-step">[], stub: ReturnType<typeof formSt
   );
 }
 
-function renderWizard(steps: Node<"wizard-step">[], stub = formStub()) {
+function renderWizard(steps: Node<"wizard-step">[], stub = fakeFormContext()) {
   return render(wizardTree(steps, stub));
 }
 
 describe("WizardComponent", () => {
   it("mounts only the first step initially and keeps visited steps mounted", () => {
     const validateFields = vi.fn((_fields, options) => options?.onSuccess?.());
-    renderWizard([fieldStep, emptyStep], formStub({ validateFields }));
+    renderWizard([fieldStep, emptyStep], fakeFormContext({ validateFields }));
 
     expect(screen.getByTestId("content-customer")).toBeInTheDocument();
     expect(screen.queryByTestId("content-review")).not.toBeInTheDocument();
@@ -75,7 +62,7 @@ describe("WizardComponent", () => {
   it("validates the step fields before advancing", () => {
     const touch = vi.fn();
     const validateFields = vi.fn();
-    renderWizard([fieldStep, emptyStep], formStub({ touch, validateFields }));
+    renderWizard([fieldStep, emptyStep], fakeFormContext({ touch, validateFields }));
 
     fireEvent.click(screen.getByTestId("wizard-next"));
 
@@ -86,7 +73,7 @@ describe("WizardComponent", () => {
 
   it("advances a fieldless step without a validation round-trip", () => {
     const validateFields = vi.fn();
-    renderWizard([emptyStep, fieldStep], formStub({ validateFields }));
+    renderWizard([emptyStep, fieldStep], fakeFormContext({ validateFields }));
 
     fireEvent.click(screen.getByTestId("wizard-next"));
 
@@ -108,16 +95,16 @@ describe("WizardComponent", () => {
   it("jumps back to the first errored step and badges it after a failed submit", () => {
     const validateFields = vi.fn((_fields, options) => options?.onSuccess?.());
     const steps = [fieldStep, emptyStep];
-    const { rerender } = renderWizard(steps, formStub({ validateFields }));
+    const { rerender } = renderWizard(steps, fakeFormContext({ validateFields }));
 
     fireEvent.click(screen.getByTestId("wizard-next"));
     expect(screen.getByTestId("content-review")).toBeInTheDocument();
 
-    rerender(wizardTree(steps, formStub({ validateFields, processing: true })));
+    rerender(wizardTree(steps, fakeFormContext({ validateFields, processing: true })));
     rerender(
       wizardTree(
         steps,
-        formStub({ validateFields, processing: false, errors: { name: "Required" } }),
+        fakeFormContext({ validateFields, processing: false, errors: { name: "Required" } }),
       ),
     );
 

--- a/resources/js/form/components/wizard.tsx
+++ b/resources/js/form/components/wizard.tsx
@@ -1,0 +1,11 @@
+import type { RendererComponent } from "@lattice-php/lattice/core/types";
+
+export const WizardComponent: RendererComponent<"wizard"> = ({ children }) => (
+  <div data-slot="wizard">{children}</div>
+);
+
+export const WizardStepComponent: RendererComponent<"wizard-step"> = ({ children, node }) => (
+  <section data-slot="wizard-step" id={`wizard-step-${node.props.name}-panel`}>
+    {children}
+  </section>
+);

--- a/resources/js/form/components/wizard.tsx
+++ b/resources/js/form/components/wizard.tsx
@@ -1,11 +1,203 @@
-import type { RendererComponent } from "@lattice-php/lattice/core/types";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
+import type { WizardStep } from "@lattice-php/lattice/types/generated";
+import { cn } from "@lattice-php/lattice/lib/utils";
+import { useT } from "@lattice-php/lattice/i18n";
+import { Icon } from "@lattice-php/lattice/icons";
+import { Button } from "@lattice-php/lattice/ui/button";
+import { Spinner } from "@lattice-php/lattice/ui/spinner";
+import { useFormContext } from "@lattice-php/lattice/form/hooks/context";
+import {
+  firstErroredStep,
+  stepFieldNames,
+  stepsWithErrors,
+  stepValidationPaths,
+} from "@lattice-php/lattice/form/lib/wizard-steps";
 
-export const WizardComponent: RendererComponent<"wizard"> = ({ children }) => (
-  <div data-slot="wizard">{children}</div>
-);
+type WizardContextValue = { activeName: string };
 
-export const WizardStepComponent: RendererComponent<"wizard-step"> = ({ children, node }) => (
-  <section data-slot="wizard-step" id={`wizard-step-${node.props.name}-panel`}>
-    {children}
-  </section>
-);
+const WizardContext = createContext<WizardContextValue>({ activeName: "" });
+
+function getSteps(node: Node<"wizard">): { items: WizardStep[]; nodes: Node[] } {
+  const nodes = (node.schema ?? []).filter((child) => child.type === "wizard-step");
+  const items = nodes.map((child) => child.props as unknown as WizardStep);
+
+  return { items, nodes };
+}
+
+export const WizardComponent: RendererComponent<"wizard"> = ({ children, node }) => {
+  const { t } = useT("lattice");
+  const { errors, processing, touch, validateFields, validating } = useFormContext();
+  const { items, nodes } = useMemo(() => getSteps(node), [node]);
+  const stepNames = useMemo(() => nodes.map((step) => stepFieldNames(step)), [nodes]);
+  const isVertical = node.props.orientation === "vertical";
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [visited, setVisited] = useState<Set<number>>(() => new Set([0]));
+  const [completed, setCompleted] = useState<Set<number>>(() => new Set());
+  const erroredSteps = useMemo(() => stepsWithErrors(stepNames, errors), [stepNames, errors]);
+  const isLast = activeIndex === items.length - 1;
+
+  const goTo = (index: number): void => {
+    setActiveIndex(index);
+    setVisited((previous) => new Set(previous).add(index));
+  };
+
+  const advance = (): void => {
+    setCompleted((previous) => new Set(previous).add(activeIndex));
+
+    if (!isLast) {
+      goTo(activeIndex + 1);
+    }
+  };
+
+  const onNext = (): void => {
+    const step = nodes[activeIndex];
+    const paths = step ? stepValidationPaths(step) : [];
+
+    if (paths.length === 0) {
+      advance();
+
+      return;
+    }
+
+    touch(paths);
+    validateFields(paths, { onSuccess: advance });
+  };
+
+  const wasProcessing = useRef(false);
+  useEffect(() => {
+    if (wasProcessing.current && !processing) {
+      const target = firstErroredStep(stepNames, errors);
+
+      if (target !== null && target !== activeIndex) {
+        goTo(target);
+      }
+    }
+
+    wasProcessing.current = processing;
+  }, [processing, errors, stepNames, activeIndex]);
+
+  const contextValue = useMemo(
+    () => ({ activeName: items[activeIndex]?.name ?? "" }),
+    [items, activeIndex],
+  );
+
+  return (
+    <WizardContext.Provider value={contextValue}>
+      <div className={cn("gap-6", isVertical ? "flex" : "grid")} data-slot="wizard">
+        <ol
+          aria-label={t("form.wizard.steps", "Steps")}
+          className={cn("gap-1", isVertical ? "flex w-56 shrink-0 flex-col" : "flex flex-wrap")}
+        >
+          {items.map((step, index) => {
+            const isActive = index === activeIndex;
+            const isDone = completed.has(index);
+            const hasError = erroredSteps.has(index);
+
+            return (
+              <li key={step.name}>
+                <button
+                  aria-current={isActive ? "step" : undefined}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lt px-3 py-2 text-left text-sm",
+                    isActive ? "bg-lt-muted font-medium text-lt-fg" : "text-lt-muted-fg",
+                    !visited.has(index) && "cursor-not-allowed opacity-60",
+                  )}
+                  data-test={`wizard-rail-${step.name}`}
+                  disabled={!visited.has(index)}
+                  id={`wizard-step-${step.name}-trigger`}
+                  onClick={() => goTo(index)}
+                  type="button"
+                >
+                  <span
+                    className={cn(
+                      "flex size-5 shrink-0 items-center justify-center rounded-full border text-xs",
+                      hasError
+                        ? "border-lt-danger text-lt-danger"
+                        : isDone
+                          ? "border-lt-primary bg-lt-primary text-lt-primary-fg"
+                          : "border-lt-border",
+                    )}
+                  >
+                    {isDone && !hasError ? (
+                      <Icon className="size-lt-icon-sm" name="check" />
+                    ) : (
+                      index + 1
+                    )}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate">{step.label}</span>
+                    {isVertical && step.description && (
+                      <span className="block truncate text-xs text-lt-muted-fg">
+                        {step.description}
+                      </span>
+                    )}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          {children}
+
+          <div className="flex items-center justify-between gap-3">
+            <Button
+              data-test="wizard-back"
+              disabled={activeIndex === 0 || processing}
+              onClick={() => goTo(activeIndex - 1)}
+              type="button"
+              variant="outline"
+            >
+              {t("form.wizard.back", "Back")}
+            </Button>
+
+            {isLast ? (
+              <Button data-test="wizard-finish" disabled={processing} type="submit">
+                {processing && <Spinner />}
+                {t("form.wizard.finish", "Finish")}
+              </Button>
+            ) : (
+              <Button
+                data-test="wizard-next"
+                disabled={processing || validating}
+                onClick={onNext}
+                type="button"
+              >
+                {validating && <Spinner />}
+                {t("form.wizard.next", "Next")}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </WizardContext.Provider>
+  );
+};
+
+export const WizardStepComponent: RendererComponent<"wizard-step"> = ({ children, node }) => {
+  const { activeName } = useContext(WizardContext);
+  const name = node.props.name;
+  const isActive = activeName === name;
+  const [hasOpened, setHasOpened] = useState(isActive);
+
+  useEffect(() => {
+    if (isActive) {
+      setHasOpened(true);
+    }
+  }, [isActive]);
+
+  return (
+    <section
+      aria-labelledby={`wizard-step-${name}-trigger`}
+      className={cn("space-y-8", !isActive && "hidden")}
+      hidden={!isActive}
+      id={`wizard-step-${name}-panel`}
+    >
+      {hasOpened ? (children as ReactNode) : null}
+    </section>
+  );
+};

--- a/resources/js/form/components/wizard.tsx
+++ b/resources/js/form/components/wizard.tsx
@@ -105,6 +105,7 @@ export const WizardComponent: RendererComponent<"wizard"> = ({ children, node })
                     isActive ? "bg-lt-muted font-medium text-lt-fg" : "text-lt-muted-fg",
                     !visited.has(index) && "cursor-not-allowed opacity-60",
                   )}
+                  data-error={hasError || undefined}
                   data-test={`wizard-rail-${step.name}`}
                   disabled={!visited.has(index)}
                   id={`wizard-step-${step.name}-trigger`}

--- a/resources/js/form/embed.ts
+++ b/resources/js/form/embed.ts
@@ -16,7 +16,7 @@ export { FormValuesProvider, useFormValues, useSetFormValue } from "./hooks/valu
 export { walkFields } from "./lib/field-props";
 export { collectFields } from "./lib/collect-fields";
 export type { CollectedFields } from "./lib/collect-fields";
-export { firstErrors } from "./lib/field-errors";
+export { errorKeyBelongsTo, firstErrors } from "./lib/field-errors";
 export type { FieldErrors } from "./lib/field-errors";
 export { appendPath, getPath, setPath } from "./lib/form-path";
 export { FORM_DEBOUNCE_MS } from "./lib/form-transport";

--- a/resources/js/form/hooks/context.tsx
+++ b/resources/js/form/hooks/context.tsx
@@ -17,7 +17,13 @@ type FormContextValue = {
     values: Record<string, unknown>,
     signal: AbortSignal,
   ) => Promise<Option[]>;
+  touch: (fields: string[]) => void;
   validate: (field: string) => void;
+  validateFields: (
+    fields: string[],
+    options?: { onSuccess?: () => void; onValidationError?: () => void },
+  ) => void;
+  validating: boolean;
 };
 
 const FormContext = createContext<FormContextValue>({
@@ -30,7 +36,10 @@ const FormContext = createContext<FormContextValue>({
   fieldLabels: {},
   precognitive: false,
   processing: false,
+  touch: () => {},
   validate: () => {},
+  validateFields: () => {},
+  validating: false,
 });
 
 export function FormProvider({

--- a/resources/js/form/hooks/context.tsx
+++ b/resources/js/form/hooks/context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
 import type { Option } from "@lattice-php/lattice/core/types";
 
-type FormContextValue = {
+export type FormContextValue = {
   action: string;
   clearErrors: (field: string) => void;
   componentId?: string;

--- a/resources/js/form/lib/field-errors.ts
+++ b/resources/js/form/lib/field-errors.ts
@@ -1,5 +1,10 @@
 export type FieldErrors = Record<string, string | undefined>;
 
+/** Whether an error-bag key targets the named field itself or a path nested under it. */
+export function errorKeyBelongsTo(key: string, name: string): boolean {
+  return key === name || key.startsWith(`${name}.`);
+}
+
 /** Reduce a Laravel 422 error bag (arrays of messages) to the first per field. */
 export function firstErrors(errors: Record<string, string[] | string> | undefined): FieldErrors {
   const result: FieldErrors = {};

--- a/resources/js/form/lib/field-props.ts
+++ b/resources/js/form/lib/field-props.ts
@@ -28,6 +28,13 @@ type FieldProps = Partial<
   >
 >;
 
+/**
+ * Field types whose value is a collection of rows. Schema walkers must not
+ * descend into their child schemas as top-level fields; children live under
+ * `name.<index>.` paths instead.
+ */
+export const ROW_FIELD_TYPES = new Set(["field.builder", "field.repeater"]);
+
 export function fieldProps(node: Node): FieldProps {
   return node.props as FieldProps;
 }

--- a/resources/js/form/lib/prefill-targets.ts
+++ b/resources/js/form/lib/prefill-targets.ts
@@ -1,5 +1,5 @@
 import type { Node } from "@lattice-php/lattice/core/types";
-import { fieldProps } from "./field-props";
+import { fieldProps, ROW_FIELD_TYPES } from "./field-props";
 import { rowSchemaFor } from "@lattice-php/lattice/form/components/fields/row-templates";
 import { appendPath, getPath } from "./form-path";
 import { buildOverrideKey, rowIdFrom } from "./override-keys";
@@ -15,8 +15,6 @@ type PrefillSnapshot = {
   targets: PrefillTarget[];
   values: Record<string, unknown>;
 };
-
-const ROW_COLLECTION_TYPES = new Set(["field.builder", "field.repeater"]);
 
 export { getPath } from "./form-path";
 
@@ -69,7 +67,7 @@ export function collectPrefillTargets(
     row: Record<string, unknown> = {},
   ): void => {
     for (const node of list ?? []) {
-      if (ROW_COLLECTION_TYPES.has(node.type)) {
+      if (ROW_FIELD_TYPES.has(node.type)) {
         const name = fieldProps(node).name;
         if (name) {
           const childCollectionPath = appendPath(rowPath, name);

--- a/resources/js/form/lib/wizard-steps.test.ts
+++ b/resources/js/form/lib/wizard-steps.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { Node } from "@lattice-php/lattice/core/types";
+import {
+  firstErroredStep,
+  stepFieldNames,
+  stepsWithErrors,
+  stepValidationPaths,
+} from "./wizard-steps";
+
+const node = (type: string, props: Record<string, unknown>, schema: Node[] = []): Node =>
+  ({ type, props, schema }) as unknown as Node;
+
+const customerStep = node("wizard-step", { name: "customer" }, [
+  node("field.text-input", { name: "name" }),
+  node("section", {}, [node("field.text-input", { name: "email" })]),
+]);
+
+const itemsStep = node("wizard-step", { name: "items" }, [
+  node("field.repeater", { name: "items" }, [
+    node("field.text-input", { name: "sku" }),
+    node("field.number-input", { name: "qty" }),
+  ]),
+  node("field.select", { name: "tags" }),
+]);
+
+describe("stepFieldNames", () => {
+  it("collects field names through nested containers", () => {
+    expect(stepFieldNames(customerStep)).toEqual(["name", "email"]);
+  });
+
+  it("does not descend into row-field children", () => {
+    expect(stepFieldNames(itemsStep)).toEqual(["items", "tags"]);
+  });
+});
+
+describe("stepValidationPaths", () => {
+  it("emits the name and a wildcard item pattern for every plain field", () => {
+    expect(stepValidationPaths(customerStep)).toEqual(["name", "name.*", "email", "email.*"]);
+  });
+
+  it("emits wildcard row patterns for row fields without descending further", () => {
+    expect(stepValidationPaths(itemsStep)).toEqual([
+      "items",
+      "items.*",
+      "items.*.sku",
+      "items.*.qty",
+      "tags",
+      "tags.*",
+    ]);
+  });
+});
+
+describe("error partitioning", () => {
+  const stepNames = [
+    ["name", "email"],
+    ["items", "tags"],
+  ];
+
+  it("maps error keys to their owning steps by name prefix", () => {
+    expect(stepsWithErrors(stepNames, { "items.0.sku": "Required", email: "Invalid" })).toEqual(
+      new Set([0, 1]),
+    );
+  });
+
+  it("ignores cleared errors and unknown keys", () => {
+    expect(stepsWithErrors(stepNames, { email: undefined, other: "x" })).toEqual(new Set());
+  });
+
+  it("returns the first errored step or null", () => {
+    expect(firstErroredStep(stepNames, { "items.0.sku": "Required" })).toBe(1);
+    expect(firstErroredStep(stepNames, {})).toBeNull();
+  });
+});

--- a/resources/js/form/lib/wizard-steps.ts
+++ b/resources/js/form/lib/wizard-steps.ts
@@ -1,7 +1,6 @@
 import type { Node } from "@lattice-php/lattice/core/types";
-import { fieldProps } from "./field-props";
-
-const ROW_FIELD_TYPES = new Set(["field.builder", "field.repeater"]);
+import { errorKeyBelongsTo } from "./field-errors";
+import { fieldProps, ROW_FIELD_TYPES } from "./field-props";
 
 export function stepFieldNames(step: Node): string[] {
   const names: string[] = [];
@@ -65,9 +64,7 @@ export function stepsWithErrors(
   const owners = new Set<number>();
 
   stepNames.forEach((names, index) => {
-    const owns = keys.some((key) =>
-      names.some((name) => key === name || key.startsWith(`${name}.`)),
-    );
+    const owns = keys.some((key) => names.some((name) => errorKeyBelongsTo(key, name)));
 
     if (owns) {
       owners.add(index);

--- a/resources/js/form/lib/wizard-steps.ts
+++ b/resources/js/form/lib/wizard-steps.ts
@@ -1,0 +1,87 @@
+import type { Node } from "@lattice-php/lattice/core/types";
+import { fieldProps } from "./field-props";
+
+const ROW_FIELD_TYPES = new Set(["field.builder", "field.repeater"]);
+
+export function stepFieldNames(step: Node): string[] {
+  const names: string[] = [];
+
+  const collect = (node: Node): void => {
+    const name = fieldProps(node).name;
+
+    if (name) {
+      names.push(name);
+    }
+    if (name && ROW_FIELD_TYPES.has(node.type)) {
+      return;
+    }
+    for (const child of node.schema ?? []) {
+      collect(child);
+    }
+  };
+
+  for (const child of step.schema ?? []) {
+    collect(child);
+  }
+
+  return names;
+}
+
+export function stepValidationPaths(step: Node): string[] {
+  const paths: string[] = [];
+
+  const expand = (node: Node): void => {
+    const name = fieldProps(node).name;
+
+    if (name) {
+      paths.push(name, `${name}.*`);
+    }
+
+    if (name && ROW_FIELD_TYPES.has(node.type)) {
+      for (const child of stepFieldNames(node)) {
+        paths.push(`${name}.*.${child}`);
+      }
+
+      return;
+    }
+
+    for (const child of node.schema ?? []) {
+      expand(child);
+    }
+  };
+
+  for (const child of step.schema ?? []) {
+    expand(child);
+  }
+
+  return paths;
+}
+
+export function stepsWithErrors(
+  stepNames: string[][],
+  errors: Record<string, string | undefined>,
+): Set<number> {
+  const keys = Object.keys(errors).filter((key) => Boolean(errors[key]));
+  const owners = new Set<number>();
+
+  stepNames.forEach((names, index) => {
+    const owns = keys.some((key) =>
+      names.some((name) => key === name || key.startsWith(`${name}.`)),
+    );
+
+    if (owns) {
+      owners.add(index);
+    }
+  });
+
+  return owners;
+}
+
+export function firstErroredStep(
+  stepNames: string[][],
+  errors: Record<string, string | undefined>,
+): number | null {
+  const owners = stepsWithErrors(stepNames, errors);
+
+  return owners.size > 0 ? Math.min(...owners) : null;
+}

--- a/resources/js/form/plugin.ts
+++ b/resources/js/form/plugin.ts
@@ -23,6 +23,8 @@ import {
   TextInputComponent,
   TimeInputComponent,
   ToggleComponent,
+  WizardComponent,
+  WizardStepComponent,
 } from "./components";
 import { RichEditorComponent } from "./components/fields/rich-editor";
 
@@ -47,6 +49,8 @@ export const formComponents = createPlugin({
     "field.text-input": eagerComponent(TextInputComponent),
     "field.time-input": eagerComponent(TimeInputComponent),
     "field.toggle": eagerComponent(ToggleComponent),
+    wizard: eagerComponent(WizardComponent),
+    "wizard-step": eagerComponent(WizardStepComponent),
   } satisfies ComponentRegistryFor<FormNodeType>,
   name: "lattice/form",
 });

--- a/resources/js/table/components/filter-controls.tsx
+++ b/resources/js/table/components/filter-controls.tsx
@@ -117,7 +117,10 @@ function SchemaControl({
         _values: Record<string, unknown>,
         signal: AbortSignal,
       ) => (onSearch ? onSearch(field, query, signal) : Promise.resolve([])),
+      touch: () => {},
       validate: () => {},
+      validateFields: () => {},
+      validating: false,
     }),
     [filter.key, onSearch, processing],
   );

--- a/resources/js/test-support.ts
+++ b/resources/js/test-support.ts
@@ -1,8 +1,27 @@
 import { render, type RenderResult } from "@testing-library/react";
 import { createElement, type ComponentType, type ReactNode } from "react";
 import type { Node, ComponentPropsOf, Schema } from "./core/types";
+import type { FormContextValue } from "./form/hooks/context";
 import { FormValuesProvider } from "./form/hooks/values";
 import type { FieldConditions } from "./types/generated";
+
+/** A complete no-op form context; override only what a case asserts on. */
+export function fakeFormContext(overrides: Partial<FormContextValue> = {}): FormContextValue {
+  return {
+    action: "#",
+    clearErrors: () => {},
+    componentRef: "",
+    errors: {},
+    fieldLabels: {},
+    precognitive: false,
+    processing: false,
+    touch: () => {},
+    validate: () => {},
+    validateFields: () => {},
+    validating: false,
+    ...overrides,
+  };
+}
 
 /** Fill the intents a case omits so a partial reads as the full wire `conditions` shape. */
 export function fakeConditions(partial: Partial<FieldConditions>): FieldConditions {

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -534,6 +534,8 @@ export type ComponentPropsMap = {
   text: Text;
   tooltip: Tooltip;
   topbar: Topbar;
+  wizard: Wizard;
+  "wizard-step": WizardStep;
 };
 export type Condition = {
   readonly field: string;
@@ -795,7 +797,9 @@ export type FormFieldNodeType =
   | "field.text-input"
   | "field.textarea"
   | "field.time-input"
-  | "field.toggle";
+  | "field.toggle"
+  | "wizard"
+  | "wizard-step";
 export type FormNodeType =
   | "field.builder"
   | "field.checkbox"
@@ -815,7 +819,9 @@ export type FormNodeType =
   | "field.textarea"
   | "field.time-input"
   | "field.toggle"
-  | "form";
+  | "form"
+  | "wizard"
+  | "wizard-step";
 export type Fragment = {
   endpoint: string | null;
   lazy: boolean;
@@ -1029,7 +1035,9 @@ export type NodeType =
   | "tabs"
   | "text"
   | "tooltip"
-  | "topbar";
+  | "topbar"
+  | "wizard"
+  | "wizard-step";
 export type NotificationItem = {
   readonly actions: Node[];
   readonly body: string | null;
@@ -1630,3 +1638,11 @@ export type UnreadCount = {
 };
 export type Variant = "success" | "info" | "warning" | "error";
 export type Width = "full" | "auto" | "sm" | "md" | "lg" | "fill";
+export type Wizard = {
+  orientation: Orientation;
+};
+export type WizardStep = {
+  description: string | null;
+  label: string;
+  name: string;
+};

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -219,10 +219,11 @@ class Form extends ContainerComponent
     {
         $children = $this->resolvedChildren();
         $hasRootWizard = count($children) === 1 && $children[0] instanceof Wizard;
-        $containsWizard = collect($this->descendants())
-            ->contains(fn (Component $component): bool => $component instanceof Wizard);
+        $wizardCount = collect($this->descendants())
+            ->filter(fn (Component $component): bool => $component instanceof Wizard)
+            ->count();
 
-        if ($containsWizard && ! $hasRootWizard) {
+        if ($wizardCount > 1 || ($wizardCount === 1 && ! $hasRootWizard)) {
             throw new LogicException('A wizard must be the sole root child of its form schema.');
         }
 

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -18,6 +18,7 @@ use Lattice\Lattice\Ui\Components\IsInteractive;
 use Lattice\Lattice\Ui\Concerns\HasHttpMethod;
 use Lattice\Lattice\Ui\Enums\ButtonVariant;
 use Lattice\Lattice\Ui\Enums\Justify;
+use LogicException;
 
 #[AsComponent('form')]
 class Form extends ContainerComponent
@@ -207,6 +208,29 @@ class Form extends ContainerComponent
         $this->status = $status;
 
         return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 190)]
+    protected function configureWizard(array $data): array
+    {
+        $children = $this->resolvedChildren();
+        $hasRootWizard = count($children) === 1 && $children[0] instanceof Wizard;
+        $containsWizard = collect($this->descendants())
+            ->contains(fn (Component $component): bool => $component instanceof Wizard);
+
+        if ($containsWizard && ! $hasRootWizard) {
+            throw new LogicException('A wizard must be the sole root child of its form schema.');
+        }
+
+        if ($hasRootWizard) {
+            $this->submitButton = false;
+        }
+
+        return $data;
     }
 
     /**

--- a/src/Forms/Components/Wizard.php
+++ b/src/Forms/Components/Wizard.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Ui\Components\ContainerComponent;
+use Lattice\Lattice\Ui\Enums\Orientation;
+use LogicException;
+
+#[AsComponent('wizard')]
+class Wizard extends ContainerComponent
+{
+    public Orientation $orientation = Orientation::Horizontal;
+
+    /**
+     * @param  array<int, WizardStep>  $steps
+     */
+    public static function make(array $steps = [], ?string $key = null): static
+    {
+        $wizard = new static($key);
+
+        if ($steps !== []) {
+            $wizard->schema($steps);
+        }
+
+        return $wizard;
+    }
+
+    public function orientation(Orientation $orientation): static
+    {
+        $this->orientation = $orientation;
+
+        return $this;
+    }
+
+    public function vertical(): static
+    {
+        return $this->orientation(Orientation::Vertical);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 290)]
+    protected function assertStepChildren(array $data): array
+    {
+        foreach ($this->renderableChildren() as $child) {
+            if (! $child instanceof WizardStep) {
+                throw new LogicException('Wizard children must be WizardStep components.');
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/Forms/Components/Wizard.php
+++ b/src/Forms/Components/Wizard.php
@@ -19,13 +19,7 @@ class Wizard extends ContainerComponent
      */
     public static function make(array $steps = [], ?string $key = null): static
     {
-        $wizard = new static($key);
-
-        if ($steps !== []) {
-            $wizard->schema($steps);
-        }
-
-        return $wizard;
+        return new static($key)->schema($steps);
     }
 
     public function orientation(Orientation $orientation): static

--- a/src/Forms/Components/WizardStep.php
+++ b/src/Forms/Components/WizardStep.php
@@ -31,9 +31,4 @@ class WizardStep extends ContainerComponent
 
         return $this;
     }
-
-    public function name(): string
-    {
-        return $this->name;
-    }
 }

--- a/src/Forms/Components/WizardStep.php
+++ b/src/Forms/Components/WizardStep.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\Components;
+
+use Illuminate\Support\Str;
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Ui\Components\ContainerComponent;
+
+#[AsComponent('wizard-step')]
+class WizardStep extends ContainerComponent
+{
+    public string $name = '';
+
+    public string $label = '';
+
+    public ?string $description = null;
+
+    public static function make(string $name, ?string $label = null, ?string $key = null): static
+    {
+        $step = new static($key);
+        $step->name = $name;
+        $step->label = $label ?? Str::headline($name);
+
+        return $step;
+    }
+
+    public function description(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/Browser/Forms/WizardTest.php
+++ b/tests/Browser/Forms/WizardTest.php
@@ -44,6 +44,12 @@ it('walks all steps and submits the accumulated state on finish', function (): v
 
     assertSeeEventually($page, 'Review your input');
 
+    retryUntil(function () use ($page): void {
+        $page->assertValue('review_name', 'Taylor')
+            ->assertValue('review_email', 'taylor@example.com')
+            ->assertValue('review_items', '2 × SKU-1');
+    });
+
     $page->click('@wizard-finish');
 
     assertSeeEventually($page, 'Order placed.');

--- a/tests/Browser/Forms/WizardTest.php
+++ b/tests/Browser/Forms/WizardTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+it('blocks advancing while the step is invalid and shows inline errors', function (): void {
+    $page = $this->visitAsWorkbenchUser('/form/wizard');
+
+    $page->assertSee('Checkout wizard')
+        ->click('@wizard-next');
+
+    assertSeeEventually($page, 'The Name field is required.');
+
+    $page->assertPresent('@wizard-next')
+        ->assertMissing('@wizard-finish')
+        ->assertNoSmoke();
+});
+
+it('advances on a valid step and preserves values when navigating back', function (): void {
+    $page = $this->visitAsWorkbenchUser('/form/wizard');
+
+    $page->fill('@name', 'Taylor')
+        ->fill('@email', 'taylor@example.com')
+        ->click('@wizard-next');
+
+    assertSeeEventually($page, 'SKU');
+
+    $page->click('@wizard-back')
+        ->assertValue('name', 'Taylor')
+        ->assertValue('email', 'taylor@example.com')
+        ->assertNoSmoke();
+});
+
+it('walks all steps and submits the accumulated state on finish', function (): void {
+    $page = $this->visitAsWorkbenchUser('/form/wizard');
+
+    $page->fill('@name', 'Taylor')
+        ->fill('@email', 'taylor@example.com')
+        ->click('@wizard-next');
+
+    assertSeeEventually($page, 'SKU');
+
+    $page->fill('@sku', 'SKU-1')
+        ->fill('@qty', '2')
+        ->click('@wizard-next');
+
+    assertSeeEventually($page, 'Review your input');
+
+    $page->click('@wizard-finish');
+
+    assertSeeEventually($page, 'Order placed.');
+
+    $page->assertNoSmoke();
+});
+
+it('lets the rail jump back to a visited step but not ahead', function (): void {
+    $page = $this->visitAsWorkbenchUser('/form/wizard');
+
+    $page->assertPresent('[data-test="wizard-rail-review"][disabled]')
+        ->fill('@name', 'Taylor')
+        ->fill('@email', 'taylor@example.com')
+        ->click('@wizard-next');
+
+    assertSeeEventually($page, 'SKU');
+
+    $page->click('@wizard-rail-customer')
+        ->assertValue('name', 'Taylor')
+        ->assertNoSmoke();
+});

--- a/tests/Browser/SmokeTest.php
+++ b/tests/Browser/SmokeTest.php
@@ -17,6 +17,7 @@ it('renders every demo page without smoke failures', function (): void {
         '/form/fields/repeater',
         '/form/fields/builder',
         '/form/dependent',
+        '/form/wizard',
         '/tables/columns/text',
         '/tables/columns/number',
         '/tables/columns/visual',

--- a/tests/Feature/Actions/ActionFormTest.php
+++ b/tests/Feature/Actions/ActionFormTest.php
@@ -13,6 +13,8 @@ use Lattice\Lattice\Forms\Components\Form as FormComponent;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\Textarea;
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\Components\Wizard;
+use Lattice\Lattice\Forms\Components\WizardStep;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Ui\Enums\HttpMethod;
@@ -114,6 +116,54 @@ it('validates the embedded form precognitively without running handle', function
     postJson('/lattice/actions/test.reject', ['reason' => 'ok'], $precognition)
         ->assertNoContent();
 });
+
+it('suppresses the submit row of a wizard form action so only the wizard controls submit', function (): void {
+    Lattice::actions([WizardActionFixture::class]);
+
+    $this->callAction(WizardActionFixture::class, ['_form' => true])
+        ->assertOk()
+        ->assertJsonPath('type', 'form')
+        ->assertJsonPath('props.submitButton', false)
+        ->assertJsonPath('schema.0.type', 'wizard');
+});
+
+it('validates an embedded wizard step precognitively without running handle', function (): void {
+    Lattice::actions([WizardActionFixture::class]);
+    $ref = $this->latticeRef(wire(ActionComponent::use(WizardActionFixture::class)));
+
+    postJson('/lattice/actions/test.wizard-checkout', ['name' => ''], array_merge($this->latticeHeaders($ref), [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'name,name.*',
+    ]))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('name');
+});
+
+#[AsAction('test.wizard-checkout')]
+class WizardActionFixture extends FormActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Checkout');
+    }
+
+    public function formSchema(FormComponent $form, Request $request): FormComponent
+    {
+        return $form->schema([
+            Wizard::make([
+                WizardStep::make('customer')->schema([
+                    TextInput::make('name', 'Name')->required(),
+                ]),
+                WizardStep::make('review'),
+            ]),
+        ]);
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success($this->validate($request));
+    }
+}
 
 it('resolves searchable options for an embedded select', function (): void {
     Lattice::actions([AssignActionFixture::class]);

--- a/tests/Feature/Docs/WizardDocsTest.php
+++ b/tests/Feature/Docs/WizardDocsTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\Wizard;
+use Lattice\Lattice\Forms\Components\WizardStep;
+use Lattice\Lattice\Support\Wire;
+use Lattice\Lattice\Ui\Components\Text;
+
+describe('docs fixtures', function (): void {
+    it('matches the wizard example fixture', function (): void {
+        assertFixtureMatches('wizard.basic', sortFixtureKeys(stripFixtureRefs(Wire::toWire([
+            Wizard::make([
+                WizardStep::make('customer')
+                    ->description('Who is this order for?')
+                    ->schema([
+                        Text::make('Confirm the customer before moving on.'),
+                    ]),
+                WizardStep::make('shipping-address')
+                    ->description('Where should we send it?')
+                    ->schema([
+                        Text::make('Add the shipping details.'),
+                    ]),
+                WizardStep::make('review')
+                    ->description('Check everything before you finish.')
+                    ->schema([
+                        Text::make('Everything looks good — finish to place the order.'),
+                    ]),
+            ])->vertical(),
+        ]))));
+    });
+});

--- a/tests/Feature/Forms/WizardComponentTest.php
+++ b/tests/Feature/Forms/WizardComponentTest.php
@@ -1,10 +1,17 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\Components\Wizard;
 use Lattice\Lattice\Forms\Components\WizardStep;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Ui\Components\Section;
 use Lattice\Lattice\Ui\Components\Text;
+use Symfony\Component\HttpFoundation\Response;
 
 test('wizard steps serialize their identity and default the label from the name', function (): void {
     $step = wire(WizardStep::make('customer-details')->description('Who is this for?'));
@@ -41,3 +48,63 @@ test('wizards serialize their orientation and step schema', function (): void {
 test('wizards reject children that are not wizard steps', function (): void {
     wire(Wizard::make()->schema([Text::make('Loose text')]));
 })->throws(LogicException::class, 'Wizard children must be WizardStep components.');
+
+test('a form with a wizard as its sole root child suppresses the default submit row', function (): void {
+    Lattice::forms([WizardCheckoutTestForm::class]);
+
+    $form = wire(Form::use(WizardCheckoutTestForm::class));
+
+    expect($form['props']['submitButton'])->toBeFalse()
+        ->and($form['schema'][0]['type'])->toBe('wizard');
+});
+
+test('a wizard beside sibling root components is rejected', function (): void {
+    wire(Form::make('broken')->schema([
+        Text::make('Intro'),
+        Wizard::make([WizardStep::make('one')]),
+    ]));
+})->throws(LogicException::class, 'sole root child');
+
+test('a wizard nested below the form root is rejected', function (): void {
+    wire(Form::make('nested')->schema([
+        Section::make('Wrapper')->schema([
+            Wizard::make([WizardStep::make('one')]),
+        ]),
+    ]));
+})->throws(LogicException::class, 'sole root child');
+
+test('a render-gated sole-root wizard is valid placement and still suppresses the submit row', function (): void {
+    $form = wire(Form::make('gated')->schema([
+        Wizard::make([WizardStep::make('one')])->hidden(),
+    ]));
+
+    expect($form['props']['submitButton'])->toBeFalse()
+        ->and($form['schema'] ?? [])->toBe([]);
+});
+
+#[AsForm('workbench.wizard-checkout')]
+class WizardCheckoutTestForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([
+            Wizard::make([
+                WizardStep::make('customer')->schema([
+                    TextInput::make('name', 'Name')->required(),
+                    TextInput::make('email', 'Email')->rules(['required', 'email']),
+                ]),
+                WizardStep::make('address')->schema([
+                    TextInput::make('street', 'Street')->required(),
+                ]),
+                WizardStep::make('review'),
+            ]),
+        ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->session()->put('handled-wizard', $request->string('name')->toString());
+
+        return response()->json(['handled' => true]);
+    }
+}

--- a/tests/Feature/Forms/WizardComponentTest.php
+++ b/tests/Feature/Forms/WizardComponentTest.php
@@ -2,7 +2,9 @@
 declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\Components\Wizard;
 use Lattice\Lattice\Forms\Components\WizardStep;
+use Lattice\Lattice\Ui\Components\Text;
 
 test('wizard steps serialize their identity and default the label from the name', function (): void {
     $step = wire(WizardStep::make('customer-details')->description('Who is this for?'));
@@ -24,3 +26,18 @@ test('wizard steps serialize an explicit label and their child schema', function
     expect($step['props'])->toMatchArray(['name' => 'customer', 'label' => 'Customer info'])
         ->and($step['schema'][0]['type'])->toBe('field.text-input');
 });
+
+test('wizards serialize their orientation and step schema', function (): void {
+    $wizard = wire(Wizard::make([
+        WizardStep::make('customer'),
+        WizardStep::make('review'),
+    ])->vertical());
+
+    expect($wizard['type'])->toBe('wizard')
+        ->and($wizard['props'])->toMatchArray(['orientation' => 'vertical'])
+        ->and(array_column($wizard['schema'], 'type'))->toBe(['wizard-step', 'wizard-step']);
+});
+
+test('wizards reject children that are not wizard steps', function (): void {
+    wire(Wizard::make()->schema([Text::make('Loose text')]));
+})->throws(LogicException::class, 'Wizard children must be WizardStep components.');

--- a/tests/Feature/Forms/WizardComponentTest.php
+++ b/tests/Feature/Forms/WizardComponentTest.php
@@ -73,6 +73,16 @@ test('a wizard nested below the form root is rejected', function (): void {
     ]));
 })->throws(LogicException::class, 'sole root child');
 
+test('a wizard nested inside a wizard step is rejected', function (): void {
+    wire(Form::make('inception')->schema([
+        Wizard::make([
+            WizardStep::make('outer')->schema([
+                Wizard::make([WizardStep::make('inner')]),
+            ]),
+        ]),
+    ]));
+})->throws(LogicException::class, 'sole root child');
+
 test('a render-gated sole-root wizard is valid placement and still suppresses the submit row', function (): void {
     $form = wire(Form::make('gated')->schema([
         Wizard::make([WizardStep::make('one')])->hidden(),

--- a/tests/Feature/Forms/WizardComponentTest.php
+++ b/tests/Feature/Forms/WizardComponentTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\Components\WizardStep;
+
+test('wizard steps serialize their identity and default the label from the name', function (): void {
+    $step = wire(WizardStep::make('customer-details')->description('Who is this for?'));
+
+    expect($step['type'])->toBe('wizard-step')
+        ->and($step['props'])->toMatchArray([
+            'name' => 'customer-details',
+            'label' => 'Customer Details',
+            'description' => 'Who is this for?',
+        ])
+        ->and($step['schema'] ?? [])->toBe([]);
+});
+
+test('wizard steps serialize an explicit label and their child schema', function (): void {
+    $step = wire(WizardStep::make('customer', 'Customer info')->schema([
+        TextInput::make('name', 'Name'),
+    ]));
+
+    expect($step['props'])->toMatchArray(['name' => 'customer', 'label' => 'Customer info'])
+        ->and($step['schema'][0]['type'])->toBe('field.text-input');
+});

--- a/tests/Feature/Forms/WizardStepValidationTest.php
+++ b/tests/Feature/Forms/WizardStepValidationTest.php
@@ -15,23 +15,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 use function Pest\Laravel\postJson;
 
-function wizardStepHeaders(string $ref, string $validateOnly): array
-{
-    return [
-        ...test()->latticeHeaders($ref),
-        'Precognition' => 'true',
-        'Precognition-Validate-Only' => $validateOnly,
-    ];
-}
-
 test('a precognitive request validates only the listed step fields', function (): void {
     Lattice::forms([WizardValidationTestForm::class]);
-    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+    $ref = $this->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
 
     postJson('/lattice/forms/workbench.wizard-validation', [
         'name' => 'Taylor',
         'email' => 'not-an-email',
-    ], wizardStepHeaders($ref, 'name,email'))
+    ], $this->latticeHeaders($ref, [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'name,email',
+    ]))
         ->assertUnprocessable()
         ->assertJsonValidationErrors('email')
         ->assertJsonMissingValidationErrors(['street', 'items']);
@@ -39,12 +33,15 @@ test('a precognitive request validates only the listed step fields', function ()
 
 test('a passing step returns 204 without running handle, even when later steps are incomplete', function (): void {
     Lattice::forms([WizardValidationTestForm::class]);
-    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+    $ref = $this->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
 
     postJson('/lattice/forms/workbench.wizard-validation', [
         'name' => 'Taylor',
         'email' => 'taylor@example.com',
-    ], wizardStepHeaders($ref, 'name,email'))
+    ], $this->latticeHeaders($ref, [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'name,email',
+    ]))
         ->assertNoContent()
         ->assertHeader('Precognition-Success', 'true');
 
@@ -53,13 +50,16 @@ test('a passing step returns 204 without running handle, even when later steps a
 
 test('expanded row paths match wildcard nested rules in a step validation', function (): void {
     Lattice::forms([WizardValidationTestForm::class]);
-    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+    $ref = $this->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
 
     postJson('/lattice/forms/workbench.wizard-validation', [
         'items' => [
             ['sku' => '', 'qty' => 'many'],
         ],
-    ], wizardStepHeaders($ref, 'items,items.0.sku,items.0.qty'))
+    ], $this->latticeHeaders($ref, [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'items,items.0.sku,items.0.qty',
+    ]))
         ->assertUnprocessable()
         ->assertJsonValidationErrors(['items.0.sku', 'items.0.qty'])
         ->assertJsonMissingValidationErrors(['name', 'email']);
@@ -67,13 +67,16 @@ test('expanded row paths match wildcard nested rules in a step validation', func
 
 test('wildcard validate-only patterns match concrete row rule keys', function (): void {
     Lattice::forms([WizardValidationTestForm::class]);
-    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+    $ref = $this->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
 
     postJson('/lattice/forms/workbench.wizard-validation', [
         'items' => [
             ['sku' => '', 'qty' => 'many'],
         ],
-    ], wizardStepHeaders($ref, 'items,items.*.sku,items.*.qty'))
+    ], $this->latticeHeaders($ref, [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'items,items.*.sku,items.*.qty',
+    ]))
         ->assertUnprocessable()
         ->assertJsonValidationErrors(['items.0.sku', 'items.0.qty'])
         ->assertJsonMissingValidationErrors(['name', 'email']);
@@ -81,11 +84,14 @@ test('wildcard validate-only patterns match concrete row rule keys', function ()
 
 test('wildcard validate-only patterns match wildcard item rule keys', function (): void {
     Lattice::forms([WizardValidationTestForm::class]);
-    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+    $ref = $this->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
 
     postJson('/lattice/forms/workbench.wizard-validation', [
         'tags' => ['not-an-option'],
-    ], wizardStepHeaders($ref, 'tags,tags.*'))
+    ], $this->latticeHeaders($ref, [
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => 'tags,tags.*',
+    ]))
         ->assertUnprocessable()
         ->assertJsonValidationErrors('tags.0')
         ->assertJsonMissingValidationErrors(['name', 'email']);
@@ -93,12 +99,12 @@ test('wildcard validate-only patterns match wildcard item rule keys', function (
 
 test('the final submit validates every step regardless of client step claims', function (): void {
     Lattice::forms([WizardValidationTestForm::class]);
-    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+    $ref = $this->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
 
     postJson('/lattice/forms/workbench.wizard-validation', [
         'name' => 'Taylor',
         'email' => 'taylor@example.com',
-    ], test()->latticeHeaders($ref))
+    ], $this->latticeHeaders($ref))
         ->assertUnprocessable()
         ->assertJsonValidationErrors('street');
 

--- a/tests/Feature/Forms/WizardStepValidationTest.php
+++ b/tests/Feature/Forms/WizardStepValidationTest.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\Select;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\Components\Wizard;
+use Lattice\Lattice\Forms\Components\WizardStep;
+use Lattice\Lattice\Forms\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+use function Pest\Laravel\postJson;
+
+function wizardStepHeaders(string $ref, string $validateOnly): array
+{
+    return [
+        ...test()->latticeHeaders($ref),
+        'Precognition' => 'true',
+        'Precognition-Validate-Only' => $validateOnly,
+    ];
+}
+
+test('a precognitive request validates only the listed step fields', function (): void {
+    Lattice::forms([WizardValidationTestForm::class]);
+    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+
+    postJson('/lattice/forms/workbench.wizard-validation', [
+        'name' => 'Taylor',
+        'email' => 'not-an-email',
+    ], wizardStepHeaders($ref, 'name,email'))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('email')
+        ->assertJsonMissingValidationErrors(['street', 'items']);
+});
+
+test('a passing step returns 204 without running handle, even when later steps are incomplete', function (): void {
+    Lattice::forms([WizardValidationTestForm::class]);
+    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+
+    postJson('/lattice/forms/workbench.wizard-validation', [
+        'name' => 'Taylor',
+        'email' => 'taylor@example.com',
+    ], wizardStepHeaders($ref, 'name,email'))
+        ->assertNoContent()
+        ->assertHeader('Precognition-Success', 'true');
+
+    expect(session('handled-wizard-validation'))->toBeNull();
+});
+
+test('expanded row paths match wildcard nested rules in a step validation', function (): void {
+    Lattice::forms([WizardValidationTestForm::class]);
+    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+
+    postJson('/lattice/forms/workbench.wizard-validation', [
+        'items' => [
+            ['sku' => '', 'qty' => 'many'],
+        ],
+    ], wizardStepHeaders($ref, 'items,items.0.sku,items.0.qty'))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['items.0.sku', 'items.0.qty'])
+        ->assertJsonMissingValidationErrors(['name', 'email']);
+});
+
+test('wildcard validate-only patterns match concrete row rule keys', function (): void {
+    Lattice::forms([WizardValidationTestForm::class]);
+    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+
+    postJson('/lattice/forms/workbench.wizard-validation', [
+        'items' => [
+            ['sku' => '', 'qty' => 'many'],
+        ],
+    ], wizardStepHeaders($ref, 'items,items.*.sku,items.*.qty'))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['items.0.sku', 'items.0.qty'])
+        ->assertJsonMissingValidationErrors(['name', 'email']);
+});
+
+test('wildcard validate-only patterns match wildcard item rule keys', function (): void {
+    Lattice::forms([WizardValidationTestForm::class]);
+    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+
+    postJson('/lattice/forms/workbench.wizard-validation', [
+        'tags' => ['not-an-option'],
+    ], wizardStepHeaders($ref, 'tags,tags.*'))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('tags.0')
+        ->assertJsonMissingValidationErrors(['name', 'email']);
+});
+
+test('the final submit validates every step regardless of client step claims', function (): void {
+    Lattice::forms([WizardValidationTestForm::class]);
+    $ref = test()->latticeRef(wire(Form::use(WizardValidationTestForm::class)));
+
+    postJson('/lattice/forms/workbench.wizard-validation', [
+        'name' => 'Taylor',
+        'email' => 'taylor@example.com',
+    ], test()->latticeHeaders($ref))
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('street');
+
+    expect(session('handled-wizard-validation'))->toBeNull();
+});
+
+#[AsForm('workbench.wizard-validation')]
+class WizardValidationTestForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([
+            Wizard::make([
+                WizardStep::make('customer')->schema([
+                    TextInput::make('name', 'Name')->required(),
+                    TextInput::make('email', 'Email')->rules(['required', 'email']),
+                ]),
+                WizardStep::make('items')->schema([
+                    Repeater::make('items', 'Items')->schema([
+                        TextInput::make('sku', 'SKU')->required(),
+                        TextInput::make('qty', 'Quantity')->rules(['required', 'integer']),
+                    ]),
+                    Select::make('tags', 'Tags')
+                        ->multiple()
+                        ->options(['red' => 'Red', 'green' => 'Green', 'blue' => 'Blue'])
+                        ->itemRules(['in:red,green,blue']),
+                ]),
+                WizardStep::make('address')->schema([
+                    TextInput::make('street', 'Street')->required(),
+                ]),
+            ]),
+        ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        $request->session()->put('handled-wizard-validation', true);
+
+        return response()->json(['handled' => true]);
+    }
+}

--- a/workbench/app/Forms/CheckoutWizardForm.php
+++ b/workbench/app/Forms/CheckoutWizardForm.php
@@ -10,8 +10,10 @@ use Lattice\Lattice\Forms\Components\Repeater;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\Components\Wizard;
 use Lattice\Lattice\Forms\Components\WizardStep;
+use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormDefinition;
 use Lattice\Lattice\Http\LatticeResponse;
+use Lattice\Lattice\Ui\Components\Grid;
 use Lattice\Lattice\Ui\Components\Text;
 
 #[AsForm('workbench.checkout-wizard')]
@@ -41,6 +43,27 @@ class CheckoutWizardForm extends FormDefinition
                     ->description(__('workbench.pages.wizard.steps.review.description'))
                     ->schema([
                         Text::make(__('workbench.pages.wizard.steps.review.body')),
+                        Grid::make()->columns(2)->schema([
+                            TextInput::make('review_name', __('workbench.pages.wizard.fields.name'))
+                                ->readOnly()
+                                ->value(fn (FormData $data): string => $data->string('name')),
+                            TextInput::make('review_email', __('workbench.pages.wizard.fields.email'))
+                                ->readOnly()
+                                ->value(fn (FormData $data): string => $data->string('email')),
+                        ]),
+                        TextInput::make('review_items', __('workbench.pages.wizard.fields.items'))
+                            ->readOnly()
+                            ->value(function (FormData $data): string {
+                                $lines = [];
+
+                                foreach ((array) $data->get('items', []) as $row) {
+                                    if (is_array($row) && ($row['sku'] ?? '') !== '') {
+                                        $lines[] = trim(($row['qty'] ?? '1').' × '.$row['sku']);
+                                    }
+                                }
+
+                                return implode(', ', $lines);
+                            }),
                     ]),
             ]),
         ]);

--- a/workbench/app/Forms/CheckoutWizardForm.php
+++ b/workbench/app/Forms/CheckoutWizardForm.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Forms;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Forms\Components\Repeater;
+use Lattice\Lattice\Forms\Components\TextInput;
+use Lattice\Lattice\Forms\Components\Wizard;
+use Lattice\Lattice\Forms\Components\WizardStep;
+use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Http\LatticeResponse;
+use Lattice\Lattice\Ui\Components\Text;
+
+#[AsForm('workbench.checkout-wizard')]
+class CheckoutWizardForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([
+            Wizard::make([
+                WizardStep::make('customer')
+                    ->description(__('workbench.pages.wizard.steps.customer.description'))
+                    ->schema([
+                        TextInput::make('name', __('workbench.pages.wizard.fields.name'))->required(),
+                        TextInput::make('email', __('workbench.pages.wizard.fields.email'))
+                            ->rules(['required', 'email']),
+                    ]),
+                WizardStep::make('items')
+                    ->description(__('workbench.pages.wizard.steps.items.description'))
+                    ->schema([
+                        Repeater::make('items', __('workbench.pages.wizard.fields.items'))->schema([
+                            TextInput::make('sku', __('workbench.pages.wizard.fields.sku'))->required(),
+                            TextInput::make('qty', __('workbench.pages.wizard.fields.qty'))
+                                ->rules(['required', 'integer']),
+                        ]),
+                    ]),
+                WizardStep::make('review')
+                    ->description(__('workbench.pages.wizard.steps.review.description'))
+                    ->schema([
+                        Text::make(__('workbench.pages.wizard.steps.review.body')),
+                    ]),
+            ]),
+        ]);
+    }
+
+    public function handle(Request $request): LatticeResponse
+    {
+        $this->validate($request);
+
+        return $this->toast(__('workbench.pages.wizard.submitted'))->back();
+    }
+}

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -74,6 +74,7 @@ use Workbench\App\Pages\Tables\NumberColumnsPage;
 use Workbench\App\Pages\Tables\PaginationPage;
 use Workbench\App\Pages\Tables\TextColumnsPage;
 use Workbench\App\Pages\Tables\VisualColumnsPage;
+use Workbench\App\Pages\WizardPage;
 use Workbench\App\Support\Logo;
 
 #[AsLayout('app')]
@@ -140,6 +141,7 @@ class AppLayout extends LayoutDefinition
                         MenuItem::fromPage(BuilderPage::class)->key('field-builder')->label(__('workbench.navigation.field-builder')),
                     ]),
                     MenuItem::fromPage(DependentFieldsPage::class)->key('dependent-fields')->label(__('workbench.navigation.dependent-fields')),
+                    MenuItem::fromPage(WizardPage::class)->key('wizard')->label(__('workbench.navigation.wizard')),
                 ]),
                 MenuItem::make(__('workbench.navigation.tables'), 'tables')->prefix(Icon::Table)->children([
                     MenuItem::make(__('workbench.navigation.columns'), 'columns')->children([

--- a/workbench/app/Pages/WizardPage.php
+++ b/workbench/app/Pages/WizardPage.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Lattice\Ui\Enums\HttpMethod;
+use Workbench\App\Forms\CheckoutWizardForm;
+
+#[AsPage(route: '/form/wizard', name: 'form.wizard')]
+class WizardPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return __('workbench.pages.wizard.title');
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('wizard-page')
+                ->gap(Gap::Large)
+                ->schema([
+                    Heading::make($this->title()),
+                    Text::make(__('workbench.pages.wizard.description')),
+                    Form::use(CheckoutWizardForm::class)->method(HttpMethod::Post),
+                ]),
+        ]);
+    }
+}

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -418,6 +418,7 @@ return [
         'tables' => 'Tabellen',
         'tabs' => 'Tabs',
         'toggle-sidebar' => 'Seitenleiste umschalten',
+        'wizard' => 'Assistent',
     ],
     'pages' => [
         'charts' => [
@@ -720,6 +721,26 @@ return [
             'title' => 'Lattice Tabs',
             'vertical' => 'Vertikale Tabs',
             'vertical-end' => 'Vertikale Tabs (rechts)',
+        ],
+        'wizard' => [
+            'title' => 'Checkout-Assistent',
+            'description' => 'Mehrstufiges Formular mit serverseitiger Validierung pro Schritt.',
+            'submitted' => 'Bestellung aufgegeben.',
+            'steps' => [
+                'customer' => ['description' => 'Wer bestellt'],
+                'items' => ['description' => 'Was bestellt wird'],
+                'review' => [
+                    'description' => 'Bestätigen und abschließen',
+                    'body' => 'Prüfen Sie Ihre Eingaben und schließen Sie ab, um das gesamte Formular zu senden.',
+                ],
+            ],
+            'fields' => [
+                'name' => 'Name',
+                'email' => 'E-Mail',
+                'items' => 'Artikel',
+                'sku' => 'SKU',
+                'qty' => 'Menge',
+            ],
         ],
     ],
     'status' => [

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -418,6 +418,7 @@ return [
         'tables' => 'Tables',
         'tabs' => 'Tabs',
         'toggle-sidebar' => 'Toggle sidebar',
+        'wizard' => 'Wizard',
     ],
     'pages' => [
         'charts' => [
@@ -720,6 +721,26 @@ return [
             'title' => 'Lattice Tabs',
             'vertical' => 'Vertical tabs',
             'vertical-end' => 'Vertical tabs (right)',
+        ],
+        'wizard' => [
+            'title' => 'Checkout wizard',
+            'description' => 'Multi-step form with per-step server validation.',
+            'submitted' => 'Order placed.',
+            'steps' => [
+                'customer' => ['description' => 'Who is ordering'],
+                'items' => ['description' => 'What they are ordering'],
+                'review' => [
+                    'description' => 'Confirm and finish',
+                    'body' => 'Review your input, then finish to submit the whole form.',
+                ],
+            ],
+            'fields' => [
+                'name' => 'Name',
+                'email' => 'Email',
+                'items' => 'Items',
+                'sku' => 'SKU',
+                'qty' => 'Quantity',
+            ],
         ],
     ],
     'status' => [


### PR DESCRIPTION
Adds a multi-step form mechanism: `Wizard`/`WizardStep` containers with per-step server-side validation, back navigation with preserved state, and whole-form validation as the gating boundary at Finish.

- `Wizard::make([WizardStep::make('customer')->schema([...]), ...])` as the sole root child of a form schema (anything else throws); the submit row is auto-suppressed and the wizard renders its own Back/Next/Finish footer. `->vertical()` renders a sidebar rail with step descriptions.
- **Next** validates only the active step through the existing Laravel Precognition pipeline — no new endpoints, no server state. The client derives `Precognition-Validate-Only` patterns from the step schema (wildcards cover repeater rows and select item rules); fieldless steps (e.g. a review step) advance without a round-trip.
- **Finish** is an ordinary form submit validating everything — steps cannot be skipped by a manipulated client. On a 422 the wizard jumps to the first errored step and badges every errored step on the rail.
- Step panels use the Tabs mount model (lazy-mount, then CSS-hide), so Back preserves values and the DOM-serialized submit sees every visited step. Wizard state is client-held; a reload restarts the wizard by design.
- The action-form modal path gained a real multi-field `validateFields` (single precognitive request, 2xx-only success), so wizards work inside action forms too.

Demo: workbench → Forms → Wizard (`/form/wizard`). Docs: `forms/wizard`. Covered by feature tests proving the precognition seam (including both wildcard matching directions), component unit tests, and a 4-scenario browser suite.