### PR TITLE
feat: improve component-package authoring DX

### DIFF
--- a/config/lattice.php
+++ b/config/lattice.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 return [
+    // Component packages add their own roots via composer `extra.lattice.discover` — no app config needed.
     'discover' => [
         base_path('app'),
     ],

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -193,6 +193,54 @@ Lattice::pages([
 Discovery is cached alongside `route:cache`, so the filesystem scan does not run on production
 requests.
 
+## Embedded pages
+
+`#[AsPage]` means "this page owns a route" — its `route` argument is what Lattice needs to register one.
+A page can also have no route at all and be rendered by returning it from your own controller instead;
+`Page` implements `Responsable`, so returning an instance is enough:
+
+```php
+use Illuminate\Http\Request;
+use Lattice\Lattice\Http\Page;
+
+class ProductEmbedController
+{
+    public function show(Request $request): Page
+    {
+        return new ProductEmbedPage($request->route('product'));
+    }
+}
+```
+
+The page itself needs no `#[AsPage]` attribute — a plain `Page` subclass works, since `layout()` and
+`container()` method overrides take precedence over attribute metadata regardless of whether the
+attribute is present:
+
+```php
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Enums\PageLayout;
+
+class ProductEmbedPage extends Page
+{
+    public function __construct(private readonly Product $product) {}
+
+    public function layout(): PageLayout
+    {
+        return PageLayout::App;
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Heading::make($this->product->name));
+    }
+}
+```
+
+A route-less `#[AsPage]` class is valid too — useful when the shared metadata (layout, container,
+middleware inheritance from a base page) is worth keeping even though the page has no route of its own.
+Either way, Lattice never builds a route for it: discovery and `Lattice::pages()` both register it in the
+page registry, but only entries with a `route` reach `Route::get()`.
+
 ## Title and breadcrumbs
 
 `title()` sets the document title. `breadcrumbs()` returns the page's trail; a layout's

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -90,6 +90,8 @@ The two `extra.lattice` keys are each read by one side of the stack:
 - **`plugin`** — the `lattice()` Vite plugin scans `vendor/composer/installed.json`, and for every package that declares it, grants Vite filesystem access to the package directory and exposes its plugin under the virtual module `virtual:lattice/plugins`. The package's TSX compiles straight into the consumer's bundle: no separate build step, one shared React instance, full tree-shaking.
 - **`discover`** — Lattice's PHP discovery merges these roots into `lattice.discover`, so the package's `#[AsComponent]` classes are picked up by `php artisan lattice:typescript` (which types `node.props` for the package's components) and by definition discovery for any forms, tables, or pages the package also ships.
 
+A package that owns full screens (an auth UI, say) does not need to register a route for each one — its controllers can return a `Page` directly instead; see [Embedded pages](/core/pages/#embedded-pages).
+
 ## Installing one
 
 For the consumer, it is a single dependency:

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -113,8 +113,10 @@ Signature::make('signature')->label('Sign the contract');
 ```
 
 <Info>
-  Run `php artisan lattice:typescript` after installing a package to refresh the `ComponentProps`
-  augmentation, so `node.props` is typed for its components.
+  The `lattice()` Vite plugin runs `php artisan lattice:typescript` for you when the dev server
+  starts, so the `ComponentProps` augmentation picks up a newly installed package automatically.
+  Run it by hand (`php artisan lattice:typescript`) for CI and editor tooling, which don't have a
+  dev server refreshing types in the background.
 </Info>
 
 <Warning title="Requires the Vite plugin">
@@ -139,7 +141,10 @@ an installed dependency. Both discovery sides account for this: PHP discovery al
 package's own `composer.json` for `extra.lattice.discover`, and the Vite plugin also reads it for
 `extra.lattice.plugin`. The same `composer.json` from [What a package ships](#what-a-package-ships)
 is enough — no pushing config into the workbench app, and no difference between how the package
-discovers itself and how a consumer discovers it once installed.
+discovers itself and how a consumer discovers it once installed. This isn't specific to a
+testbench workbench, either — any composer ROOT (including a real app) can declare
+`extra.lattice.discover`/`plugin` directly in its own `composer.json`, and it is picked up the same
+way.
 
 ## Styling
 

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -131,6 +131,16 @@ roots and JS plugin each installed component package contributes, and whether th
 manifest is cached. Run it after `composer require`-ing a package to confirm it was picked up
 without inspecting `installed.json` by hand.
 
+## Testing your package
+
+A package's own test suite (a Testbench workbench, typically) never appears in
+`vendor/composer/installed.json` — Composer treats it as the ROOT project while its tests run, not
+an installed dependency. Both discovery sides account for this: PHP discovery also reads the
+package's own `composer.json` for `extra.lattice.discover`, and the Vite plugin also reads it for
+`extra.lattice.plugin`. The same `composer.json` from [What a package ships](#what-a-package-ships)
+is enough — no pushing config into the workbench app, and no difference between how the package
+discovers itself and how a consumer discovers it once installed.
+
 ## Styling
 
 <Warning title="Style with Lattice tokens">

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -124,6 +124,13 @@ Signature::make('signature')->label('Sign the contract');
   kit already have it.
 </Warning>
 
+## Verifying your package is discovered
+
+`php artisan about` has a `Lattice` section listing the configured discover paths, the discovery
+roots and JS plugin each installed component package contributes, and whether the discovery
+manifest is cached. Run it after `composer require`-ing a package to confirm it was picked up
+without inspecting `installed.json` by hand.
+
 ## Styling
 
 <Warning title="Style with Lattice tokens">

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -114,9 +114,9 @@ Signature::make('signature')->label('Sign the contract');
 
 <Info>
   The `lattice()` Vite plugin runs `php artisan lattice:typescript` for you when the dev server
-  starts, so the `ComponentProps` augmentation picks up a newly installed package automatically.
-  Run it by hand (`php artisan lattice:typescript`) for CI and editor tooling, which don't have a
-  dev server refreshing types in the background.
+  starts, so the `ComponentProps` augmentation picks up a newly installed package automatically. Run
+  it by hand (`php artisan lattice:typescript`) for CI and editor tooling, which don't have a dev
+  server refreshing types in the background.
 </Info>
 
 <Warning title="Requires the Vite plugin">

--- a/resources/js/vite-typescript-refresh.test.ts
+++ b/resources/js/vite-typescript-refresh.test.ts
@@ -1,0 +1,115 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import path from "node:path";
+import type { Logger } from "vite";
+import { describe, expect, it, vi } from "vitest";
+import { refreshTypeScriptTypes } from "./vite-typescript-refresh";
+
+type FakeLogger = Pick<Logger, "info" | "warn">;
+
+function fakeLogger(): FakeLogger {
+  return { info: vi.fn(), warn: vi.fn() };
+}
+
+function fakeChild(): EventEmitter & { stderr: EventEmitter } {
+  const child = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
+
+  child.stderr = new EventEmitter();
+
+  return child;
+}
+
+describe("refreshTypeScriptTypes", () => {
+  it("spawns php artisan lattice:typescript when the project has an artisan file", () => {
+    const appRoot = path.resolve("/tmp/lattice-app");
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(appRoot, logger, spawnProcess, fileExists);
+
+    expect(fileExists).toHaveBeenCalledWith(path.join(appRoot, "artisan"));
+    expect(spawnProcess).toHaveBeenCalledWith("php", ["artisan", "lattice:typescript"], {
+      cwd: appRoot,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+
+    child.emit("exit", 0);
+
+    expect(logger.info).toHaveBeenCalledWith("[lattice] refreshed TypeScript types");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("skips silently when the project has no artisan file", () => {
+    const spawnProcess = vi.fn();
+    const fileExists = vi.fn().mockReturnValue(false);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("warns, without crashing, when the spawned process itself fails", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+
+    expect(() => child.emit("error", new Error("spawn php ENOENT"))).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[lattice] could not refresh TypeScript types: spawn php ENOENT",
+    );
+  });
+
+  it("warns with the command's stderr when it exits with a non-zero code", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+    child.stderr.emit("data", Buffer.from('Class "App\\Models\\Widget" not found\n'));
+    child.emit("exit", 1);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[lattice] php artisan lattice:typescript exited with code 1: Class "App\\Models\\Widget" not found',
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("warns with just the exit code when the command produced no stderr", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+    child.emit("exit", 1);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[lattice] php artisan lattice:typescript exited with code 1",
+    );
+  });
+
+  it("truncates a runaway stderr instead of flooding the warning", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+    child.stderr.emit("data", Buffer.from("x".repeat(2000)));
+    child.emit("exit", 1);
+
+    const [message] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
+
+    expect(message.length).toBeLessThan(600);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/resources/js/vite-typescript-refresh.test.ts
+++ b/resources/js/vite-typescript-refresh.test.ts
@@ -97,11 +97,6 @@ describe("refreshTypeScriptTypes", () => {
   });
 
   it("waits for close before warning, since exit can fire before stderr finishes flushing", () => {
-    // Regression test for the event-ordering race: Node documents that "exit"
-    // may fire before a child's stdio streams have flushed their final "data"
-    // events, while "close" is guaranteed to fire only after they have. Here
-    // the stderr chunk arrives strictly between "exit" and "close" — a
-    // premature (exit-based) read would warn without ever having seen it.
     const child = fakeChild();
     const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
     const fileExists = vi.fn().mockReturnValue(true);
@@ -161,8 +156,7 @@ describe("refreshTypeScriptTypes", () => {
 
     refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
     child.emit("error", new Error("spawn php ENOENT"));
-    // Node still emits "close" (with a null code) alongside "error" when the
-    // process itself never spawned — this must not produce a second warning.
+    // Node emits "close" (null code) even when the process never spawned.
     child.emit("close", null);
 
     expect(logger.warn).toHaveBeenCalledTimes(1);

--- a/resources/js/vite-typescript-refresh.test.ts
+++ b/resources/js/vite-typescript-refresh.test.ts
@@ -36,6 +36,7 @@ describe("refreshTypeScriptTypes", () => {
     });
 
     child.emit("exit", 0);
+    child.emit("close", 0);
 
     expect(logger.info).toHaveBeenCalledWith("[lattice] refreshed TypeScript types");
     expect(logger.warn).not.toHaveBeenCalled();
@@ -67,7 +68,18 @@ describe("refreshTypeScriptTypes", () => {
     );
   });
 
-  it("warns with the command's stderr when it exits with a non-zero code", () => {
+  it("does not crash when the piped stderr stream itself errors (e.g. EPIPE)", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+
+    expect(() => child.stderr.emit("error", new Error("EPIPE"))).not.toThrow();
+  });
+
+  it("warns with the command's stderr once the stream has closed", () => {
     const child = fakeChild();
     const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
     const fileExists = vi.fn().mockReturnValue(true);
@@ -76,11 +88,37 @@ describe("refreshTypeScriptTypes", () => {
     refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
     child.stderr.emit("data", Buffer.from('Class "App\\Models\\Widget" not found\n'));
     child.emit("exit", 1);
+    child.emit("close", 1);
 
     expect(logger.warn).toHaveBeenCalledWith(
       '[lattice] php artisan lattice:typescript exited with code 1: Class "App\\Models\\Widget" not found',
     );
     expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("waits for close before warning, since exit can fire before stderr finishes flushing", () => {
+    // Regression test for the event-ordering race: Node documents that "exit"
+    // may fire before a child's stdio streams have flushed their final "data"
+    // events, while "close" is guaranteed to fire only after they have. Here
+    // the stderr chunk arrives strictly between "exit" and "close" — a
+    // premature (exit-based) read would warn without ever having seen it.
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+    child.emit("exit", 1);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    child.stderr.emit("data", Buffer.from("Class-not-found error from a slow flush"));
+    child.emit("close", 1);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[lattice] php artisan lattice:typescript exited with code 1: Class-not-found error from a slow flush",
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
   it("warns with just the exit code when the command produced no stderr", () => {
@@ -91,6 +129,7 @@ describe("refreshTypeScriptTypes", () => {
 
     refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
     child.emit("exit", 1);
+    child.emit("close", 1);
 
     expect(logger.warn).toHaveBeenCalledWith(
       "[lattice] php artisan lattice:typescript exited with code 1",
@@ -106,10 +145,29 @@ describe("refreshTypeScriptTypes", () => {
     refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
     child.stderr.emit("data", Buffer.from("x".repeat(2000)));
     child.emit("exit", 1);
+    child.emit("close", 1);
 
     const [message] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0] as [string];
 
     expect(message.length).toBeLessThan(600);
     expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns only once when both the spawn error and close fire for the same failure", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+    child.emit("error", new Error("spawn php ENOENT"));
+    // Node still emits "close" (with a null code) alongside "error" when the
+    // process itself never spawned — this must not produce a second warning.
+    child.emit("close", null);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[lattice] could not refresh TypeScript types: spawn php ENOENT",
+    );
   });
 });

--- a/resources/js/vite-typescript-refresh.ts
+++ b/resources/js/vite-typescript-refresh.ts
@@ -38,6 +38,16 @@ export function refreshTypeScriptTypes(
   });
 
   let stderr = "";
+  let warned = false;
+
+  const warnOnce = (message: string): void => {
+    if (warned) {
+      return;
+    }
+
+    warned = true;
+    logger.warn(message);
+  };
 
   child.stderr?.on("data", (chunk: Buffer) => {
     if (stderr.length < MAX_STDERR_CHARS) {
@@ -45,19 +55,34 @@ export function refreshTypeScriptTypes(
     }
   });
 
+  // A piped stream can itself emit "error" (e.g. EPIPE) — without a listener
+  // here, Node treats it as unhandled and can crash the dev server, a failure
+  // surface that didn't exist while stderr was `stdio: "ignore"`.
+  child.stderr?.on("error", () => {});
+
   child.on("error", (error) => {
-    logger.warn(`[lattice] could not refresh TypeScript types: ${error.message}`);
+    warnOnce(`[lattice] could not refresh TypeScript types: ${error.message}`);
   });
 
   child.on("exit", (code) => {
     if (code === 0) {
       logger.info("[lattice] refreshed TypeScript types");
+    }
+  });
+
+  // "exit" can fire before the child's final stderr "data" events arrive —
+  // "close" is the event Node guarantees only fires once all stdio has
+  // finished flowing, so the buffered stderr is complete by the time we read
+  // it here. `warnOnce` keeps this and the "error" handler above from ever
+  // both firing a warning for the same failure.
+  child.on("close", (code) => {
+    if (code === 0) {
       return;
     }
 
     const detail = stderr.trim().slice(0, MAX_STDERR_CHARS);
 
-    logger.warn(
+    warnOnce(
       `[lattice] php artisan lattice:typescript exited with code ${code}${detail ? `: ${detail}` : ""}`,
     );
   });

--- a/resources/js/vite-typescript-refresh.ts
+++ b/resources/js/vite-typescript-refresh.ts
@@ -3,24 +3,12 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import type { Logger } from "vite";
 
-/**
- * Upper bound on how much of the child's stderr gets folded into the failure
- * warning — enough to see the actual error, not enough to flood the terminal
- * with a runaway stack trace or a misconfigured command's full output.
- */
 const MAX_STDERR_CHARS = 500;
 
 /**
- * Best-effort: skips silently when the project has no `artisan` (e.g. a
- * plain JS workspace, or a package's own workbench that isn't Laravel-shaped),
- * logs one short line on success, and only warns — never throws — on failure,
- * so a broken `php` install can't crash the dev server.
- *
- * Kept out of the published `vite` subpath on purpose: this module is not
- * listed in `package.json#exports`, so it's unreachable from outside the
- * package even though it compiles into `dist/`. `spawnProcess`/`fileExists`
- * are test seams (default to the real Node APIs) — `vite.ts`'s
- * `typescriptPlugin`, the only real caller, always uses the defaults.
+ * Deliberately absent from `package.json#exports`: unreachable from outside
+ * the package even though it compiles into `dist/`. `spawnProcess`/`fileExists`
+ * are test seams — the only real caller uses the defaults.
  */
 export function refreshTypeScriptTypes(
   appRoot: string,
@@ -55,9 +43,7 @@ export function refreshTypeScriptTypes(
     }
   });
 
-  // A piped stream can itself emit "error" (e.g. EPIPE) — without a listener
-  // here, Node treats it as unhandled and can crash the dev server, a failure
-  // surface that didn't exist while stderr was `stdio: "ignore"`.
+  // An unhandled "error" on the piped stream (e.g. EPIPE) would crash the dev server.
   child.stderr?.on("error", () => {});
 
   child.on("error", (error) => {
@@ -70,11 +56,7 @@ export function refreshTypeScriptTypes(
     }
   });
 
-  // "exit" can fire before the child's final stderr "data" events arrive —
-  // "close" is the event Node guarantees only fires once all stdio has
-  // finished flowing, so the buffered stderr is complete by the time we read
-  // it here. `warnOnce` keeps this and the "error" handler above from ever
-  // both firing a warning for the same failure.
+  // "exit" can fire before stderr has flushed; "close" only fires once all stdio has drained.
   child.on("close", (code) => {
     if (code === 0) {
       return;

--- a/resources/js/vite-typescript-refresh.ts
+++ b/resources/js/vite-typescript-refresh.ts
@@ -1,0 +1,64 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type { Logger } from "vite";
+
+/**
+ * Upper bound on how much of the child's stderr gets folded into the failure
+ * warning — enough to see the actual error, not enough to flood the terminal
+ * with a runaway stack trace or a misconfigured command's full output.
+ */
+const MAX_STDERR_CHARS = 500;
+
+/**
+ * Best-effort: skips silently when the project has no `artisan` (e.g. a
+ * plain JS workspace, or a package's own workbench that isn't Laravel-shaped),
+ * logs one short line on success, and only warns — never throws — on failure,
+ * so a broken `php` install can't crash the dev server.
+ *
+ * Kept out of the published `vite` subpath on purpose: this module is not
+ * listed in `package.json#exports`, so it's unreachable from outside the
+ * package even though it compiles into `dist/`. `spawnProcess`/`fileExists`
+ * are test seams (default to the real Node APIs) — `vite.ts`'s
+ * `typescriptPlugin`, the only real caller, always uses the defaults.
+ */
+export function refreshTypeScriptTypes(
+  appRoot: string,
+  logger: Pick<Logger, "info" | "warn">,
+  spawnProcess: typeof spawn = spawn,
+  fileExists: typeof existsSync = existsSync,
+): void {
+  if (!fileExists(path.join(appRoot, "artisan"))) {
+    return;
+  }
+
+  const child = spawnProcess("php", ["artisan", "lattice:typescript"], {
+    cwd: appRoot,
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+
+  let stderr = "";
+
+  child.stderr?.on("data", (chunk: Buffer) => {
+    if (stderr.length < MAX_STDERR_CHARS) {
+      stderr += chunk.toString();
+    }
+  });
+
+  child.on("error", (error) => {
+    logger.warn(`[lattice] could not refresh TypeScript types: ${error.message}`);
+  });
+
+  child.on("exit", (code) => {
+    if (code === 0) {
+      logger.info("[lattice] refreshed TypeScript types");
+      return;
+    }
+
+    const detail = stderr.trim().slice(0, MAX_STDERR_CHARS);
+
+    logger.warn(
+      `[lattice] php artisan lattice:typescript exited with code ${code}${detail ? `: ${detail}` : ""}`,
+    );
+  });
+}

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -5,6 +5,7 @@ import type { Plugin } from "vite";
 import { describe, expect, it } from "vitest";
 import {
   collectComponentPackages,
+  collectRootComponentPackage,
   componentPackagesPlugin,
   discoverComponentPackages,
   lattice,
@@ -137,6 +138,49 @@ describe("lattice Vite helper", () => {
         name: "acme/signature",
         dir: path.resolve("/tmp/app/vendor/acme/signature"),
         plugin: path.resolve("/tmp/app/vendor/acme/signature/resources/js/plugin.ts"),
+      },
+    ]);
+  });
+
+  it("resolves the app root's own composer.json as a component package", () => {
+    const appRoot = path.resolve("/tmp/app");
+
+    expect(
+      collectRootComponentPackage(
+        { name: "acme/signature", extra: { lattice: { plugin: "resources/js/plugin.ts" } } },
+        appRoot,
+      ),
+    ).toEqual([
+      {
+        name: "acme/signature",
+        dir: appRoot,
+        plugin: path.resolve(appRoot, "resources/js/plugin.ts"),
+      },
+    ]);
+  });
+
+  it("ignores the app root's composer.json when it declares no plugin entry", () => {
+    const appRoot = path.resolve("/tmp/app");
+
+    expect(collectRootComponentPackage({ name: "acme/plain" }, appRoot)).toEqual([]);
+    expect(
+      collectRootComponentPackage(
+        { extra: { lattice: { plugin: "resources/js/plugin.ts" } } },
+        appRoot,
+      ),
+    ).toEqual([]);
+  });
+
+  it("discovers a component package that is its own composer ROOT project", () => {
+    // Mirrors a package's own testbench-driven test suite, where the package
+    // itself is the app root and never appears in vendor/composer/installed.json.
+    const appRoot = path.resolve("tests/Fixtures/PackageDiscovery/root-package");
+
+    expect(discoverComponentPackages(appRoot)).toEqual([
+      {
+        name: "acme/root-widget",
+        dir: appRoot,
+        plugin: path.resolve(appRoot, "resources/js/plugin.ts"),
       },
     ]);
   });

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -1,5 +1,3 @@
-import type { ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { searchForWorkspaceRoot } from "vite";
@@ -12,10 +10,9 @@ import {
   discoverComponentPackages,
   lattice,
   latticeConfig,
-  refreshTypeScriptTypes,
   resolveIconOptions,
-  typescriptPlugin,
 } from "./vite";
+import * as typescriptRefresh from "./vite-typescript-refresh";
 
 type PackageJson = {
   exports: Record<string, unknown>;
@@ -26,10 +23,6 @@ type FakeServer = { config: { logger: FakeLogger } };
 
 function fakeLogger(): FakeLogger {
   return { info: vi.fn(), warn: vi.fn() };
-}
-
-function fakeChild(): EventEmitter {
-  return new EventEmitter();
 }
 
 type ResolveIdFn = (
@@ -46,6 +39,18 @@ function optionalPeersPlugin(): Plugin {
 
   if (!plugin) {
     throw new Error("optional-peers plugin not registered");
+  }
+
+  return plugin;
+}
+
+function typescriptPlugin(options: Parameters<typeof lattice>[0] = {}): Plugin {
+  const plugin = (lattice({ icons: false, ...options }) as Plugin[]).find(
+    (candidate) => candidate?.name === "lattice:typescript",
+  );
+
+  if (!plugin) {
+    throw new Error("typescript plugin not registered");
   }
 
   return plugin;
@@ -249,88 +254,34 @@ describe("lattice Vite helper", () => {
   it("refreshes TypeScript types on configureServer with default options", () => {
     const appRoot = path.resolve("/tmp/lattice-app");
     const logger = fakeLogger();
-    const refresh = vi.fn();
-    const configureServer = typescriptPlugin({ appRoot }, refresh).configureServer as unknown as (
+    const refresh = vi
+      .spyOn(typescriptRefresh, "refreshTypeScriptTypes")
+      .mockImplementation(() => {});
+    const configureServer = typescriptPlugin({ appRoot }).configureServer as unknown as (
       server: FakeServer,
     ) => void;
 
     configureServer({ config: { logger } });
 
     expect(refresh).toHaveBeenCalledWith(appRoot, logger);
+
+    refresh.mockRestore();
   });
 
   it("does not refresh when the typescript option is false", () => {
-    const refresh = vi.fn();
-    const configureServer = typescriptPlugin(
-      { appRoot: path.resolve("/tmp/lattice-app"), typescript: false },
-      refresh,
-    ).configureServer as unknown as (server: FakeServer) => void;
+    const refresh = vi
+      .spyOn(typescriptRefresh, "refreshTypeScriptTypes")
+      .mockImplementation(() => {});
+    const configureServer = typescriptPlugin({
+      appRoot: path.resolve("/tmp/lattice-app"),
+      typescript: false,
+    }).configureServer as unknown as (server: FakeServer) => void;
 
     configureServer({ config: { logger: fakeLogger() } });
 
     expect(refresh).not.toHaveBeenCalled();
-  });
 
-  it("spawns php artisan lattice:typescript when the project has an artisan file", () => {
-    const appRoot = path.resolve("/tmp/lattice-app");
-    const child = fakeChild();
-    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
-    const fileExists = vi.fn().mockReturnValue(true);
-    const logger = fakeLogger();
-
-    refreshTypeScriptTypes(appRoot, logger, spawnProcess, fileExists);
-
-    expect(fileExists).toHaveBeenCalledWith(path.join(appRoot, "artisan"));
-    expect(spawnProcess).toHaveBeenCalledWith("php", ["artisan", "lattice:typescript"], {
-      cwd: appRoot,
-      stdio: "ignore",
-    });
-
-    child.emit("exit", 0);
-
-    expect(logger.info).toHaveBeenCalledWith("[lattice] refreshed TypeScript types");
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
-  it("skips silently when the project has no artisan file", () => {
-    const spawnProcess = vi.fn();
-    const fileExists = vi.fn().mockReturnValue(false);
-    const logger = fakeLogger();
-
-    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
-
-    expect(spawnProcess).not.toHaveBeenCalled();
-    expect(logger.warn).not.toHaveBeenCalled();
-    expect(logger.info).not.toHaveBeenCalled();
-  });
-
-  it("warns, without crashing, when the spawned process itself fails", () => {
-    const child = fakeChild();
-    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
-    const fileExists = vi.fn().mockReturnValue(true);
-    const logger = fakeLogger();
-
-    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
-
-    expect(() => child.emit("error", new Error("spawn php ENOENT"))).not.toThrow();
-    expect(logger.warn).toHaveBeenCalledWith(
-      "[lattice] could not refresh TypeScript types: spawn php ENOENT",
-    );
-  });
-
-  it("warns when the command exits with a non-zero code", () => {
-    const child = fakeChild();
-    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
-    const fileExists = vi.fn().mockReturnValue(true);
-    const logger = fakeLogger();
-
-    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
-    child.emit("exit", 1);
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      "[lattice] php artisan lattice:typescript exited with code 1",
-    );
-    expect(logger.info).not.toHaveBeenCalled();
+    refresh.mockRestore();
   });
 
   it("merges a partial dts override over the default file/augment targets", () => {

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -192,8 +192,6 @@ describe("lattice Vite helper", () => {
   });
 
   it("discovers a component package that is its own composer ROOT project", () => {
-    // Mirrors a package's own testbench-driven test suite, where the package
-    // itself is the app root and never appears in vendor/composer/installed.json.
     const appRoot = path.resolve("tests/Fixtures/PackageDiscovery/root-package");
 
     expect(discoverComponentPackages(appRoot)).toEqual([

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -1,8 +1,10 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { searchForWorkspaceRoot } from "vite";
-import type { Plugin } from "vite";
-import { describe, expect, it } from "vitest";
+import type { Logger, Plugin } from "vite";
+import { describe, expect, it, vi } from "vitest";
 import {
   collectComponentPackages,
   collectRootComponentPackage,
@@ -10,12 +12,25 @@ import {
   discoverComponentPackages,
   lattice,
   latticeConfig,
+  refreshTypeScriptTypes,
   resolveIconOptions,
+  typescriptPlugin,
 } from "./vite";
 
 type PackageJson = {
   exports: Record<string, unknown>;
 };
+
+type FakeLogger = Pick<Logger, "info" | "warn">;
+type FakeServer = { config: { logger: FakeLogger } };
+
+function fakeLogger(): FakeLogger {
+  return { info: vi.fn(), warn: vi.fn() };
+}
+
+function fakeChild(): EventEmitter {
+  return new EventEmitter();
+}
 
 type ResolveIdFn = (
   this: { resolve: (id: string, importer?: string, options?: unknown) => Promise<unknown> },
@@ -229,6 +244,93 @@ describe("lattice Vite helper", () => {
 
     expect(load("\0virtual:lattice/plugins")).toContain("export default [];");
     expect(config()).toEqual({});
+  });
+
+  it("refreshes TypeScript types on configureServer with default options", () => {
+    const appRoot = path.resolve("/tmp/lattice-app");
+    const logger = fakeLogger();
+    const refresh = vi.fn();
+    const configureServer = typescriptPlugin({ appRoot }, refresh).configureServer as unknown as (
+      server: FakeServer,
+    ) => void;
+
+    configureServer({ config: { logger } });
+
+    expect(refresh).toHaveBeenCalledWith(appRoot, logger);
+  });
+
+  it("does not refresh when the typescript option is false", () => {
+    const refresh = vi.fn();
+    const configureServer = typescriptPlugin(
+      { appRoot: path.resolve("/tmp/lattice-app"), typescript: false },
+      refresh,
+    ).configureServer as unknown as (server: FakeServer) => void;
+
+    configureServer({ config: { logger: fakeLogger() } });
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("spawns php artisan lattice:typescript when the project has an artisan file", () => {
+    const appRoot = path.resolve("/tmp/lattice-app");
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(appRoot, logger, spawnProcess, fileExists);
+
+    expect(fileExists).toHaveBeenCalledWith(path.join(appRoot, "artisan"));
+    expect(spawnProcess).toHaveBeenCalledWith("php", ["artisan", "lattice:typescript"], {
+      cwd: appRoot,
+      stdio: "ignore",
+    });
+
+    child.emit("exit", 0);
+
+    expect(logger.info).toHaveBeenCalledWith("[lattice] refreshed TypeScript types");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("skips silently when the project has no artisan file", () => {
+    const spawnProcess = vi.fn();
+    const fileExists = vi.fn().mockReturnValue(false);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+
+    expect(spawnProcess).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("warns, without crashing, when the spawned process itself fails", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+
+    expect(() => child.emit("error", new Error("spawn php ENOENT"))).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[lattice] could not refresh TypeScript types: spawn php ENOENT",
+    );
+  });
+
+  it("warns when the command exits with a non-zero code", () => {
+    const child = fakeChild();
+    const spawnProcess = vi.fn().mockReturnValue(child as unknown as ChildProcess);
+    const fileExists = vi.fn().mockReturnValue(true);
+    const logger = fakeLogger();
+
+    refreshTypeScriptTypes(path.resolve("/tmp/lattice-app"), logger, spawnProcess, fileExists);
+    child.emit("exit", 1);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[lattice] php artisan lattice:typescript exited with code 1",
+    );
+    expect(logger.info).not.toHaveBeenCalled();
   });
 
   it("merges a partial dts override over the default file/augment targets", () => {

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -65,6 +65,11 @@ type InstalledPackage = {
   extra?: { lattice?: { plugin?: string } };
 };
 
+type RootPackageJson = {
+  name?: string;
+  extra?: { lattice?: { plugin?: string } };
+};
+
 /**
  * Resolve every Composer package that declares `extra.lattice.plugin` into an
  * absolute plugin-entry path. `installPathsRelativeTo` is `vendor/composer` (the
@@ -89,19 +94,52 @@ export function collectComponentPackages(
   });
 }
 
-/** Read `<appRoot>/vendor/composer/installed.json` and collect component packages. */
-export function discoverComponentPackages(appRoot: string): LatticeComponentPackage[] {
-  const composerDir = path.resolve(appRoot, "vendor/composer");
+/**
+ * Resolve the composer ROOT project's own `extra.lattice.plugin` — Composer
+ * never lists the root package in `installed.json`, so a component package
+ * declaring the plugin entry in its own composer.json would otherwise be
+ * invisible to its own dev server (e.g. inside a testbench workbench, where
+ * the package itself is the app root).
+ */
+export function collectRootComponentPackage(
+  composerJson: RootPackageJson,
+  appRoot: string,
+): LatticeComponentPackage[] {
+  const entry = composerJson.extra?.lattice?.plugin;
 
-  let raw: string;
-
-  try {
-    raw = readFileSync(path.join(composerDir, "installed.json"), "utf8");
-  } catch {
+  if (typeof entry !== "string" || typeof composerJson.name !== "string") {
     return [];
   }
 
-  return collectComponentPackages(JSON.parse(raw), composerDir);
+  return [{ name: composerJson.name, dir: appRoot, plugin: path.resolve(appRoot, entry) }];
+}
+
+/**
+ * Read `<appRoot>/vendor/composer/installed.json` and `<appRoot>/composer.json`
+ * and collect every component package they contribute.
+ */
+export function discoverComponentPackages(appRoot: string): LatticeComponentPackage[] {
+  const composerDir = path.resolve(appRoot, "vendor/composer");
+
+  let installed: LatticeComponentPackage[] = [];
+
+  try {
+    const raw = readFileSync(path.join(composerDir, "installed.json"), "utf8");
+    installed = collectComponentPackages(JSON.parse(raw), composerDir);
+  } catch {
+    installed = [];
+  }
+
+  let root: LatticeComponentPackage[] = [];
+
+  try {
+    const raw = readFileSync(path.join(appRoot, "composer.json"), "utf8");
+    root = collectRootComponentPackage(JSON.parse(raw), appRoot);
+  } catch {
+    root = [];
+  }
+
+  return [...installed, ...root];
 }
 
 const VIRTUAL_PLUGINS_ID = "virtual:lattice/plugins";

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -1,10 +1,10 @@
-import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { svgSprite } from "@lattice-php/vite-svg-sprite";
 import type { IconTypesOptions, SvgSpriteOptions } from "@lattice-php/vite-svg-sprite";
 import { searchForWorkspaceRoot } from "vite";
-import type { Logger, Plugin, PluginOption, UserConfig } from "vite";
+import type { Plugin, PluginOption, UserConfig } from "vite";
+import { refreshTypeScriptTypes } from "./vite-typescript-refresh";
 
 type InlineDependency = string | RegExp;
 
@@ -286,64 +286,27 @@ function optionalPeersPlugin(): Plugin {
  * build machine may not have PHP installed, and the generated file is a dev
  * ergonomics artifact, not a build input.
  *
- * `refresh` is a seam for tests (defaults to the real `refreshTypeScriptTypes`)
- * — this file is itself imported by `vite.config.ts` to build the workbench's
- * own plugin list, which pins an unmocked module instance in Vitest's SSR
- * cache, so mocking `node:child_process`/`node:fs` here would not reliably
- * reach this closure. Exported so tests can inject a fake directly.
+ * Module-private like its siblings `optionalPeersPlugin`/`corePlugin` — the
+ * `refreshTypeScriptTypes` DI seam it defers to lives in
+ * `./vite-typescript-refresh`, which isn't part of the published `vite`
+ * subpath either (see that module for why).
  */
-export function typescriptPlugin(
-  options: LatticeViteOptions,
-  refresh: typeof refreshTypeScriptTypes = refreshTypeScriptTypes,
-): Plugin {
+function typescriptPlugin(options: LatticeViteOptions): Plugin {
   return {
     name: "lattice:typescript",
     apply: "serve",
     configureServer(server) {
-      if (options.typescript === false) {
+      const typescript = options.typescript ?? true;
+
+      if (typescript === false) {
         return;
       }
 
       const { appRoot } = resolveRoots(options);
 
-      refresh(appRoot, server.config.logger);
+      refreshTypeScriptTypes(appRoot, server.config.logger);
     },
   };
-}
-
-/**
- * Best-effort: skips silently when the project has no `artisan` (e.g. a
- * plain JS workspace, or a package's own workbench that isn't Laravel-shaped),
- * logs one short line on success, and only warns — never throws — on failure,
- * so a broken `php` install can't crash the dev server. `spawnProcess`/
- * `fileExists` are seams for tests, defaulting to the real Node APIs.
- */
-export function refreshTypeScriptTypes(
-  appRoot: string,
-  logger: Pick<Logger, "info" | "warn">,
-  spawnProcess: typeof spawn = spawn,
-  fileExists: typeof existsSync = existsSync,
-): void {
-  if (!fileExists(path.join(appRoot, "artisan"))) {
-    return;
-  }
-
-  const child = spawnProcess("php", ["artisan", "lattice:typescript"], {
-    cwd: appRoot,
-    stdio: "ignore",
-  });
-
-  child.on("error", (error) => {
-    logger.warn(`[lattice] could not refresh TypeScript types: ${error.message}`);
-  });
-
-  child.on("exit", (code) => {
-    if (code === 0) {
-      logger.info("[lattice] refreshed TypeScript types");
-    } else {
-      logger.warn(`[lattice] php artisan lattice:typescript exited with code ${code}`);
-    }
-  });
 }
 
 export function resolveIconOptions(options: LatticeViteOptions): SvgSpriteOptions | null {

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -1,9 +1,10 @@
-import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { svgSprite } from "@lattice-php/vite-svg-sprite";
 import type { IconTypesOptions, SvgSpriteOptions } from "@lattice-php/vite-svg-sprite";
 import { searchForWorkspaceRoot } from "vite";
-import type { Plugin, PluginOption, UserConfig } from "vite";
+import type { Logger, Plugin, PluginOption, UserConfig } from "vite";
 
 type InlineDependency = string | RegExp;
 
@@ -27,6 +28,8 @@ export type LatticeViteOptions = {
   icons?: boolean | LatticeViteIconsOptions;
   root?: string;
   source?: boolean;
+  /** Refresh generated TypeScript types via the dev server. Defaults to `true`. */
+  typescript?: boolean;
 };
 
 type Roots = {
@@ -40,6 +43,7 @@ export function lattice(options: LatticeViteOptions = {}): PluginOption[] {
     corePlugin(options),
     optionalPeersPlugin(),
     componentPackagesPlugin(discoverComponentPackages(appRoot)),
+    typescriptPlugin(options),
   ];
   const iconOptions = resolveIconOptions(options);
 
@@ -272,6 +276,74 @@ function optionalPeersPlugin(): Plugin {
       return OPTIONAL_PEER_STUBS[id.slice(OPTIONAL_PEER_STUB_PREFIX.length)] ?? null;
     },
   };
+}
+
+/**
+ * Refreshes `node.props` typings from the app's own `php artisan
+ * lattice:typescript` whenever the dev server starts — installing or updating
+ * a component package would otherwise leave its generated types stale until
+ * someone remembers to run the command by hand. Dev-server only: a production
+ * build machine may not have PHP installed, and the generated file is a dev
+ * ergonomics artifact, not a build input.
+ *
+ * `refresh` is a seam for tests (defaults to the real `refreshTypeScriptTypes`)
+ * — this file is itself imported by `vite.config.ts` to build the workbench's
+ * own plugin list, which pins an unmocked module instance in Vitest's SSR
+ * cache, so mocking `node:child_process`/`node:fs` here would not reliably
+ * reach this closure. Exported so tests can inject a fake directly.
+ */
+export function typescriptPlugin(
+  options: LatticeViteOptions,
+  refresh: typeof refreshTypeScriptTypes = refreshTypeScriptTypes,
+): Plugin {
+  return {
+    name: "lattice:typescript",
+    apply: "serve",
+    configureServer(server) {
+      if (options.typescript === false) {
+        return;
+      }
+
+      const { appRoot } = resolveRoots(options);
+
+      refresh(appRoot, server.config.logger);
+    },
+  };
+}
+
+/**
+ * Best-effort: skips silently when the project has no `artisan` (e.g. a
+ * plain JS workspace, or a package's own workbench that isn't Laravel-shaped),
+ * logs one short line on success, and only warns — never throws — on failure,
+ * so a broken `php` install can't crash the dev server. `spawnProcess`/
+ * `fileExists` are seams for tests, defaulting to the real Node APIs.
+ */
+export function refreshTypeScriptTypes(
+  appRoot: string,
+  logger: Pick<Logger, "info" | "warn">,
+  spawnProcess: typeof spawn = spawn,
+  fileExists: typeof existsSync = existsSync,
+): void {
+  if (!fileExists(path.join(appRoot, "artisan"))) {
+    return;
+  }
+
+  const child = spawnProcess("php", ["artisan", "lattice:typescript"], {
+    cwd: appRoot,
+    stdio: "ignore",
+  });
+
+  child.on("error", (error) => {
+    logger.warn(`[lattice] could not refresh TypeScript types: ${error.message}`);
+  });
+
+  child.on("exit", (code) => {
+    if (code === 0) {
+      logger.info("[lattice] refreshed TypeScript types");
+    } else {
+      logger.warn(`[lattice] php artisan lattice:typescript exited with code ${code}`);
+    }
+  });
 }
 
 export function resolveIconOptions(options: LatticeViteOptions): SvgSpriteOptions | null {

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -50,6 +50,9 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract
     }
 
     /**
+     * Imperative registration, layered over discovered definitions. Package
+     * authors should prefer composer `extra.lattice.discover` over calling this.
+     *
      * @param  class-string<TDefinition>|array<int, class-string<TDefinition>>  $definitions
      */
     public function register(string|array $definitions): void

--- a/src/Core/Discovery/ComponentPackages.php
+++ b/src/Core/Discovery/ComponentPackages.php
@@ -36,11 +36,7 @@ final class ComponentPackages
     }
 
     /**
-     * Every installed package that declares `extra.lattice`, with its discovery
-     * roots resolved to absolute paths and its JS plugin entry (if any) — the
-     * data the `php artisan about` panel surfaces per package. Includes the
-     * composer ROOT project itself (see `rootPackage()`), since it never
-     * appears in `installed.json`.
+     * Includes the composer ROOT project — it never appears in `installed.json`.
      *
      * @return list<array{name: string, roots: list<string>, plugin: string|null}>
      */
@@ -143,9 +139,6 @@ final class ComponentPackages
     }
 
     /**
-     * Resolve a package's `extra.lattice` entry to its absolute discovery roots
-     * and JS plugin path, or null when it declares neither.
-     *
      * @param  array<string, mixed>  $lattice
      * @return array{name: string, roots: list<string>, plugin: string|null}|null
      */

--- a/src/Core/Discovery/ComponentPackages.php
+++ b/src/Core/Discovery/ComponentPackages.php
@@ -19,17 +19,37 @@ final class ComponentPackages
     /** @return list<string> */
     public static function discoverRoots(): array
     {
-        $file = new ReflectionClass(InstalledVersions::class)->getFileName();
-
-        return is_string($file)
-            ? self::fromInstalled(dirname($file).'/installed.json')
-            : [];
+        return self::rootsOf(self::packages());
     }
 
     /**
      * @return list<string>
      */
     public static function fromInstalled(string $installedJsonPath): array
+    {
+        return self::rootsOf(self::packagesFromInstalled($installedJsonPath));
+    }
+
+    /**
+     * Every installed package that declares `extra.lattice`, with its discovery
+     * roots resolved to absolute paths and its JS plugin entry (if any) — the
+     * data the `php artisan about` panel surfaces per package.
+     *
+     * @return list<array{name: string, roots: list<string>, plugin: string|null}>
+     */
+    public static function packages(): array
+    {
+        $file = new ReflectionClass(InstalledVersions::class)->getFileName();
+
+        return is_string($file)
+            ? self::packagesFromInstalled(dirname($file).'/installed.json')
+            : [];
+    }
+
+    /**
+     * @return list<array{name: string, roots: list<string>, plugin: string|null}>
+     */
+    public static function packagesFromInstalled(string $installedJsonPath): array
     {
         if (! is_file($installedJsonPath)) {
             return [];
@@ -44,13 +64,20 @@ final class ComponentPackages
         /** @var list<array<string, mixed>> $packages */
         $packages = is_array($data['packages'] ?? null) ? $data['packages'] : [];
         $composerDir = dirname($installedJsonPath);
-        $roots = [];
+        $result = [];
 
         foreach ($packages as $package) {
-            $discover = $package['extra']['lattice']['discover'] ?? null;
+            $lattice = $package['extra']['lattice'] ?? null;
             $name = $package['name'] ?? null;
 
-            if (! is_array($discover) || ! is_string($name)) {
+            if (! is_array($lattice) || ! is_string($name)) {
+                continue;
+            }
+
+            $discover = is_array($lattice['discover'] ?? null) ? $lattice['discover'] : [];
+            $plugin = is_string($lattice['plugin'] ?? null) ? $lattice['plugin'] : null;
+
+            if ($discover === [] && $plugin === null) {
                 continue;
             }
 
@@ -58,6 +85,7 @@ final class ComponentPackages
                 ? $package['install-path']
                 : '../'.$name;
             $packageDir = $composerDir.'/'.$installPath;
+            $roots = [];
 
             foreach ($discover as $relative) {
                 if (! is_string($relative)) {
@@ -69,6 +97,29 @@ final class ComponentPackages
                 if ($resolved !== false) {
                     $roots[$resolved] = $resolved;
                 }
+            }
+
+            $result[] = [
+                'name' => $name,
+                'roots' => array_values($roots),
+                'plugin' => $plugin !== null ? (realpath($packageDir.'/'.$plugin) ?: null) : null,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  list<array{name: string, roots: list<string>, plugin: string|null}>  $packages
+     * @return list<string>
+     */
+    private static function rootsOf(array $packages): array
+    {
+        $roots = [];
+
+        foreach ($packages as $package) {
+            foreach ($package['roots'] as $root) {
+                $roots[$root] = $root;
             }
         }
 

--- a/src/Core/Discovery/ComponentPackages.php
+++ b/src/Core/Discovery/ComponentPackages.php
@@ -13,6 +13,11 @@ use ReflectionClass;
  * to the `extra.lattice.plugin` the Vite plugin reads for the JS renderer. This
  * is what lets a plain `composer require` surface a package's components to
  * definition discovery and TypeScript generation without editing app config.
+ *
+ * Also reads the composer ROOT project's own `extra.lattice` (see
+ * `rootPackage()`), since `installed.json` never lists it — the mechanism a
+ * component package's own testbench-driven test suite relies on to discover
+ * its own `src/` declaratively.
  */
 final class ComponentPackages
 {
@@ -33,7 +38,9 @@ final class ComponentPackages
     /**
      * Every installed package that declares `extra.lattice`, with its discovery
      * roots resolved to absolute paths and its JS plugin entry (if any) — the
-     * data the `php artisan about` panel surfaces per package.
+     * data the `php artisan about` panel surfaces per package. Includes the
+     * composer ROOT project itself (see `rootPackage()`), since it never
+     * appears in `installed.json`.
      *
      * @return list<array{name: string, roots: list<string>, plugin: string|null}>
      */
@@ -41,9 +48,56 @@ final class ComponentPackages
     {
         $file = new ReflectionClass(InstalledVersions::class)->getFileName();
 
-        return is_string($file)
+        $installed = is_string($file)
             ? self::packagesFromInstalled(dirname($file).'/installed.json')
             : [];
+
+        return [...$installed, ...self::rootPackage()];
+    }
+
+    /**
+     * The composer ROOT project's own `extra.lattice`, read from its
+     * composer.json — Composer never lists the root package in
+     * `installed.json`, so without this a component package that declares
+     * `extra.lattice.discover` would be invisible to discovery inside its own
+     * testbench-driven test suite, where the package itself is the root.
+     *
+     * @return list<array{name: string, roots: list<string>, plugin: string|null}>
+     */
+    public static function rootPackage(): array
+    {
+        $resolved = realpath(InstalledVersions::getRootPackage()['install_path']);
+
+        return $resolved !== false
+            ? self::packagesFromRootComposerJson($resolved.'/composer.json')
+            : [];
+    }
+
+    /**
+     * @return list<array{name: string, roots: list<string>, plugin: string|null}>
+     */
+    public static function packagesFromRootComposerJson(string $composerJsonPath): array
+    {
+        if (! is_file($composerJsonPath)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($composerJsonPath), true);
+
+        if (! is_array($data)) {
+            return [];
+        }
+
+        $lattice = $data['extra']['lattice'] ?? null;
+        $name = $data['name'] ?? null;
+
+        if (! is_array($lattice) || ! is_string($name)) {
+            return [];
+        }
+
+        $package = self::resolvePackage($name, $lattice, dirname($composerJsonPath));
+
+        return $package !== null ? [$package] : [];
     }
 
     /**
@@ -74,39 +128,55 @@ final class ComponentPackages
                 continue;
             }
 
-            $discover = is_array($lattice['discover'] ?? null) ? $lattice['discover'] : [];
-            $plugin = is_string($lattice['plugin'] ?? null) ? $lattice['plugin'] : null;
-
-            if ($discover === [] && $plugin === null) {
-                continue;
-            }
-
             $installPath = is_string($package['install-path'] ?? null)
                 ? $package['install-path']
                 : '../'.$name;
-            $packageDir = $composerDir.'/'.$installPath;
-            $roots = [];
 
-            foreach ($discover as $relative) {
-                if (! is_string($relative)) {
-                    continue;
-                }
+            $resolvedPackage = self::resolvePackage($name, $lattice, $composerDir.'/'.$installPath);
 
-                $resolved = realpath($packageDir.'/'.$relative);
-
-                if ($resolved !== false) {
-                    $roots[$resolved] = $resolved;
-                }
+            if ($resolvedPackage !== null) {
+                $result[] = $resolvedPackage;
             }
-
-            $result[] = [
-                'name' => $name,
-                'roots' => array_values($roots),
-                'plugin' => $plugin !== null ? (realpath($packageDir.'/'.$plugin) ?: null) : null,
-            ];
         }
 
         return $result;
+    }
+
+    /**
+     * Resolve a package's `extra.lattice` entry to its absolute discovery roots
+     * and JS plugin path, or null when it declares neither.
+     *
+     * @param  array<string, mixed>  $lattice
+     * @return array{name: string, roots: list<string>, plugin: string|null}|null
+     */
+    private static function resolvePackage(string $name, array $lattice, string $packageDir): ?array
+    {
+        $discover = is_array($lattice['discover'] ?? null) ? $lattice['discover'] : [];
+        $plugin = is_string($lattice['plugin'] ?? null) ? $lattice['plugin'] : null;
+
+        if ($discover === [] && $plugin === null) {
+            return null;
+        }
+
+        $roots = [];
+
+        foreach ($discover as $relative) {
+            if (! is_string($relative)) {
+                continue;
+            }
+
+            $resolved = realpath($packageDir.'/'.$relative);
+
+            if ($resolved !== false) {
+                $roots[$resolved] = $resolved;
+            }
+        }
+
+        return [
+            'name' => $name,
+            'roots' => array_values($roots),
+            'plugin' => $plugin !== null ? (realpath($packageDir.'/'.$plugin) ?: null) : null,
+        ];
     }
 
     /**

--- a/src/Core/Discovery/DiscoveryManifest.php
+++ b/src/Core/Discovery/DiscoveryManifest.php
@@ -120,11 +120,7 @@ final class DiscoveryManifest
                 }
 
                 if (Attributes::has($class, DiscoveryKinds::PAGE_ATTRIBUTE)) {
-                    $metadata = PageMetadata::reflect($class);
-
-                    if ($metadata->route !== null) {
-                        $manifest['pages'][$class] = $metadata->toArray();
-                    }
+                    $manifest['pages'][$class] = PageMetadata::reflect($class)->toArray();
                 }
             }
         }

--- a/src/Http/PageRegistry.php
+++ b/src/Http/PageRegistry.php
@@ -31,6 +31,10 @@ final class PageRegistry
     }
 
     /**
+     * Every discovered and registered page, routed or not — a route-less
+     * `#[AsPage]` is a valid embedded page, so it belongs here; callers that
+     * only want routable pages (e.g. route registration) filter on `route`.
+     *
      * @return array<int, PageMetadata>
      */
     public function all(): array
@@ -50,11 +54,7 @@ final class PageRegistry
                 continue;
             }
 
-            $metadata = $this->metadata->for($page);
-
-            if ($metadata->route !== null) {
-                $pages[$page] = $metadata;
-            }
+            $pages[$page] = $this->metadata->for($page);
         }
 
         return array_values($pages);

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice;
 use BackedEnum;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Blade;
@@ -38,6 +39,7 @@ use Lattice\Lattice\Console\Commands\PublishAssetsCommand;
 use Lattice\Lattice\Console\Commands\TypeScriptCommand;
 use Lattice\Lattice\Core\Contracts\ResolvesReferenceIdentity;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Lattice\Core\Discovery\ComponentPackages;
 use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\PageMetadataResolver;
@@ -164,6 +166,8 @@ final class LatticeServiceProvider extends PackageServiceProvider
             $this->publishes([
                 __DIR__.'/../lang' => $this->app->langPath('vendor/'.self::$name),
             ], 'lattice-translations');
+
+            AboutCommand::add('Lattice', fn (DiscoveryManifest $manifest): array => $this->aboutData($manifest));
         }
 
         $this->optimizes(
@@ -199,5 +203,72 @@ final class LatticeServiceProvider extends PackageServiceProvider
         }
 
         Route::getRoutes()->refreshNameLookups();
+    }
+
+    /**
+     * Data for the `Lattice` section of `php artisan about` — the configured
+     * discover paths, the roots and JS plugins contributed by installed
+     * component packages, and whether the discovery manifest is cached.
+     *
+     * @return array<string, mixed>
+     */
+    private function aboutData(DiscoveryManifest $manifest): array
+    {
+        $configured = array_values(array_filter((array) config('lattice.discover', []), is_string(...)));
+        $packages = ComponentPackages::packages();
+
+        $roots = collect($packages)
+            ->filter(fn (array $package): bool => $package['roots'] !== [])
+            ->map(fn (array $package): array => [
+                'name' => $package['name'],
+                'roots' => array_map(self::relativeToBase(...), $package['roots']),
+            ])
+            ->values()
+            ->all();
+
+        $plugins = collect($packages)
+            ->filter(fn (array $package): bool => $package['plugin'] !== null)
+            ->map(fn (array $package): array => [
+                'name' => $package['name'],
+                'plugin' => self::relativeToBase($package['plugin']),
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'Discover Paths' => AboutCommand::format(
+                array_map(self::relativeToBase(...), $configured),
+                console: fn (array $paths): string => $paths === [] ? '<fg=yellow;options=bold>none</>' : implode(', ', $paths),
+                json: fn (array $paths): array => $paths,
+            ),
+            'Package Roots' => AboutCommand::format(
+                $roots,
+                console: fn (array $roots): string => $roots === []
+                    ? '<fg=yellow;options=bold>none</>'
+                    : implode(', ', array_map(fn (array $package): string => $package['name'].': '.implode(', ', $package['roots']), $roots)),
+                json: fn (array $roots): array => $roots,
+            ),
+            'Component Plugins' => AboutCommand::format(
+                $plugins,
+                console: fn (array $plugins): string => $plugins === []
+                    ? '<fg=yellow;options=bold>none</>'
+                    : implode(', ', array_map(fn (array $package): string => $package['name'].': '.$package['plugin'], $plugins)),
+                json: fn (array $plugins): array => $plugins,
+            ),
+            'Manifest Cache' => AboutCommand::format(
+                $manifest->isCached(),
+                console: fn (bool $cached): string => $cached
+                    ? '<fg=green;options=bold>CACHED</> '.self::relativeToBase($manifest->path())
+                    : '<fg=yellow;options=bold>NOT CACHED</>',
+                json: fn (bool $cached): array => ['cached' => $cached, 'path' => $manifest->path()],
+            ),
+        ];
+    }
+
+    private static function relativeToBase(string $path): string
+    {
+        $base = base_path().DIRECTORY_SEPARATOR;
+
+        return str_starts_with($path, $base) ? substr($path, strlen($base)) : $path;
     }
 }

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -185,10 +185,15 @@ final class LatticeServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * Build a route for every discovered and registered page — but only when the
-     * router is not serving a cached route table. With `route:cache` active,
-     * Laravel loads the routes from the cache, so re-scanning the filesystem and
-     * re-registering them here on every request would be redundant work.
+     * Build a route for every discovered and registered page that declares one
+     * — but only when the router is not serving a cached route table. With
+     * `route:cache` active, Laravel loads the routes from the cache, so
+     * re-scanning the filesystem and re-registering them here on every request
+     * would be redundant work.
+     *
+     * A page with no route is a valid embedded page (rendered by returning it
+     * from a developer-owned controller, never dispatched by Lattice itself),
+     * so it is skipped here rather than passed to `Route::get()`.
      */
     public function bootPages(): void
     {
@@ -197,6 +202,10 @@ final class LatticeServiceProvider extends PackageServiceProvider
         }
 
         foreach (Lattice::pageRegistry()->all() as $page) {
+            if ($page->route === null) {
+                continue;
+            }
+
             Route::get($page->route, [$page->class, 'render'])
                 ->name($page->name)
                 ->middleware($page->middleware);

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -206,10 +206,6 @@ final class LatticeServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * Data for the `Lattice` section of `php artisan about` — the configured
-     * discover paths, the roots and JS plugins contributed by installed
-     * component packages, and whether the discovery manifest is cached.
-     *
      * @return array<string, mixed>
      */
     private function aboutData(DiscoveryManifest $manifest): array

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -221,7 +221,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
             ->filter(fn (array $package): bool => $package['roots'] !== [])
             ->map(fn (array $package): array => [
                 'name' => $package['name'],
-                'roots' => array_map(self::relativeToBase(...), $package['roots']),
+                'roots' => array_map($this->relativeToBase(...), $package['roots']),
             ])
             ->values()
             ->all();
@@ -230,14 +230,14 @@ final class LatticeServiceProvider extends PackageServiceProvider
             ->filter(fn (array $package): bool => $package['plugin'] !== null)
             ->map(fn (array $package): array => [
                 'name' => $package['name'],
-                'plugin' => self::relativeToBase($package['plugin']),
+                'plugin' => $this->relativeToBase($package['plugin']),
             ])
             ->values()
             ->all();
 
         return [
             'Discover Paths' => AboutCommand::format(
-                array_map(self::relativeToBase(...), $configured),
+                array_map($this->relativeToBase(...), $configured),
                 console: fn (array $paths): string => $paths === [] ? '<fg=yellow;options=bold>none</>' : implode(', ', $paths),
                 json: fn (array $paths): array => $paths,
             ),
@@ -258,14 +258,14 @@ final class LatticeServiceProvider extends PackageServiceProvider
             'Manifest Cache' => AboutCommand::format(
                 $manifest->isCached(),
                 console: fn (bool $cached): string => $cached
-                    ? '<fg=green;options=bold>CACHED</> '.self::relativeToBase($manifest->path())
+                    ? '<fg=green;options=bold>CACHED</> '.$this->relativeToBase($manifest->path())
                     : '<fg=yellow;options=bold>NOT CACHED</>',
                 json: fn (bool $cached): array => ['cached' => $cached, 'path' => $manifest->path()],
             ),
         ];
     }
 
-    private static function relativeToBase(string $path): string
+    private function relativeToBase(string $path): string
     {
         $base = base_path().DIRECTORY_SEPARATOR;
 

--- a/tests/Feature/Console/AboutCommandTest.php
+++ b/tests/Feature/Console/AboutCommandTest.php
@@ -10,9 +10,7 @@ afterEach(function (): void {
 });
 
 it('surfaces discovery state in the lattice section of php artisan about', function (): void {
-    // The discovery config value in this dev workbench points outside base_path()
-    // (Workbench mounts app/ from the repo, not the testbench skeleton), so pin
-    // it here to a path base_path() actually resolves against for the assertion.
+    // Workbench mounts app/ from the repo, outside base_path() — pin a path it resolves against.
     config()->set('lattice.discover', [base_path('app')]);
 
     $signaturePath = InstalledVersions::getInstallPath('lattice-php/signature-example') ?? '';

--- a/tests/Feature/Console/AboutCommandTest.php
+++ b/tests/Feature/Console/AboutCommandTest.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+use Composer\InstalledVersions;
+use Illuminate\Support\Facades\Artisan;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+
+afterEach(function (): void {
+    app(DiscoveryManifest::class)->clear();
+});
+
+it('surfaces discovery state in the lattice section of php artisan about', function (): void {
+    // The discovery config value in this dev workbench points outside base_path()
+    // (Workbench mounts app/ from the repo, not the testbench skeleton), so pin
+    // it here to a path base_path() actually resolves against for the assertion.
+    config()->set('lattice.discover', [base_path('app')]);
+
+    $signaturePath = InstalledVersions::getInstallPath('lattice-php/signature-example') ?? '';
+    $discoverRoot = realpath($signaturePath.'/src');
+    $pluginPath = realpath($signaturePath.'/resources/js/plugin.ts');
+
+    Artisan::call('about', ['--json' => true]);
+    $data = json_decode((string) Artisan::output(), true);
+
+    expect($data)->toHaveKey('lattice');
+
+    $lattice = $data['lattice'];
+
+    $packageRoot = null;
+
+    foreach ((array) $lattice['package_roots'] as $entry) {
+        if (is_array($entry) && ($entry['name'] ?? null) === 'lattice-php/signature-example') {
+            $packageRoot = $entry;
+        }
+    }
+
+    $componentPlugin = null;
+
+    foreach ((array) $lattice['component_plugins'] as $entry) {
+        if (is_array($entry) && ($entry['name'] ?? null) === 'lattice-php/signature-example') {
+            $componentPlugin = $entry;
+        }
+    }
+
+    expect($lattice['discover_paths'])->toContain('app')
+        ->and($packageRoot)
+        ->toMatchArray(['name' => 'lattice-php/signature-example', 'roots' => [str_replace(base_path().'/', '', $discoverRoot)]])
+        ->and($componentPlugin)
+        ->toMatchArray(['name' => 'lattice-php/signature-example', 'plugin' => str_replace(base_path().'/', '', $pluginPath)])
+        ->and($lattice['manifest_cache'])->toMatchArray(['cached' => false]);
+});
+
+it('reports the manifest cache path once cached', function (): void {
+    $manifest = app(DiscoveryManifest::class);
+    $manifest->cache();
+
+    Artisan::call('about', ['--json' => true]);
+    $data = json_decode((string) Artisan::output(), true);
+
+    expect($data['lattice']['manifest_cache'])
+        ->toMatchArray(['cached' => true, 'path' => $manifest->path()]);
+});

--- a/tests/Feature/Discovery/ComponentPackagesTest.php
+++ b/tests/Feature/Discovery/ComponentPackagesTest.php
@@ -39,6 +39,39 @@ it('returns no packages when installed.json is absent', function (): void {
     expect(ComponentPackages::packagesFromInstalled('/no/such/installed.json'))->toBe([]);
 });
 
+it('resolves the root package from its own composer.json extra.lattice', function (): void {
+    $packages = ComponentPackages::packagesFromRootComposerJson(
+        __DIR__.'/../../Fixtures/PackageDiscovery/root-package/composer.json',
+    );
+
+    expect($packages)->toBe([
+        [
+            'name' => 'acme/root-widget',
+            'roots' => [realpath(__DIR__.'/../../Fixtures/PackageDiscovery/root-package/src')],
+            'plugin' => realpath(__DIR__.'/../../Fixtures/PackageDiscovery/root-package/resources/js/plugin.ts'),
+        ],
+    ]);
+});
+
+it('returns nothing for a root composer.json without extra.lattice', function (): void {
+    $packages = ComponentPackages::packagesFromRootComposerJson(
+        __DIR__.'/../../Fixtures/PackageDiscovery/root-plain/composer.json',
+    );
+
+    expect($packages)->toBe([]);
+});
+
+it('returns nothing when the root composer.json is absent', function (): void {
+    expect(ComponentPackages::packagesFromRootComposerJson('/no/such/composer.json'))->toBe([]);
+});
+
+it('reads the root package via Composer\InstalledVersions::getRootPackage()', function (): void {
+    // Under this package's own testbench suite, the composer ROOT project is
+    // this repo itself — it declares no extra.lattice, so the real root
+    // resolution should degrade to no packages rather than throwing.
+    expect(ComponentPackages::rootPackage())->toBe([]);
+});
+
 it('merges installed component-package roots into the configured discover paths', function (): void {
     $packagePath = InstalledVersions::getInstallPath('lattice-php/signature-example') ?? '';
     $discoverPath = realpath($packagePath.'/src');

--- a/tests/Feature/Discovery/ComponentPackagesTest.php
+++ b/tests/Feature/Discovery/ComponentPackagesTest.php
@@ -66,9 +66,7 @@ it('returns nothing when the root composer.json is absent', function (): void {
 });
 
 it('reads the root package via Composer\InstalledVersions::getRootPackage()', function (): void {
-    // Under this package's own testbench suite, the composer ROOT project is
-    // this repo itself — it declares no extra.lattice, so the real root
-    // resolution should degrade to no packages rather than throwing.
+    // The composer ROOT here is this repo itself, which declares no extra.lattice.
     expect(ComponentPackages::rootPackage())->toBe([]);
 });
 

--- a/tests/Feature/Discovery/ComponentPackagesTest.php
+++ b/tests/Feature/Discovery/ComponentPackagesTest.php
@@ -21,6 +21,24 @@ it('returns nothing when installed.json is absent', function (): void {
     expect(ComponentPackages::fromInstalled('/no/such/installed.json'))->toBe([]);
 });
 
+it('maps installed packages to their name, roots and plugin entry', function (): void {
+    $packages = ComponentPackages::packagesFromInstalled(
+        __DIR__.'/../../Fixtures/PackageDiscovery/composer/installed.json',
+    );
+
+    expect($packages)->toBe([
+        [
+            'name' => 'acme/widget',
+            'roots' => [realpath(__DIR__.'/../../Fixtures/PackageDiscovery/acme/widget/src')],
+            'plugin' => realpath(__DIR__.'/../../Fixtures/PackageDiscovery/acme/widget/resources/js/plugin.ts'),
+        ],
+    ]);
+});
+
+it('returns no packages when installed.json is absent', function (): void {
+    expect(ComponentPackages::packagesFromInstalled('/no/such/installed.json'))->toBe([]);
+});
+
 it('merges installed component-package roots into the configured discover paths', function (): void {
     $packagePath = InstalledVersions::getInstallPath('lattice-php/signature-example') ?? '';
     $discoverPath = realpath($packagePath.'/src');

--- a/tests/Feature/Discovery/DiscoveryManifestTest.php
+++ b/tests/Feature/Discovery/DiscoveryManifestTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Route;
 use Lattice\Lattice\Attributes\AsAction;
 use Lattice\Lattice\Attributes\AsBulkAction;
 use Lattice\Lattice\Attributes\AsForm;
@@ -11,10 +12,12 @@ use Lattice\Lattice\Attributes\AsTable;
 use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\LatticeServiceProvider;
 use Lattice\Lattice\Support\Discovery\ClassWalker;
 use Lattice\Lattice\Tables\Columns\BadgeColumn;
 use Lattice\Lattice\Tables\Enums\ColumnType;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredDemoPage;
+use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredEmbeddedPage;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredProfileForm;
 use Lattice\Lattice\Tests\Fixtures\Discovery\DiscoveredUsersTable;
 
@@ -94,6 +97,18 @@ test('discovered pages are available through the page registry', function (): vo
     $classes = collect(Lattice::pageRegistry()->all())->pluck('class');
 
     expect($classes)->toContain(DiscoveredDemoPage::class);
+});
+
+test('a discovered route-less page registers no route, while a routed sibling still gets its route', function (): void {
+    discoverFixtures();
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    $actions = collect(Route::getRoutes()->getRoutes())->map(fn ($route) => $route->getActionName());
+
+    expect(collect(Lattice::pageRegistry()->all())->pluck('class'))->toContain(DiscoveredEmbeddedPage::class)
+        ->and($actions)->not->toContain(DiscoveredEmbeddedPage::class.'@render')
+        ->and(Route::getRoutes()->getByName('discovered.demo'))->not->toBeNull();
 });
 
 test('the class walker returns classes under a path and an empty list for a missing path', function (): void {

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -25,6 +25,15 @@ final class RegWidgetsPage extends RegBasePage
     }
 }
 
+#[AsPage(name: 'registered.embedded')]
+final class RegEmbeddedPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Embedded'));
+    }
+}
+
 test('Lattice::pageRegistry()->all() resolves route metadata for registered pages', function (): void {
     Lattice::pages([RegWidgetsPage::class]);
 
@@ -56,6 +65,18 @@ test('the service provider builds a named GET route for each page', function ():
         ->and($route->uri())->toBe('widgets')
         ->and($route->getActionName())->toBe(RegWidgetsPage::class.'@render')
         ->and($route->gatherMiddleware())->toContain('web');
+});
+
+test('an imperatively registered route-less page registers no route, while a routed sibling still gets its route', function (): void {
+    Lattice::pages([RegWidgetsPage::class, RegEmbeddedPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    $actions = collect(Route::getRoutes()->getRoutes())->map(fn ($route) => $route->getActionName());
+
+    expect(collect(Lattice::pageRegistry()->all())->pluck('class'))->toContain(RegEmbeddedPage::class)
+        ->and($actions)->not->toContain(RegEmbeddedPage::class.'@render')
+        ->and(Route::getRoutes()->getByName('widgets.index'))->not->toBeNull();
 });
 
 test('the service provider skips building routes when the route cache is active', function (): void {

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Tab;
 use Lattice\Lattice\Ui\Components\Tabs;
 use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\PageLayout;
 use Orchestra\Testbench\Factories\UserFactory;
 use Workbench\App\Pages\HomePage;
 use Workbench\App\Pages\Tables\PaginationPage;
@@ -233,6 +234,22 @@ test('directly returned pages resolve route arguments and bound models in render
         );
 });
 
+test('a plain page with no attribute renders through a developer-owned controller, honoring its layout override', function (): void {
+    Route::get('embedded-page', fn (): Page => new EmbeddedLayoutPage)
+        ->middleware('web')
+        ->name('embedded-page.show');
+
+    withoutVite();
+
+    get('/embedded-page')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->component('lattice/page')
+            ->where('lattice.layout.key', 'app')
+            ->where('lattice.schema.0.props.text', 'Embedded page')
+        );
+});
+
 test('directly returned pages resolve render dependencies through the container, including form requests', function (): void {
     Route::get('responsable-form-request', fn (): Page => new WorkbenchFormRequestPage)
         ->middleware('web')
@@ -333,6 +350,20 @@ final class WorkbenchFormRequestPage extends Page
     public function render(PageSchema $schema, WorkbenchPageFormRequest $request): PageSchema
     {
         return $schema->component(Text::make($request->string('label').' via form request'));
+    }
+}
+
+final class EmbeddedLayoutPage extends Page
+{
+    #[Override]
+    public function layout(): PageLayout
+    {
+        return PageLayout::App;
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Embedded page'));
     }
 }
 

--- a/tests/Fixtures/Discovery/DiscoveredEmbeddedPage.php
+++ b/tests/Fixtures/Discovery/DiscoveredEmbeddedPage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\Discovery;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page as BasePage;
+use Lattice\Lattice\Ui\Components\Text;
+
+#[AsPage(name: 'discovered.embedded')]
+final class DiscoveredEmbeddedPage extends BasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Embedded'));
+    }
+}

--- a/tests/Fixtures/PackageDiscovery/acme/widget/resources/js/plugin.ts
+++ b/tests/Fixtures/PackageDiscovery/acme/widget/resources/js/plugin.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/Fixtures/PackageDiscovery/composer/installed.json
+++ b/tests/Fixtures/PackageDiscovery/composer/installed.json
@@ -3,7 +3,7 @@
         {
             "name": "acme/widget",
             "install-path": "../acme/widget",
-            "extra": { "lattice": { "discover": ["src"] } }
+            "extra": { "lattice": { "discover": ["src"], "plugin": "resources/js/plugin.ts" } }
         },
         {
             "name": "acme/plain",

--- a/tests/Fixtures/PackageDiscovery/root-package/composer.json
+++ b/tests/Fixtures/PackageDiscovery/root-package/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/root-widget",
+    "extra": { "lattice": { "discover": ["src"], "plugin": "resources/js/plugin.ts" } }
+}

--- a/tests/Fixtures/PackageDiscovery/root-package/resources/js/plugin.ts
+++ b/tests/Fixtures/PackageDiscovery/root-package/resources/js/plugin.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/tests/Fixtures/PackageDiscovery/root-plain/composer.json
+++ b/tests/Fixtures/PackageDiscovery/root-plain/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "acme/root-plain"
+}


### PR DESCRIPTION
Four DX improvements for component-package authors:

- **`php artisan about` panel** — a Lattice section showing configured discover paths, package-contributed roots (with owning package), detected JS component plugins, and discovery-manifest cache status. Plus doc crumbs pointing package authors at `extra.lattice.discover` from the config stub and registry docblocks.
- **Root-manifest discovery** — `ComponentPackages` (PHP) and the Vite plugin (JS) now also read the composer ROOT package's `extra.lattice`, so a component package's own testbench suite discovers its `src/` with zero config — and any app can declare `extra.lattice` directly in its own composer.json.
- **Automatic TypeScript refresh** — the Vite dev server runs `php artisan lattice:typescript` on boot (non-blocking, once per boot; silent skip without `artisan`; bounded stderr surfaced in a single warning on failure; opt out with `lattice({ typescript: false })`). Production builds are untouched.
- **Embedded pages are first-class** — route-less pages (returned from a developer's own controllers, e.g. an auth package's view layer) are now uniformly excluded from route registration whether discovered or imperatively registered, and documented: a plain `Page` subclass overriding `layout()`/`container()` needs no `#[AsPage]` at all; the attribute now means exactly "this page owns a route". Previously the manifest silently dropped route-less pages at build time.

The published `@lattice-php/lattice/vite` surface gains only the `typescript?: boolean` option — test seams live outside `package.json#exports`, verified against the built `dist/vite.d.ts`.