### PR TITLE
fix(ci): quote the standalone-assets guard so the workflow parses again

### DIFF
--- a/.github/workflows/standalone-assets.yml
+++ b/.github/workflows/standalone-assets.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     # The asset commit below is pushed with a PAT and would re-trigger this
     # workflow; skip runs caused by our own commit to break the loop.
-    if: github.event.head_commit.message != 'chore: build standalone assets'
+    if: "github.event.head_commit.message != 'chore: build standalone assets'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The self-retrigger guard added in #315 contains a colon-space inside an unquoted YAML scalar (`if: github.event.head_commit.message != 'chore: build standalone assets'`), which is invalid YAML. GitHub has failed to parse the workflow since — a failed zero-job run on every push to any branch, and the release branch's asset rebuild never runs, which is why "Release assets are fresh" fails on the release PR.

One line: quote the expression. Verified: the file (and every other workflow) now parses; once merged, the next release-branch update triggers the rebuild and the freshness check recovers on its own.