### PR TITLE
feat: working form reset and ref renewal for Inertia submits

### DIFF
--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -72,9 +72,12 @@ const pendingRefRefreshes = new Map<string, Promise<string | null>>();
 
 /**
  * Trade an expired-but-authentic ref for a fresh one. Deduped per original ref
- * so a burst of 403s from one component costs a single round-trip.
+ * so a burst of 403s from one component costs a single round-trip. The renewed
+ * token lands in the component-ref map, so every later request that resolves
+ * its ref through withHeaders picks it up — this is the transport-agnostic
+ * primitive both the fetch funnel below and the Inertia form retry build on.
  */
-async function refreshRef(componentRef: string): Promise<string | null> {
+export async function refreshRef(componentRef: string): Promise<string | null> {
   const pending = pendingRefRefreshes.get(componentRef);
 
   if (pending) {

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -11,6 +11,7 @@ import { i18nConfigFromPageProps } from "./i18n/shared-props";
 import {
   createLayoutResolver,
   createPageResolver,
+  registerRefRenewal,
   withVisitHeaders,
   type CreateLayoutResolverOptions,
   type PageModules,
@@ -129,6 +130,7 @@ export function createLatticeApp({
     plugins && plugins.length > 0 ? extendRegistry(baseRegistry, ...plugins) : baseRegistry;
 
   setDefaultRegistry(activeRegistry);
+  registerRefRenewal();
 
   const i18nEnabled = i18n !== false;
   const pluginI18n = plugins?.flatMap((plugin) => (plugin.i18n ? [plugin.i18n] : [])) ?? [];

--- a/resources/js/form/components/form.test.tsx
+++ b/resources/js/form/components/form.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRefreshedRefs } from "@lattice-php/lattice/core/component-ref";
 import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
 import ButtonComponent from "@lattice-php/lattice/ui/button";
 import { fakeNode } from "@lattice-php/lattice/test-support";
@@ -21,6 +22,15 @@ const formSlotState = vi.hoisted(() => ({
   validate: vi.fn<(field: string) => void>(),
 }));
 
+const formCallbacks = vi.hoisted(
+  (): {
+    onError?: () => void;
+    onHttpException?: (response: { status: number }) => boolean | undefined;
+    onStart?: () => void;
+    onSuccess?: () => void;
+  } => ({}),
+);
+
 vi.mock("@inertiajs/react", async () =>
   (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock({
     Form: ({
@@ -30,6 +40,11 @@ vi.mock("@inertiajs/react", async () =>
       resetOnSuccess: _resetOnSuccess,
       headers,
       validationTimeout,
+      onError,
+      onHttpException,
+      onStart,
+      onSuccess,
+      ref: _ref,
       ...props
     }: {
       children: (state: {
@@ -48,25 +63,37 @@ vi.mock("@inertiajs/react", async () =>
       resetOnSuccess?: boolean | string[];
       headers?: Record<string, string>;
       validationTimeout?: number;
-    }) => (
-      <form
-        {...props}
-        data-headers={JSON.stringify(headers ?? null)}
-        data-validation-timeout={validationTimeout}
-      >
-        {children({
-          clearErrors: formSlotState.clearErrors,
-          errors: {},
-          invalid: () => false,
-          processing: false,
-          reset: formSlotState.reset,
-          touch: formSlotState.touch,
-          validate: formSlotState.validate,
-          validating: false,
-          valid: () => false,
-        })}
-      </form>
-    ),
+      onError?: () => void;
+      onHttpException?: (response: { status: number }) => boolean | undefined;
+      onStart?: () => void;
+      onSuccess?: () => void;
+      ref?: unknown;
+    }) => {
+      formCallbacks.onError = onError;
+      formCallbacks.onHttpException = onHttpException;
+      formCallbacks.onStart = onStart;
+      formCallbacks.onSuccess = onSuccess;
+
+      return (
+        <form
+          {...props}
+          data-headers={JSON.stringify(headers ?? null)}
+          data-validation-timeout={validationTimeout}
+        >
+          {children({
+            clearErrors: formSlotState.clearErrors,
+            errors: {},
+            invalid: () => false,
+            processing: false,
+            reset: formSlotState.reset,
+            touch: formSlotState.touch,
+            validate: formSlotState.validate,
+            validating: false,
+            valid: () => false,
+          })}
+        </form>
+      );
+    },
     Link: ({ children, ...props }: { children: ReactNode; href: string }) => (
       <a {...props}>{children}</a>
     ),
@@ -79,6 +106,11 @@ describe("Lattice form schema components", () => {
     formSlotState.reset.mockClear();
     formSlotState.touch.mockClear();
     formSlotState.validate.mockClear();
+  });
+
+  afterEach(() => {
+    clearRefreshedRefs();
+    vi.unstubAllGlobals();
   });
 
   it("sends the sealed component reference as a header", () => {
@@ -382,6 +414,146 @@ describe("Lattice form schema components", () => {
       new CustomEvent("lattice:reset-form", { detail: { form: "teams.create" } }),
     );
     expect(formSlotState.reset).toHaveBeenCalledOnce();
+  });
+
+  it("resets the value store on submit success when resetOnSuccess is set", () => {
+    const nameNode = fakeNode({
+      props: { label: "Name", name: "name", value: "" },
+      type: "field.text-input",
+    });
+    const formNode = fakeNode({
+      id: "resetting-form",
+      props: { action: "/items", resetOnSuccess: true, submitButton: false },
+      schema: [nameNode],
+      type: "form",
+    });
+
+    render(
+      <FormComponent node={formNode}>
+        <TextInputComponent node={nameNode}>{null}</TextInputComponent>
+      </FormComponent>,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Name" });
+    fireEvent.change(input, { target: { value: "Widget" } });
+    expect(input).toHaveValue("Widget");
+
+    act(() => formCallbacks.onSuccess?.());
+
+    expect(input).toHaveValue("");
+  });
+
+  it("resets only the configured fields and keeps values without configuration", () => {
+    const nameNode = fakeNode({
+      props: { label: "Name", name: "name", value: "" },
+      type: "field.text-input",
+    });
+    const emailNode = fakeNode({
+      props: { label: "Email", name: "email", value: "" },
+      type: "field.text-input",
+    });
+    const formNode = fakeNode({
+      id: "partial-reset-form",
+      props: { action: "/items", resetOnSuccess: ["name"], submitButton: false },
+      schema: [nameNode, emailNode],
+      type: "form",
+    });
+
+    render(
+      <FormComponent node={formNode}>
+        <TextInputComponent node={nameNode}>{null}</TextInputComponent>
+        <TextInputComponent node={emailNode}>{null}</TextInputComponent>
+      </FormComponent>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "Widget" },
+    });
+    fireEvent.change(screen.getByRole("textbox", { name: "Email" }), {
+      target: { value: "a@example.com" },
+    });
+
+    act(() => formCallbacks.onSuccess?.());
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("");
+    expect(screen.getByRole("textbox", { name: "Email" })).toHaveValue("a@example.com");
+  });
+
+  it("clears controlled values through the reset-form event", () => {
+    const nameNode = fakeNode({
+      props: { label: "Name", name: "name", value: "" },
+      type: "field.text-input",
+    });
+    const formNode = fakeNode({
+      id: "event-reset-form",
+      props: { action: "/items", submitButton: false },
+      schema: [nameNode],
+      type: "form",
+    });
+
+    render(
+      <FormComponent node={formNode}>
+        <TextInputComponent node={nameNode}>{null}</TextInputComponent>
+      </FormComponent>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "Widget" },
+    });
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("lattice:reset-form", { detail: { form: null } }));
+    });
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("");
+  });
+
+  it("suppresses a sealed form's first 403, renews the ref, and lets the second surface", async () => {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({ ref: "renewed-ref" }),
+        }) as unknown as Response,
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formNode = fakeNode({
+      id: "sealed-form",
+      props: { action: "/items", ref: "sealed-form-ref", submitButton: false },
+      type: "form",
+    });
+
+    render(<FormComponent node={formNode}>{null}</FormComponent>);
+
+    let firstResult: boolean | undefined;
+    await act(async () => {
+      firstResult = formCallbacks.onHttpException?.({ status: 403 });
+    });
+
+    expect(firstResult).toBe(false);
+    expect(fetchMock).toHaveBeenCalledWith("/lattice/refs/refresh", expect.anything());
+
+    act(() => formCallbacks.onStart?.());
+
+    expect(formCallbacks.onHttpException?.({ status: 403 })).toBeUndefined();
+  });
+
+  it("does not intercept a 403 on a form without a ref", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formNode = fakeNode({
+      id: "unsealed-form",
+      props: { action: "/items", submitButton: false },
+      type: "form",
+    });
+
+    render(<FormComponent node={formNode}>{null}</FormComponent>);
+
+    expect(formCallbacks.onHttpException?.({ status: 403 })).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("renders custom submit buttons, substituting the managed submit button", () => {

--- a/resources/js/form/components/form.tsx
+++ b/resources/js/form/components/form.tsx
@@ -1,4 +1,6 @@
+import type { FormComponentRef, HttpExceptionResponse } from "@inertiajs/core";
 import { Form as InertiaForm } from "@inertiajs/react";
+import { refreshRef } from "@lattice-php/lattice/core/api";
 import { withHeaders } from "@lattice-php/lattice/core/headers";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
 import { useWindowEvent } from "@lattice-php/lattice/core/hooks/use-window-event";
@@ -7,14 +9,14 @@ import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { Emphasis, Justify, Variant } from "@lattice-php/lattice/types/generated";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FormSubmitButton } from "./base/submit-button";
 import { FormProvider } from "@lattice-php/lattice/form/hooks/context";
 import { collectFields } from "@lattice-php/lattice/form/lib/collect-fields";
 import { PrefillProvider } from "@lattice-php/lattice/form/hooks/prefill-context";
 import { ResolvedNodesProvider } from "@lattice-php/lattice/form/hooks/resolved-nodes";
 import { useFormResolver } from "@lattice-php/lattice/form/hooks/use-form-resolver";
-import { FormValuesProvider } from "@lattice-php/lattice/form/hooks/values";
+import { FormValuesProvider, useResetFormValues } from "@lattice-php/lattice/form/hooks/values";
 
 const JUSTIFY_CLASS: Record<Justify, string> = {
   start: "justify-start",
@@ -32,11 +34,14 @@ function FormResetListener({
   componentId?: string;
   reset: (...fields: string[]) => void;
 }) {
+  const resetValues = useResetFormValues();
+
   useWindowEvent(LATTICE_EVENT.resetForm, (event) => {
     const detail = (event as CustomEvent<{ form: string | null }>).detail;
 
     if (!detail?.form || detail.form === componentId) {
       reset();
+      resetValues();
     }
   });
 
@@ -109,7 +114,30 @@ function FormBody({
   );
 }
 
+function configuredResetFields(
+  configured: string[] | boolean | null | undefined,
+): string[] | undefined | false {
+  if (!configured || (Array.isArray(configured) && configured.length === 0)) {
+    return false;
+  }
+
+  return Array.isArray(configured) ? configured : undefined;
+}
+
 export const FormComponent: RendererComponent<"form"> = ({ children, node }) => {
+  const initialValues = useMemo(
+    () => ({ ...collectFields(node.schema).values, ...node.props.state }),
+    [node.schema, node.props.state],
+  );
+
+  return (
+    <FormValuesProvider initial={initialValues}>
+      <FormShell node={node}>{children}</FormShell>
+    </FormValuesProvider>
+  );
+};
+
+function FormShell({ children, node }: { children: React.ReactNode; node: Node<"form"> }) {
   const { t } = useT("lattice");
   const props = node.props;
   const action = props.action ?? "#";
@@ -119,12 +147,7 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
   const precognitive = props.precognitive;
   const resetOnError = props.resetOnError ?? false;
   const resetOnSuccess = props.resetOnSuccess ?? [];
-  const state = props.state;
-  const { labels: fieldLabels, values: fieldValues } = useMemo(
-    () => collectFields(node.schema),
-    [node.schema],
-  );
-  const initialValues = useMemo(() => ({ ...fieldValues, ...state }), [fieldValues, state]);
+  const fieldLabels = useMemo(() => collectFields(node.schema).labels, [node.schema]);
   const shouldRenderSubmitButton = props.submitButton;
   const submitButtons = props.submitButtons ?? undefined;
   const submitJustify = props.submitJustify ?? undefined;
@@ -134,8 +157,33 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
   const summaryLabel = props.validationSummaryLabel;
   const validationTimeout = props.validationTimeout ?? undefined;
 
+  const resetValues = useResetFormValues();
+  const resetConfigured = (configured: string[] | boolean | null | undefined): void => {
+    const fields = configuredResetFields(configured);
+
+    if (fields !== false) {
+      resetValues(fields);
+    }
+  };
+
+  const formRef = useRef<FormComponentRef | null>(null);
+  // One renewal attempt per user-initiated submit: 'renewing' marks the window
+  // between the 403 and our programmatic retry, 'retried' lets the second
+  // failure surface normally.
+  const retryPhase = useRef<"idle" | "renewing" | "retried">("idle");
+  const [renewedSubmitTick, setRenewedSubmitTick] = useState(0);
+
+  useEffect(() => {
+    // The state bump forces this render first, so the headers prop below has
+    // re-resolved the renewed token before the retry goes out.
+    if (renewedSubmitTick > 0 && retryPhase.current === "renewing") {
+      formRef.current?.submit();
+    }
+  }, [renewedSubmitTick]);
+
   return (
     <InertiaForm
+      ref={formRef}
       action={action}
       data-slot="form"
       data-lattice-component={node.id}
@@ -146,6 +194,23 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
       validationTimeout={precognitive ? validationTimeout : undefined}
       headers={withHeaders(componentRef)}
       className="mx-auto flex w-full max-w-2xl flex-col gap-6"
+      onStart={() => {
+        retryPhase.current = retryPhase.current === "renewing" ? "retried" : "idle";
+      }}
+      onSuccess={() => resetConfigured(resetOnSuccess)}
+      onError={() => resetConfigured(resetOnError)}
+      onHttpException={(response: HttpExceptionResponse) => {
+        if (response.status !== 403 || componentRef === "" || retryPhase.current === "retried") {
+          return undefined;
+        }
+
+        retryPhase.current = "renewing";
+        // Retry even when the renewal failed: a genuine 403 then surfaces
+        // through the second attempt instead of being swallowed here.
+        void refreshRef(componentRef).finally(() => setRenewedSubmitTick((tick) => tick + 1));
+
+        return false;
+      }}
     >
       {({ clearErrors, errors, processing, reset, touch, validate, validating }) => (
         <FormProvider
@@ -170,24 +235,22 @@ export const FormComponent: RendererComponent<"form"> = ({ children, node }) => 
             <div className="text-center text-sm font-medium text-lt-success">{props.status}</div>
           )}
 
-          <FormValuesProvider initial={initialValues}>
-            <FormBody
-              action={action}
-              componentRef={componentRef}
-              nodes={node.schema}
-              shouldRenderSubmitButton={shouldRenderSubmitButton}
-              submitButtons={submitButtons}
-              submitEmphasis={submitEmphasis}
-              submitJustify={submitJustify}
-              submitLabel={submitLabel}
-              submitVariant={submitVariant}
-              summaryLabel={summaryLabel}
-            >
-              {children}
-            </FormBody>
-          </FormValuesProvider>
+          <FormBody
+            action={action}
+            componentRef={componentRef}
+            nodes={node.schema}
+            shouldRenderSubmitButton={shouldRenderSubmitButton}
+            submitButtons={submitButtons}
+            submitEmphasis={submitEmphasis}
+            submitJustify={submitJustify}
+            submitLabel={submitLabel}
+            submitVariant={submitVariant}
+            summaryLabel={summaryLabel}
+          >
+            {children}
+          </FormBody>
         </FormProvider>
       )}
     </InertiaForm>
   );
-};
+}

--- a/resources/js/form/hooks/values.test.tsx
+++ b/resources/js/form/hooks/values.test.tsx
@@ -6,6 +6,7 @@ import {
   useFormValue,
   useFormValues,
   useFormValuesFor,
+  useResetFormValues,
   useSetFormValue,
 } from "./values";
 
@@ -45,6 +46,46 @@ describe("FormValues", () => {
 
     expect(result.current.value).toBe("B");
     expect(result.current.values).toEqual({ items: [{ children: [{ name: "B" }] }] });
+  });
+
+  it("resets every value back to the initial snapshot", () => {
+    const { result } = renderHook(
+      () => ({
+        values: useFormValues(),
+        setValue: useSetFormValue(),
+        reset: useResetFormValues(),
+      }),
+      { wrapper: wrapper({ name: "", items: [{ qty: 1 }] }) },
+    );
+
+    act(() => {
+      result.current.setValue("name", "Widget");
+      result.current.setValue("items.0.qty", 5);
+    });
+
+    act(() => result.current.reset());
+
+    expect(result.current.values).toEqual({ name: "", items: [{ qty: 1 }] });
+  });
+
+  it("resets only the given fields and keeps the rest", () => {
+    const { result } = renderHook(
+      () => ({
+        values: useFormValues(),
+        setValue: useSetFormValue(),
+        reset: useResetFormValues(),
+      }),
+      { wrapper: wrapper({ name: "", email: "" }) },
+    );
+
+    act(() => {
+      result.current.setValue("name", "Widget");
+      result.current.setValue("email", "a@example.com");
+    });
+
+    act(() => result.current.reset(["name"]));
+
+    expect(result.current.values).toEqual({ name: "", email: "a@example.com" });
   });
 
   it("rerenders only the field whose selected value changed", () => {

--- a/resources/js/form/hooks/values.tsx
+++ b/resources/js/form/hooks/values.tsx
@@ -14,11 +14,14 @@ export type SetFormValue = (
   value: unknown | ((previous: unknown) => unknown),
 ) => void;
 
+export type ResetFormValues = (fields?: string[]) => void;
+
 type FormValuesStore = {
   getPathSnapshot: (path: string) => unknown;
   getPathsSnapshot: (paths: string[]) => Record<string, unknown>;
   getSnapshot: () => Record<string, unknown>;
   replaceInitial: (initial: Record<string, unknown>) => void;
+  reset: ResetFormValues;
   setValue: SetFormValue;
   subscribe: (listener: () => void) => () => void;
   subscribePath: (path: string, listener: () => void) => () => void;
@@ -163,6 +166,20 @@ function createFormValuesStore(initial: Record<string, unknown>): FormValuesStor
       initialValues = nextInitial;
       updateValues(nextInitial, "");
     },
+    reset: (fields?: string[]): void => {
+      if (fields === undefined) {
+        updateValues(initialValues, "");
+
+        return;
+      }
+
+      const next = fields.reduce(
+        (accumulated, field) => setPath(accumulated, field, getPath(initialValues, field)),
+        values,
+      );
+
+      updateValues(next, "");
+    },
     setValue: (name: string, value: unknown | ((previous: unknown) => unknown)): void => {
       const previous = getPath(values, name);
       const next = typeof value === "function" ? value(previous) : value;
@@ -260,4 +277,16 @@ export function useFormValuesFor(paths: string[]): Record<string, unknown> {
 
 export function useSetFormValue(): SetFormValue {
   return useContext(SetFormValueContext);
+}
+
+/**
+ * Reset values to the store's initial snapshot — all of them, or just the
+ * given field paths. This is the reset that actually clears controlled
+ * fields; Inertia's own form reset only touches its internal data and the
+ * DOM, which store-driven inputs ignore.
+ */
+export function useResetFormValues(): ResetFormValues {
+  const store = useFormValuesStore();
+
+  return useCallback((fields?: string[]) => store.reset(fields), [store]);
 }

--- a/resources/js/inertia.ts
+++ b/resources/js/inertia.ts
@@ -1,5 +1,6 @@
 import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
-import type { ResolvedComponent } from "@inertiajs/react";
+import { http, type ResolvedComponent } from "@inertiajs/react";
+import { LATTICE_REF_HEADER, latestRef } from "./core/component-ref";
 import { withHeaders } from "./core/headers";
 import { SchemaLayout } from "./layout";
 import Page from "./page";
@@ -50,4 +51,30 @@ export function withVisitHeaders(_href: string, options: VisitOptions): VisitOpt
     ...options,
     headers: withHeaders("", options.headers),
   };
+}
+
+let refRenewalRegistered = false;
+
+/**
+ * Resolve the outgoing X-Lattice-Ref header through the renewed-token map at
+ * request time. Component props bake the originally sealed ref into headers at
+ * render time, so without this rewrite an Inertia request fired between a
+ * renewal and the next re-render would still carry the expired token.
+ */
+export function registerRefRenewal(): void {
+  if (refRenewalRegistered) {
+    return;
+  }
+
+  refRenewalRegistered = true;
+
+  http.onRequest((config) => {
+    const sealed = config.headers?.[LATTICE_REF_HEADER];
+
+    if (config.headers && typeof sealed === "string" && sealed !== "") {
+      config.headers[LATTICE_REF_HEADER] = latestRef(sealed);
+    }
+
+    return config;
+  });
 }

--- a/resources/js/test/inertia-mock.tsx
+++ b/resources/js/test/inertia-mock.tsx
@@ -31,6 +31,11 @@ export function inertiaMock(overrides: Record<string, unknown> = {}): Record<str
       reload: vi.fn<() => void>(),
       visit: vi.fn<(url: string, options?: unknown) => void>(),
     },
+    http: {
+      onError: vi.fn<(handler: unknown) => () => void>(() => () => undefined),
+      onRequest: vi.fn<(handler: unknown) => () => void>(() => () => undefined),
+      onResponse: vi.fn<(handler: unknown) => () => void>(() => () => undefined),
+    },
     ...overrides,
   };
 }

--- a/tests/Browser/Fields/BuilderTest.php
+++ b/tests/Browser/Fields/BuilderTest.php
@@ -1,12 +1,8 @@
 <?php
 declare(strict_types=1);
 
-// The form redirects back to the same URL on success, which leaves no
-// client-observable state change (form values live in the client store and
-// survive same-page visits). The server-side round-trip is asserted in
-// NestedFieldFormSubmitTest; these tests cover the client interactions.
 it('adds heterogeneous blocks and submits a typed payload', function (): void {
-    $this->visitAsWorkbenchUser('/form/fields/builder')
+    $page = $this->visitAsWorkbenchUser('/form/fields/builder')
         ->assertSee('Builder')
         ->assertSee('Line items')
         ->click('[id="stack-panel"] [data-test="builder-add"]')
@@ -17,8 +13,15 @@ it('adds heterogeneous blocks and submits a typed payload', function (): void {
         ->fill('input[name="items[1][product]"]', 'SKU-1')
         ->fill('input[name="items[1][qty]"]', '3')
         ->fill('input[name="items[1][price]"]', '9.50')
-        ->click('@form-submit')
-        ->assertNoSmoke();
+        ->click('@form-submit');
+
+    // The form declares resetOnSuccess, so the emptied builder is the success
+    // signal — a validation failure would keep the filled blocks mounted.
+    retryUntil(function () use ($page): void {
+        $page->assertMissing('textarea[name="items[0][content]"]');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('surfaces a per-row required error for the active block', function (): void {
@@ -46,8 +49,13 @@ it('renders the table layout with a shared header and round-trips a typed payloa
         ->fill('textarea[name="rows[1][content]"]', 'Note row')
         ->assertNoJavaScriptErrors();
 
-    $page->click('@form-submit')
-        ->assertNoSmoke();
+    $page->click('@form-submit');
+
+    retryUntil(function () use ($page): void {
+        $page->assertMissing('input[name="rows[0][product]"]');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('reveals a reset control for custom row-table column widths and clears them on click', function (): void {

--- a/tests/Browser/Fields/RepeaterTest.php
+++ b/tests/Browser/Fields/RepeaterTest.php
@@ -11,12 +11,8 @@ it('renders the repeater with one default row', function (): void {
         ->assertNoSmoke();
 });
 
-// The form redirects back to the same URL on success, which leaves no
-// client-observable state change (form values live in the client store and
-// survive same-page visits). The server-side round-trip is asserted in
-// NestedFieldFormSubmitTest; these tests cover the client interactions.
-it('round-trips a repeater payload through submit', function (): void {
-    $this->visitAsWorkbenchUser('/form/fields/repeater')
+it('round-trips a repeater payload through submit and resets on success', function (): void {
+    $page = $this->visitAsWorkbenchUser('/form/fields/repeater')
         ->assertSee('Line items')
         ->fill('input[name="items[0][name]"]', 'Widget')
         ->fill('input[name="items[0][qty]"]', '2')
@@ -24,8 +20,15 @@ it('round-trips a repeater payload through submit', function (): void {
         ->assertPresent('[data-test="repeater-items-row-1"]')
         ->fill('input[name="items[1][name]"]', 'Gadget')
         ->fill('input[name="items[1][qty]"]', '5')
-        ->click('@form-submit')
-        ->assertNoSmoke();
+        ->click('@form-submit');
+
+    // The form declares resetOnSuccess, so cleared values are the success
+    // signal — a validation failure would keep the filled values in place.
+    retryUntil(function () use ($page): void {
+        $page->assertValue('input[name="items[0][name]"]', '');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('reorders rows and submits successfully', function (): void {
@@ -43,8 +46,13 @@ it('reorders rows and submits successfully', function (): void {
         $page->assertValue('input[name="items[0][name]"]', 'Second');
     });
 
-    $page->click('@form-submit')
-        ->assertNoSmoke();
+    $page->click('@form-submit');
+
+    retryUntil(function () use ($page): void {
+        $page->assertValue('input[name="items[0][name]"]', '');
+    });
+
+    $page->assertNoSmoke();
 });
 
 it('surfaces the per-row required validation error on submit', function (): void {

--- a/workbench/app/Forms/Fields/BuilderFieldForm.php
+++ b/workbench/app/Forms/Fields/BuilderFieldForm.php
@@ -22,7 +22,7 @@ class BuilderFieldForm extends FormDefinition
 {
     public function definition(FormComponent $form, Request $request): FormComponent
     {
-        return $form->schema([
+        return $form->resetOnSuccess()->schema([
             Tabs::make('builder-variants')
                 ->queryKey('type')
                 ->orientation(Orientation::Vertical)

--- a/workbench/app/Forms/Fields/RepeaterFieldForm.php
+++ b/workbench/app/Forms/Fields/RepeaterFieldForm.php
@@ -21,6 +21,7 @@ class RepeaterFieldForm extends FormDefinition
     {
         return $form
             ->precognitive(300)
+            ->resetOnSuccess()
             ->schema([
                 Tabs::make('repeater-variants')
                     ->queryKey('type')


### PR DESCRIPTION
Closes the two follow-ups from PR #315.

**`resetOnSuccess`/`resetOnError` now actually reset Lattice forms.** The props only reached Inertia's internal data and the DOM, which store-controlled fields ignore — they were effectively inert, and the `resetForm` action effect had the same gap. The value store exposes `reset(fields?)` (full or per-field), and the form wires it to `onSuccess`/`onError` and the `lattice:reset-form` listener. The workbench repeater/builder forms declare `resetOnSuccess`, and their browser tests assert the cleared values as the post-submit signal — the assertion that was impossible to write before this.

**Inertia-native submits recover from expired refs.** PR #315 added ref renewal only to the fetch funnel; a form POST itself still died on a 403 after 30 minutes. A sealed form now intercepts its first 403 (`onHttpException`, cancellable), exchanges the ref through the existing refresh endpoint, re-renders so the headers pick up the renewal, and resubmits once — a second failure surfaces normally, so genuine authorization 403s still show. A boot-registered `http.onRequest` interceptor additionally re-resolves the `X-Lattice-Ref` header through the renewed-token map at request time for all Inertia traffic (precognition included).

Transport notes: the primitives (`reset`, `refreshRef`, `latestRef`, the endpoint) live in the Inertia-free core; the Inertia glue is confined to `form.tsx` and the boot seam (`registerRefRenewal()` in `createLatticeApp`, no module side-effect). Known limitation: components holding local state seeded from props (file-upload chips) don't clear on store reset — pre-existing, tracked separately.