### PR TITLE
feat!: typed context accessors and render-time page metadata

### DIFF
--- a/docs/content/docs/actions/overview.mdx
+++ b/docs/content/docs/actions/overview.mdx
@@ -95,9 +95,9 @@ Action::use(ArchiveProductAction::class)
     ->context(['product_id' => $row['id']]);
 ```
 
-`context()` carries data from the page to the action; `handle()` reads it back with
-`$this->context('product_id')`. The context is signed into the action's reference, so it
-can't be tampered with on the way back.
+`->context()` carries data from the page to the action; `handle()` reads it back server-side, typically
+through a typed accessor like `contextModel()` (see [Defining an action](#defining-an-action)). The
+context is signed into the action's reference, so it can't be tampered with on the way back.
 
 Group related actions behind a single trigger with `ActionGroup`:
 

--- a/docs/content/docs/actions/overview.mdx
+++ b/docs/content/docs/actions/overview.mdx
@@ -51,12 +51,15 @@ use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Ui\Enums\Emphasis;
 use Lattice\Lattice\Ui\Enums\Variant;
 
 #[AsAction('app.products.archive')]
 class ArchiveProductAction extends ActionDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(Action $action): Action
     {
         return $action
@@ -67,7 +70,7 @@ class ArchiveProductAction extends ActionDefinition
 
     public function handle(Request $request): ActionResult
     {
-        $product = Product::findOrFail($this->context('product_id'));
+        $product = $this->contextModel('product_id', Product::class);
         $product->update(['status' => 'archived']);
 
         return ActionResult::success()
@@ -76,6 +79,11 @@ class ArchiveProductAction extends ActionDefinition
     }
 }
 ```
+
+`contextModel()` reads the sealed context and resolves it into the model through its own
+[route binding](/core/authorization/#reading-trusted-context) — it aborts with a 404 when the key is
+missing or nothing matches. It comes from the opt-in `ResolvesContextModels` trait rather than
+`context()` itself, which stays untyped on every definition.
 
 ## Placing an action
 
@@ -135,9 +143,14 @@ through `$this->context()` — and returns a boolean; a denied action never reac
 ```php
 public function authorize(Request $request): bool
 {
-    return Product::findOrFail($this->context('product_id'))->status !== 'archived';
+    return $this->contextModel('product_id', Product::class)->status !== 'archived';
 }
 ```
+
+An action's `authorize()` also runs at render time — when it's hidden from the page rather than
+rejected outright, a strict accessor's 404 takes the whole page down with it. See
+[Authorization](/core/authorization/#reading-trusted-context) for the `OrNull` variants to reach for
+there instead.
 
 ## Next steps
 

--- a/docs/content/docs/core/authorization.md
+++ b/docs/content/docs/core/authorization.md
@@ -40,18 +40,43 @@ defense in depth, not a replacement for it. A forged or stale reference is still
 ## Reading trusted context
 
 A definition often needs the record it acts on. Pass it as [context](/actions/overview/#placing-an-action)
-when placing the component, and read it back with `context()`:
+when placing the component, and read it back with a typed accessor:
 
 ```php
 Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]);
+```
 
-// inside the action:
-protected function product(): Product
+```php
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
+
+class ArchiveProductAction extends ActionDefinition
 {
-    return Product::query()->findOrFail($this->context('product_id'));
+    use ResolvesContextModels;
+
+    protected function product(): Product
+    {
+        return $this->contextModel('product_id', Product::class);
+    }
 }
 ```
+
+`contextModel()` resolves the context value through the model's own `resolveRouteBinding()` — the
+same column a route parameter would bind against — and aborts with a 404 when the key is missing or
+no record matches. It lives on the opt-in `ResolvesContextModels` trait rather than on `Definition`
+itself, because the package does not depend on `illuminate/database`. `Definition::context()` and its
+typed scalar siblings — `contextString()`/`contextStringOrNull()`, `contextInt()`/`contextIntOrNull()`
+— are available on every definition without the trait; the strict variants abort with a 404 on a
+missing or wrongly-typed value instead of coercing it.
 
 The context is sealed into the component's signed reference, so the value `authorize()` and `handle()`
 read is the value the server issued — not something a client can change. See
 [Security](/advanced/security/) for how that sealing works.
+
+:::caution
+Inside `authorize()` on a component that renders as part of a page, use the `OrNull` accessors
+(`contextModelOrNull()`, `contextStringOrNull()`, `contextIntOrNull()`) instead of their strict
+counterparts. At the endpoint, a `false` from `authorize()` is a 403 — but at render time an
+unauthorized component is simply hidden, and a strict accessor's `abort(404)` would take the whole
+page down with it instead.
+:::

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -256,7 +256,7 @@ for a link to another page, `Breadcrumb::toPage()`, which resolves the label and
 page class so the trail can't drift out of sync with a renamed route:
 
 ```php
-use Lattice\Lattice\Http\Breadcrumb;
+use Lattice\Lattice\Core\Breadcrumb;
 
 public function breadcrumbs(): array
 {

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -287,7 +287,7 @@ public function render(PageSchema $schema, Product $product): PageSchema
         ->title($product->name)
         ->breadcrumbs([
             Breadcrumb::toPage(ProductsPage::class),
-            Breadcrumb::make($product->name, "/products/{$product->getKey()}/edit"),
+            Breadcrumb::toPage(self::class, ['product' => $product->getKey()])->title($product->name),
         ])
         ->schema([
             // …

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -249,16 +249,49 @@ page registry, but only entries with a `route` reach `Route::get()`.
 
 ## Title and breadcrumbs
 
-`title()` sets the document title. `breadcrumbs()` returns the page's trail; a layout's
-[`Breadcrumbs`](/core/navigation/#breadcrumbs) component renders whatever the active page provides:
+`title()` sets the document title and `breadcrumbs()` the page's trail; a layout's
+[`Breadcrumbs`](/core/navigation/#breadcrumbs) component renders whatever the active page provides.
+`breadcrumbs()` returns `Breadcrumb` instances — build one directly with `Breadcrumb::make()`, or,
+for a link to another page, `Breadcrumb::toPage()`, which resolves the label and href from the target
+page class so the trail can't drift out of sync with a renamed route:
 
 ```php
+use Lattice\Lattice\Http\Breadcrumb;
+
 public function breadcrumbs(): array
 {
     return [
-        ['title' => 'Products', 'href' => '/products'],
-        ['title' => 'Edit', 'href' => ''],
+        Breadcrumb::toPage(ProductsPage::class),
+        Breadcrumb::make('Edit', ''),
     ];
+}
+```
+
+Chain `->title()` onto a `Breadcrumb` to override the label `toPage()` derived:
+
+```php
+Breadcrumb::toPage(ProductsPage::class)->title(__('Products'));
+```
+
+`title()` and `breadcrumbs()` take no parameters, so they can't read the route or an injected model.
+When a value depends on the request — a record's name, say — set it on the `PageSchema` from
+`render()` instead, which is dispatched with the same route parameters as any other controller
+method. A value set on the schema wins over the corresponding `Page` method; leaving it unset falls
+through to the method, and passing `->breadcrumbs([])` deliberately clears the trail rather than
+falling through to it:
+
+```php
+public function render(PageSchema $schema, Product $product): PageSchema
+{
+    return $schema
+        ->title($product->name)
+        ->breadcrumbs([
+            Breadcrumb::toPage(ProductsPage::class),
+            Breadcrumb::make($product->name, "/products/{$product->getKey()}/edit"),
+        ])
+        ->schema([
+            // …
+        ]);
 }
 ```
 

--- a/src/Core/Breadcrumb.php
+++ b/src/Core/Breadcrumb.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-namespace Lattice\Lattice\Http;
+namespace Lattice\Lattice\Core;
 
 use Lattice\Lattice\Attributes\TypeScript;
-use Lattice\Lattice\Core\PageRoute;
 
 #[TypeScript]
 final readonly class Breadcrumb

--- a/src/Core/Concerns/ResolvesContextModels.php
+++ b/src/Core/Concerns/ResolvesContextModels.php
@@ -36,8 +36,12 @@ trait ResolvesContextModels
 
     /**
      * Absent and not-found both yield null. A definition that must tell them
-     * apart — an edit form where no id means "create" — reads the scalar and
-     * runs its own lookup.
+     * apart — an edit form where no id means "create" — tests
+     * `$this->context($key)` for presence (`null`/`''`) itself, then calls
+     * the strict {@see self::contextModel()} for the lookup. Do not swap in
+     * `contextIntOrNull()` for the presence check: it silently folds
+     * "present but non-numeric" (e.g. a UUID/ULID key) into "absent", turning
+     * an edit into a create.
      *
      * @template TModel of Model
      *

--- a/src/Core/Concerns/ResolvesContextModels.php
+++ b/src/Core/Concerns/ResolvesContextModels.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Lattice\Lattice\Core\Definition;
+
+/**
+ * Resolves a context value into an Eloquent record through the model's own
+ * route binding, so a context key resolves exactly as the same value would in
+ * a route — `getRouteKeyName()` overrides and custom `resolveRouteBinding()`
+ * included. Opt-in rather than part of {@see Definition}
+ * because the package does not depend on illuminate/database.
+ *
+ * @phpstan-require-extends Definition
+ */
+trait ResolvesContextModels
+{
+    /**
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $model
+     * @return TModel
+     */
+    protected function contextModel(string $key, string $model, ?string $by = null): Model
+    {
+        $resolved = $this->contextModelOrNull($key, $model, $by);
+
+        if ($resolved === null) {
+            abort(404);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Absent and not-found both yield null. A definition that must tell them
+     * apart — an edit form where no id means "create" — reads the scalar and
+     * runs its own lookup.
+     *
+     * @template TModel of Model
+     *
+     * @param  class-string<TModel>  $model
+     * @return TModel|null
+     */
+    protected function contextModelOrNull(string $key, string $model, ?string $by = null): ?Model
+    {
+        $value = $this->context($key);
+
+        if ((! is_string($value) && ! is_int($value)) || $value === '') {
+            return null;
+        }
+
+        $instance = new $model;
+
+        return $instance->resolveRouteBinding($value, $by);
+    }
+}

--- a/src/Core/Definition.php
+++ b/src/Core/Definition.php
@@ -41,6 +41,11 @@ abstract class Definition implements Authorizable
      * when the key is absent or holds the wrong type — inside a render-time
      * authorize() use the OrNull variants instead, or a missing key takes the
      * whole page down rather than hiding the component.
+     *
+     * The type policy differs per accessor: `contextString`/`contextStringOrNull`
+     * require a non-empty `string` and never coerce (an `int` is rejected), while
+     * `contextInt`/`contextIntOrNull` accept any `is_numeric` value — including
+     * numeric strings — and cast it to `int`.
      */
     protected function contextString(string $key): string
     {

--- a/src/Core/Definition.php
+++ b/src/Core/Definition.php
@@ -35,4 +35,46 @@ abstract class Definition implements Authorizable
     {
         return data_get($this->context, $key, $default);
     }
+
+    /**
+     * Typed reads of the sealed context. The strict variants abort with a 404
+     * when the key is absent or holds the wrong type — inside a render-time
+     * authorize() use the OrNull variants instead, or a missing key takes the
+     * whole page down rather than hiding the component.
+     */
+    protected function contextString(string $key): string
+    {
+        $value = $this->contextStringOrNull($key);
+
+        if ($value === null) {
+            abort(404);
+        }
+
+        return $value;
+    }
+
+    protected function contextStringOrNull(string $key): ?string
+    {
+        $value = $this->context($key);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    protected function contextInt(string $key): int
+    {
+        $value = $this->contextIntOrNull($key);
+
+        if ($value === null) {
+            abort(404);
+        }
+
+        return $value;
+    }
+
+    protected function contextIntOrNull(string $key): ?int
+    {
+        $value = $this->context($key);
+
+        return is_numeric($value) ? (int) $value : null;
+    }
 }

--- a/src/Core/PageRoute.php
+++ b/src/Core/PageRoute.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core;
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Lattice\Lattice\Core\Contracts\PageContract;
+
+/**
+ * Resolves the href and default label of a registered Lattice page, shared by
+ * every component that links to one.
+ */
+final class PageRoute
+{
+    /**
+     * @param  class-string  $page
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function href(string $page, array $parameters = []): string
+    {
+        if (! is_a($page, PageContract::class, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Page [%s] must implement [%s].',
+                $page,
+                PageContract::class,
+            ));
+        }
+
+        $route = self::route($page);
+
+        if (! $route instanceof Route) {
+            throw new InvalidArgumentException(sprintf(
+                'No Lattice page route is registered for [%s].',
+                $page,
+            ));
+        }
+
+        return app('url')->toRoute($route, $parameters, false);
+    }
+
+    /**
+     * @param  class-string  $page
+     */
+    public static function label(string $page): string
+    {
+        return Str::headline(Str::beforeLast(class_basename($page), 'Page'));
+    }
+
+    /**
+     * Pages booted by Lattice are named routes, so the name lookup is the fast
+     * path; a page route registered by hand may be unnamed, hence the scan.
+     *
+     * @param  class-string  $page
+     */
+    private static function route(string $page): ?Route
+    {
+        $routes = app('router')->getRoutes();
+        $action = $page.'@render';
+        $named = $routes->getByName(PageMetadata::for($page)->name);
+
+        if ($named instanceof Route && $named->getActionName() === $action) {
+            return $named;
+        }
+
+        return collect($routes->getRoutes())->first(
+            static fn (Route $route): bool => $route->getActionName() === $action,
+        );
+    }
+}

--- a/src/Core/PageSchema.php
+++ b/src/Core/PageSchema.php
@@ -47,6 +47,10 @@ final class PageSchema
         return $this;
     }
 
+    /**
+     * Read only by `Http\Page::toArray()` via {@see self::resolvedTitle()};
+     * ignored when this schema builds a fragment or layout.
+     */
     public function title(string $title): static
     {
         $this->title = $title;
@@ -55,6 +59,9 @@ final class PageSchema
     }
 
     /**
+     * Read only by `Http\Page::toArray()` via {@see self::resolvedBreadcrumbs()};
+     * ignored when this schema builds a fragment or layout.
+     *
      * @param  array<int, Breadcrumb>  $breadcrumbs
      */
     public function breadcrumbs(array $breadcrumbs): static

--- a/src/Core/PageSchema.php
+++ b/src/Core/PageSchema.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core;
 
+use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Concerns\FiltersRenderableComponents;
 use Lattice\Lattice\Ui\Concerns\ResolvesSchemaEntries;
@@ -17,6 +18,13 @@ final class PageSchema
      * @var array<int, SchemaEntry>
      */
     private array $components = [];
+
+    private ?string $title = null;
+
+    /**
+     * @var array<int, Breadcrumb>|null
+     */
+    private ?array $breadcrumbs = null;
 
     public static function make(): self
     {
@@ -38,6 +46,39 @@ final class PageSchema
         $this->components[] = $component;
 
         return $this;
+    }
+
+    public function title(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, Breadcrumb>  $breadcrumbs
+     */
+    public function breadcrumbs(array $breadcrumbs): static
+    {
+        $this->breadcrumbs = $breadcrumbs;
+
+        return $this;
+    }
+
+    public function resolvedTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * Null when render() set nothing, so the page's own breadcrumbs() applies;
+     * an empty array is a deliberate override that clears them.
+     *
+     * @return array<int, Breadcrumb>|null
+     */
+    public function resolvedBreadcrumbs(): ?array
+    {
+        return $this->breadcrumbs;
     }
 
     /**

--- a/src/Core/PageSchema.php
+++ b/src/Core/PageSchema.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Core;
 
-use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Ui\Components\Component;
 use Lattice\Lattice\Ui\Concerns\FiltersRenderableComponents;
 use Lattice\Lattice\Ui\Concerns\ResolvesSchemaEntries;

--- a/src/Http/Breadcrumb.php
+++ b/src/Http/Breadcrumb.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Http;
 
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Core\PageRoute;
 
 #[TypeScript]
 final readonly class Breadcrumb
@@ -12,4 +13,23 @@ final readonly class Breadcrumb
         public string $title,
         public string $href,
     ) {}
+
+    public static function make(string $title, string $href): self
+    {
+        return new self($title, $href);
+    }
+
+    /**
+     * @param  class-string  $page
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function toPage(string $page, array $parameters = []): self
+    {
+        return new self(PageRoute::label($page), PageRoute::href($page, $parameters));
+    }
+
+    public function title(string $title): self
+    {
+        return new self($title, $this->href);
+    }
 }

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -28,7 +28,7 @@ abstract class Page implements PageContract, Responsable
     }
 
     /**
-     * @return array<int, array{title: string, href: string}>
+     * @return array<int, Breadcrumb>
      */
     public function breadcrumbs(): array
     {
@@ -141,13 +141,10 @@ abstract class Page implements PageContract, Responsable
         $container = $this->container() ?? $metadata->container;
 
         $payload = new PagePayload(
-            title: $this->title(),
+            title: $schema->resolvedTitle() ?? $this->title(),
             layout: $this->resolveLayout($layout, $request),
             container: $this->serializePageMetadata($container),
-            breadcrumbs: array_map(
-                static fn (array $breadcrumb): Breadcrumb => new Breadcrumb($breadcrumb['title'], $breadcrumb['href']),
-                $this->breadcrumbs(),
-            ),
+            breadcrumbs: $schema->resolvedBreadcrumbs() ?? $this->breadcrumbs(),
             schema: $schema->renderable(),
             listeners: $this->resolveListeners(),
         );

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Core\Contracts\PageContract;
 use Lattice\Lattice\Core\PageMetadata;
 use Lattice\Lattice\Core\PageSchema;

--- a/src/Http/PagePayload.php
+++ b/src/Http/PagePayload.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Http;
 
 use Lattice\Lattice\Attributes\TypeScript;
+use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Realtime\Listen;
 use Lattice\Lattice\Ui\Components\Component;
 

--- a/src/Layouts/Components/MenuItem.php
+++ b/src/Layouts/Components/MenuItem.php
@@ -3,12 +3,10 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Layouts\Components;
 
-use Illuminate\Routing\Route;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Attributes\AsComponent;
-use Lattice\Lattice\Core\Contracts\PageContract;
+use Lattice\Lattice\Core\PageRoute;
 use Lattice\Lattice\Ui\Components\ContainerComponent;
 use Lattice\Lattice\Ui\Concerns\HasAffixes;
 use Lattice\Lattice\Ui\Concerns\HasIcon;
@@ -46,27 +44,8 @@ class MenuItem extends ContainerComponent
      */
     public static function fromPage(string $page, array $parameters = []): static
     {
-        if (! is_a($page, PageContract::class, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'Menu item page [%s] must implement [%s].',
-                $page,
-                PageContract::class,
-            ));
-        }
-
-        $route = collect(app('router')->getRoutes()->getRoutes())->first(
-            static fn (Route $route): bool => $route->getActionName() === $page.'@render',
-        );
-
-        if (! $route instanceof Route) {
-            throw new InvalidArgumentException(sprintf(
-                'No Lattice page route is registered for [%s].',
-                $page,
-            ));
-        }
-
-        return static::make(self::defaultLabel($page))
-            ->href(app('url')->toRoute($route, $parameters, false));
+        return static::make(PageRoute::label($page))
+            ->href(PageRoute::href($page, $parameters));
     }
 
     /**
@@ -92,13 +71,5 @@ class MenuItem extends ContainerComponent
         }
 
         return $this->schema($children);
-    }
-
-    /**
-     * @param  class-string  $page
-     */
-    private static function defaultLabel(string $page): string
-    {
-        return Str::headline(Str::beforeLast(class_basename($page), 'Page'));
     }
 }

--- a/tests/Feature/Core/BreadcrumbTest.php
+++ b/tests/Feature/Core/BreadcrumbTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Ui\Components\Text;
 

--- a/tests/Feature/Core/DefinitionContextModelTest.php
+++ b/tests/Feature/Core/DefinitionContextModelTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Tests\Fixtures\Workbench\WorkbenchContextModelAction;
+use Workbench\App\Models\Product;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+beforeEach(function (): void {
+    Lattice::actions([WorkbenchContextModelAction::class]);
+});
+
+test('context models resolve by primary key and by an explicit column', function (): void {
+    $byKey = Product::factory()->create(['name' => 'Keyed Product', 'sku' => 'KEYED-1']);
+    $bySku = Product::factory()->create(['name' => 'Skued Product', 'sku' => 'SKUED-1']);
+
+    $this->callAction(WorkbenchContextModelAction::class, [], [
+        'product_id' => $byKey->getKey(),
+        'sku' => 'SKUED-1',
+    ])
+        ->assertOk()
+        ->assertJsonPath('data.byKey', 'Keyed Product')
+        ->assertJsonPath('data.bySku', 'Skued Product')
+        ->assertJsonPath('data.optional', null);
+});
+
+test('a strict context model aborts when the record does not exist', function (): void {
+    Product::factory()->create(['name' => 'Skued Product', 'sku' => 'SKUED-1']);
+
+    $this->callAction(WorkbenchContextModelAction::class, [], [
+        'product_id' => 99999,
+        'sku' => 'SKUED-1',
+    ])
+        ->assertNotFound();
+});
+
+test('a strict context model aborts when the key is absent', function (): void {
+    Product::factory()->create(['name' => 'Skued Product', 'sku' => 'SKUED-1']);
+
+    $this->callAction(WorkbenchContextModelAction::class, [], ['sku' => 'SKUED-1'])
+        ->assertNotFound();
+});
+
+test('an OrNull accessor in a render-time authorize hides the component instead of aborting', function (): void {
+    Lattice::actions([ContextGatedAction::class]);
+
+    Route::get('context-gated', [ContextGatedPage::class, 'render'])
+        ->middleware('web')
+        ->name('context-gated.show');
+
+    withoutVite();
+
+    $response = get('/context-gated')->assertOk();
+
+    $this->assertLatticePage($response)->assertNotRendered('action:workbench.context-gated');
+});
+
+#[AsAction('workbench.context-gated')]
+class ContextGatedAction extends ActionDefinition
+{
+    use ResolvesContextModels;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Gated');
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return $this->contextModelOrNull('product_id', Product::class) instanceof Product;
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success(['ok' => true]);
+    }
+}
+
+class ContextGatedPage extends Page
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(ActionComponent::use(ContextGatedAction::class));
+    }
+}

--- a/tests/Feature/Core/DefinitionContextTest.php
+++ b/tests/Feature/Core/DefinitionContextTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Facades\Lattice;
+use Lattice\Lattice\Tests\Fixtures\Workbench\WorkbenchContextAction;
+
+beforeEach(function (): void {
+    Lattice::actions([WorkbenchContextAction::class]);
+});
+
+test('typed accessors read sealed context and resolve dot paths', function (): void {
+    $this->callAction(WorkbenchContextAction::class, [], [
+        'project' => 'acme',
+        'role' => '7',
+        'team' => ['slug' => 'core'],
+    ])
+        ->assertOk()
+        ->assertJsonPath('data.project', 'acme')
+        ->assertJsonPath('data.role', 7)
+        ->assertJsonPath('data.nested', 'core')
+        ->assertJsonPath('data.missingString', null)
+        ->assertJsonPath('data.missingInt', null);
+});
+
+test('a strict string accessor aborts when the key is absent', function (): void {
+    $this->callAction(WorkbenchContextAction::class, [], ['role' => 7])
+        ->assertNotFound();
+});
+
+test('a strict string accessor aborts on an empty string', function (): void {
+    $this->callAction(WorkbenchContextAction::class, [], ['project' => '', 'role' => 7])
+        ->assertNotFound();
+});
+
+test('the string accessor is strict about type rather than coercive', function (): void {
+    $this->callAction(WorkbenchContextAction::class, [], ['project' => 5, 'role' => 7])
+        ->assertNotFound();
+});
+
+test('a strict int accessor aborts on a non-numeric value', function (): void {
+    $this->callAction(WorkbenchContextAction::class, [], ['project' => 'acme', 'role' => 'seven'])
+        ->assertNotFound();
+});

--- a/tests/Feature/Core/PageRouteTest.php
+++ b/tests/Feature/Core/PageRouteTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageRoute;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Ui\Components\Text;
+
+#[AsPage(route: '/route-probe/{product}', name: 'route-probe.show')]
+class RouteProbePage extends Page
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Probe'));
+    }
+}
+
+test('a page href resolves from its named route', function (): void {
+    Route::get('/route-probe/{product}', [RouteProbePage::class, 'render'])->name('route-probe.show');
+
+    expect(PageRoute::href(RouteProbePage::class, ['product' => 7]))->toBe('/route-probe/7');
+});
+
+test('a page href still resolves when the route was registered without a name', function (): void {
+    Route::get('/route-probe/{product}', [RouteProbePage::class, 'render']);
+
+    expect(PageRoute::href(RouteProbePage::class, ['product' => 7]))->toBe('/route-probe/7');
+});
+
+test('a page label defaults to the humanised class name', function (): void {
+    expect(PageRoute::label(RouteProbePage::class))->toBe('Route Probe');
+});
+
+test('a class that is not a lattice page is rejected', function (): void {
+    expect(fn (): string => PageRoute::href(stdClass::class))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('a page without a registered route is rejected', function (): void {
+    expect(fn (): string => PageRoute::href(RouteProbePage::class))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Feature/Forms/ProductFormTest.php
+++ b/tests/Feature/Forms/ProductFormTest.php
@@ -147,7 +147,7 @@ test('the product edit page binds existing product state', function (): void {
 
     $response->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
         ->component('lattice/page', false)
-        ->where('lattice.title', 'Edit Product'));
+        ->where('lattice.title', 'Desk Lamp'));
 
     $this->assertLatticePage($response)
         ->component('form', 'workbench.products.form', fn ($form) => $form->assertProps([

--- a/tests/Feature/Http/BreadcrumbTest.php
+++ b/tests/Feature/Http/BreadcrumbTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Breadcrumb;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Ui\Components\Text;
+
+#[AsPage(route: '/crumb-target/{product}', name: 'crumb-target.show')]
+class CrumbTargetPage extends Page
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Target'));
+    }
+}
+
+test('a breadcrumb is built from a title and href', function (): void {
+    $crumb = Breadcrumb::make('Dashboard', '/dashboard');
+
+    expect($crumb->title)->toBe('Dashboard')
+        ->and($crumb->href)->toBe('/dashboard');
+});
+
+test('a breadcrumb resolves a page route and default title', function (): void {
+    Route::get('/crumb-target/{product}', [CrumbTargetPage::class, 'render'])->name('crumb-target.show');
+
+    $crumb = Breadcrumb::toPage(CrumbTargetPage::class, ['product' => 3]);
+
+    expect($crumb->title)->toBe('Crumb Target')
+        ->and($crumb->href)->toBe('/crumb-target/3');
+});
+
+test('a breadcrumb title can be overridden without losing the href', function (): void {
+    Route::get('/crumb-target/{product}', [CrumbTargetPage::class, 'render'])->name('crumb-target.show');
+
+    $crumb = Breadcrumb::toPage(CrumbTargetPage::class, ['product' => 3])->title('Widgets');
+
+    expect($crumb->title)->toBe('Widgets')
+        ->and($crumb->href)->toBe('/crumb-target/3');
+});
+
+test('a breadcrumb to a page without a route is rejected', function (): void {
+    expect(fn (): Breadcrumb => Breadcrumb::toPage(CrumbTargetPage::class))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Feature/Http/PageMetadataOverridesTest.php
+++ b/tests/Feature/Http/PageMetadataOverridesTest.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Ui\Components\Text;
 

--- a/tests/Feature/Http/PageMetadataOverridesTest.php
+++ b/tests/Feature/Http/PageMetadataOverridesTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Breadcrumb;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Ui\Components\Text;
+
+test('a title set on the schema wins over the title method', function (): void {
+    $page = new class extends Page
+    {
+        public function title(): string
+        {
+            return 'Method title';
+        }
+
+        public function render(PageSchema $schema): PageSchema
+        {
+            return $schema->title('Schema title')->component(Text::make('Body'));
+        }
+    };
+
+    expect($page->toArray($page->render(PageSchema::make()), new Request))
+        ->toMatchArray(['title' => 'Schema title']);
+});
+
+test('the title method still applies when the schema sets nothing', function (): void {
+    $page = new class extends Page
+    {
+        public function title(): string
+        {
+            return 'Method title';
+        }
+
+        public function render(PageSchema $schema): PageSchema
+        {
+            return $schema->component(Text::make('Body'));
+        }
+    };
+
+    expect($page->toArray($page->render(PageSchema::make()), new Request))
+        ->toMatchArray(['title' => 'Method title']);
+});
+
+test('breadcrumbs set on the schema win over the breadcrumbs method', function (): void {
+    $page = new class extends Page
+    {
+        public function breadcrumbs(): array
+        {
+            return [Breadcrumb::make('Method', '/method')];
+        }
+
+        public function render(PageSchema $schema): PageSchema
+        {
+            return $schema
+                ->breadcrumbs([Breadcrumb::make('Schema', '/schema')])
+                ->component(Text::make('Body'));
+        }
+    };
+
+    expect(wire($page->toArray($page->render(PageSchema::make()), new Request)['breadcrumbs']))
+        ->toBe([['title' => 'Schema', 'href' => '/schema']]);
+});
+
+test('an empty breadcrumb array on the schema clears the method breadcrumbs', function (): void {
+    $page = new class extends Page
+    {
+        public function breadcrumbs(): array
+        {
+            return [Breadcrumb::make('Method', '/method')];
+        }
+
+        public function render(PageSchema $schema): PageSchema
+        {
+            return $schema->breadcrumbs([])->component(Text::make('Body'));
+        }
+    };
+
+    expect($page->toArray($page->render(PageSchema::make()), new Request)['breadcrumbs'])
+        ->toBe([]);
+});

--- a/tests/Feature/Http/PageSerializationTest.php
+++ b/tests/Feature/Http/PageSerializationTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Core\PageSchema;
-use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Enums\PageContainer;

--- a/tests/Feature/Http/PageSerializationTest.php
+++ b/tests/Feature/Http/PageSerializationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Http\Page;
 use Lattice\Lattice\Ui\Components\Text;
 use Lattice\Lattice\Ui\Enums\PageContainer;
@@ -82,12 +83,7 @@ test('pages serialize breadcrumb metadata', function (): void {
     {
         public function breadcrumbs(): array
         {
-            return [
-                [
-                    'title' => 'Dashboard',
-                    'href' => '/demo/dashboard',
-                ],
-            ];
+            return [Breadcrumb::make('Dashboard', '/demo/dashboard')];
         }
 
         public function render(PageSchema $schema): PageSchema

--- a/tests/Fixtures/Workbench/WorkbenchContextAction.php
+++ b/tests/Fixtures/Workbench/WorkbenchContextAction.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\Workbench;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+
+#[AsAction('workbench.context-reader')]
+class WorkbenchContextAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Context reader');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success([
+            'project' => $this->contextString('project'),
+            'role' => $this->contextInt('role'),
+            'nested' => $this->contextStringOrNull('team.slug'),
+            'missingString' => $this->contextStringOrNull('missing'),
+            'missingInt' => $this->contextIntOrNull('missing'),
+        ]);
+    }
+}

--- a/tests/Fixtures/Workbench/WorkbenchContextModelAction.php
+++ b/tests/Fixtures/Workbench/WorkbenchContextModelAction.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\Workbench;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
+use Workbench\App\Models\Product;
+
+#[AsAction('workbench.context-model-reader')]
+class WorkbenchContextModelAction extends ActionDefinition
+{
+    use ResolvesContextModels;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Context model reader');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success([
+            'byKey' => $this->contextModel('product_id', Product::class)->name,
+            'bySku' => $this->contextModel('sku', Product::class, by: 'sku')->name,
+            'optional' => $this->contextModelOrNull('missing_id', Product::class)?->name,
+        ]);
+    }
+}

--- a/tests/Unit/Core/ComponentTypeResolutionTest.php
+++ b/tests/Unit/Core/ComponentTypeResolutionTest.php
@@ -19,13 +19,7 @@ it('resolves the wire type from the AsComponent attribute', function (): void {
 });
 
 it('throws a clear error when the attribute is missing', function (): void {
-    $component = new class extends Component
-    {
-        protected function type(): string
-        {
-            return parent::type();
-        }
-    };
+    $component = new class extends Component {};
 
     expect(fn (): array => $component->jsonSerialize())
         ->toThrow(LogicException::class, 'missing the #[AsComponent] attribute');

--- a/workbench/app/Actions/ArchiveProductAction.php
+++ b/workbench/app/Actions/ArchiveProductAction.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Effects\Builtin\Toast;
 use Lattice\Lattice\Ui\Components\Link;
 use Lattice\Lattice\Ui\Enums\HttpMethod;
@@ -17,6 +18,8 @@ use Workbench\App\Models\Product;
 #[AsAction('workbench.products.archive')]
 class ArchiveProductAction extends ActionDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(ActionComponent $action): ActionComponent
     {
         return $action
@@ -48,6 +51,6 @@ class ArchiveProductAction extends ActionDefinition
 
     private function product(): Product
     {
-        return Product::query()->findOrFail($this->context('product_id'));
+        return $this->contextModel('product_id', Product::class);
     }
 }

--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -9,6 +9,7 @@ use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Actions\FormActionDefinition;
 use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Effects\Builtin\Toast;
 use Lattice\Lattice\Forms\Components\FileUpload;
 use Lattice\Lattice\Forms\Components\Form;
@@ -20,6 +21,8 @@ use Workbench\App\Models\Product;
 #[AsAction('workbench.products.edit-modal')]
 class EditProductAction extends FormActionDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(Action $action): Action
     {
         return $action
@@ -79,6 +82,6 @@ class EditProductAction extends FormActionDefinition
 
     private function product(): Product
     {
-        return Product::query()->findOrFail($this->context('product_id'));
+        return $this->contextModel('product_id', Product::class);
     }
 }

--- a/workbench/app/Actions/RejectProductAction.php
+++ b/workbench/app/Actions/RejectProductAction.php
@@ -8,6 +8,7 @@ use Lattice\Lattice\Actions\ActionDefinition;
 use Lattice\Lattice\Actions\ActionResult;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Attributes\AsAction;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Select;
 use Lattice\Lattice\Forms\Components\Textarea;
@@ -18,6 +19,8 @@ use Workbench\App\Models\Product;
 #[AsAction('workbench.products.reject')]
 class RejectProductAction extends ActionDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(ActionComponent $action): ActionComponent
     {
         return $action
@@ -60,6 +63,6 @@ class RejectProductAction extends ActionDefinition
 
     private function product(): Product
     {
-        return Product::query()->findOrFail($this->context('product_id'));
+        return $this->contextModel('product_id', Product::class);
     }
 }

--- a/workbench/app/Forms/BusinessPartnerForm.php
+++ b/workbench/app/Forms/BusinessPartnerForm.php
@@ -166,12 +166,8 @@ class BusinessPartnerForm extends FormDefinition
 
     private function partner(): ?BusinessPartner
     {
-        $id = $this->context('business_partner_id');
+        $id = $this->contextIntOrNull('business_partner_id');
 
-        if ($id === null || $id === '') {
-            return null;
-        }
-
-        return BusinessPartner::query()->findOrFail($id);
+        return $id === null ? null : BusinessPartner::query()->findOrFail($id);
     }
 }

--- a/workbench/app/Forms/BusinessPartnerForm.php
+++ b/workbench/app/Forms/BusinessPartnerForm.php
@@ -5,6 +5,7 @@ namespace Workbench\App\Forms;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Core\EloquentOptions;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
@@ -24,6 +25,8 @@ use Workbench\App\Pricing\PriceResolver;
 #[AsForm('workbench.business-partners.form')]
 class BusinessPartnerForm extends FormDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(FormComponent $form, Request $request): FormComponent
     {
         $partner = $this->partner();
@@ -166,8 +169,8 @@ class BusinessPartnerForm extends FormDefinition
 
     private function partner(): ?BusinessPartner
     {
-        $id = $this->contextIntOrNull('business_partner_id');
+        $id = $this->context('business_partner_id');
 
-        return $id === null ? null : BusinessPartner::query()->findOrFail($id);
+        return $id === null || $id === '' ? null : $this->contextModel('business_partner_id', BusinessPartner::class);
     }
 }

--- a/workbench/app/Forms/GroupForm.php
+++ b/workbench/app/Forms/GroupForm.php
@@ -41,12 +41,8 @@ class GroupForm extends FormDefinition
 
     private function group(): ?Group
     {
-        $id = $this->context('group_id');
+        $id = $this->contextIntOrNull('group_id');
 
-        if ($id === null || $id === '') {
-            return null;
-        }
-
-        return Group::query()->findOrFail($id);
+        return $id === null ? null : Group::query()->findOrFail($id);
     }
 }

--- a/workbench/app/Forms/GroupForm.php
+++ b/workbench/app/Forms/GroupForm.php
@@ -5,6 +5,7 @@ namespace Workbench\App\Forms;
 
 use Illuminate\Http\Request;
 use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Forms\Components\Form as FormComponent;
 use Lattice\Lattice\Forms\Components\TextInput;
 use Lattice\Lattice\Forms\FormDefinition;
@@ -15,6 +16,8 @@ use Workbench\App\Models\Group;
 #[AsForm('workbench.groups.form')]
 class GroupForm extends FormDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(FormComponent $form, Request $request): FormComponent
     {
         return $form->schema([
@@ -41,8 +44,8 @@ class GroupForm extends FormDefinition
 
     private function group(): ?Group
     {
-        $id = $this->contextIntOrNull('group_id');
+        $id = $this->context('group_id');
 
-        return $id === null ? null : Group::query()->findOrFail($id);
+        return $id === null || $id === '' ? null : $this->contextModel('group_id', Group::class);
     }
 }

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Core\EloquentOptions;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Choice;
@@ -29,6 +30,8 @@ use Workbench\App\Models\SalesPrice;
 #[AsForm('workbench.products.form')]
 class ProductForm extends FormDefinition
 {
+    use ResolvesContextModels;
+
     public function definition(FormComponent $form, Request $request): FormComponent
     {
         $product = $this->product();
@@ -277,8 +280,8 @@ class ProductForm extends FormDefinition
 
     private function product(): ?Product
     {
-        $id = $this->contextIntOrNull('product_id');
+        $id = $this->context('product_id');
 
-        return $id === null ? null : Product::query()->findOrFail($id);
+        return $id === null || $id === '' ? null : $this->contextModel('product_id', Product::class);
     }
 }

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -277,12 +277,8 @@ class ProductForm extends FormDefinition
 
     private function product(): ?Product
     {
-        $id = $this->context('product_id');
+        $id = $this->contextIntOrNull('product_id');
 
-        if ($id === null || $id === '') {
-            return null;
-        }
-
-        return Product::query()->findOrFail($id);
+        return $id === null ? null : Product::query()->findOrFail($id);
     }
 }

--- a/workbench/app/Forms/SalesOrderForm.php
+++ b/workbench/app/Forms/SalesOrderForm.php
@@ -205,12 +205,8 @@ class SalesOrderForm extends FormDefinition
 
     private function order(): ?SalesOrder
     {
-        $id = $this->context('sales_order_id');
+        $id = $this->contextIntOrNull('sales_order_id');
 
-        if ($id === null || $id === '') {
-            return null;
-        }
-
-        return SalesOrder::query()->findOrFail($id);
+        return $id === null ? null : SalesOrder::query()->findOrFail($id);
     }
 }

--- a/workbench/app/Forms/SalesOrderForm.php
+++ b/workbench/app/Forms/SalesOrderForm.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Lattice\Lattice\Attributes\AsForm;
+use Lattice\Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Lattice\Core\EloquentOptions;
 use Lattice\Lattice\Core\Option;
 use Lattice\Lattice\Forms\Components\Choice;
@@ -29,6 +30,8 @@ use Workbench\App\Pricing\PriceResolver;
 #[AsForm('workbench.sales-orders.form')]
 class SalesOrderForm extends FormDefinition
 {
+    use ResolvesContextModels;
+
     public function __construct(private readonly PriceResolver $priceResolver) {}
 
     public function definition(FormComponent $form, Request $request): FormComponent
@@ -205,8 +208,8 @@ class SalesOrderForm extends FormDefinition
 
     private function order(): ?SalesOrder
     {
-        $id = $this->contextIntOrNull('sales_order_id');
+        $id = $this->context('sales_order_id');
 
-        return $id === null ? null : SalesOrder::query()->findOrFail($id);
+        return $id === null || $id === '' ? null : $this->contextModel('sales_order_id', SalesOrder::class);
     }
 }

--- a/workbench/app/Fragments/SalesOrderLinesFragment.php
+++ b/workbench/app/Fragments/SalesOrderLinesFragment.php
@@ -21,7 +21,9 @@ final class SalesOrderLinesFragment extends FragmentDefinition
 {
     public function schema(PageSchema $schema): PageSchema
     {
-        $order = SalesOrder::query()->with('lines.product')->find((int) $this->context('orderId'));
+        $order = SalesOrder::query()
+            ->with('lines.product')
+            ->find($this->contextIntOrNull('orderId'));
 
         if ($order === null) {
             return $schema->component(Text::make(__('workbench.commerce.sales-orders.detail.missing')));

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -25,7 +25,7 @@ class ProductEditPage extends WorkbenchPage
             ->title($product->name)
             ->breadcrumbs([
                 Breadcrumb::toPage(ProductsPage::class)->title(__('workbench.pages.products.title')),
-                Breadcrumb::make($product->name, "/products/{$product->getKey()}/edit"),
+                Breadcrumb::toPage(self::class, ['product' => $product->getKey()])->title($product->name),
             ])
             ->schema([
                 Stack::make('product-edit-page')

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -6,6 +6,7 @@ namespace Workbench\App\Pages;
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
+use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Enums\Gap;
@@ -16,32 +17,33 @@ use Workbench\App\Models\Product;
 #[AsPage(route: '/products/{product}/edit')]
 class ProductEditPage extends WorkbenchPage
 {
-    public function title(): string
-    {
-        return __('workbench.pages.product-edit.title');
-    }
-
     public function render(PageSchema $schema, Product $product): PageSchema
     {
         $productForm = app(ProductForm::class);
 
-        return $schema->schema([
-            Stack::make('product-edit-page')
-                ->gap(Gap::Large)
-                ->schema([
-                    Heading::make(__('workbench.pages.product-edit.heading')),
-                    Form::use(ProductForm::class, ['product_id' => $product->getKey()])
-                        ->method(HttpMethod::Patch)
-                        ->submitLabel(__('workbench.pages.product-edit.submit'))
-                        ->fill([
-                            'name' => $product->name,
-                            'sku' => $product->sku,
-                            'status' => $product->status,
-                            'related_products' => $product->relatedProducts()->pluck('products.id')->all(),
-                            'images' => $productForm->imagePaths($product),
-                            'sales_prices' => $productForm->salesPriceRows($product),
-                        ]),
-                ]),
-        ]);
+        return $schema
+            ->title($product->name)
+            ->breadcrumbs([
+                Breadcrumb::toPage(ProductsPage::class)->title(__('workbench.pages.products.title')),
+                Breadcrumb::make($product->name, "/products/{$product->getKey()}/edit"),
+            ])
+            ->schema([
+                Stack::make('product-edit-page')
+                    ->gap(Gap::Large)
+                    ->schema([
+                        Heading::make(__('workbench.pages.product-edit.heading')),
+                        Form::use(ProductForm::class, ['product_id' => $product->getKey()])
+                            ->method(HttpMethod::Patch)
+                            ->submitLabel(__('workbench.pages.product-edit.submit'))
+                            ->fill([
+                                'name' => $product->name,
+                                'sku' => $product->sku,
+                                'status' => $product->status,
+                                'related_products' => $product->relatedProducts()->pluck('products.id')->all(),
+                                'images' => $productForm->imagePaths($product),
+                                'sales_prices' => $productForm->salesPriceRows($product),
+                            ]),
+                    ]),
+            ]);
     }
 }

--- a/workbench/app/Pages/ProductEditPage.php
+++ b/workbench/app/Pages/ProductEditPage.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Workbench\App\Pages;
 
 use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Forms\Components\Form;
-use Lattice\Lattice\Http\Breadcrumb;
 use Lattice\Lattice\Ui\Components\Heading;
 use Lattice\Lattice\Ui\Components\Stack;
 use Lattice\Lattice\Ui\Enums\Gap;


### PR DESCRIPTION
Closes two context papercuts that made consumers hand-roll the same guards.

**Typed context accessors.** `context($key)` returned `mixed`, so every consumer wrote its own `is_string()`/`abort_unless` checks — the workbench had three byte-identical `findOrFail($this->context('product_id'))` helpers, and both starter kits grew near-identical private traits. `Definition` now has `contextString`/`contextInt` and their `OrNull` counterparts; strict variants `abort(404)`.

Model resolution lives in the opt-in trait `Core\Concerns\ResolvesContextModels` rather than on `Definition`, because the package deliberately doesn't require `illuminate/database` and keeps Eloquent behind opt-in bridges. It resolves through the model's own `resolveRouteBinding()`, so a context value resolves exactly as the same value would in a route — `getRouteKeyName()` overrides included, which makes `by:` unnecessary in most cases.

**Render-time page metadata.** `title()`/`breadcrumbs()` take no arguments and run after `render()`, so pages cached a model on a private property just to bridge the two. `render()` can now set both on the returned `PageSchema`, which wins over the methods (`null` falls through, `[]` deliberately clears). The static `title()` method stays — it's the 95% case.

`Breadcrumb` gains `make()`, `toPage()` and a fluent `title()`, backed by a new `Core\PageRoute` that also de-duplicates `MenuItem::fromPage()`.

### Breaking

- `Page::breadcrumbs()` returns `array<int, Breadcrumb>` instead of `array{title: string, href: string}[]`.
- `Breadcrumb` moved from `Lattice\Lattice\Http` to `Lattice\Lattice\Core` — `PageSchema` is in `Core` and can't depend upward on `Http`.

Old array-shaped breadcrumbs still serialize identically on the wire, so this is a static-analysis-only break: update the return type and the import.

### Two traps, both documented and pinned by tests

- Inside a render-time `authorize()`, use the `OrNull` accessors. A `false` there hides the component, but a strict accessor's 404 takes the whole page down. (At the endpoint, `false` is a 403.)
- Don't compose `contextIntOrNull` + `findOrFail` for edit forms — that collapses "id absent" with "id not an integer", so a UUID/ULID key makes an edit submission *insert a new row*. Presence-test the raw `context()` value, then call strict `contextModel()`.
