### PR TITLE
P0 audit batch: security default, ref refresh, perf fixes, de-flaked browser suite

### DIFF
--- a/.github/workflows/standalone-assets.yml
+++ b/.github/workflows/standalone-assets.yml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   build:
+    # The asset commit below is pushed with a PAT and would re-trigger this
+    # workflow; skip runs caused by our own commit to break the loop.
+    if: github.event.head_commit.message != 'chore: build standalone assets'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/config/lattice.php
+++ b/config/lattice.php
@@ -15,6 +15,10 @@ return [
         'ref_lifetime' => 30,
     ],
 
+    'refs' => [
+        'middleware' => ['web'],
+    ],
+
     'files' => [
         'disk' => env('LATTICE_FILES_DISK', 'public'),
         'temp_prefix' => 'tmp',

--- a/config/lattice.php
+++ b/config/lattice.php
@@ -36,6 +36,13 @@ return [
         'echo' => null,
     ],
 
+    // Pages ship unauthenticated by default; authorization is opt-in via
+    // attribute middleware or Page::authorize(). `#[AsPage(middleware: [])]`
+    // opts a page out of this default entirely.
+    'pages' => [
+        'middleware' => ['web'],
+    ],
+
     'forms' => [
         'endpoint' => 'lattice/forms/{form}',
         'middleware' => ['web', 'auth'],

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -132,7 +132,7 @@ too.
 | `name`       | The route name. Defaults to the route segments joined by dots (`products.edit`), falling back to the class name without its `Page` suffix.                           |
 | `layout`     | The [layout](/core/layouts/) the page renders into — a [`PageLayout`](/advanced/enums/#pages) or a registered layout key. Defaults to `PageLayout::None` (no shell). |
 | `container`  | How the content is framed — a [`PageContainer`](/advanced/enums/#pages) (`Default` or `Centered`). Defaults to `PageContainer::Centered`.                            |
-| `middleware` | Middleware for the page's route — a string or an array.                                                                                                              |
+| `middleware` | Middleware for the page's route — a string or an array. Defaults to the `lattice.pages.middleware` config (`['web']`); pass `[]` to register the route with none.    |
 
 ```php
 use Lattice\Lattice\Ui\Enums\PageContainer;
@@ -146,6 +146,12 @@ use Lattice\Lattice\Ui\Enums\PageLayout;
     middleware: ['web', 'auth'],
 )]
 ```
+
+:::caution
+Pages are **not authenticated by default** — the default stack is `['web']` only. Add `auth` via the
+attribute (or a shared base page), or gate access with [`authorize()`](#authorization), for any page
+that must not be public.
+:::
 
 ## Shared base pages
 

--- a/resources/js/core/api.test.ts
+++ b/resources/js/core/api.test.ts
@@ -8,6 +8,7 @@ import {
   remoteJson,
   type RemoteAccess,
 } from "./api";
+import { clearRefreshedRefs } from "./component-ref";
 
 function okResponse(body: unknown = {}): Response {
   return { ok: true, status: 200, json: async () => body } as unknown as Response;
@@ -15,6 +16,7 @@ function okResponse(body: unknown = {}): Response {
 
 afterEach(() => {
   clearRemoteTokenCache();
+  clearRefreshedRefs();
   document.cookie = "XSRF-TOKEN=;path=/;max-age=0";
 });
 
@@ -138,6 +140,69 @@ describe("apiFetch", () => {
     );
 
     await expect(apiFetch("/x", { throwOnError: false })).resolves.toBe(response);
+  });
+});
+
+describe("ref refresh", () => {
+  const forbidden = () => ({ ok: false, status: 403 }) as unknown as Response;
+
+  it("refreshes an expired ref on 403 and retries with the renewed token", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(forbidden())
+      .mockResolvedValueOnce(okResponse({ ref: "renewed-ref" }))
+      .mockResolvedValueOnce(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await apiFetch("/x", { ref: "sealed-ref" });
+
+    expect(response.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/lattice/refs/refresh");
+    expect(fetchMock.mock.calls[1]?.[1]?.body).toBe(JSON.stringify({ ref: "sealed-ref" }));
+    expect(fetchMock.mock.calls[2]?.[1]?.headers).toMatchObject({
+      "X-Lattice-Ref": "renewed-ref",
+    });
+  });
+
+  it("sends the renewed token for subsequent requests without another refresh", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(forbidden())
+      .mockResolvedValueOnce(okResponse({ ref: "renewed-ref" }))
+      .mockResolvedValue(okResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiFetch("/x", { ref: "sealed-ref" });
+    await apiFetch("/x", { ref: "sealed-ref" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[3]?.[1]?.headers).toMatchObject({
+      "X-Lattice-Ref": "renewed-ref",
+    });
+  });
+
+  it("throws the original 403 when the refresh is rejected", async () => {
+    const original = forbidden();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(original)
+      .mockResolvedValueOnce(forbidden());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const error = await apiFetch("/x", { ref: "sealed-ref" }).catch((reason: unknown) => reason);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect((error as ApiError).response).toBe(original);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not attempt a refresh for a 403 without a ref", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(forbidden());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiFetch("/x")).rejects.toBeInstanceOf(ApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -6,6 +6,7 @@
  * which carries its own headers.
  */
 
+import { latestRef, storeRefreshedRef } from "./component-ref";
 import { withHeaders } from "./headers";
 import { localeHeader } from "@lattice-php/lattice/i18n/locale";
 import type {
@@ -65,17 +66,60 @@ function defaultHeaders(method: string | undefined): Record<string, string> {
   };
 }
 
+const REF_REFRESH_ENDPOINT = "/lattice/refs/refresh";
+
+const pendingRefRefreshes = new Map<string, Promise<string | null>>();
+
+/**
+ * Trade an expired-but-authentic ref for a fresh one. Deduped per original ref
+ * so a burst of 403s from one component costs a single round-trip.
+ */
+async function refreshRef(componentRef: string): Promise<string | null> {
+  const pending = pendingRefRefreshes.get(componentRef);
+
+  if (pending) {
+    return pending;
+  }
+
+  const request = apiJson<{ ref: string }>(REF_REFRESH_ENDPOINT, {
+    method: "POST",
+    body: JSON.stringify({ ref: latestRef(componentRef) }),
+  })
+    .then((data) => {
+      storeRefreshedRef(componentRef, data.ref);
+
+      return data.ref;
+    })
+    .catch(() => null)
+    .finally(() => {
+      pendingRefRefreshes.delete(componentRef);
+    });
+
+  pendingRefRefreshes.set(componentRef, request);
+
+  return request;
+}
+
 export async function apiFetch(url: string, init: ApiInit = {}): Promise<Response> {
-  const { ref, headers, throwOnError = true, method, ...rest } = init;
+  const { ref = "", headers, throwOnError = true, method, ...rest } = init;
   // Some servers reject a lower-case method line, and fetch only normalizes the
   // standard verbs, so upper-case it here.
   const normalizedMethod = method?.toUpperCase();
-  const response = await fetch(url, {
-    credentials: "same-origin",
-    ...rest,
-    method: normalizedMethod,
-    headers: withHeaders(ref ?? "", { ...defaultHeaders(normalizedMethod), ...headers }),
-  });
+  const request = () =>
+    fetch(url, {
+      credentials: "same-origin",
+      ...rest,
+      method: normalizedMethod,
+      // withHeaders resolves the latest refreshed token for the ref, so the
+      // retry below picks up the renewal without threading it through.
+      headers: withHeaders(ref, { ...defaultHeaders(normalizedMethod), ...headers }),
+    });
+
+  let response = await request();
+
+  if (ref !== "" && response.status === 403 && (await refreshRef(ref)) !== null) {
+    response = await request();
+  }
 
   if (throwOnError && !response.ok) {
     throw new ApiError(response);

--- a/resources/js/core/component-ref.ts
+++ b/resources/js/core/component-ref.ts
@@ -6,6 +6,29 @@
  */
 export const LATTICE_REF_HEADER = "X-Lattice-Ref";
 
+/**
+ * Refs are sealed with a lifetime and baked into node props at render time, so
+ * a long-lived tab cannot pick up a renewed token through React state. Renewed
+ * tokens are instead kept here, keyed by the original prop value, and resolved
+ * whenever a ref travels — every consumer keeps passing the ref it was rendered
+ * with.
+ */
+const refreshedRefs = new Map<string, string>();
+
+export function latestRef(componentRef: string): string {
+  return refreshedRefs.get(componentRef) ?? componentRef;
+}
+
+export function storeRefreshedRef(componentRef: string, refreshed: string): void {
+  refreshedRefs.set(componentRef, refreshed);
+}
+
+export function clearRefreshedRefs(): void {
+  refreshedRefs.clear();
+}
+
 export function withRefHeader(componentRef: string): Record<string, string> {
-  return componentRef ? { [LATTICE_REF_HEADER]: componentRef } : {};
+  const ref = latestRef(componentRef);
+
+  return ref ? { [LATTICE_REF_HEADER]: ref } : {};
 }

--- a/resources/js/form/components/fields/date-picker-field.tsx
+++ b/resources/js/form/components/fields/date-picker-field.tsx
@@ -147,7 +147,7 @@ export function DatePickerField({
           disabled={disabled || readOnly}
           size="icon"
           type="button"
-          color="secondary"
+          variant="secondary"
         >
           <Icon name="calendar" className="size-lt-icon-md" aria-hidden="true" />
         </Button>

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -69,9 +69,10 @@ function FormBody({
   summaryLabel: string;
 }) {
   const { nodes: resolvedNodes, markUserEdit } = useFormResolver(action, componentRef, nodes);
+  const prefill = useMemo(() => ({ markUserEdit }), [markUserEdit]);
 
   return (
-    <PrefillProvider value={{ markUserEdit }}>
+    <PrefillProvider value={prefill}>
       <ResolvedNodesProvider nodes={resolvedNodes}>
         <div className="flex flex-col gap-6">
           {children}

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -231,7 +231,6 @@ describe("lattice Vite helper", () => {
       searchForWorkspaceRoot("/app"),
       "/app/vendor/acme/signature",
     ]);
-    // With no configured root, it falls back to the cwd's workspace root.
     expect(config({}).server.fs.allow).toEqual([
       searchForWorkspaceRoot(process.cwd()),
       "/app/vendor/acme/signature",

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use Lattice\Lattice\Http\Controllers\BulkActionController;
 use Lattice\Lattice\Http\Controllers\FormController;
 use Lattice\Lattice\Http\Controllers\FragmentController;
 use Lattice\Lattice\Http\Controllers\NotificationController;
+use Lattice\Lattice\Http\Controllers\RefRefreshController;
 use Lattice\Lattice\Http\Controllers\RemoteSourceTokenController;
 use Lattice\Lattice\Http\Controllers\TableController;
 
@@ -24,6 +25,13 @@ Route::middleware(config('lattice.fragments.middleware', ['web', 'auth']))
     ->get(config('lattice.fragments.endpoint', 'lattice/fragments/{fragment}'), FragmentController::class)
     ->where('fragment', '.*')
     ->name('lattice.fragments.show');
+
+// The path is fixed (not config-templated) because the client hardcodes it as
+// its recovery route for expired refs; auth comes from the identity binding
+// inside the signer, so the route itself stays on the page-level default.
+Route::middleware(config('lattice.refs.middleware', ['web']))
+    ->post('lattice/refs/refresh', RefRefreshController::class)
+    ->name('lattice.refs.refresh');
 
 Route::middleware(config('lattice.remote-sources.middleware', ['web', 'auth']))
     ->post(config('lattice.remote-sources.endpoint', 'lattice/remote-sources/{source}/token'), RemoteSourceTokenController::class)

--- a/src/Core/Contracts/SignsComponentReferences.php
+++ b/src/Core/Contracts/SignsComponentReferences.php
@@ -25,4 +25,13 @@ interface SignsComponentReferences
      * @return array<string, mixed>|null
      */
     public function unseal(string $token, string $type, string $key): ?array;
+
+    /**
+     * Re-seal a token whose lifetime has (or is about to have) run out. The
+     * token's integrity and identity binding are fully verified — only expiry
+     * is ignored, so a long-lived tab can renew its refs without a reload while
+     * a forged token or a rotated session still fails. Returns the fresh token,
+     * or null when the token is missing, forged, or bound to another identity.
+     */
+    public function refresh(string $token): ?string;
 }

--- a/src/Core/PageMetadata.php
+++ b/src/Core/PageMetadata.php
@@ -14,8 +14,12 @@ use Spatie\Attributes\Attributes;
 final readonly class PageMetadata
 {
     /**
+     * `$middleware` is null when no attribute in the class hierarchy declares
+     * one — the route falls back to `lattice.pages.middleware` at registration
+     * time. An explicit `middleware: []` opts the route out of any middleware.
+     *
      * @param  class-string  $class
-     * @param  array<int, string>  $middleware
+     * @param  array<int, string>|null  $middleware
      */
     private function __construct(
         public string $class,
@@ -23,7 +27,7 @@ final readonly class PageMetadata
         public string $name,
         public PageLayout|string $layout,
         public PageContainer|string $container,
-        public array $middleware,
+        public ?array $middleware,
     ) {}
 
     public static function for(PageContract|string $page): self
@@ -43,12 +47,22 @@ final readonly class PageMetadata
             name: self::resolveName($class, $own),
             layout: self::inherited($class, fn (AsPage $a): PageLayout|string|null => $a->layout) ?? PageLayout::None,
             container: self::inherited($class, fn (AsPage $a): PageContainer|string|null => $a->container) ?? PageContainer::Centered,
-            middleware: (array) (self::inherited($class, fn (AsPage $a): string|array|null => $a->middleware) ?? []),
+            middleware: self::inheritedMiddleware($class),
         );
     }
 
     /**
-     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>, layout: string, container: string}
+     * @return array<int, string>|null
+     */
+    private static function inheritedMiddleware(string $class): ?array
+    {
+        $middleware = self::inherited($class, fn (AsPage $a): string|array|null => $a->middleware);
+
+        return $middleware === null ? null : (array) $middleware;
+    }
+
+    /**
+     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, container: string}
      */
     public function toArray(): array
     {
@@ -63,7 +77,7 @@ final readonly class PageMetadata
     }
 
     /**
-     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>, layout: string, container: string}  $descriptor
+     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, container: string}  $descriptor
      */
     public static function fromArray(array $descriptor): self
     {

--- a/src/Core/Services/ComponentReferenceSigner.php
+++ b/src/Core/Services/ComponentReferenceSigner.php
@@ -53,6 +53,21 @@ final readonly class ComponentReferenceSigner implements SignsComponentReference
         return $context;
     }
 
+    public function refresh(string $token): ?string
+    {
+        $payload = $this->identityBoundPayload($token);
+
+        if ($payload === null || ! is_string($payload['type'] ?? null) || ! is_string($payload['key'] ?? null)) {
+            return null;
+        }
+
+        return $this->seal(
+            $payload['type'],
+            $payload['key'],
+            is_array($payload['context'] ?? null) ? $payload['context'] : [],
+        );
+    }
+
     /**
      * Decrypt and fully validate a sealed token: structure, type/key, expiry, and
      * the identity it was bound to. Returns the trusted context on success (an
@@ -62,6 +77,31 @@ final readonly class ComponentReferenceSigner implements SignsComponentReference
      * @return array<string, mixed>|null
      */
     private function verify(string $token, string $type, string $key): ?array
+    {
+        $payload = $this->identityBoundPayload($token);
+
+        if ($payload === null) {
+            return null;
+        }
+
+        if (($payload['type'] ?? null) !== $type || ($payload['key'] ?? null) !== $key) {
+            return null;
+        }
+
+        if (! is_int($payload['expires_at'] ?? null) || $payload['expires_at'] < now()->timestamp) {
+            return null;
+        }
+
+        return is_array($payload['context'] ?? null) ? $payload['context'] : [];
+    }
+
+    /**
+     * Decrypt a token and verify everything that does not depend on the caller's
+     * expectations or the clock: payload structure and the user/session binding.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function identityBoundPayload(string $token): ?array
     {
         if ($token === '') {
             return null;
@@ -77,14 +117,6 @@ final readonly class ComponentReferenceSigner implements SignsComponentReference
             return null;
         }
 
-        if (($payload['type'] ?? null) !== $type || ($payload['key'] ?? null) !== $key) {
-            return null;
-        }
-
-        if (! is_int($payload['expires_at'] ?? null) || $payload['expires_at'] < now()->timestamp) {
-            return null;
-        }
-
         $identity = $this->identity->current();
 
         if (! $this->userMatches($identity, $payload['user_id'] ?? null)) {
@@ -95,7 +127,7 @@ final readonly class ComponentReferenceSigner implements SignsComponentReference
             return null;
         }
 
-        return is_array($payload['context'] ?? null) ? $payload['context'] : [];
+        return $payload;
     }
 
     private function token(Request $request): string

--- a/src/Http/Controllers/RefRefreshController.php
+++ b/src/Http/Controllers/RefRefreshController.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+
+final readonly class RefRefreshController
+{
+    public function __construct(private SignsComponentReferences $references) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $ref = $request->string('ref')->toString();
+        abort_if($ref === '', 403);
+
+        $refreshed = $this->references->refresh($ref);
+
+        abort_if($refreshed === null, 403);
+
+        return response()->json(['ref' => $refreshed]);
+    }
+}

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -211,7 +211,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
             Route::get($page->route, [$page->class, 'render'])
                 ->name($page->name)
-                ->middleware($page->middleware);
+                ->middleware($page->middleware ?? config('lattice.pages.middleware', ['web']));
         }
 
         Route::getRoutes()->refreshNameLookups();

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -164,10 +164,6 @@ arch('the support utilities do not depend on the feature domains')
     ]);
 
 /*
- * Structural conventions.
- */
-
-/*
  * Cross-boundary contracts live in a `Contracts` namespace and are interfaces.
  * Local capability interfaces that are not cross-boundary contracts, such as
  * Support\TypeScript\TypeScriptProfile, can sit beside their implementations.

--- a/tests/Browser/App/AuthenticationTest.php
+++ b/tests/Browser/App/AuthenticationTest.php
@@ -14,19 +14,27 @@ beforeEach(function (): void {
 });
 
 it('signs a workbench user in through the rendered login form', function (): void {
-    visit('/login')
+    $page = visit('/login')
         ->assertSee('Lattice Workbench')
-        ->click('@form-submit')
-        ->assertPathIs('/')
-        ->assertSee('Workbench page')
+        ->click('@form-submit');
+
+    retryUntil(function () use ($page): void {
+        $page->assertPathIs('/');
+    });
+
+    $page->assertSee('Workbench page')
         ->assertNoSmoke();
 });
 
 it('keeps invalid credentials on the login form', function (): void {
-    visit('/login')
+    $page = visit('/login')
         ->fill('@password', 'wrong-password')
-        ->click('@form-submit')
-        ->assertPathIs('/login')
-        ->assertSee('These credentials do not match the seeded workbench user.')
+        ->click('@form-submit');
+
+    retryUntil(function () use ($page): void {
+        $page->assertSee('These credentials do not match the seeded workbench user.');
+    });
+
+    $page->assertPathIs('/login')
         ->assertNoSmoke();
 });

--- a/tests/Browser/App/BusinessPartnerTest.php
+++ b/tests/Browser/App/BusinessPartnerTest.php
@@ -12,18 +12,22 @@ it('renders the business partners index page', function (): void {
 });
 
 it('creates a business partner via the form', function (): void {
-    $this->visitAsWorkbenchUser('/business-partners/create')
+    $page = $this->visitAsWorkbenchUser('/business-partners/create')
         ->assertSee('Create business partner')
         ->fill('input[name="name"]', 'Test Partner')
         ->fill('input[name="email"]', 'partner@example.com')
         ->click('[data-test="repeater-addresses-row-0"] [data-test="row-action-remove"]')
-        ->click('@form-submit')
-        ->assertSee('Business partners')
-        ->assertNoSmoke();
+        ->click('@form-submit');
+
+    retryUntil(function (): void {
+        expect(BusinessPartner::query()->where('email', 'partner@example.com')->exists())->toBeTrue();
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('adds an address row in the repeater and submits', function (): void {
-    $this->visitAsWorkbenchUser('/business-partners/create')
+    $page = $this->visitAsWorkbenchUser('/business-partners/create')
         ->assertSee('Create business partner')
         ->assertPresent('[data-test="repeater-addresses-row-0"]')
         ->fill('input[name="name"]', 'Repeater Partner')
@@ -33,9 +37,13 @@ it('adds an address row in the repeater and submits', function (): void {
         ->fill('input[name="addresses[0][city]"]', 'Berlin')
         ->fill('input[name="addresses[0][postal_code]"]', '10115')
         ->fill('input[name="addresses[0][country]"]', 'DE')
-        ->click('@form-submit')
-        ->assertSee('Business partners')
-        ->assertNoSmoke();
+        ->click('@form-submit');
+
+    retryUntil(function (): void {
+        expect(Address::query()->where('label', 'HQ')->where('city', 'Berlin')->exists())->toBeTrue();
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('renders the edit page for an existing partner', function (): void {

--- a/tests/Browser/App/ProductFormTest.php
+++ b/tests/Browser/App/ProductFormTest.php
@@ -25,11 +25,13 @@ it('disables the submit button while precognition errors are active', function (
 });
 
 it('surfaces server validation errors after submitting an empty form', function (): void {
-    $this->visitAsWorkbenchUser('/products/create')
+    $page = $this->visitAsWorkbenchUser('/products/create')
         ->assertSee('Create Product')
-        ->click('@form-submit')
-        ->assertSee('The Name field is required.')
-        ->assertDisabled('@form-submit');
+        ->click('@form-submit');
+
+    assertSeeEventually($page, 'The Name field is required.');
+
+    $page->assertDisabled('@form-submit');
 
     expect(Product::query()->count())->toBe(0);
 });
@@ -56,7 +58,7 @@ it('attaches related products via search when creating', function (): void {
     $this->actingAs(workbenchTestUser());
     $related = Product::factory()->create(['name' => 'Walnut Desk']);
 
-    visit('/products/create')
+    $page = visit('/products/create')
         ->assertSee('Create Product')
         ->fill('@name', 'Gadget')
         ->fill('@sku', 'GAD-100')
@@ -67,9 +69,13 @@ it('attaches related products via search when creating', function (): void {
         ->assertSee('Walnut Desk')
         ->click("@select-related_products-option-{$related->getKey()}")
         ->assertPresent("[data-test=\"select-related_products-remove-{$related->getKey()}\"]")
-        ->click('@form-submit')
-        ->assertSee('Products')
-        ->assertNoSmoke();
+        ->click('@form-submit');
+
+    retryUntil(function (): void {
+        expect(Product::query()->where('sku', 'GAD-100')->exists())->toBeTrue();
+    });
+
+    $page->assertNoSmoke();
 
     $product = Product::query()->where('sku', 'GAD-100')->firstOrFail();
 
@@ -78,7 +84,7 @@ it('attaches related products via search when creating', function (): void {
 });
 
 it('creates and edits a product through the form flow', function (): void {
-    $this->visitAsWorkbenchUser('/products')
+    $page = $this->visitAsWorkbenchUser('/products')
         ->assertSee('Products')
         ->click('@create-product')
         ->assertSee('Create Product')
@@ -86,20 +92,28 @@ it('creates and edits a product through the form flow', function (): void {
         ->fill('@sku', 'LAMP-001')
         ->fill('input[name="sales_prices[0][amount]"]', '49.99')
         ->click('@status-active')
-        ->click('@form-submit')
-        ->assertSee('Products')
-        ->assertSee('Desk Lamp')
-        ->click('@product-actions')
+        ->click('@form-submit');
+
+    // Typed input values are not text nodes, so the table cell is the only
+    // "Desk Lamp" the text assertion can match — a real post-submit signal.
+    retryUntil(function () use ($page): void {
+        $page->assertSee('Desk Lamp');
+    });
+
+    $page->click('@product-actions')
         ->click('@product-edit')
         ->assertSee('Edit Product')
         ->assertValue('Name', 'Desk Lamp')
         ->fill('@name', 'Updated Lamp')
         ->assertValue('Name', 'Updated Lamp')
         ->assertEnabled('@form-submit')
-        ->click('@form-submit')
-        ->assertSee('Products')
-        ->assertSee('Updated Lamp')
-        ->assertNoSmoke();
+        ->click('@form-submit');
+
+    retryUntil(function () use ($page): void {
+        $page->assertSee('Updated Lamp');
+    });
+
+    $page->assertNoSmoke();
 
     expect(Product::query()->where('sku', 'LAMP-001')->value('name'))->toBe('Updated Lamp');
 });

--- a/tests/Browser/App/SalesOrderTest.php
+++ b/tests/Browser/App/SalesOrderTest.php
@@ -48,12 +48,20 @@ it('auto-resolves, re-resolves on partner change, and persists a manual override
 
     $page->fill('input[name="lines[0][quantity]"]', '2')
         ->fill('input[name="lines[0][unit_price]"]', '73.50')
-        ->click('@form-submit')
-        ->assertSee('Sales orders')
-        ->assertNoSmoke();
+        ->click('@form-submit');
 
-    $line = $vipPartner->salesOrders()->firstOrFail()->lines()->firstOrFail();
+    // The index page also renders a "Create sales order" button, so absence of
+    // the form's inputs is the navigation signal — not the heading text.
+    retryUntil(function () use ($page): void {
+        $page->assertMissing('input[name="lines[0][unit_price]"]');
+    });
 
-    expect($line->unit_price)->toBe('73.50')
-        ->and($line->quantity)->toBe(2);
+    retryUntil(function () use ($vipPartner): void {
+        $line = $vipPartner->salesOrders()->firstOrFail()->lines()->firstOrFail();
+
+        expect($line->unit_price)->toBe('73.50')
+            ->and($line->quantity)->toBe(2);
+    });
+
+    $page->assertNoSmoke();
 });

--- a/tests/Browser/Components/NotificationBellTest.php
+++ b/tests/Browser/Components/NotificationBellTest.php
@@ -9,15 +9,19 @@ it('shows the bell, opens the panel, and marks notifications read', function ():
 
     $this->actingAs($user);
 
-    visit('/')
+    $page = visit('/')
         ->assertPresent('@notifications-trigger')
         ->assertPresent('[data-test="notifications-badge"]')
         ->assertSeeIn('[data-test="notifications-badge"]', '1')
         ->click('@notifications-trigger')
         ->assertSee('Order #1234 shipped')
-        ->click('Mark all read')
-        ->assertNotPresent('[data-test="notifications-badge"]')
-        ->assertNoSmoke();
+        ->click('Mark all read');
+
+    retryUntil(function () use ($page): void {
+        $page->assertNotPresent('[data-test="notifications-badge"]');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('renders the slide-out variant when configured', function (): void {

--- a/tests/Browser/Fields/BuilderTest.php
+++ b/tests/Browser/Fields/BuilderTest.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+// The form redirects back to the same URL on success, which leaves no
+// client-observable state change (form values live in the client store and
+// survive same-page visits). The server-side round-trip is asserted in
+// NestedFieldFormSubmitTest; these tests cover the client interactions.
 it('adds heterogeneous blocks and submits a typed payload', function (): void {
     $this->visitAsWorkbenchUser('/form/fields/builder')
         ->assertSee('Builder')
@@ -14,7 +18,6 @@ it('adds heterogeneous blocks and submits a typed payload', function (): void {
         ->fill('input[name="items[1][qty]"]', '3')
         ->fill('input[name="items[1][price]"]', '9.50')
         ->click('@form-submit')
-        ->assertSee('Builder')
         ->assertNoSmoke();
 });
 
@@ -44,7 +47,6 @@ it('renders the table layout with a shared header and round-trips a typed payloa
         ->assertNoJavaScriptErrors();
 
     $page->click('@form-submit')
-        ->assertSee('Builder')
         ->assertNoSmoke();
 });
 

--- a/tests/Browser/Fields/FileUploadTest.php
+++ b/tests/Browser/Fields/FileUploadTest.php
@@ -9,7 +9,7 @@ use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Rules\FileUploadItem;
 use Lattice\Lattice\Ui\Enums\HttpMethod;
 
-it('uploads a file through a multipart payload', function (): void {
+it('attaches a file and submits the multipart form', function (): void {
     $page = $this->visitAsWorkbenchUser('/form/fields/file-upload')
         ->assertSee('Drop files here or click to browse');
 
@@ -17,18 +17,28 @@ it('uploads a file through a multipart payload', function (): void {
 
     assertSeeEventually($page, 'avatar.jpg');
 
+    // The plugin's in-process server drops uploaded files (LaravelHttpServer
+    // builds the kernel request with an empty files array), so the stored
+    // result cannot be asserted here — FileUploadFieldTest covers the
+    // server-side multipart store. This test covers the client interaction.
     $page->click('@form-submit')
-        ->assertSee('File upload')
         ->assertNoSmoke();
 });
 
 it('removes an existing file from the prefilled form', function (): void {
-    $this->visitAsWorkbenchUser('/form/fields/file-upload?state=existing')
+    $page = $this->visitAsWorkbenchUser('/form/fields/file-upload?state=existing')
         ->assertSee('avatar-existing.jpg')
-        ->click('@avatar-remove-existing')
-        ->assertDontSee('avatar-existing.jpg')
-        ->click('@form-submit')
-        ->assertNoSmoke();
+        ->click('@avatar-remove-existing');
+
+    assertDontSeeEventually($page, 'avatar-existing.jpg');
+
+    $page->click('@form-submit');
+
+    retryUntil(function (): void {
+        expect(Storage::disk('public')->exists('uploads/avatar-existing.jpg'))->toBeFalse();
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('uploads directly to s3 via the signed flow', function (): void {

--- a/tests/Browser/Fields/RepeaterTest.php
+++ b/tests/Browser/Fields/RepeaterTest.php
@@ -11,6 +11,10 @@ it('renders the repeater with one default row', function (): void {
         ->assertNoSmoke();
 });
 
+// The form redirects back to the same URL on success, which leaves no
+// client-observable state change (form values live in the client store and
+// survive same-page visits). The server-side round-trip is asserted in
+// NestedFieldFormSubmitTest; these tests cover the client interactions.
 it('round-trips a repeater payload through submit', function (): void {
     $this->visitAsWorkbenchUser('/form/fields/repeater')
         ->assertSee('Line items')
@@ -21,12 +25,11 @@ it('round-trips a repeater payload through submit', function (): void {
         ->fill('input[name="items[1][name]"]', 'Gadget')
         ->fill('input[name="items[1][qty]"]', '5')
         ->click('@form-submit')
-        ->assertSee('Line items')
         ->assertNoSmoke();
 });
 
 it('reorders rows and submits successfully', function (): void {
-    $this->visitAsWorkbenchUser('/form/fields/repeater')
+    $page = $this->visitAsWorkbenchUser('/form/fields/repeater')
         ->assertSee('Line items')
         ->fill('input[name="items[0][name]"]', 'First')
         ->fill('input[name="items[0][qty]"]', '1')
@@ -34,9 +37,13 @@ it('reorders rows and submits successfully', function (): void {
         ->assertPresent('[data-test="repeater-items-row-1"]')
         ->fill('input[name="items[1][name]"]', 'Second')
         ->fill('input[name="items[1][qty]"]', '2')
-        ->click('@repeater-items-down-0')
-        ->click('@form-submit')
-        ->assertSee('Line items')
+        ->click('@repeater-items-down-0');
+
+    retryUntil(function () use ($page): void {
+        $page->assertValue('input[name="items[0][name]"]', 'Second');
+    });
+
+    $page->click('@form-submit')
         ->assertNoSmoke();
 });
 

--- a/tests/Browser/Forms/DependentFieldsTest.php
+++ b/tests/Browser/Forms/DependentFieldsTest.php
@@ -2,14 +2,20 @@
 declare(strict_types=1);
 
 it('toggles the company field instantly based on type', function (): void {
-    $this->visitAsWorkbenchUser('/form/dependent')
+    $page = $this->visitAsWorkbenchUser('/form/dependent')
         ->assertSee('Dependent & computed')
         ->assertMissing('input[name="company"]')
-        ->click('@type-business')
-        ->assertPresent('input[name="company"]')
-        ->click('@type-personal')
-        ->assertMissing('input[name="company"]')
-        ->assertNoSmoke();
+        ->click('@type-business');
+
+    assertPresentEventually($page, 'input[name="company"]');
+
+    $page->click('@type-personal');
+
+    retryUntil(function () use ($page): void {
+        $page->assertMissing('input[name="company"]');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('requires the company field for business on submit', function (): void {

--- a/tests/Browser/Layout/ChatLayoutToggleTest.php
+++ b/tests/Browser/Layout/ChatLayoutToggleTest.php
@@ -17,8 +17,12 @@ it('reveals the docked chat panel when the chat layout is toggled', function ():
     $page
         ->assertMissing('@assistant-chat-trigger')
         ->assertSee('Dock chat back to floating')
-        ->click('@chat-layout-toggle')
-        ->assertVisible('@assistant-chat-trigger')
-        ->assertMissing('@chat-box')
+        ->click('@chat-layout-toggle');
+
+    retryUntil(function () use ($page): void {
+        $page->assertVisible('@assistant-chat-trigger');
+    });
+
+    $page->assertMissing('@chat-box')
         ->assertNoSmoke();
 });

--- a/tests/Browser/Layout/DropdownTest.php
+++ b/tests/Browser/Layout/DropdownTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 it('opens the composed user dropdown and reveals its items', function (): void {
     $this->visitAsWorkbenchUser('/')
-        ->assertSee('Workbench User')
+        ->assertSeeIn('[data-test="user-menu"]', 'Workbench User')
         ->assertDontSee('Log out')
         ->click('@user-menu')
         ->assertSee('Log out')
@@ -25,11 +25,13 @@ it('keeps the user dropdown usable when the sidebar is collapsed', function (): 
 });
 
 it('logs the user out through the user dropdown action', function (): void {
-    $this->visitAsWorkbenchUser('/')
+    $page = $this->visitAsWorkbenchUser('/')
         ->click('@user-menu')
-        ->click('Log out')
-        ->assertSee('Use the seeded account to enter the workbench.')
-        ->assertNoSmoke();
+        ->click('Log out');
+
+    assertSeeEventually($page, 'Use the seeded account to enter the workbench.');
+
+    $page->assertNoSmoke();
 });
 
 it('renders the workbench locale switcher as a topbar dropdown', function (): void {

--- a/tests/Browser/Layout/SidebarTest.php
+++ b/tests/Browser/Layout/SidebarTest.php
@@ -58,7 +58,11 @@ it('opens the sidebar as an off-canvas drawer on mobile', function (): void {
 
     $page
         ->click('@menu-components')
-        ->click('@menu-tabs')
-        ->assertMissing('[data-test="sidebar-backdrop"]')
-        ->assertNoSmoke();
+        ->click('@menu-tabs');
+
+    retryUntil(function () use ($page): void {
+        $page->assertMissing('[data-test="sidebar-backdrop"]');
+    });
+
+    $page->assertNoSmoke();
 });

--- a/tests/Browser/Tables/ImageLightboxTest.php
+++ b/tests/Browser/Tables/ImageLightboxTest.php
@@ -8,11 +8,15 @@ it('opens an image cell in a lightbox and closes it again', function (): void {
     Product::query()->delete();
     $product = Product::factory()->withImages()->create(['status' => 'active']);
 
-    visit('/products')
+    $page = visit('/products')
         ->assertSee($product->name)
         ->click('@preview-image')
         ->assertPresent('[data-slot="image-lightbox"]')
-        ->click('@lightbox-close')
-        ->assertNotPresent('[data-slot="image-lightbox"]')
-        ->assertNoSmoke();
+        ->click('@lightbox-close');
+
+    retryUntil(function () use ($page): void {
+        $page->assertNotPresent('[data-slot="image-lightbox"]');
+    });
+
+    $page->assertNoSmoke();
 });

--- a/tests/Browser/Tables/PaginationTest.php
+++ b/tests/Browser/Tables/PaginationTest.php
@@ -1,20 +1,6 @@
 <?php
 declare(strict_types=1);
 
-use Pest\Browser\Api\PendingAwaitablePage;
-
-/**
- * The infinite tab's IntersectionObserver auto-fires loadMore() when the
- * sentinel enters its 240px root margin — which can happen before the first
- * page paints under CI load, unmounting the "Load more" button mid-test.
- * use-table bails when the API is undefined, pinning these tests to the
- * manual load path.
- */
-function disableInfiniteScrollAutoLoad(PendingAwaitablePage $page): void
-{
-    $page->script('window.IntersectionObserver = undefined');
-}
-
 it('shows pagination modes in lazily loaded tabs', function (): void {
     $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();

--- a/tests/Browser/Tables/ProductsTableTest.php
+++ b/tests/Browser/Tables/ProductsTableTest.php
@@ -9,8 +9,7 @@ it('renders the custom status-badge column cell', function (): void {
 
     visit('/products')
         ->assertSee('Badge Product')
-        ->assertPresent('[data-testid="status-badge"]')
-        ->assertSee('Active')
+        ->assertSeeIn('[data-testid="status-badge"]', 'Active')
         ->assertNoSmoke();
 });
 
@@ -18,14 +17,18 @@ it('archives a product via the row action with confirmation', function (): void 
     $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
-    visit('/products')
+    $page = visit('/products')
         ->assertSee('Desk Lamp')
         ->click('@product-actions')
         ->click('@action-archive')
         ->assertSee('Archive product?')
-        ->click('@confirm-accept')
-        ->assertSee('Archived')
-        ->assertNoSmoke();
+        ->click('@confirm-accept');
+
+    retryUntil(function () use ($page): void {
+        $page->assertSeeIn('[data-testid="status-badge"]', 'Archived');
+    });
+
+    $page->assertNoSmoke();
 
     expect($product->fresh()->status)->toBe('archived');
 });
@@ -48,29 +51,41 @@ it('rejects a product through a modal form', function (): void {
     $this->actingAs(workbenchTestUser());
     $product = Product::factory()->create(['name' => 'Desk Lamp', 'sku' => 'LAMP-1', 'status' => 'active']);
 
-    visit('/products')
+    $page = visit('/products')
         ->click('@product-actions')
         ->click('@action-reject')
         ->assertSee('Reject product?')
-        ->click('@action-form-submit')
-        ->assertSee('The Reason field is required.')
-        ->fill('@reason', 'Counterfeit listing')
-        ->click('@action-form-submit')
-        ->assertNoSmoke();
+        ->click('@action-form-submit');
 
-    expect($product->fresh()->status)->toBe('archived');
+    assertSeeEventually($page, 'The Reason field is required.');
+
+    $page->fill('@reason', 'Counterfeit listing')
+        ->click('@action-form-submit');
+
+    retryUntil(function () use ($page): void {
+        $page->assertDontSee('Reject product?');
+    });
+
+    retryUntil(function () use ($product): void {
+        expect($product->fresh()->status)->toBe('archived');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('archives selected products in bulk', function (): void {
     $this->actingAs(workbenchTestUser());
     Product::factory()->count(3)->create(['status' => 'active']);
 
-    visit('/products')
+    $page = visit('/products')
         ->click('@select-all')
-        ->click('@bulk-action-archive-selected')
-        ->assertNoSmoke();
+        ->click('@bulk-action-archive-selected');
 
-    expect(Product::query()->where('status', 'archived')->count())->toBe(3);
+    retryUntil(function (): void {
+        expect(Product::query()->where('status', 'archived')->count())->toBe(3);
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('edits a product in a prefilled modal form', function (): void {
@@ -81,17 +96,20 @@ it('edits a product in a prefilled modal form', function (): void {
         'status' => 'active',
     ]);
 
-    visit('/products')
+    $page = visit('/products')
         ->assertSee('Desk Lamp')
         ->click('@product-actions')
         ->click('@action-edit-modal')
         ->assertSee('Edit product')
         ->assertValue('#name', 'Desk Lamp')
         ->fill('#name', 'Renamed Lamp')
-        ->click('@action-form-submit')
-        ->assertNoSmoke();
+        ->click('@action-form-submit');
 
-    expect(Product::query()->where('sku', 'LAMP-001')->value('name'))->toBe('Renamed Lamp');
+    retryUntil(function (): void {
+        expect(Product::query()->where('sku', 'LAMP-001')->value('name'))->toBe('Renamed Lamp');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('searches products inside the reject modal form', function (): void {

--- a/tests/Browser/Tables/UsersTableTest.php
+++ b/tests/Browser/Tables/UsersTableTest.php
@@ -8,8 +8,10 @@ it('lists users with their columns', function (): void {
     $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
 
-    visit('/')
-        ->assertSee('Workbench users')
+    $page = visit('/');
+    disableInfiniteScrollAutoLoad($page);
+
+    $page->assertSee('Workbench users')
         ->assertSee('Maya Chen')
         ->assertSee('Ada Lovelace')
         ->assertSee('Created at')
@@ -23,8 +25,10 @@ it('copies a cell value to the clipboard', function (): void {
     User::query()->delete();
     UserFactory::new()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
 
-    visit('/')
-        ->click('@copy-email')
-        ->assertSee('Copied')
-        ->assertNoSmoke();
+    $page = visit('/')
+        ->click('@copy-email');
+
+    assertSeeEventually($page, 'Copied');
+
+    $page->assertNoSmoke();
 });

--- a/tests/Feature/Core/ComponentReferenceSignerTest.php
+++ b/tests/Feature/Core/ComponentReferenceSignerTest.php
@@ -65,6 +65,54 @@ it('returns null for a token sealed for a different user', function (): void {
     expect(signer()->unseal($token, 'file', 'avatar'))->toBeNull();
 });
 
+it('refreshes an expired token into one that unseals with the original context', function (): void {
+    $token = signer()->seal('file', 'avatar', ['disk' => 's3', 'path' => 'uploads/a.jpg']);
+
+    $this->travel(config('lattice.security.ref_lifetime', 30) + 1)->minutes();
+
+    expect(signer()->unseal($token, 'file', 'avatar'))->toBeNull();
+
+    $refreshed = signer()->refresh($token);
+
+    expect($refreshed)->not->toBeNull()
+        ->and(signer()->unseal((string) $refreshed, 'file', 'avatar'))
+        ->toBe(['disk' => 's3', 'path' => 'uploads/a.jpg']);
+});
+
+it('refreshes a still-valid token', function (): void {
+    $token = signer()->seal('file', 'avatar', ['path' => 'x']);
+
+    $refreshed = signer()->refresh($token);
+
+    expect($refreshed)->not->toBeNull()
+        ->and(signer()->unseal((string) $refreshed, 'file', 'avatar'))->toBe(['path' => 'x']);
+});
+
+it('refuses to refresh a forged or empty token', function (): void {
+    expect(signer()->refresh('not-a-real-token'))->toBeNull()
+        ->and(signer()->refresh(''))->toBeNull();
+});
+
+it('refuses to refresh a token sealed for a different user', function (): void {
+    $identity = fakeIdentity();
+    $identity->identity = new ReferenceIdentity('7', null);
+    $token = signer()->seal('file', 'avatar', ['path' => 'x']);
+
+    $identity->identity = new ReferenceIdentity('8', null);
+
+    expect(signer()->refresh($token))->toBeNull();
+});
+
+it('refuses to refresh a token once the sealed session no longer matches', function (): void {
+    $identity = fakeIdentity();
+    $identity->identity = new ReferenceIdentity(null, 'session-hash-a');
+    $token = signer()->seal('file', 'avatar', ['path' => 'x']);
+
+    $identity->identity = new ReferenceIdentity(null, 'session-hash-b');
+
+    expect(signer()->refresh($token))->toBeNull();
+});
+
 it('unseals a token while its sealed session still matches', function (): void {
     $identity = fakeIdentity();
     $identity->identity = new ReferenceIdentity(null, 'session-hash-a');

--- a/tests/Feature/Core/PageMetadataTest.php
+++ b/tests/Feature/Core/PageMetadataTest.php
@@ -32,7 +32,7 @@ test('metadata inherits layout and container from a base AsPage attribute', func
         ->and($meta->name)->toBe('products.index')
         ->and($meta->layout)->toBe(PageLayout::App)
         ->and($meta->container)->toBe(PageContainer::Default)
-        ->and($meta->middleware)->toBe([]);
+        ->and($meta->middleware)->toBeNull();
 });
 
 test('metadata derives the route name when none is given', function (): void {
@@ -56,7 +56,7 @@ test('a page without any attribute resolves to defaults', function (): void {
     expect($meta->route)->toBeNull()
         ->and($meta->layout)->toBe(PageLayout::None)
         ->and($meta->container)->toBe(PageContainer::Centered)
-        ->and($meta->middleware)->toBe([]);
+        ->and($meta->middleware)->toBeNull();
 });
 
 test('page metadata round-trips through an array descriptor', function (): void {

--- a/tests/Feature/Forms/NestedFieldFormSubmitTest.php
+++ b/tests/Feature/Forms/NestedFieldFormSubmitTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\Form;
+use Workbench\App\Forms\Fields\BuilderFieldForm;
+use Workbench\App\Forms\Fields\RepeaterFieldForm;
+
+use function Pest\Laravel\post;
+
+it('accepts a valid repeater payload through the form endpoint', function (): void {
+    $this->actingAs(workbenchTestUser());
+    $form = wire(Form::use(RepeaterFieldForm::class));
+
+    post('/lattice/forms/workbench.fields.repeater.form', [
+        'items' => [
+            ['name' => 'Widget', 'qty' => 2],
+            ['name' => 'Gadget', 'qty' => 5],
+        ],
+    ], $this->latticeHeaders($form))->assertRedirect('/form/fields/repeater');
+});
+
+it('rejects a repeater payload missing a required row field', function (): void {
+    $this->actingAs(workbenchTestUser());
+    $form = wire(Form::use(RepeaterFieldForm::class));
+
+    post('/lattice/forms/workbench.fields.repeater.form', [
+        'items' => [
+            ['name' => '', 'qty' => 2],
+        ],
+    ], $this->latticeHeaders($form))->assertSessionHasErrors(['items.0.name']);
+});
+
+it('accepts a valid builder payload through the form endpoint', function (): void {
+    $this->actingAs(workbenchTestUser());
+    $form = wire(Form::use(BuilderFieldForm::class));
+
+    post('/lattice/forms/workbench.fields.builder.form', [
+        'items' => [
+            ['type' => 'text', 'content' => 'Intro line'],
+            ['type' => 'product', 'product' => 'SKU-1', 'qty' => 3, 'price' => '9.50'],
+        ],
+    ], $this->latticeHeaders($form))->assertRedirect('/form/fields/builder');
+});
+
+it('rejects a builder payload missing a required block field', function (): void {
+    $this->actingAs(workbenchTestUser());
+    $form = wire(Form::use(BuilderFieldForm::class));
+
+    post('/lattice/forms/workbench.fields.builder.form', [
+        'items' => [
+            ['type' => 'product', 'product' => '', 'qty' => 3, 'price' => '9.50'],
+        ],
+    ], $this->latticeHeaders($form))->assertSessionHasErrors(['items.0.product']);
+});

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -34,6 +34,24 @@ final class RegEmbeddedPage extends RegBasePage
     }
 }
 
+#[AsPage(route: '/gadgets', name: 'gadgets.index')]
+final class RegGadgetsPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Gadgets'));
+    }
+}
+
+#[AsPage(route: '/bare', name: 'bare.index', middleware: [])]
+final class RegBarePage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Bare'));
+    }
+}
+
 test('Lattice::pageRegistry()->all() resolves route metadata for registered pages', function (): void {
     Lattice::pages([RegWidgetsPage::class]);
 
@@ -65,6 +83,31 @@ test('the service provider builds a named GET route for each page', function ():
         ->and($route->uri())->toBe('widgets')
         ->and($route->getActionName())->toBe(RegWidgetsPage::class.'@render')
         ->and($route->gatherMiddleware())->toContain('web');
+});
+
+test('a page without attribute middleware registers with the configured default', function (): void {
+    Lattice::pages([RegGadgetsPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    expect(Route::getRoutes()->getByName('gadgets.index')->gatherMiddleware())->toBe(['web']);
+});
+
+test('the page middleware default is configurable', function (): void {
+    config(['lattice.pages.middleware' => ['web', 'auth']]);
+    Lattice::pages([RegGadgetsPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    expect(Route::getRoutes()->getByName('gadgets.index')->gatherMiddleware())->toBe(['web', 'auth']);
+});
+
+test('an explicit empty middleware attribute opts the page out of the default', function (): void {
+    Lattice::pages([RegBarePage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    expect(Route::getRoutes()->getByName('bare.index')->gatherMiddleware())->toBe([]);
 });
 
 test('an imperatively registered route-less page registers no route, while a routed sibling still gets its route', function (): void {

--- a/tests/Feature/Http/RefRefreshEndpointTest.php
+++ b/tests/Feature/Http/RefRefreshEndpointTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+
+it('exchanges an expired ref for a fresh one that unseals again', function (): void {
+    $signer = app(SignsComponentReferences::class);
+    $token = $signer->seal('table', 'users', ['scope' => 'active']);
+
+    $this->travel(config('lattice.security.ref_lifetime', 30) + 1)->minutes();
+
+    expect($signer->unseal($token, 'table', 'users'))->toBeNull();
+
+    $response = $this->postJson(route('lattice.refs.refresh'), ['ref' => $token])
+        ->assertSuccessful();
+
+    $refreshed = $response->json('ref');
+
+    expect($refreshed)->toBeString()
+        ->and($signer->unseal($refreshed, 'table', 'users'))->toBe(['scope' => 'active']);
+});
+
+it('rejects a forged ref', function (): void {
+    $this->postJson(route('lattice.refs.refresh'), ['ref' => 'not-a-real-token'])
+        ->assertForbidden();
+});
+
+it('rejects a request without a ref', function (): void {
+    $this->postJson(route('lattice.refs.refresh'))
+        ->assertForbidden();
+});
+
+it('honours the configured middleware stack', function (): void {
+    expect(app('router')->getRoutes()->getByName('lattice.refs.refresh')->gatherMiddleware())
+        ->toBe(['web']);
+});

--- a/tests/Support/Browser.php
+++ b/tests/Support/Browser.php
@@ -56,6 +56,18 @@ function assertPresentEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $
     });
 }
 
+/**
+ * The infinite tab's IntersectionObserver auto-fires loadMore() when the
+ * sentinel enters its 240px root margin — which can happen before the first
+ * page paints under CI load, unmounting the "Load more" button mid-test.
+ * use-table bails when the API is undefined, pinning these tests to the
+ * manual load path.
+ */
+function disableInfiniteScrollAutoLoad(PendingAwaitablePage $page): void
+{
+    $page->script('window.IntersectionObserver = undefined');
+}
+
 function rustfsIsReachable(): bool
 {
     $key = 'lattice-test-probes/'.Str::uuid().'.txt';

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -143,9 +143,6 @@ class ProductForm extends FormDefinition
     }
 
     /**
-     * Validates the single-default invariant and replaces the product's sales prices.
-     * Throws a ValidationException when more than one row has an empty/null group_id.
-     *
      * @param  array<int, array{group_id?: string|null, amount: string}>  $priceRows
      *
      * @throws ValidationException


### PR DESCRIPTION
First batch from the 2026-07-26 architecture/quality audit — all six P0 findings.

**Pages default to `['web']` middleware** (breaking). Pages previously registered with no middleware at all unless the attribute set one; they now default to the new `lattice.pages.middleware` config so sessions work out of the box. Auth stays opt-in (attribute middleware or `authorize()`); `#[AsPage(middleware: [])]` opts out entirely. Docs updated with a caution callout.

**Component refs can be refreshed.** Sealed refs expire after 30 minutes and turned every interaction in a long-lived tab into a hard 403 until a reload. The signer now re-seals tokens whose integrity and identity binding still verify (only expiry ignored) via `POST lattice/refs/refresh`; the client funnel retries a 403 once after exchanging the ref and keeps the renewal for all later requests.

**Two one-line client bugs:** the date-picker trigger passed the removed `color` prop to Button (rendered solid primary), and `PrefillProvider` minted a fresh context value each render, invalidating every field's memoization per keystroke.

**standalone-assets workflow self-retrigger guard.** The workflow pushes to the branch that triggers it (proof: stacked bot commits `2d6423f6`/`23a68156`); it now skips runs caused by its own commit. The underlying Tailwind build nondeterminism is a follow-up.

**Browser suite de-flaked.** Race-prone post-interaction assertions wrapped in `retryUntil`, vacuous success assertions (sidebar labels/page headings that exist pre-submit) replaced with discriminating signals, ambiguous substrings scoped to testids, `disableInfiniteScrollAutoLoad` promoted to shared support. The sweep surfaced two flows the browser server cannot test: multipart submits (pest-plugin-browser builds the kernel request with an empty files array — upstream `@TODO`) and same-URL redirect forms (no client-observable success state). Those tests now cover client interaction only; server round-trips are asserted by the existing multipart feature test and the new `NestedFieldFormSubmitTest`.

Follow-ups noted during the work: `resetOnSuccess` doesn't reach the Lattice client value store (effectively inert for Lattice fields), and Inertia-native submits (form POST itself) still lack the ref-refresh retry — they only benefit from previously renewed tokens.