### PR TITLE
feat!: protocol window — route-minted endpoints, one sub-request envelope, centralized authorize gate

### DIFF
--- a/config/lattice.php
+++ b/config/lattice.php
@@ -48,32 +48,26 @@ return [
     ],
 
     'forms' => [
-        'endpoint' => 'lattice/forms/{form}',
         'middleware' => ['web', 'auth'],
     ],
 
     'tables' => [
-        'endpoint' => 'lattice/tables/{table}',
         'middleware' => ['web', 'auth'],
     ],
 
     'fragments' => [
-        'endpoint' => 'lattice/fragments/{fragment}',
         'middleware' => ['web', 'auth'],
     ],
 
     'remote-sources' => [
-        'endpoint' => 'lattice/remote-sources/{source}/token',
         'middleware' => ['web', 'auth'],
     ],
 
     'actions' => [
-        'endpoint' => 'lattice/actions/{action}',
         'middleware' => ['web', 'auth'],
     ],
 
     'bulk-actions' => [
-        'endpoint' => 'lattice/bulk-actions/{bulkAction}',
         'middleware' => ['web', 'auth'],
     ],
 

--- a/docs/content/docs/forms/overview.mdx
+++ b/docs/content/docs/forms/overview.mdx
@@ -89,9 +89,9 @@ form only accepts submissions for the schema it actually rendered. `FormControll
     U->>B: Interact (type, search, change a dependent field)
     B->>L: POST form endpoint with signed ref
     Note over L: one endpoint, routed by request kind
-    alt searchable Select (_search)
+    alt searchable Select (_sub=search)
         L-->>B: matching options
-    else dependent field (_resolve)
+    else dependent field (_sub=resolve)
         L-->>B: recomputed field nodes + values
     else live validation (Precognition)
         L-->>B: 204 valid / 422 messages

--- a/docs/content/docs/introduction/configuration.md
+++ b/docs/content/docs/introduction/configuration.md
@@ -34,26 +34,30 @@ The same method exists for `fragments`, `actions`, `bulkActions`, `layouts`, `pa
 
 ## Endpoints and middleware
 
-Each definition type is served by a dedicated endpoint with its own middleware stack. The defaults all run behind `web` and `auth`:
+Each definition type is served by a dedicated named route with its own middleware stack. The
+defaults all run behind `web` and `auth`:
 
-| Type           | Endpoint                                | Middleware        |
-| -------------- | --------------------------------------- | ----------------- |
-| Forms          | `lattice/forms/{form}`                  | `['web', 'auth']` |
-| Tables         | `lattice/tables/{table}`                | `['web', 'auth']` |
-| Fragments      | `lattice/fragments/{fragment}`          | `['web', 'auth']` |
-| Actions        | `lattice/actions/{action}`              | `['web', 'auth']` |
-| Bulk actions   | `lattice/bulk-actions/{bulkAction}`     | `['web', 'auth']` |
-| Remote sources | `lattice/remote-sources/{source}/token` | `['web', 'auth']` |
-| Notifications  | `lattice/notifications`                 | `['web', 'auth']` |
+| Type           | Route name                     | Path                                    | Middleware        |
+| -------------- | ------------------------------ | --------------------------------------- | ----------------- |
+| Forms          | `lattice.forms.handle`         | `lattice/forms/{form}`                  | `['web', 'auth']` |
+| Tables         | `lattice.tables.show`          | `lattice/tables/{table}`                | `['web', 'auth']` |
+| Fragments      | `lattice.fragments.show`       | `lattice/fragments/{fragment}`          | `['web', 'auth']` |
+| Actions        | `lattice.actions.handle`       | `lattice/actions/{action}`              | `['web', 'auth']` |
+| Bulk actions   | `lattice.bulk-actions.handle`  | `lattice/bulk-actions/{bulkAction}`     | `['web', 'auth']` |
+| Remote sources | `lattice.remote-sources.token` | `lattice/remote-sources/{source}/token` | `['web', 'auth']` |
+| Notifications  | `lattice.notifications.*`      | `lattice/notifications`                 | `['web', 'auth']` |
 
-Change the endpoint or middleware stack per type:
+Change the middleware stack per type:
 
 ```php
 'forms' => [
-    'endpoint' => 'lattice/forms/{form}',
     'middleware' => ['web', 'auth'],
 ],
 ```
+
+Endpoint URLs are minted from the named routes, so they honour your app's base path —
+subdirectory installs included. To serve a type from a different path, register your own route
+under the same name after Lattice's routes load; the components pick it up automatically.
 
 The `notifications` block also takes `per_page`, `polling_interval`, and `prune_after_days` — see
 [Notifications](/components/notifications/#configuration).

--- a/docs/content/docs/tables/filtering.mdx
+++ b/docs/content/docs/tables/filtering.mdx
@@ -174,7 +174,7 @@ chips with a single **Reset all** that clears them both.
 
 A `SelectFilter`'s options can come from an `OptionSource` instead of a fixed list, and
 `->searchable()` fetches them as the user types rather than shipping the whole list up front. The
-lookup is a `_search` round-trip to the table endpoint with a namespaced target —
+lookup is a search sub-request to the table endpoint with a namespaced `_target` —
 `filter:<key>.<field>` for a dedicated filter's field, `column:<key>` for a searchable column
 filter — so filter keys and dot-keyed relation columns can never collide:
 

--- a/resources/js/action/components/action-form.test.tsx
+++ b/resources/js/action/components/action-form.test.tsx
@@ -304,7 +304,7 @@ describe("action form modal", () => {
     };
     const fetchMock = vi.fn<FetchMock>().mockImplementation((_url, init) => {
       const body = JSON.parse(String(init.body)) as Record<string, unknown>;
-      const payload = body._form ? formNode : { effects: [], ok: true };
+      const payload = body._sub === "schema" ? formNode : { effects: [], ok: true };
 
       return Promise.resolve({
         json: async () => payload,
@@ -321,7 +321,7 @@ describe("action form modal", () => {
     expect(await screen.findByRole("textbox", { name: "Title" })).toBeVisible();
     const [, init] = fetchMock.mock.calls.find(
       ([, requestInit]) =>
-        (JSON.parse(String((requestInit as RequestInit).body)) as { _form?: boolean })._form,
+        (JSON.parse(String((requestInit as RequestInit).body)) as { _sub?: string })._sub,
     ) as [string, RequestInit];
 
     expect(init.method).toBe("POST");

--- a/resources/js/action/components/action-form.tsx
+++ b/resources/js/action/components/action-form.tsx
@@ -71,7 +71,7 @@ export function useLazyActionForm(
     const controller = new AbortController();
 
     void apiFetch(endpoint, {
-      body: JSON.stringify({ _form: true }),
+      body: JSON.stringify({ _sub: "schema" }),
       ref: componentRef,
       method: "POST",
       signal: controller.signal,

--- a/resources/js/core/api.ts
+++ b/resources/js/core/api.ts
@@ -66,7 +66,15 @@ function defaultHeaders(method: string | undefined): Record<string, string> {
   };
 }
 
-const REF_REFRESH_ENDPOINT = "/lattice/refs/refresh";
+let refRefreshEndpoint = "/lattice/refs/refresh";
+
+/**
+ * Boot paths call this with the server-minted URL so subdirectory installs
+ * refresh against the right path; the default covers root installs.
+ */
+export function setRefRefreshEndpoint(url: string): void {
+  refRefreshEndpoint = url;
+}
 
 const pendingRefRefreshes = new Map<string, Promise<string | null>>();
 
@@ -84,7 +92,7 @@ export async function refreshRef(componentRef: string): Promise<string | null> {
     return pending;
   }
 
-  const request = apiJson<{ ref: string }>(REF_REFRESH_ENDPOINT, {
+  const request = apiJson<{ ref: string }>(refRefreshEndpoint, {
     method: "POST",
     body: JSON.stringify({ ref: latestRef(componentRef) }),
   })

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -2,6 +2,8 @@ import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
 import { createInertiaApp } from "@inertiajs/react";
 import { useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { initializeAppearance } from "./appearance";
+import { setRefRefreshEndpoint } from "./core/api";
+import { isRecord } from "./core/materialize";
 import { extendRegistry, type Plugin, type PluginI18n, type Registry } from "./core/registry";
 import { setDefaultRegistry } from "./core/registry-context";
 import type { SpriteValue } from "./icons/sprite";
@@ -154,6 +156,16 @@ export function createLatticeApp({
       const pending: Promise<unknown>[] = [];
 
       if (!ssr) {
+        const shared = page.props.lattice;
+
+        if (
+          isRecord(shared) &&
+          isRecord(shared.urls) &&
+          typeof shared.urls.refreshRef === "string"
+        ) {
+          setRefRefreshEndpoint(shared.urls.refreshRef);
+        }
+
         // Loaded on demand so apps without the shared i18n prop never ship the
         // i18next backend; the disabled-config call still stores the timezone.
         if (i18nEnabled && i18nConfigFromPageProps(page.props) !== undefined) {

--- a/resources/js/form/components/fields/file-upload.test.tsx
+++ b/resources/js/form/components/fields/file-upload.test.tsx
@@ -306,7 +306,8 @@ describe("FileUploadComponent image previews", () => {
         sku: "LMP-001",
         images: [],
         images__removed: [],
-        _upload: "images",
+        _sub: "upload",
+        _target: "images",
         filename: "lamp.jpg",
         contentType: "image/jpeg",
       }),
@@ -434,7 +435,7 @@ describe("FileUploadComponent image previews", () => {
     expect(apiFetch).toHaveBeenCalledWith(
       "/forms/products",
       expect.objectContaining({
-        body: expect.stringContaining('"_upload":"items.0.images"'),
+        body: expect.stringContaining('"_target":"items.0.images"'),
       }),
     );
   });

--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -151,7 +151,8 @@ export const FileUploadComponent: RendererComponent<"field.file-upload"> = ({ no
       ref: componentRef,
       body: JSON.stringify({
         ...values,
-        _upload: uploadKey,
+        _sub: "upload",
+        _target: uploadKey,
         filename: file.name,
         contentType: file.type,
       }),

--- a/resources/js/form/components/fields/select.test.tsx
+++ b/resources/js/form/components/fields/select.test.tsx
@@ -93,7 +93,7 @@ describe("SelectComponent search", () => {
     expect(postFormAction).toHaveBeenCalledWith(
       "/forms/products",
       "ref-1",
-      { _search: "items.0.product", q: "desk", ...initial },
+      { _sub: "search", _target: "items.0.product", _q: "desk", ...initial },
       expect.any(AbortSignal),
     );
   });

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -112,7 +112,7 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
       void postFormAction<{ options?: Option[] }>(
         action,
         componentRef,
-        { ...valuesRef.current, _search: searchKey, q: query },
+        { ...valuesRef.current, _sub: "search", _target: searchKey, _q: query },
         controller.signal,
       )
         .then((response) => {

--- a/resources/js/form/hooks/use-form-resolver.ts
+++ b/resources/js/form/hooks/use-form-resolver.ts
@@ -128,7 +128,7 @@ export function useFormResolver(
       void postFormAction<ResolveResponse>(
         action,
         componentRef,
-        { _resolve: true, ...values },
+        { _sub: "resolve", ...values },
         controller.signal,
       )
         .then((response) => {

--- a/resources/js/form/lib/form-transport.test.ts
+++ b/resources/js/form/lib/form-transport.test.ts
@@ -13,8 +13,9 @@ describe("postFormAction", () => {
       "/forms/products",
       "component-ref",
       {
-        _search: "items.0.product",
-        q: "desk",
+        _sub: "search",
+        _target: "items.0.product",
+        _q: "desk",
         items: [{ [ROW_ID_KEY]: "9f3cf7c2-6c2e-4f0e-9c1a-0e1a2b3c4d5e", category: "chairs" }],
       },
       new AbortController().signal,
@@ -23,8 +24,9 @@ describe("postFormAction", () => {
     const body = fetchMock.mock.calls[0]?.[1]?.body;
 
     expect(JSON.parse(String(body))).toEqual({
-      _search: "items.0.product",
-      q: "desk",
+      _sub: "search",
+      _target: "items.0.product",
+      _q: "desk",
       items: [{ [ROW_ID_KEY]: "9f3cf7c2-6c2e-4f0e-9c1a-0e1a2b3c4d5e", category: "chairs" }],
     });
   });

--- a/resources/js/standalone/config.ts
+++ b/resources/js/standalone/config.ts
@@ -1,5 +1,6 @@
 export type StandaloneConfig = {
   spriteUrl?: string;
+  refreshRefUrl?: string;
   echo?: Record<string, unknown>;
 };
 

--- a/resources/js/standalone/main.tsx
+++ b/resources/js/standalone/main.tsx
@@ -1,4 +1,5 @@
 import "./standalone.css";
+import { setRefRefreshEndpoint } from "@lattice-php/lattice/core/api";
 import { createLatticeApp } from "@lattice-php/lattice/create-app";
 import { withVisitHeaders } from "@lattice-php/lattice/inertia";
 import { readStandaloneConfig } from "./config";
@@ -6,6 +7,10 @@ import { readStandaloneConfig } from "./config";
 const config = readStandaloneConfig(document);
 
 async function boot(): Promise<void> {
+  if (config.refreshRefUrl) {
+    setRefRefreshEndpoint(config.refreshRefUrl);
+  }
+
   if (config.echo) {
     try {
       const { configureEcho } = await import("@laravel/echo-react");

--- a/resources/js/table/components/column-select-filter.test.tsx
+++ b/resources/js/table/components/column-select-filter.test.tsx
@@ -137,7 +137,7 @@ describe("column select filter", () => {
 
   it("supports a searchable column select that emits an eq clause", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
-      if (String(input).includes("_search")) {
+      if (String(input).includes("_sub=search")) {
         return Response.json({ options: [{ label: "Active", value: "active" }] });
       }
 

--- a/resources/js/table/components/searchable-filter.test.tsx
+++ b/resources/js/table/components/searchable-filter.test.tsx
@@ -67,7 +67,7 @@ const node: TableNode = {
 
 function stubFetch() {
   const fetch = vi.fn<typeof globalThis.fetch>(async (input) => {
-    if (String(input).includes("_search")) {
+    if (String(input).includes("_sub=search")) {
       return Response.json({
         options: [
           { label: "Ada", value: "1" },
@@ -149,7 +149,7 @@ describe("searchable select filter", () => {
     });
   });
 
-  it("issues a _search request as the user types", async () => {
+  it("issues a search sub-request as the user types", async () => {
     const fetch = stubFetch();
 
     renderWithRegistry(<TableComponent node={node} />, registry);
@@ -161,7 +161,7 @@ describe("searchable select filter", () => {
     await waitFor(() => {
       expect(
         fetch.mock.calls.some((call) =>
-          String(call[0]).includes("_search=filter%3Aauthor.value&_q=ad"),
+          String(call[0]).includes("_sub=search&_target=filter%3Aauthor.value&_q=ad"),
         ),
       ).toBe(true);
     });

--- a/resources/js/table/hooks/use-table.ts
+++ b/resources/js/table/hooks/use-table.ts
@@ -155,7 +155,8 @@ export function useTable(node: TableNode) {
       }
 
       const url = new URL(endpoint, window.location.origin);
-      url.searchParams.set("_search", searchKey);
+      url.searchParams.set("_sub", "search");
+      url.searchParams.set("_target", searchKey);
       url.searchParams.set("_q", search);
 
       const response = await apiFetch(`${url.pathname}${url.search}`, {

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,18 +11,18 @@ use Lattice\Lattice\Http\Controllers\RefRefreshController;
 use Lattice\Lattice\Http\Controllers\RemoteSourceTokenController;
 use Lattice\Lattice\Http\Controllers\TableController;
 
-Route::middleware(config('lattice.forms.middleware', ['web', 'auth']))
-    ->match(['post', 'put', 'patch', 'delete'], config('lattice.forms.endpoint', 'lattice/forms/{form}'), FormController::class)
+Route::middleware(config('lattice.forms.middleware'))
+    ->match(['post', 'put', 'patch', 'delete'], 'lattice/forms/{form}', FormController::class)
     ->where('form', '.*')
     ->name('lattice.forms.handle');
 
-Route::middleware(config('lattice.tables.middleware', ['web', 'auth']))
-    ->get(config('lattice.tables.endpoint', 'lattice/tables/{table}'), TableController::class)
+Route::middleware(config('lattice.tables.middleware'))
+    ->get('lattice/tables/{table}', TableController::class)
     ->where('table', '.*')
     ->name('lattice.tables.show');
 
-Route::middleware(config('lattice.fragments.middleware', ['web', 'auth']))
-    ->get(config('lattice.fragments.endpoint', 'lattice/fragments/{fragment}'), FragmentController::class)
+Route::middleware(config('lattice.fragments.middleware'))
+    ->get('lattice/fragments/{fragment}', FragmentController::class)
     ->where('fragment', '.*')
     ->name('lattice.fragments.show');
 
@@ -33,18 +33,18 @@ Route::middleware(config('lattice.refs.middleware', ['web']))
     ->post('lattice/refs/refresh', RefRefreshController::class)
     ->name('lattice.refs.refresh');
 
-Route::middleware(config('lattice.remote-sources.middleware', ['web', 'auth']))
-    ->post(config('lattice.remote-sources.endpoint', 'lattice/remote-sources/{source}/token'), RemoteSourceTokenController::class)
+Route::middleware(config('lattice.remote-sources.middleware'))
+    ->post('lattice/remote-sources/{source}/token', RemoteSourceTokenController::class)
     ->where('source', '.*')
     ->name('lattice.remote-sources.token');
 
-Route::middleware(config('lattice.actions.middleware', ['web', 'auth']))
-    ->match(['post', 'put', 'patch', 'delete'], config('lattice.actions.endpoint', 'lattice/actions/{action}'), ActionController::class)
+Route::middleware(config('lattice.actions.middleware'))
+    ->match(['post', 'put', 'patch', 'delete'], 'lattice/actions/{action}', ActionController::class)
     ->where('action', '.*')
     ->name('lattice.actions.handle');
 
-Route::middleware(config('lattice.bulk-actions.middleware', ['web', 'auth']))
-    ->match(['post', 'put', 'patch', 'delete'], config('lattice.bulk-actions.endpoint', 'lattice/bulk-actions/{bulkAction}'), BulkActionController::class)
+Route::middleware(config('lattice.bulk-actions.middleware'))
+    ->match(['post', 'put', 'patch', 'delete'], 'lattice/bulk-actions/{bulkAction}', BulkActionController::class)
     ->where('bulkAction', '.*')
     ->name('lattice.bulk-actions.handle');
 

--- a/src/Actions/ActionRegistry.php
+++ b/src/Actions/ActionRegistry.php
@@ -56,6 +56,11 @@ final class ActionRegistry extends DefinitionRegistry
         return 'action';
     }
 
+    protected function routeName(): string
+    {
+        return 'lattice.actions.handle';
+    }
+
     public function group(): string
     {
         return 'actions';

--- a/src/Actions/ActionRegistry.php
+++ b/src/Actions/ActionRegistry.php
@@ -19,24 +19,20 @@ final class ActionRegistry extends DefinitionRegistry
      */
     public function component(string $action, array $context = []): ActionComponent
     {
-        $key = $this->registeredKeyFor($action);
+        return $this->gatedComponent(
+            $action,
+            fn (string $key): ActionComponent => ActionComponent::make($key),
+            function (ActionDefinition $definition, ActionComponent $component, string $key): ActionComponent {
+                $component = $definition->definition($component)->endpoint($this->endpointFor($key));
 
-        $definition = $this->make($action)->withContext($context);
+                if ($definition instanceof FormActionDefinition) {
+                    $component->lazyForm();
+                }
 
-        if (! $this->authorizedToRender($definition)) {
-            return ActionComponent::make($key)->hidden();
-        }
-
-        $component = $definition->definition(ActionComponent::make($key))
-            ->signedAs($key)
-            ->context($context)
-            ->endpoint($this->endpointFor($key));
-
-        if ($definition instanceof FormActionDefinition) {
-            $component->lazyForm();
-        }
-
-        return $component;
+                return $component;
+            },
+            $context,
+        );
     }
 
     /**

--- a/src/Actions/ActionRegistry.php
+++ b/src/Actions/ActionRegistry.php
@@ -56,6 +56,7 @@ final class ActionRegistry extends DefinitionRegistry
         return 'action';
     }
 
+    #[\Override]
     protected function routeName(): string
     {
         return 'lattice.actions.handle';

--- a/src/Actions/BulkActionRegistry.php
+++ b/src/Actions/BulkActionRegistry.php
@@ -51,6 +51,7 @@ final class BulkActionRegistry extends DefinitionRegistry
         return 'bulkAction';
     }
 
+    #[\Override]
     protected function routeName(): string
     {
         return 'lattice.bulk-actions.handle';

--- a/src/Actions/BulkActionRegistry.php
+++ b/src/Actions/BulkActionRegistry.php
@@ -20,18 +20,14 @@ final class BulkActionRegistry extends DefinitionRegistry
      */
     public function component(string $bulkAction, array $context = []): ActionComponent
     {
-        $key = $this->registeredKeyFor($bulkAction);
-        $definition = $this->make($bulkAction)->withContext($context);
-
-        if (! $this->authorizedToRender($definition)) {
-            return BulkActionComponent::make($key)->hidden();
-        }
-
-        return $definition
-            ->definition(BulkActionComponent::make($key))
-            ->signedAs($key)
-            ->context($context)
-            ->endpoint($this->endpointFor($key));
+        return $this->gatedComponent(
+            $bulkAction,
+            fn (string $key): ActionComponent => BulkActionComponent::make($key),
+            fn (BulkActionDefinition $definition, ActionComponent $component, string $key): ActionComponent => $definition
+                ->definition($component)
+                ->endpoint($this->endpointFor($key)),
+            $context,
+        );
     }
 
     /**

--- a/src/Actions/BulkActionRegistry.php
+++ b/src/Actions/BulkActionRegistry.php
@@ -51,6 +51,11 @@ final class BulkActionRegistry extends DefinitionRegistry
         return 'bulkAction';
     }
 
+    protected function routeName(): string
+    {
+        return 'lattice.bulk-actions.handle';
+    }
+
     public function group(): string
     {
         return 'bulk-actions';

--- a/src/Actions/Components/Action.php
+++ b/src/Actions/Components/Action.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Actions\ActionRegistry;
 use Lattice\Lattice\Actions\Confirmation;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Forms\Components\Field;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Ui\Components\Component;
@@ -21,7 +22,7 @@ use Lattice\Lattice\Ui\Enums\ModalWidth;
 use Lattice\Lattice\Ui\Enums\Side;
 
 #[AsComponent('action')]
-class Action extends Component
+class Action extends Component implements InteractiveComponent
 {
     use HasHttpMethod;
     use HasIcon;

--- a/src/Actions/Components/ActionGroup.php
+++ b/src/Actions/Components/ActionGroup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Actions\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
 use Lattice\Lattice\Ui\Components\IsInteractive;
 use Lattice\Lattice\Ui\Concerns\HasLabel;
@@ -11,7 +12,7 @@ use Lattice\Lattice\Ui\Contracts\SchemaEntry;
 use Lattice\Lattice\Ui\Enums\Orientation;
 
 #[AsComponent('action.group')]
-class ActionGroup extends ContainerComponent
+class ActionGroup extends ContainerComponent implements InteractiveComponent
 {
     use HasLabel;
     use IsInteractive;

--- a/src/Actions/Contracts/InteractsWithForm.php
+++ b/src/Actions/Contracts/InteractsWithForm.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form;
 use Lattice\Lattice\Forms\Components\SignedUpload;
 use Lattice\Lattice\Forms\ResolveResponse;
+use Lattice\Lattice\Http\SubRequest;
 
 /**
  * An action definition that drives an embedded form: it validates the submission
@@ -26,9 +27,9 @@ interface InteractsWithForm
     /**
      * @return array{options: list<Option>}
      */
-    public function searchOptions(Request $request): array;
+    public function searchOptions(Request $request, SubRequest $sub): array;
 
     public function resolveFields(Request $request): ResolveResponse;
 
-    public function signUpload(Request $request): SignedUpload;
+    public function signUpload(Request $request, SubRequest $sub): SignedUpload;
 }

--- a/src/Core/Contracts/InteractiveComponent.php
+++ b/src/Core/Contracts/InteractiveComponent.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Contracts;
+
+/**
+ * A wire component that carries a sealed reference and its render context —
+ * what the registry gate needs to promise about anything it seals.
+ */
+interface InteractiveComponent
+{
+    public function signedAs(string $signatureKey): static;
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function context(array $context): static;
+}

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -24,8 +24,6 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract
      */
     protected array $definitions = [];
 
-    private ?string $endpointTemplate = null;
-
     public function __construct(
         protected readonly Container $container,
         protected readonly DiscoveryManifest $manifest,
@@ -104,15 +102,19 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract
         return $this->make($definitions[$key]);
     }
 
+    /**
+     * Minted from the named route so the path honours the app's base path —
+     * subdirectory installs included. Apps needing a different path
+     * re-register the route under the same name.
+     */
     public function endpointFor(string $key): string
     {
-        $this->endpointTemplate ??= (string) config(
-            "lattice.{$this->group()}.endpoint",
-            "lattice/{$this->group()}/{{$this->name()}}",
-        );
-        $path = str_replace('{'.$this->name().'}', rawurlencode($key), ltrim($this->endpointTemplate, '/'));
+        return route($this->routeName(), [$this->name() => $key], absolute: false);
+    }
 
-        return '/'.$path;
+    protected function routeName(): string
+    {
+        return "lattice.{$this->group()}.show";
     }
 
     /**

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -37,6 +37,34 @@ abstract class DefinitionRegistry implements DefinitionRegistryContract
     }
 
     /**
+     * The gate every wire component build passes through: an unauthorized
+     * definition yields a bare hidden component; an authorized one is
+     * configured and then sealed. Registries supply only the construction
+     * closures so this sequence cannot drift between them.
+     *
+     * @template TComponent of \Lattice\Lattice\Ui\Components\Component&Contracts\InteractiveComponent
+     *
+     * @param  class-string<TDefinition>  $definitionClass
+     * @param  callable(string): TComponent  $component
+     * @param  callable(TDefinition, TComponent, string): TComponent  $configure
+     * @param  array<string, mixed>  $context
+     * @return TComponent
+     */
+    protected function gatedComponent(string $definitionClass, callable $component, callable $configure, array $context = [])
+    {
+        $key = $this->registeredKeyFor($definitionClass);
+        $definition = $this->make($definitionClass)->withContext($context);
+
+        if (! $this->authorizedToRender($definition)) {
+            return $component($key)->hidden();
+        }
+
+        return $configure($definition, $component($key), $key)
+            ->signedAs($key)
+            ->context($context);
+    }
+
+    /**
      * Explicit registrations layered over the discovered manifest entries.
      *
      * @return array<string, class-string<TDefinition>>

--- a/src/Forms/Components/Form.php
+++ b/src/Forms/Components/Form.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Forms\Contracts\ProvidesRowFields;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormDefinition;
@@ -22,7 +23,7 @@ use Lattice\Lattice\Ui\Enums\Variant;
 use LogicException;
 
 #[AsComponent('form')]
-class Form extends ContainerComponent
+class Form extends ContainerComponent implements InteractiveComponent
 {
     use HasHttpMethod;
     use IsInteractive;

--- a/src/Forms/Concerns/ResolvesFormFields.php
+++ b/src/Forms/Concerns/ResolvesFormFields.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Forms\Components\SignedUpload;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormSchemaWalker;
 use Lattice\Lattice\Forms\ResolveResponse;
+use Lattice\Lattice\Http\SubRequest;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -35,25 +36,23 @@ trait ResolvesFormFields
      *
      * @return array{options: list<Option>}
      */
-    public function searchOptions(Request $request): array
+    public function searchOptions(Request $request, SubRequest $sub): array
     {
-        $name = $request->string('_search')->toString();
-        $query = $request->string('q')->toString();
         $data = FormData::fromRequest($request);
         $fields = $this->formFields($request);
 
-        $instance = app(FormSchemaWalker::class)->find($fields, $name, $data);
+        $instance = app(FormSchemaWalker::class)->find($fields, $sub->target, $data);
         $field = $instance?->field;
 
         abort_if($field === null, Response::HTTP_NOT_FOUND);
         abort_unless($field instanceof Select && $field->isSearchable(), Response::HTTP_UNPROCESSABLE_ENTITY);
 
-        return ['options' => $field->resolveSearch($query, $instance->scope, $request)];
+        return ['options' => $field->resolveSearch($sub->query, $instance->scope, $request)];
     }
 
-    public function signUpload(Request $request): SignedUpload
+    public function signUpload(Request $request, SubRequest $sub): SignedUpload
     {
-        $name = $request->string('_upload')->toString();
+        $name = $sub->target;
         $data = FormData::fromRequest($request);
         $fields = $this->formFields($request);
 

--- a/src/Forms/FormRegistry.php
+++ b/src/Forms/FormRegistry.php
@@ -57,6 +57,7 @@ final class FormRegistry extends DefinitionRegistry
         return 'form';
     }
 
+    #[\Override]
     protected function routeName(): string
     {
         return 'lattice.forms.handle';

--- a/src/Forms/FormRegistry.php
+++ b/src/Forms/FormRegistry.php
@@ -20,20 +20,15 @@ final class FormRegistry extends DefinitionRegistry
      */
     public function component(string $form, array $context = []): FormComponent
     {
-        $key = $this->registeredKeyFor($form);
-        $definition = $this->make($form)->withContext($context);
-        $request = $this->container->make(Request::class);
-
-        if (! $this->authorizedToRender($definition)) {
-            return FormComponent::make($key)->hidden();
-        }
-
-        $component = FormComponent::make($key)->signedAs($key)->context($context);
-
-        return $definition
-            ->definition($component, $request)
-            ->action($this->endpointFor($key))
-            ->errorBag($this->errorBagFor($key));
+        return $this->gatedComponent(
+            $form,
+            fn (string $key): FormComponent => FormComponent::make($key),
+            fn (FormDefinition $definition, FormComponent $component, string $key): FormComponent => $definition
+                ->definition($component, $this->container->make(Request::class))
+                ->action($this->endpointFor($key))
+                ->errorBag($this->errorBagFor($key)),
+            $context,
+        );
     }
 
     public function errorBagFor(string $id): string

--- a/src/Forms/FormRegistry.php
+++ b/src/Forms/FormRegistry.php
@@ -57,6 +57,11 @@ final class FormRegistry extends DefinitionRegistry
         return 'form';
     }
 
+    protected function routeName(): string
+    {
+        return 'lattice.forms.handle';
+    }
+
     public function group(): string
     {
         return 'forms';

--- a/src/Fragments/Components/Fragment.php
+++ b/src/Fragments/Components/Fragment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Fragments\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Fragments\FragmentDefinition;
 use Lattice\Lattice\Fragments\FragmentRegistry;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
@@ -11,7 +12,7 @@ use Lattice\Lattice\Ui\Components\IsInteractive;
 use Lattice\Lattice\Ui\Concerns\HasSize;
 
 #[AsComponent('fragment')]
-class Fragment extends ContainerComponent
+class Fragment extends ContainerComponent implements InteractiveComponent
 {
     use HasSize;
     use IsInteractive;

--- a/src/Fragments/FragmentRegistry.php
+++ b/src/Fragments/FragmentRegistry.php
@@ -20,21 +20,17 @@ final class FragmentRegistry extends DefinitionRegistry
      */
     public function lazyComponent(string $fragment, array $context = []): FragmentComponent
     {
-        $key = $this->registeredKeyFor($fragment);
-        $definition = $this->make($fragment)->withContext($context);
+        return $this->gatedComponent(
+            $fragment,
+            fn (string $key): FragmentComponent => FragmentComponent::make($key),
+            function (FragmentDefinition $definition, FragmentComponent $component, string $key): FragmentComponent {
+                $component->endpoint($this->endpointFor($key));
+                $component->lazy = true;
 
-        if (! $this->authorizedToRender($definition)) {
-            return FragmentComponent::make($key)->hidden();
-        }
-
-        $component = FragmentComponent::make($key)
-            ->signedAs($key)
-            ->context($context)
-            ->endpoint($this->endpointFor($key));
-
-        $component->lazy = true;
-
-        return $component;
+                return $component;
+            },
+            $context,
+        );
     }
 
     public function response(string $key, ?FragmentDefinition $definition = null): FragmentResponse

--- a/src/Http/Controllers/Concerns/HandlesFormSubRequests.php
+++ b/src/Http/Controllers/Concerns/HandlesFormSubRequests.php
@@ -7,33 +7,32 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Actions\Contracts\InteractsWithForm;
 use Lattice\Lattice\Forms\FormDefinition;
+use Lattice\Lattice\Http\SubRequest;
+use Lattice\Lattice\Http\SubRequestType;
 use Symfony\Component\HttpFoundation\Response;
 
 trait HandlesFormSubRequests
 {
     /**
-     * Dispatch the form sub-requests made against a form or action endpoint —
+     * Dispatch the sub-requests made against a form or action endpoint —
      * lazy schema fetch (actions only), signed uploads, option search, field
      * resolution — returning null when the request is the submission itself.
      */
     protected function formSubRequest(Request $request, FormDefinition|InteractsWithForm $definition): ?Response
     {
-        if ($definition instanceof InteractsWithForm && $request->boolean('_form')) {
-            return new JsonResponse($definition->resolveFormSchema($request));
+        $sub = SubRequest::from($request);
+
+        if (! $sub instanceof SubRequest) {
+            return null;
         }
 
-        if ($request->filled('_upload')) {
-            return new JsonResponse($definition->signUpload($request));
-        }
-
-        if ($request->filled('_search')) {
-            return new JsonResponse($definition->searchOptions($request));
-        }
-
-        if ($request->boolean('_resolve')) {
-            return new JsonResponse($definition->resolveFields($request));
-        }
-
-        return null;
+        return match ($sub->type) {
+            SubRequestType::Schema => $definition instanceof InteractsWithForm
+                ? new JsonResponse($definition->resolveFormSchema($request))
+                : null,
+            SubRequestType::Upload => new JsonResponse($definition->signUpload($request, $sub)),
+            SubRequestType::Search => new JsonResponse($definition->searchOptions($request, $sub)),
+            SubRequestType::Resolve => new JsonResponse($definition->resolveFields($request)),
+        };
     }
 }

--- a/src/Http/Controllers/TableController.php
+++ b/src/Http/Controllers/TableController.php
@@ -7,6 +7,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Lattice\Http\SubRequest;
+use Lattice\Lattice\Http\SubRequestType;
 use Lattice\Lattice\Tables\TableRegistry;
 
 final readonly class TableController
@@ -21,9 +23,10 @@ final readonly class TableController
     public function __invoke(Request $request, string $table): JsonResponse
     {
         [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->tables, 'table', $table);
+        $sub = SubRequest::from($request);
 
-        if ($request->filled('_search')) {
-            return response()->json($this->tables->searchFilterOptions($table, $request, $definition));
+        if ($sub?->type === SubRequestType::Search) {
+            return response()->json($this->tables->searchFilterOptions($table, $request, $sub, $definition));
         }
 
         return response()->json($this->tables->response($table, $request, $definition));

--- a/src/Http/SubRequest.php
+++ b/src/Http/SubRequest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http;
+
+use Illuminate\Http\Request;
+
+/**
+ * The envelope every component sub-request travels in: `_sub` names the
+ * type, `_target` the addressed field or filter, `_q` the user's query.
+ * Reserved keys are underscore-prefixed so they cannot collide with field
+ * names, and every endpoint parses the same shape.
+ */
+final readonly class SubRequest
+{
+    private function __construct(
+        public SubRequestType $type,
+        public string $target,
+        public string $query,
+    ) {}
+
+    public static function from(Request $request): ?self
+    {
+        $type = SubRequestType::tryFrom($request->string('_sub')->toString());
+
+        if ($type === null) {
+            return null;
+        }
+
+        return new self(
+            $type,
+            $request->string('_target')->toString(),
+            $request->string('_q')->toString(),
+        );
+    }
+}

--- a/src/Http/SubRequestType.php
+++ b/src/Http/SubRequestType.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Http;
+
+enum SubRequestType: string
+{
+    case Schema = 'schema';
+    case Upload = 'upload';
+    case Search = 'search';
+    case Resolve = 'resolve';
+}

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -160,6 +160,12 @@ final class LatticeServiceProvider extends PackageServiceProvider
             }
         });
 
+        $this->callAfterResolving(ResponseFactory::class, function (ResponseFactory $inertia): void {
+            $inertia->share('lattice.urls', fn (): array => [
+                'refreshRef' => route('lattice.refs.refresh', absolute: false),
+            ]);
+        });
+
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../stubs/registry.ts' => resource_path('js/registry.ts'),

--- a/src/Remote/Components/RemoteNode.php
+++ b/src/Remote/Components/RemoteNode.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Remote\Components;
 
 use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Components\IsInteractive;
 
-final class RemoteNode extends Component
+final class RemoteNode extends Component implements InteractiveComponent
 {
     use IsInteractive;
 

--- a/src/Remote/RemoteSourceRegistry.php
+++ b/src/Remote/RemoteSourceRegistry.php
@@ -48,6 +48,11 @@ final class RemoteSourceRegistry extends DefinitionRegistry
         return 'source';
     }
 
+    protected function routeName(): string
+    {
+        return 'lattice.remote-sources.token';
+    }
+
     public function group(): string
     {
         return 'remote-sources';

--- a/src/Remote/RemoteSourceRegistry.php
+++ b/src/Remote/RemoteSourceRegistry.php
@@ -48,6 +48,7 @@ final class RemoteSourceRegistry extends DefinitionRegistry
         return 'source';
     }
 
+    #[\Override]
     protected function routeName(): string
     {
         return 'lattice.remote-sources.token';

--- a/src/Support/Frontend/StandaloneAssets.php
+++ b/src/Support/Frontend/StandaloneAssets.php
@@ -46,6 +46,7 @@ final class StandaloneAssets
     {
         $config = array_filter([
             'spriteUrl' => $this->versionedUrl('sprite.svg'),
+            'refreshRefUrl' => route('lattice.refs.refresh', absolute: false),
             'echo' => $frontend['echo'] ?? null,
         ], static fn (mixed $value): bool => $value !== null);
 

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Tables\Components;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Filters\Filter;
 use Lattice\Lattice\Tables\TableDefinition;
@@ -17,7 +18,7 @@ use Lattice\Lattice\Ui\Components\IsInteractive;
 use Lattice\Lattice\Ui\Concerns\FiltersRenderableComponents;
 
 #[AsComponent('table')]
-class Table extends Component
+class Table extends Component implements InteractiveComponent
 {
     use FiltersRenderableComponents;
     use IsInteractive;

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -64,36 +64,32 @@ final class TableRegistry extends DefinitionRegistry
      */
     private function buildComponent(string $table, callable $result, array $context = [], bool $lazy = false): TableComponent
     {
-        $key = $this->registeredKeyFor($table);
-        $definition = $this->make($table)->withContext($context);
+        return $this->gatedComponent(
+            $table,
+            fn (string $key): TableComponent => TableComponent::make($key),
+            function (TableDefinition $definition, TableComponent $component, string $key) use ($result, $context, $lazy): TableComponent {
+                $columns = $definition->columns();
+                $query = TableQuery::empty($definition->perPage());
 
-        if (! $this->authorizedToRender($definition)) {
-            return TableComponent::make($key)->hidden();
-        }
+                $component
+                    ->endpoint($this->endpointFor($key))
+                    ->columns($columns)
+                    ->filters($definition->filters())
+                    ->searchable($this->hasSearchableColumns($columns))
+                    ->layout($definition->layout())
+                    ->striped($definition->striped())
+                    ->resizableColumns($definition->resizableColumns(), $definition->resizeIndicator())
+                    ->actionsLabel($definition->actionsLabel())
+                    ->emptyLabel($definition->emptyLabel())
+                    ->bulkActions($this->bulkActions($definition, $key, $context))
+                    ->result($this->decorateResult($definition, $result($definition, $query), $columns), $query);
 
-        $columns = $definition->columns();
-        $query = TableQuery::empty($definition->perPage());
+                $component->lazy = $lazy;
 
-        $component = TableComponent::make($key)
-            ->signedAs($key)
-            ->context($context)
-            ->endpoint($this->endpointFor($key))
-            ->columns($columns)
-            ->filters($definition->filters())
-            ->searchable($this->hasSearchableColumns($columns))
-            ->layout($definition->layout())
-            ->striped($definition->striped())
-            ->resizableColumns($definition->resizableColumns(), $definition->resizeIndicator())
-            ->actionsLabel($definition->actionsLabel())
-            ->emptyLabel($definition->emptyLabel())
-            ->bulkActions($this->bulkActions($definition, $key, $context))
-            ->result($this->decorateResult($definition, $result($definition, $query), $columns), $query);
-
-        if ($lazy) {
-            $component->lazy = true;
-        }
-
-        return $component;
+                return $component;
+            },
+            $context,
+        );
     }
 
     public function response(string $key, Request $request, ?TableDefinition $definition = null): TableResult

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -12,6 +12,7 @@ use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\FormSchemaWalker;
+use Lattice\Lattice\Http\SubRequest;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Components\Table as TableComponent;
 use Lattice\Lattice\Tables\Contracts\Filterable;
@@ -102,25 +103,23 @@ final class TableRegistry extends DefinitionRegistry
     }
 
     /**
-     * Resolve options for a searchable filter from the user's query (the `_search`
-     * sub-action of the table endpoint). Targets are namespaced — `filter:<key>.<field>`
+     * Resolve options for a searchable filter from the user's query (the search
+     * sub-request of the table endpoint). Targets are namespaced — `filter:<key>.<field>`
      * addresses a dedicated filter's schema field, `column:<key>` a column filter — so
      * a filter key can never shadow a dot-keyed relation column.
      *
      * @return array{options: list<Option>}
      */
-    public function searchFilterOptions(string $key, Request $request, ?TableDefinition $definition = null): array
+    public function searchFilterOptions(string $key, Request $request, SubRequest $sub, ?TableDefinition $definition = null): array
     {
         $definition ??= $this->resolve($key);
-        $searchKey = $request->string('_search')->toString();
-        $query = $request->string('_q')->toString();
 
-        if (str_starts_with($searchKey, 'filter:')) {
-            return ['options' => $this->searchFilterFieldOptions($definition, substr($searchKey, strlen('filter:')), $query, $request)];
+        if (str_starts_with($sub->target, 'filter:')) {
+            return ['options' => $this->searchFilterFieldOptions($definition, substr($sub->target, strlen('filter:')), $sub->query, $request)];
         }
 
-        if (str_starts_with($searchKey, 'column:')) {
-            return ['options' => $this->searchColumnFilterOptions($definition, substr($searchKey, strlen('column:')), $query)];
+        if (str_starts_with($sub->target, 'column:')) {
+            return ['options' => $this->searchColumnFilterOptions($definition, substr($sub->target, strlen('column:')), $sub->query)];
         }
 
         abort(Response::HTTP_NOT_FOUND);

--- a/src/Ui/Components/Modal.php
+++ b/src/Ui/Components/Modal.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Ui\Components;
 
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Ui\Enums\ModalWidth;
 use Lattice\Lattice\Ui\Enums\Side;
 
 #[AsComponent('modal')]
-class Modal extends ContainerComponent
+class Modal extends ContainerComponent implements InteractiveComponent
 {
     use IsInteractive;
 

--- a/tests/Feature/Actions/ActionEndpointTest.php
+++ b/tests/Feature/Actions/ActionEndpointTest.php
@@ -15,8 +15,6 @@ use Workbench\App\Models\User;
 use function Pest\Laravel\postJson;
 
 test('registered actions serialize their configured endpoint method and label', function (): void {
-    config(['lattice.actions.endpoint' => 'custom/actions/{action}']);
-
     Lattice::actions([WorkbenchPingAction::class]);
 
     $action = wire(ActionComponent::use(WorkbenchPingAction::class));
@@ -26,7 +24,7 @@ test('registered actions serialize their configured endpoint method and label', 
             'type' => 'action',
             'id' => 'workbench.ping',
             'props' => [
-                'endpoint' => '/custom/actions/workbench.ping',
+                'endpoint' => '/lattice/actions/workbench.ping',
                 'label' => 'Ping',
                 'method' => 'post',
                 'ref' => $this->latticeRef($action),

--- a/tests/Feature/Actions/ActionFormTest.php
+++ b/tests/Feature/Actions/ActionFormTest.php
@@ -34,7 +34,7 @@ it('marks a form-action component as lazy without inlining the schema', function
 it('returns a prefilled schema for a lazy form action', function (): void {
     Lattice::actions([EditActionFixture::class]);
 
-    $this->callAction(EditActionFixture::class, ['_form' => true], ['current_title' => 'Existing'])
+    $this->callAction(EditActionFixture::class, ['_sub' => 'schema'], ['current_title' => 'Existing'])
         ->assertOk()
         ->assertJsonPath('type', 'form')
         ->assertJsonPath('props.state.title', 'Existing');
@@ -120,7 +120,7 @@ it('validates the embedded form precognitively without running handle', function
 it('suppresses the submit row of a wizard form action so only the wizard controls submit', function (): void {
     Lattice::actions([WizardActionFixture::class]);
 
-    $this->callAction(WizardActionFixture::class, ['_form' => true])
+    $this->callAction(WizardActionFixture::class, ['_sub' => 'schema'])
         ->assertOk()
         ->assertJsonPath('type', 'form')
         ->assertJsonPath('props.submitButton', false)
@@ -168,7 +168,7 @@ class WizardActionFixture extends FormActionDefinition
 it('resolves searchable options for an embedded select', function (): void {
     Lattice::actions([AssignActionFixture::class]);
 
-    $this->callAction(AssignActionFixture::class, ['_search' => 'owner', 'q' => 'taylor'])
+    $this->callAction(AssignActionFixture::class, ['_sub' => 'search', '_target' => 'owner', '_q' => 'taylor'])
         ->assertOk()
         ->assertJsonPath('options.0.label', 'Match: taylor')
         ->assertJsonPath('options.0.value', '7');
@@ -177,7 +177,7 @@ it('resolves searchable options for an embedded select', function (): void {
 it('resolves computed fields for an embedded form', function (): void {
     Lattice::actions([AssignActionFixture::class]);
 
-    $this->callAction(AssignActionFixture::class, ['_resolve' => true, 'qty' => '5'])
+    $this->callAction(AssignActionFixture::class, ['_sub' => 'resolve', 'qty' => '5'])
         ->assertOk()
         ->assertJsonPath('values.total', 7.5);
 });

--- a/tests/Feature/Forms/FileUploadFieldTest.php
+++ b/tests/Feature/Forms/FileUploadFieldTest.php
@@ -23,7 +23,7 @@ it('signs an upload through the form endpoint', function (): void {
 
     Lattice::forms([FileUploadFieldForm::class]);
 
-    $this->submitForm(FileUploadFieldForm::class, ['_upload' => 'document', 'filename' => 'invoice.pdf'])
+    $this->submitForm(FileUploadFieldForm::class, ['_sub' => 'upload', '_target' => 'document', 'filename' => 'invoice.pdf'])
         ->assertOk()
         ->assertJsonStructure(['key', 'url', 'headers', 'method']);
 });
@@ -37,7 +37,8 @@ it('signs an upload for a file field inside a repeater row', function (): void {
     Lattice::forms([FileUploadFieldForm::class]);
 
     $this->submitForm(FileUploadFieldForm::class, [
-        '_upload' => 'documents.0.file',
+        '_sub' => 'upload',
+        '_target' => 'documents.0.file',
         'filename' => 'invoice.pdf',
         'documents' => [
             ['file' => null],
@@ -72,15 +73,16 @@ it('signs an upload for a file field inside nested repeater rows', function (): 
         }
     };
 
-    $result = $definition->signUpload(Request::create('/', 'POST', [
-        '_upload' => 'sections.0.documents.0.file',
+    $result = $definition->signUpload(...subRequest(Request::create('/', 'POST', [
+        '_sub' => 'upload',
+        '_target' => 'sections.0.documents.0.file',
         'filename' => 'invoice.pdf',
         'sections' => [[
             'documents' => [
                 ['file' => null],
             ],
         ]],
-    ]));
+    ])));
 
     expect((array) $result)->toHaveKeys(['key', 'url', 'headers', 'method']);
 });
@@ -90,7 +92,7 @@ it('returns 422 when the field does not use signed uploads', function (): void {
 
     Lattice::forms([FileUploadFieldForm::class]);
 
-    $this->submitForm(FileUploadFieldForm::class, ['_upload' => 'avatar', 'filename' => 'photo.jpg'])
+    $this->submitForm(FileUploadFieldForm::class, ['_sub' => 'upload', '_target' => 'avatar', 'filename' => 'photo.jpg'])
         ->assertUnprocessable();
 });
 
@@ -99,7 +101,7 @@ it('returns 404 when the upload field does not exist', function (): void {
 
     Lattice::forms([FileUploadFieldForm::class]);
 
-    $this->submitForm(FileUploadFieldForm::class, ['_upload' => 'nonexistent', 'filename' => 'file.pdf'])
+    $this->submitForm(FileUploadFieldForm::class, ['_sub' => 'upload', '_target' => 'nonexistent', 'filename' => 'file.pdf'])
         ->assertNotFound();
 });
 

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 use Lattice\Lattice\Attributes\AsForm;
 use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Forms\Components\Form;
@@ -16,9 +17,17 @@ use function Pest\Laravel\getJson;
 use function Pest\Laravel\patch;
 use function Pest\Laravel\patchJson;
 
-test('registered forms serialize their configured endpoint and isolated error bag', function (): void {
-    config(['lattice.forms.endpoint' => 'custom/forms/{form}']);
+test('endpoints honour the app base path for subdirectory installs', function (): void {
+    URL::forceRootUrl('http://localhost/subdir');
 
+    Lattice::forms([WorkbenchProfileForm::class]);
+
+    $form = wire(Form::use(WorkbenchProfileForm::class));
+
+    expect($form['props']['action'])->toBe('/subdir/lattice/forms/settings.profile');
+});
+
+test('registered forms serialize their configured endpoint and isolated error bag', function (): void {
     Lattice::forms([WorkbenchProfileForm::class]);
 
     $form = wire(Form::use(WorkbenchProfileForm::class));
@@ -28,7 +37,7 @@ test('registered forms serialize their configured endpoint and isolated error ba
             'type' => 'form',
             'id' => 'settings.profile',
             'props' => [
-                'action' => '/custom/forms/settings.profile',
+                'action' => '/lattice/forms/settings.profile',
                 'errorBag' => 'settings_profile',
                 'method' => 'patch',
                 'ref' => $this->latticeRef($form),

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -113,8 +113,8 @@ function nestedRowSearchDefinition(): FormDefinition
 }
 
 it('resolves options for a searchable field', function (): void {
-    $result = searchableDefinition()->searchOptions(
-        Request::create('/', 'POST', ['_search' => 'author_id', 'q' => 'jane']),
+    $result = searchableDefinition()->searchOptions(...subRequest(
+        Request::create('/', 'POST', ['_sub' => 'search', '_target' => 'author_id', '_q' => 'jane'])),
     );
 
     expect($result)->toEqual([
@@ -126,27 +126,27 @@ it('resolves options for a searchable field', function (): void {
 });
 
 it('aborts with 404 when the searched field does not exist', function (): void {
-    searchableDefinition()->searchOptions(
-        Request::create('/', 'POST', ['_search' => 'missing', 'q' => 'x']),
+    searchableDefinition()->searchOptions(...subRequest(
+        Request::create('/', 'POST', ['_sub' => 'search', '_target' => 'missing', '_q' => 'x'])),
     );
 })->throws(NotFoundHttpException::class);
 
 it('aborts with 422 when the field is not searchable', function (): void {
-    searchableDefinition()->searchOptions(
-        Request::create('/', 'POST', ['_search' => 'plan', 'q' => 'x']),
+    searchableDefinition()->searchOptions(...subRequest(
+        Request::create('/', 'POST', ['_sub' => 'search', '_target' => 'plan', '_q' => 'x'])),
     );
 })->throws(HttpException::class);
 
 it('resolves options for a searchable select inside a repeater row', function (): void {
-    $result = rowSearchDefinition()->searchOptions(
+    $result = rowSearchDefinition()->searchOptions(...subRequest(
         Request::create('/', 'POST', [
-            '_search' => 'items.0.product',
-            'q' => 'desk',
+            '_sub' => 'search', '_target' => 'items.0.product',
+            '_q' => 'desk',
             'customer' => 'acme',
             'items' => [
                 ['category' => 'chairs'],
             ],
-        ]),
+        ])),
     );
 
     expect($result)->toEqual([
@@ -157,15 +157,15 @@ it('resolves options for a searchable select inside a repeater row', function ()
 });
 
 it('resolves options for a searchable select inside a builder row', function (): void {
-    $result = rowSearchDefinition()->searchOptions(
+    $result = rowSearchDefinition()->searchOptions(...subRequest(
         Request::create('/', 'POST', [
-            '_search' => 'blocks.0.product',
-            'q' => 'lamp',
+            '_sub' => 'search', '_target' => 'blocks.0.product',
+            '_q' => 'lamp',
             'customer' => 'initech',
             'blocks' => [
                 ['type' => 'product', 'category' => 'lighting'],
             ],
-        ]),
+        ])),
     );
 
     expect($result)->toEqual([
@@ -176,10 +176,10 @@ it('resolves options for a searchable select inside a builder row', function ():
 });
 
 it('resolves options for a searchable select inside nested repeater rows', function (): void {
-    $result = nestedRowSearchDefinition()->searchOptions(
+    $result = nestedRowSearchDefinition()->searchOptions(...subRequest(
         Request::create('/', 'POST', [
-            '_search' => 'sections.0.items.0.product',
-            'q' => 'desk',
+            '_sub' => 'search', '_target' => 'sections.0.items.0.product',
+            '_q' => 'desk',
             'customer' => 'acme',
             'sections' => [[
                 'section' => 'office',
@@ -187,7 +187,7 @@ it('resolves options for a searchable select inside nested repeater rows', funct
                     ['category' => 'chairs'],
                 ],
             ]],
-        ]),
+        ])),
     );
 
     expect($result)->toEqual([
@@ -201,14 +201,14 @@ it('aborts with 422 when a row select is not searchable', function (): void {
     $status = null;
 
     try {
-        rowSearchDefinition()->searchOptions(
+        rowSearchDefinition()->searchOptions(...subRequest(
             Request::create('/', 'POST', [
-                '_search' => 'items.0.plan',
-                'q' => 'free',
+                '_sub' => 'search', '_target' => 'items.0.plan',
+                '_q' => 'free',
                 'items' => [
                     ['category' => 'chairs'],
                 ],
-            ]),
+            ])),
         );
     } catch (HttpException $exception) {
         $status = $exception->getStatusCode();
@@ -226,8 +226,8 @@ it('searches options through the form endpoint with a signed reference', functio
     $ref = wire(Form::use(SelectFieldForm::class))['props']['ref'];
 
     post('/lattice/forms/workbench.fields.select.form', [
-        '_search' => 'related_products',
-        'q' => 'walnut',
+        '_sub' => 'search', '_target' => 'related_products',
+        '_q' => 'walnut',
     ], $this->latticeHeaders($ref))
         ->assertOk()
         ->assertExactJson([

--- a/tests/Feature/Remote/DynamicRemoteSourceTest.php
+++ b/tests/Feature/Remote/DynamicRemoteSourceTest.php
@@ -59,7 +59,7 @@ test('dynamic remote source keys are injected into schema refs', function (): vo
         ->and($wire[0]['props']['remote']['audience'])->toBe('https://acme.example.test')
         ->and($wire[0]['props']['remote']['scopes'])->toBe(['tickets.read'])
         ->and($wire[0]['props']['remote']['nodeId'])->toBe('tickets')
-        ->and($wire[0]['props']['remote']['tokenEndpoint'])->toBe('/lattice/remote-sources/external-app%3Aacme/token')
+        ->and($wire[0]['props']['remote']['tokenEndpoint'])->toBe('/lattice/remote-sources/external-app:acme/token')
         ->and($wire[0]['props']['remote']['ref'])->toBeString()->not->toBe('');
 });
 

--- a/tests/Feature/Remote/RemoteSchemaResolverTest.php
+++ b/tests/Feature/Remote/RemoteSchemaResolverTest.php
@@ -277,9 +277,7 @@ test('source schema rejects invalid local json files', function (): void {
     )->toThrow(InvalidRemoteSchema::class, 'valid JSON');
 });
 
-test('remote schema refs use configured token endpoints', function (): void {
-    config()->set('lattice.remote-sources.endpoint', 'custom/remotes/{source}/browser-token');
-
+test('remote schema refs use the route-minted token endpoint', function (): void {
     Http::preventStrayRequests();
     Http::fake([
         'https://crm.example.test/schema.json' => Http::response([
@@ -307,7 +305,7 @@ test('remote schema refs use configured token endpoints', function (): void {
         ->resolve('fixtures.remote-crm')
         ->schema(request()));
 
-    expect($wire[0]['props']['remote']['tokenEndpoint'])->toBe('/custom/remotes/fixtures.remote-crm/browser-token');
+    expect($wire[0]['props']['remote']['tokenEndpoint'])->toBe('/lattice/remote-sources/fixtures.remote-crm/token');
 });
 
 test('source schema rejects invalid manifest payloads', function (array|string $payload, string $message): void {

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -26,8 +26,6 @@ use Workbench\App\Tables\UsersTable as WorkbenchAppUsersTable;
 use function Pest\Laravel\getJson;
 
 test('registered tables serialize their configured endpoint columns state and initial data', function (): void {
-    config(['lattice.tables.endpoint' => 'custom/tables/{table}']);
-
     Lattice::tables([WorkbenchUsersTable::class]);
 
     $table = wire(Table::use(WorkbenchUsersTable::class));
@@ -37,7 +35,7 @@ test('registered tables serialize their configured endpoint columns state and in
             'type' => 'table',
             'id' => 'workbench.users',
             'props' => [
-                'endpoint' => '/custom/tables/workbench.users',
+                'endpoint' => '/lattice/tables/workbench.users',
                 'ref' => $this->latticeRef($table),
                 'layout' => null,
                 'bulkActions' => [],
@@ -143,8 +141,6 @@ test('registered tables serialize their configured endpoint columns state and in
 });
 
 test('registered tables can serialize lazily without running their query', function (): void {
-    config(['lattice.tables.endpoint' => 'custom/tables/{table}']);
-
     Lattice::tables([WorkbenchLazyUsersTable::class]);
 
     $table = wire(Table::lazy(WorkbenchLazyUsersTable::class));
@@ -154,7 +150,7 @@ test('registered tables can serialize lazily without running their query', funct
             'type' => 'table',
             'id' => 'workbench.lazy-users',
             'props' => [
-                'endpoint' => '/custom/tables/workbench.lazy-users',
+                'endpoint' => '/lattice/tables/workbench.lazy-users',
                 'lazy' => true,
                 'ref' => $this->latticeRef($table),
                 'layout' => null,

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -70,7 +70,7 @@ test('a table rejects a filter key that is not declared', function (): void {
 test('a table searches declared searchable targets through the endpoint', function (string $target): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
-    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => $target, '_q' => 'ad'])
+    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_sub' => 'search', '_target' => $target, '_q' => 'ad'])
         ->assertOk()
         ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1', 'data' => null]]]);
 })->with([
@@ -82,7 +82,7 @@ test('a table searches declared searchable targets through the endpoint', functi
 test('a table 404s invalid search targets', function (string $target): void {
     Lattice::tables([WorkbenchSearchableFilterTable::class]);
 
-    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_search' => $target, '_q' => 'a'])
+    $this->loadTable(WorkbenchSearchableFilterTable::class, ['_sub' => 'search', '_target' => $target, '_q' => 'a'])
         ->assertNotFound();
 })->with([
     'unknown filter' => 'filter:nope',
@@ -92,7 +92,7 @@ test('a table 404s invalid search targets', function (string $target): void {
 test('a table rejects searching a filter that is not searchable', function (): void {
     Lattice::tables([WorkbenchFilteredProductsTable::class]);
 
-    $this->loadTable(WorkbenchFilteredProductsTable::class, ['_search' => 'filter:status', '_q' => 'a'])
+    $this->loadTable(WorkbenchFilteredProductsTable::class, ['_sub' => 'search', '_target' => 'filter:status', '_q' => 'a'])
         ->assertUnprocessable();
 });
 

--- a/tests/Support/TestFixtures.php
+++ b/tests/Support/TestFixtures.php
@@ -2,10 +2,29 @@
 
 declare(strict_types=1);
 
+use Illuminate\Http\Request;
 use Lattice\Lattice\Core\Contracts\OptionSource;
 use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\RowsField;
+use Lattice\Lattice\Http\SubRequest;
+
+/**
+ * Spreadable request-plus-envelope pair for calling sub-request methods
+ * directly: `->searchOptions(...subRequest(Request::create(...)))`.
+ *
+ * @return array{0: Request, 1: SubRequest}
+ */
+function subRequest(Request $request): array
+{
+    $sub = SubRequest::from($request);
+
+    if (! $sub instanceof SubRequest) {
+        throw new RuntimeException('The request does not carry a sub-request envelope.');
+    }
+
+    return [$request, $sub];
+}
 
 function discoverFixtures(): void
 {


### PR DESCRIPTION
The coordinated breaking batch on the wire/registry seam from the audit roadmap. Three commits in risk order, each independently revertable.

**`refactor:` centralized authorize-gate build.** The registered-key → authorize → hidden-or-sealed sequence existed as five near-identical registry copies that could drift independently. `gatedComponent()` owns it once; registries supply construction closures, `InteractiveComponent` names the sealing contract, and sealing happens after configuration so a definition returning a replacement component still comes out sealed. The tree package (sixth copy) keeps compiling — the method is additive — and adopts on its own schedule.

**`feat!:` endpoints minted from named routes.** `endpointFor()` resolves the group's named route with `absolute: false`, so URLs honour the app base path — subdirectory installs included, pinned by a `forceRootUrl` test. The six `lattice.*.endpoint` config keys and the duplicated route fallbacks are gone; an app needing a different path re-registers the named route (documented). The client learns the ref-refresh URL through a shared Inertia prop and the standalone boot config, with the root path as fallback.

**`feat!:` one sub-request envelope.** `_form` / `_upload` / `_search`+`q` (forms, actions) / `_search`+`_q` (tables) become `_sub` (schema | upload | search | resolve) + `_target` + `_q`, parsed by a single `SubRequest` value object for every endpoint. The table controller's inline variant is gone, and the unprefixed `q` key can no longer collide with a form field of the same name.

Verification: 1,326 PHP tests (parallel), 608 client tests, and 28 browser tests covering every envelope consumer (select search, dependent resolves, signed uploads, table filter search, action schema fetches) against the rebuilt bundle. Docs updated: endpoints table now lists route names with the re-register escape hatch; sub-request mentions reworded.

**Breaking:** endpoint config keys removed · sub-request wire keys renamed (client and server ship together — no compat shim) · `searchOptions()`/`signUpload()` take the `SubRequest` VO (felt only by consumers who overrode the trait methods) · `route()` no longer over-encodes `:` in definition keys.

Coordination note: `lattice-php/tree` should adopt `gatedComponent()` and gains route-minted endpoints automatically once its route follows the `lattice.{group}.show` naming convention.