### PR TITLE
refactor: align authorization on can and authorize()

### DIFF
--- a/docs/content/docs/core/authorization.md
+++ b/docs/content/docs/core/authorization.md
@@ -1,24 +1,21 @@
 ---
 title: Authorization
-description: Gate any definition — form, table, action, fragment, or layout — with an authorize() check.
+description: Gate a definition, page, or component with can and authorize().
 ---
 
-Every Lattice definition is `Authorizable`. Override `authorize()` to decide whether the current
-request may use it; it returns `true` by default, so a definition is open until you say otherwise.
+Lattice gates everything with the same two tools. **`can`** declares subject-less abilities — the
+same word as Laravel's `can:` middleware and `$user->can()`. **`authorize()`** holds the logic that
+needs the request or the record it acts on.
 
-```php
-use Illuminate\Http\Request;
+|                                                                 | declare an ability     | custom logic                 |
+| --------------------------------------------------------------- | ---------------------- | ---------------------------- |
+| Definition — form, table, action, bulk action, fragment, layout | `#[AsTable(can: 'x')]` | `authorize()`                |
+| Page                                                            | `#[AsPage(can: 'x')]`  | `authorize()`                |
+| Component, column, filter, row action                           | `->can('x')`           | `->visible()` / `->hidden()` |
 
-public function authorize(Request $request): bool
-{
-    return $request->user()?->can('update', $this->product()) ?? false;
-}
-```
+## Declaring `can`
 
-## Declaring abilities on the attribute
-
-When the check is a plain, subject-less ability, declare it with `can` on the definition attribute
-instead of writing a method:
+Put the ability on the attribute — no method needed:
 
 ```php
 #[AsTable('admin.users', can: 'admin.users.manage')]
@@ -31,25 +28,54 @@ Pass an array when several must hold — every one has to pass:
 #[AsTable('admin.users', can: ['admin.access', 'admin.users.manage'])]
 ```
 
-Declared abilities are checked against `Gate::forUser($request->user())` **in addition to**
-`authorize()`, at both seams — render and endpoint. An `authorize()` override can narrow what the
-attribute declared, never widen it, so a `can` declaration holds wherever the definition is reached
-from. That includes a bulk action, which is gated by its own declaration _and_ its table's.
+Pages take the same argument:
 
-Abilities that need a subject — `can('view', $project)` — stay in `authorize()`, where the sealed
-context is available to resolve the record.
+```php
+#[AsPage(route: '/admin/users', can: 'admin.access')]
+class AdminUsersPage extends Page { /* … */ }
+```
+
+And any component, column, filter, or row action takes it as a method:
+
+```php
+TextColumn::make('cost')->can('finance.costs');
+Heading::make('Internal notes')->can(['support.access', 'support.notes']);
+```
+
+A `can` declaration is checked against `Gate::forUser($request->user())` and is **never widened** by
+the custom logic beside it — an `authorize()` override can only narrow it further, and `->visible(true)`
+cannot bring back a component whose `can` failed. That holds wherever the thing is reached from, which
+includes a bulk action, gated by its own declaration _and_ its table's.
 
 :::caution
-A page's `middleware` does **not** protect the definitions rendered on it. Every definition is
-reached through its own endpoint (`lattice/tables/{table}`, `lattice/actions/{action}`, …), which
+A page's `can` (or `middleware`) does **not** protect the definitions rendered on it. Every definition
+is reached through its own endpoint (`lattice/tables/{table}`, `lattice/actions/{action}`, …), which
 runs the middleware in `config('lattice.<group>.middleware')` — `['web', 'auth']` by default — and
-then the definition's own authorization. Putting `can:admin.users.manage` on a page gates who can
-_load_ the page; it does not gate the table on it. Declare the ability on the definition too.
+then the definition's own gate. Putting `can: 'admin.users.manage'` on a page gates who can _load_ the
+page; it does not gate the table on it. Declare the ability on the definition too.
 :::
 
-The check runs on the definition's own endpoint before any work happens:
+## Writing `authorize()`
 
-- An **action** or **bulk action** that fails `authorize()` never reaches `handle()`.
+Abilities that need a subject — `can('view', $project)` — go in `authorize()`, where the sealed
+context is available to resolve the record. It returns `true` by default, so a definition or page is
+open until you say otherwise.
+
+```php
+use Illuminate\Http\Request;
+
+public function authorize(Request $request): bool
+{
+    return $request->user()?->can('update', $this->product()) ?? false;
+}
+```
+
+`authorize()` is the only method you override. The framework never calls it directly — it composes
+it with whatever `can` declared, so the two can't drift apart.
+
+The gate runs on the definition's own endpoint before any work happens:
+
+- An **action** or **bulk action** that fails never reaches `handle()`.
 - A **form** is validated and handled only when authorized.
 - A **table** or **fragment** that fails resolves to nothing rather than leaking data.
 
@@ -58,15 +84,16 @@ the authorization lives in one place and can't be bypassed by calling the endpoi
 
 ## Hidden at render time, not just at the endpoint
 
-An unauthorized definition-backed component doesn't just 403 if you call its endpoint — it's hidden
-from the page in the first place. Registries resolve a failed `authorize()` check to an unsealed,
-hidden component, and every place that embeds definition-backed components (page schemas, table row
-actions, notification actions, a form nested under an action) filters them out before serializing.
-The client never sees a trace of it: no id, no endpoint, no signed reference.
+A component that fails its gate doesn't just 403 if you call its endpoint — it's hidden from the page
+in the first place. Registries resolve a failed check to an unsealed, hidden component, and every
+place that embeds definition-backed components (page schemas, table row actions, notification actions,
+a form nested under an action) filters them out before serializing. The client never sees a trace of
+it: no id, no endpoint, no signed reference. A plain component's `->can()` drops it the same way.
 
 :::note
-The endpoint's own `authorize()` check still runs on every request — hiding at render time is
-defense in depth, not a replacement for it. A forged or stale reference is still rejected.
+The endpoint's own gate still runs on every request — hiding at render time is defense in depth, not
+a replacement for it. A forged or stale reference is still rejected. A plain component has no endpoint
+of its own, so `->can()` is a render gate only; anything that loads data must be a definition.
 :::
 
 ## Reading trusted context

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -133,6 +133,7 @@ too.
 | `layout`     | The [layout](/core/layouts/) the page renders into — a [`PageLayout`](/advanced/enums/#pages) or a registered layout key. Defaults to `PageLayout::None` (no shell). |
 | `container`  | How the content is framed — a [`PageContainer`](/advanced/enums/#pages) (`Default` or `Centered`). Defaults to `PageContainer::Centered`.                            |
 | `middleware` | Middleware for the page's route — a string or an array. Defaults to the `lattice.pages.middleware` config (`['web']`); pass `[]` to register the route with none.    |
+| `can`        | Abilities the current user must pass before the page renders — a string or an array. See [Authorization](/core/authorization/).                                      |
 
 ```php
 use Lattice\Lattice\Ui\Enums\PageContainer;
@@ -297,8 +298,14 @@ public function render(PageSchema $schema, Product $product): PageSchema
 
 ## Authorization
 
-Override `authorize()` to gate the whole page; it returns `true` by default. A request that fails the
-check is rejected before `render()` runs:
+Declare a subject-less ability with `can` on the attribute:
+
+```php
+#[AsPage(route: '/products', can: 'products.view')]
+```
+
+For anything that needs the request or a record, override `authorize()`; it returns `true` by default.
+A request that fails either check is rejected before `render()` runs:
 
 ```php
 use Illuminate\Http\Request;
@@ -309,5 +316,5 @@ public function authorize(Request $request): bool
 }
 ```
 
-This is the same `authorize()` every Lattice definition carries — see
-[Authorization](/core/authorization/) for how it behaves across forms, tables, and actions.
+These are the same two tools every Lattice definition carries — see
+[Authorization](/core/authorization/) for how they behave across forms, tables, and actions.

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -116,5 +116,16 @@ This is a one-time server decision, not a reactive one — for a field that shou
 user fills in the rest of the form, use [`->visibleWhen()`](/forms/conditional-fields/#visible-when)
 instead.
 
+When the reason is permission rather than state, reach for `->can()` instead of a `->visible()`
+closure. It takes the same abilities as a definition's `can` attribute argument, and `->visible()`
+cannot widen it:
+
+```php
+TextInput::make('salary', 'Salary')->can('payroll.view');
+```
+
+See [Authorization](/core/authorization/) for how `can` behaves across pages, definitions, and
+components.
+
 To show or hide a field based on another field's value, see
 [Conditional fields](/forms/conditional-fields/).

--- a/src/Attributes/AsPage.php
+++ b/src/Attributes/AsPage.php
@@ -5,14 +5,21 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Attributes;
 
 use Attribute;
+use Lattice\Lattice\Core\Contracts\DeclaresGate;
 use Lattice\Lattice\Ui\Enums\PageContainer;
 use Lattice\Lattice\Ui\Enums\PageLayout;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-final readonly class AsPage
+final readonly class AsPage implements DeclaresGate
 {
     /**
+     * @var array<int, string>
+     */
+    private array $can;
+
+    /**
      * @param  array<int, string>|string|null  $middleware
+     * @param  string|array<int, string>  $can
      */
     public function __construct(
         public ?string $route = null,
@@ -20,5 +27,13 @@ final readonly class AsPage
         public PageLayout|string|null $layout = null,
         public PageContainer|string|null $container = null,
         public array|string|null $middleware = null,
-    ) {}
+        string|array $can = [],
+    ) {
+        $this->can = (array) $can;
+    }
+
+    public function can(): array
+    {
+        return $this->can;
+    }
 }

--- a/src/Attributes/DefinitionAttribute.php
+++ b/src/Attributes/DefinitionAttribute.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Attributes;
 
+use Lattice\Lattice\Core\Contracts\DeclaresGate;
 use Lattice\Lattice\Core\Definition;
 
 /**
@@ -16,12 +17,12 @@ use Lattice\Lattice\Core\Definition;
  * widen what the attribute declared. Abilities needing a subject stay in
  * `authorize()`, where the sealed context is available to resolve one.
  */
-abstract class DefinitionAttribute
+abstract class DefinitionAttribute implements DeclaresGate
 {
     /**
      * @var array<int, string>
      */
-    public readonly array $can;
+    private readonly array $can;
 
     /**
      * @param  string|array<int, string>  $can
@@ -29,5 +30,10 @@ abstract class DefinitionAttribute
     public function __construct(public readonly string $key, string|array $can = [])
     {
         $this->can = (array) $can;
+    }
+
+    public function can(): array
+    {
+        return $this->can;
     }
 }

--- a/src/Core/Authorization.php
+++ b/src/Core/Authorization.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Lattice\Lattice\Core\Contracts\Authorizable;
+use Lattice\Lattice\Core\Contracts\DeclaresGate;
+use Spatie\Attributes\Attributes;
+
+/**
+ * Where a gate is composed and applied. The `can` declared on a class attribute
+ * is checked here rather than on the subject, so an authorize() override can
+ * narrow what `can` declared but has no way to widen it.
+ *
+ * The two consequences are deliberately different and both live here: an
+ * endpoint aborts, while a definition that fails at render time is hidden
+ * instead — see DefinitionRegistry::gatedComponent().
+ */
+final class Authorization
+{
+    public static function passes(Authorizable $subject, Request $request): bool
+    {
+        return self::allows(self::declaredGate($subject), $request)
+            && $subject->authorize($request);
+    }
+
+    public static function ensure(Authorizable $subject, Request $request): void
+    {
+        abort_unless(self::passes($subject, $request), 403);
+    }
+
+    /**
+     * @param  array<int, string>  $can
+     */
+    public static function allows(array $can, Request $request): bool
+    {
+        return $can === [] || Gate::forUser($request->user())->check($can);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function declaredGate(Authorizable $subject): array
+    {
+        return Attributes::get($subject, DeclaresGate::class)?->can() ?? [];
+    }
+}

--- a/src/Core/Concerns/InteractsWithComponents.php
+++ b/src/Core/Concerns/InteractsWithComponents.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Concerns;
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Authorization;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Core\Definition;
 use Lattice\Lattice\Core\DefinitionRegistry;
@@ -32,7 +33,7 @@ trait InteractsWithComponents
             abort(404);
         }
 
-        abort_unless($definition->authorized($request), 403);
+        Authorization::ensure($definition, $request);
 
         return [$request, $definition, $context];
     }

--- a/src/Core/Contracts/Authorizable.php
+++ b/src/Core/Contracts/Authorizable.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core\Contracts;
 
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Authorization;
 
+/**
+ * The one method a definition or page overrides to gate itself. Callers never
+ * invoke it directly — {@see Authorization} composes it with the abilities
+ * declared on the class attribute.
+ */
 interface Authorizable
 {
     public function authorize(Request $request): bool;

--- a/src/Core/Contracts/DeclaresGate.php
+++ b/src/Core/Contracts/DeclaresGate.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Core\Contracts;
+
+/**
+ * Implemented by a class attribute that declares a `can` gate. Authorization
+ * resolves it by interface, so a new attribute opts its whole layer into `can`
+ * by implementing this and nothing else changes.
+ */
+interface DeclaresGate
+{
+    /**
+     * The abilities the current user must pass, as declared by `can`.
+     *
+     * @return array<int, string>
+     */
+    public function can(): array;
+}

--- a/src/Core/Definition.php
+++ b/src/Core/Definition.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Core;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
-use Lattice\Lattice\Attributes\DefinitionAttribute;
 use Lattice\Lattice\Core\Contracts\Authorizable;
-use Spatie\Attributes\Attributes;
 
 abstract class Definition implements Authorizable
 {
@@ -29,32 +26,9 @@ abstract class Definition implements Authorizable
         return $this;
     }
 
-    /**
-     * The gate both seams call — render (registry) and endpoint (controller).
-     * Abilities declared on the definition attribute are checked first and
-     * cannot be widened by an override, so a `can` declaration holds wherever
-     * the definition is reached from.
-     */
-    final public function authorized(Request $request): bool
-    {
-        return $this->passesDeclaredAbilities($request) && $this->authorize($request);
-    }
-
     public function authorize(Request $request): bool
     {
         return true;
-    }
-
-    private function passesDeclaredAbilities(Request $request): bool
-    {
-        $attribute = Attributes::get(static::class, DefinitionAttribute::class);
-        $declared = $attribute instanceof DefinitionAttribute ? $attribute->can : [];
-
-        if ($declared === []) {
-            return true;
-        }
-
-        return Gate::forUser($request->user())->check($declared);
     }
 
     protected function context(string $key, mixed $default = null): mixed

--- a/src/Core/DefinitionRegistry.php
+++ b/src/Core/DefinitionRegistry.php
@@ -26,11 +26,6 @@ abstract class DefinitionRegistry
         protected readonly DiscoveryManifest $manifest,
     ) {}
 
-    protected function authorizedToRender(Definition $definition): bool
-    {
-        return $definition->authorized($this->container->make(Request::class));
-    }
-
     /**
      * The gate every wire component build passes through: an unauthorized
      * definition yields a bare hidden component; an authorized one is
@@ -50,7 +45,7 @@ abstract class DefinitionRegistry
         $key = $this->registeredKeyFor($definitionClass);
         $definition = $this->make($definitionClass)->withContext($context);
 
-        if (! $this->authorizedToRender($definition)) {
+        if (! Authorization::passes($definition, $this->container->make(Request::class))) {
             return $component($key)->hidden();
         }
 

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Lattice\Actions\BulkActionRegistry;
+use Lattice\Lattice\Core\Authorization;
 use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Core\Exceptions\UnknownComponent;
@@ -45,7 +46,7 @@ final readonly class BulkActionController
         $tableKey = $this->trustedTableKey($context);
         $table = $this->resolveTable($tableKey)->withContext($context);
 
-        abort_unless($table->authorized($request), 403);
+        Authorization::ensure($table, $request);
 
         $records = $this->resolveRecords($request, $table, $tableKey);
 

--- a/src/Http/Controllers/RemoteSourceTokenController.php
+++ b/src/Http/Controllers/RemoteSourceTokenController.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Authorization;
 use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Lattice\Remote\RemoteSourceRegistry;
 
@@ -35,7 +36,7 @@ final readonly class RemoteSourceTokenController
 
         $definition = $this->remoteSources->resolve($source);
 
-        abort_unless($definition->authorized($request), 403);
+        Authorization::ensure($definition, $request);
 
         return response()->json($definition->issueBrowserToken($request));
     }

--- a/src/Http/Page.php
+++ b/src/Http/Page.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Lattice\Lattice\Core\Authorization;
 use Lattice\Lattice\Core\Breadcrumb;
 use Lattice\Lattice\Core\Contracts\PageContract;
 use Lattice\Lattice\Core\PageMetadata;
@@ -84,7 +85,7 @@ abstract class Page implements PageContract, Responsable
             ));
         }
 
-        abort_unless($this->authorize(app(Request::class)), 403);
+        Authorization::ensure($this, app(Request::class));
 
         return $this->pageResponse($method, $this->{$method}(...array_values($parameters)));
     }
@@ -94,7 +95,7 @@ abstract class Page implements PageContract, Responsable
      */
     public function toResponse($request): HttpResponse
     {
-        abort_unless($this->authorize($request), 403);
+        Authorization::ensure($this, $request);
 
         // schema is passed so the container resolves render()'s other
         // dependencies but does not rebuild PageSchema itself; the route's

--- a/src/Ui/Concerns/GatesRendering.php
+++ b/src/Ui/Concerns/GatesRendering.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Ui\Concerns;
 
 use Closure;
 use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Authorization;
 use Lattice\Lattice\Support\Evaluation\EvaluationContext;
 use Lattice\Lattice\Support\Evaluation\Evaluator;
 
@@ -24,6 +25,26 @@ trait GatesRendering
     private bool $negatesCondition = false;
 
     private ?bool $resolvedVisibility = null;
+
+    /**
+     * @var array<int, string>
+     */
+    private array $can = [];
+
+    /**
+     * The permission half of the gate, spelled the same `can` as the attribute
+     * on a definition or page. Checked in addition to visible()/hidden() and
+     * never widened by them, so the order of the calls does not matter.
+     *
+     * @param  string|array<int, string>  $can
+     */
+    public function can(string|array $can): static
+    {
+        $this->can = [...$this->can, ...(array) $can];
+        $this->resolvedVisibility = null;
+
+        return $this;
+    }
 
     public function visible(Closure|bool $condition = true): static
     {
@@ -46,14 +67,28 @@ trait GatesRendering
     public function shouldRender(): bool
     {
         if ($this->resolvedVisibility === null) {
-            $condition = $this->visibleCondition instanceof Closure
-                ? (bool) app(Evaluator::class)->resolve($this->visibleCondition, $this->renderContext())
-                : $this->visibleCondition;
-
-            $this->resolvedVisibility = $this->negatesCondition ? ! $condition : $condition;
+            $this->resolvedVisibility = $this->passesAuthorization() && $this->passesVisibleCondition();
         }
 
         return $this->resolvedVisibility;
+    }
+
+    private function passesAuthorization(): bool
+    {
+        if ($this->can === []) {
+            return true;
+        }
+
+        return Authorization::allows($this->can, request());
+    }
+
+    private function passesVisibleCondition(): bool
+    {
+        $condition = $this->visibleCondition instanceof Closure
+            ? (bool) app(Evaluator::class)->resolve($this->visibleCondition, $this->renderContext())
+            : $this->visibleCondition;
+
+        return $this->negatesCondition ? ! $condition : $condition;
     }
 
     protected function renderContext(): EvaluationContext

--- a/tests/Feature/Authorization/DeclaredAbilityTest.php
+++ b/tests/Feature/Authorization/DeclaredAbilityTest.php
@@ -11,6 +11,7 @@ use Lattice\Lattice\Actions\BulkActionDefinition;
 use Lattice\Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Lattice\Attributes\AsAction;
 use Lattice\Lattice\Attributes\AsBulkAction;
+use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Attributes\AsTable;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Core\Services\ComponentReferenceSigner;
@@ -23,6 +24,7 @@ use Lattice\Lattice\Tables\Contracts\TableSource;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableResult;
+use Lattice\Lattice\Ui\Components\Heading;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
@@ -46,6 +48,10 @@ beforeEach(function (): void {
     Route::get('declared-ability-test', [DeclaredAbilityPage::class, 'render'])
         ->middleware('web')
         ->name('declared-ability-test.show');
+
+    Route::get('declared-ability-page-test', [DeclaredAbilityAttributePage::class, 'render'])
+        ->middleware('web')
+        ->name('declared-ability-page-test.show');
 
     withoutVite();
 });
@@ -162,6 +168,61 @@ test('a bulk action inherits its table\'s declared ability', function (): void {
     )->assertForbidden();
 });
 
+test('a declared ability on the page attribute gates the page', function (array $allowed, bool $expected): void {
+    allowAbilities(...$allowed);
+
+    $response = get('/declared-ability-page-test');
+
+    $expected ? $response->assertOk() : $response->assertForbidden();
+})->with([
+    'denied' => [[], false],
+    'allowed' => [['manage-widgets'], true],
+]);
+
+test('an authorize() override cannot widen a page\'s declared ability', function (): void {
+    allowAbilities();
+
+    get('/declared-ability-page-test')->assertForbidden();
+});
+
+test('a declared ability on a component drops it from the payload', function (): void {
+    allowAbilities();
+
+    $this->assertLatticePage(get('/declared-ability-test')->assertOk())
+        ->assertNotRendered('heading:gated-heading');
+
+    allowAbilities('inspect-widgets');
+
+    $this->assertLatticePage(get('/declared-ability-test')->assertOk())
+        ->assertRendered('heading:gated-heading');
+});
+
+test('visible() cannot widen a component\'s declared ability', function (): void {
+    allowAbilities();
+
+    expect(Heading::make('x')->can('manage-widgets')->visible(true)->shouldRender())->toBeFalse();
+});
+
+#[AsPage(can: 'manage-widgets')]
+final class DeclaredAbilityAttributePage extends Page
+{
+    public function title(): string
+    {
+        return 'Declared ability page';
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return true;
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([]);
+    }
+}
+
 #[AsAction('declared.action', can: 'manage-widgets')]
 final class DeclaredAbilityAction extends ActionDefinition
 {
@@ -271,6 +332,7 @@ final class DeclaredAbilityPage extends Page
         return $schema->schema([
             ActionComponent::use(DeclaredAbilityAction::class),
             TableComponent::use(DeclaredAbilityTable::class),
+            Heading::make('Gated heading')->key('gated-heading')->can('inspect-widgets'),
         ]);
     }
 }


### PR DESCRIPTION
Gating was spelled three different ways:

- **Definitions** had an `authorize()` hook plus a `final authorized()` composing it with the attribute's `can`.
- **Pages** had only `authorize()` — no `can`.
- **Components** had `visible()`/`hidden()` closures and no ability check at all.

`authorize` and `authorized` differed by one letter and meant opposite things — one you override, one you must never call.

## What changed

The composition moves into `Core\Authorization`, so there is nothing to `final`-wrap. It reads `can` off the class attribute via the new `DeclaresGate` contract and ANDs it with the subject's `authorize()`. `Definition` drops `authorized()` and its attribute reflection, `Page` drops nothing extra, and `Authorizable` declares just the one method a user overrides.

That leaves one word per concept:

|                                                                 | declare an ability     | custom logic                 |
| --------------------------------------------------------------- | ---------------------- | ---------------------------- |
| Definition — form, table, action, bulk action, fragment, layout | `#[AsTable(can: 'x')]` | `authorize()`                |
| Page                                                            | `#[AsPage(can: 'x')]`  | `authorize()`                |
| Component, column, filter, row action                           | `->can('x')`           | `->visible()` / `->hidden()` |

Pages gain `#[AsPage(can: ...)]` and components gain `->can(...)`, both resolved by the same seam.

A `can` declaration is now un-widenable **by construction** rather than by `final` — the check no longer lives in a class the user extends, so an override cannot reach it, and `->visible(true)` cannot bring back a component whose `can` failed.

## Breaking

- `Core\Contracts\Authorizable` no longer declares `authorized()` (it was only ever added mid-branch); `authorize()` is unchanged, so code extending `Definition` or `Page` is unaffected.
- `DefinitionAttribute::$can` is now private with `can()` as the reader. Nothing read the property.
- `DefinitionRegistry::authorizedToRender()` is inlined — one caller, no overrides.

Pre-1.0, and no user-facing override changes name.

## Tests

Five new tests cover `#[AsPage(can:)]` gating, `->can()` dropping a component from the payload, and both non-widening rules. Mutation-checked: removing `DeclaresGate` from `AsPage` fails exactly the page tests, no-oping the component check fails exactly the component tests.

`1483 passed (5377 assertions)`, PHPStan clean, docs build clean.