### PR TITLE
Safety batch: seed integrity, suite isolation, flake hardening, dist hygiene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,9 @@
 # Keep the Composer distribution lean
 /.agents export-ignore
 /.ai export-ignore
+/.githooks export-ignore
 /.github export-ignore
+/packages export-ignore
 /.idea export-ignore
 /docs export-ignore
 /tests export-ignore

--- a/tests/Browser/I18nTest.php
+++ b/tests/Browser/I18nTest.php
@@ -35,6 +35,10 @@ function waitForLatticeBrowserTestTranslation(string $file, string $key): mixed
 }
 
 it('dumps missing React lattice keys back into the package lang file', function (): void {
+    // Opt back in over BrowserTestCase's suite-wide guard: this test removes a
+    // key deliberately and restores the file in its finally block.
+    config(['i18next.save_missing.enabled' => true]);
+
     $this->actingAs(workbenchTestUser());
     $file = package_path('lang/en/form.php');
     $original = File::get($file);

--- a/tests/Browser/Platform/StandaloneTest.php
+++ b/tests/Browser/Platform/StandaloneTest.php
@@ -13,4 +13,6 @@ it('boots a server-driven page through the published standalone bundle', functio
     visit('/standalone-demo')
         ->assertSee('Workbench page')
         ->assertNoSmoke();
-});
+    // lattice:assets delete-then-copies the shared skeleton public/ — parallel
+    // workers requesting assets mid-delete would 404 and trip their smoke checks.
+})->group('serial');

--- a/tests/Browser/Tables/PaginationTest.php
+++ b/tests/Browser/Tables/PaginationTest.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use Workbench\App\Models\User;
+
 it('shows pagination modes in lazily loaded tabs', function (): void {
     $this->actingAs(workbenchTestUser());
     seedWorkbenchUsers();
@@ -19,7 +21,7 @@ it('shows pagination modes in lazily loaded tabs', function (): void {
         ->click('@tab-table')
         ->assertSee('Table pagination');
 
-    assertSeeEventually($page, 'Showing 1-25 of 30');
+    assertSeeEventually($page, 'Showing 1-25 of '.User::query()->count());
 
     $page->click('@tab-infinite')
         ->assertSee('Infinite pagination');
@@ -35,14 +37,16 @@ it('navigates between pages in table pagination mode', function (): void {
 
     $page = visit('/tables/pagination');
 
+    $total = User::query()->count();
+
     $page->click('@tab-table');
-    assertSeeEventually($page, 'Showing 1-25 of 30');
+    assertSeeEventually($page, "Showing 1-25 of {$total}");
 
     $page->click('@pagination-next');
-    assertSeeEventually($page, 'Showing 26-30 of 30');
+    assertSeeEventually($page, "Showing 26-{$total} of {$total}");
 
     $page->click('@pagination-page-1');
-    assertSeeEventually($page, 'Showing 1-25 of 30');
+    assertSeeEventually($page, "Showing 1-25 of {$total}");
 
     $page->assertNoSmoke();
 });

--- a/tests/Browser/Tables/ProductsTableTest.php
+++ b/tests/Browser/Tables/ProductsTableTest.php
@@ -105,8 +105,14 @@ it('edits a product in a prefilled modal form', function (): void {
         ->fill('#name', 'Renamed Lamp')
         ->click('@action-form-submit');
 
+    // A submit click can be swallowed under CI load; re-click while the modal
+    // is still open between attempts — the rename is idempotent.
     retryUntil(function (): void {
         expect(Product::query()->where('sku', 'LAMP-001')->value('name'))->toBe('Renamed Lamp');
+    }, between: function () use ($page): void {
+        $page->script(<<<'JS'
+            () => document.querySelector('[data-test="action-form-submit"]')?.click()
+        JS);
     });
 
     $page->assertNoSmoke();

--- a/tests/Browser/Tables/UsersTableTest.php
+++ b/tests/Browser/Tables/UsersTableTest.php
@@ -1,7 +1,6 @@
 <?php
 declare(strict_types=1);
 
-use Illuminate\Foundation\Auth\User;
 use Orchestra\Testbench\Factories\UserFactory;
 
 it('lists users with their columns', function (): void {
@@ -22,7 +21,7 @@ it('lists users with their columns', function (): void {
 
 it('copies a cell value to the clipboard', function (): void {
     $this->actingAs(workbenchTestUser());
-    User::query()->delete();
+    deleteWorkbenchUsersExceptAuthenticated();
     UserFactory::new()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
 
     $page = visit('/')

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -27,6 +27,12 @@ class BrowserTestCase extends TestCase
         // CI runners are slower than Playwright's tight 5s default, which
         // intermittently trips browser actions/assertions under load.
         Playwright::setTimeout(15_000);
+
+        // The saveMissing dumper writes into the package's tracked lang/ dir
+        // (the workbench points lang_path() there), so any page hitting a
+        // missing key mid-suite would leave junk behind. No browser test
+        // needs the dump — keep it off.
+        config(['i18next.save_missing.enabled' => false]);
     }
 
     private function assertWorkbenchManifestExists(): void

--- a/tests/Support/Browser.php
+++ b/tests/Support/Browser.php
@@ -87,9 +87,22 @@ function rustfsIsReachable(): bool
     }
 }
 
+function deleteWorkbenchUsersExceptAuthenticated(): void
+{
+    $query = User::query();
+
+    if (($authenticatedId = auth()->id()) !== null) {
+        $query->whereKeyNot($authenticatedId);
+    }
+
+    $query->delete();
+}
+
 function seedNamedWorkbenchUsers(): void
 {
-    User::query()->delete();
+    // Deleting the actingAs() user would only keep working through
+    // SessionGuard's in-memory cache — preserve it instead.
+    deleteWorkbenchUsersExceptAuthenticated();
 
     foreach (['Maya Chen', 'Ada Lovelace', 'Grace Hopper', 'Katherine Johnson'] as $name) {
         UserFactory::new()->create([


### PR DESCRIPTION
The non-breaking safety items from the audit roadmap, hardening the suites that gate auto-merge.

- **`seedWorkbenchUsers()` preserves the authenticated user.** It deleted every user including the `actingAs()` one, which only kept working through SessionGuard's in-memory cache — any change that fresh-loads the auth user would have broken a dozen browser tests confusingly. Pagination totals now derive from the actual user count instead of a magic 30.
- **`StandaloneTest` runs in the serial group.** `lattice:assets` delete-then-copies the shared skeleton `public/`; parallel workers requesting assets mid-delete 404 and trip their smoke checks. The existing two-pass plumbing picks it up.
- **`saveMissing` dumps are off for the browser suite.** Any page hitting a missing key wrote junk into the package's tracked `lang/` dir mid-suite (the recurring `signature-example.php` incident). Suite-wide guard in `BrowserTestCase`; the one test that exercises the dump deliberately opts back in and restores the file it edits.
- **Modal-edit flake hardened.** The submit click can be swallowed under CI load (observed on #318's CI); the DB retry now re-clicks while the modal is still open — the rename is idempotent, so a double submit is harmless.
- **`packages/` and `.githooks/` are `export-ignore`d.** Both are dev-only; the signature-example path repo is `require-dev` and dependency-level repositories are ignored by Composer for consumers anyway.