### PR TITLE
feat(js): dnd export seam for component packages

### DIFF
--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -208,10 +208,16 @@ primitives from `@lattice-php/lattice/dnd` (Atlassian's `pragmatic-drag-and-drop
 core) instead of depending on the library directly:
 
 ```ts
-import { draggable, attachInstruction, announce, type Edge } from "@lattice-php/lattice/dnd";
+import {
+  draggable,
+  attachTreeItemInstruction,
+  announce,
+  type Edge,
+} from "@lattice-php/lattice/dnd";
 ```
 
 A Composer package has no way to deliver npm dependencies into the consumer's bundle, so core owns
-the dependency and republishes it under its export map, the same way it does for `.../i18n` above.
+the dependency and republishes it under its export map, the same way core owns i18next behind
+`.../i18n` above.
 
 See [Registry and types](/extending/registry-and-types/) for how the `type` string couples the two sides, and how generated types keep `node.props` sound.

--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -201,4 +201,17 @@ $this->app->make('translation.loader')->addNamespace('acme-signature', __DIR__.'
   render them as-is, and a loaded translation for the key always wins.
 </Info>
 
+## Drag and drop
+
+A package that needs drag-and-drop — reordering a list, moving cards between columns — imports the
+primitives from `@lattice-php/lattice/dnd` (Atlassian's `pragmatic-drag-and-drop`, re-exported by
+core) instead of depending on the library directly:
+
+```ts
+import { draggable, attachInstruction, announce, type Edge } from "@lattice-php/lattice/dnd";
+```
+
+A Composer package has no way to deliver npm dependencies into the consumer's bundle, so core owns
+the dependency and republishes it under its export map, the same way it does for `.../i18n` above.
+
 See [Registry and types](/extending/registry-and-types/) for how the `type` string couples the two sides, and how generated types keep `node.props` sound.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+        "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
+        "@atlaskit/pragmatic-drag-and-drop-live-region": "^2.0.0",
         "@internationalized/date": "^3.12.2",
         "@lattice-php/vite-svg-sprite": "^0.3.0",
         "@radix-ui/react-checkbox": "^1.1.4",
@@ -769,6 +773,46 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-2.0.1.tgz",
+      "integrity": "sha512-5iSbCveKuWYh0HijDxfSsYKD2VE0UPObI9jO1pqq+RBk9LzaoOYeKyW0Fobv/6db8HAPcyT3vhRy8bmk5TMcMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-auto-scroll": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-auto-scroll/-/pragmatic-drag-and-drop-auto-scroll-3.0.0.tgz",
+      "integrity": "sha512-8TlkMi417zIPrTnCpbNV0Ce63JTKBn3dGkqiadkGQROvzDAox7Y9TYRHpvbQiEdtPoHWnmyRBi+RsGDxXsQxgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-2.0.0.tgz",
+      "integrity": "sha512-vkXCB/23pT8YgYU8biGmR9uu0fr9oWoaq2GMSKyiNPk3reA12XVrCdgB2SLBoB24Ic1FOm9PdaQJ9ZSUQdCVpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^2.0.0",
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-live-region": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-live-region/-/pragmatic-drag-and-drop-live-region-2.0.0.tgz",
+      "integrity": "sha512-GrlZdZQSw4yegSrU8EDcaO6IBDEAYbSMgv3tTTfkbdmOjpEnwXmNGHe7CiA3GR9LgUNiKpERR9tlfa+viXIGvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -1037,7 +1081,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -7520,6 +7563,12 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -13298,6 +13347,12 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
       "types": "./dist/core/index.d.ts",
       "import": "./dist/core/index.js"
     },
+    "./dnd": {
+      "types": "./dist/dnd/index.d.ts",
+      "import": "./dist/dnd/index.js"
+    },
     "./form": {
       "types": "./dist/form/index.d.ts",
       "import": "./dist/form/index.js"
@@ -169,6 +173,10 @@
     "docs:preview": "astro preview"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
+    "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
+    "@atlaskit/pragmatic-drag-and-drop-live-region": "^2.0.0",
     "@internationalized/date": "^3.12.2",
     "@lattice-php/vite-svg-sprite": "^0.3.0",
     "@radix-ui/react-checkbox": "^1.1.4",

--- a/resources/js/dnd/index.ts
+++ b/resources/js/dnd/index.ts
@@ -33,11 +33,15 @@ export {
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 export type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 export {
-  attachInstruction,
-  extractInstruction,
+  attachInstruction as attachTreeItemInstruction,
+  extractInstruction as extractTreeItemInstruction,
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item";
-export type { Instruction, ItemMode } from "@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item";
+export type {
+  Instruction as TreeItemInstruction,
+  ItemMode as TreeItemMode,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item";
 export { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
+export { reorderWithEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/reorder-with-edge";
 export {
   announce,
   cleanup as cleanupLiveRegion,
@@ -46,3 +50,4 @@ export {
   autoScrollForElements,
   autoScrollWindowForElements,
 } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+export { pointerOutsideOfPreview } from "@atlaskit/pragmatic-drag-and-drop/element/pointer-outside-of-preview";

--- a/resources/js/dnd/index.ts
+++ b/resources/js/dnd/index.ts
@@ -1,0 +1,48 @@
+export {
+  draggable,
+  dropTargetForElements,
+  monitorForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+export type {
+  ElementDragPayload,
+  ElementEventBasePayload,
+  ElementDropTargetEventBasePayload,
+  ElementGetFeedbackArgs,
+  ElementDropTargetGetFeedbackArgs,
+  ElementMonitorGetFeedbackArgs,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+export { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+export { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder";
+export { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+export { preserveOffsetOnSource } from "@atlaskit/pragmatic-drag-and-drop/element/preserve-offset-on-source";
+export type {
+  AllDragTypes,
+  BaseEventPayload,
+  CleanupFn,
+  DragLocation,
+  DragLocationHistory,
+  DropTargetRecord,
+  ElementDragType,
+  Input,
+  MonitorArgs,
+  Position,
+} from "@atlaskit/pragmatic-drag-and-drop/types";
+export {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+export type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+export {
+  attachInstruction,
+  extractInstruction,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item";
+export type { Instruction, ItemMode } from "@atlaskit/pragmatic-drag-and-drop-hitbox/tree-item";
+export { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
+export {
+  announce,
+  cleanup as cleanupLiveRegion,
+} from "@atlaskit/pragmatic-drag-and-drop-live-region";
+export {
+  autoScrollForElements,
+  autoScrollWindowForElements,
+} from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -330,6 +330,7 @@ export default defineConfig(({ mode }) => {
                   /^node:/,
                   /^react($|\/)/,
                   /^react-dom($|\/)/,
+                  /^@atlaskit\//,
                   /^@inertiajs\//,
                   /^@internationalized\/date($|\/)/,
                   /^@lattice-php\/vite-svg-sprite($|\/)/,


### PR DESCRIPTION
Adds a `@lattice-php/lattice/dnd` export path re-exporting Atlassian's pragmatic-drag-and-drop primitives, so Composer-distributed component packages (tree's upcoming drag-and-drop, the planned board package) can use them. A Composer package cannot deliver npm dependencies into the consumer's bundle and is restricted to core's export map — so core owns the dependency family and republishes the primitives.

New dependencies (must always move majors in lockstep — hitbox/auto-scroll pin `^2.0.0` on the core dnd package internally, and a split resolution would create two adapter-registry instances that silently stop exchanging drop payloads):
- `@atlaskit/pragmatic-drag-and-drop` ^2.0.1
- `@atlaskit/pragmatic-drag-and-drop-hitbox` ^2.0.0
- `@atlaskit/pragmatic-drag-and-drop-live-region` ^2.0.0
- `@atlaskit/pragmatic-drag-and-drop-auto-scroll` ^3.0.0

The barrel is a thin re-export (element adapter, combine/reorder, closest-edge + tree-item hitboxes — tree-item qualified as `attachTreeItemInstruction`/`TreeItemInstruction` to avoid colliding with hitbox's identically-named list-item entry point — `reorderWithEdge`, `getReorderDestinationIndex`, drag-preview helpers, `announce`, auto-scroll). No wrappers until the consumers reveal shared patterns.

- `@atlaskit/*` stays external in the lib build: consumers that never import `/dnd` bundle nothing.
- publint + attw pass clean on the new entrypoint (no exclusion needed).
- Verified from the consumer side: packed tarball installed in a clean project, import probe typechecks with `tsc --strict` (deps resolve transitively).
- Gates: `npm run check` and `composer check` green (pre-push hook re-ran both).