### PR TITLE
Build components after refreshing the request identity in test helpers

### DIFF
--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -33,7 +33,7 @@ final readonly class ActionController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, fn () => $definition->validate($request));
+            return $this->validatePrecognitive($request, fn (): array => $definition->validate($request));
         }
 
         $definition->validate($request);

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -40,7 +40,7 @@ final readonly class BulkActionController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, fn () => $definition->validate($request));
+            return $this->validatePrecognitive($request, fn (): array => $definition->validate($request));
         }
 
         $tableKey = $this->trustedTableKey($context);

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -34,7 +34,7 @@ final readonly class FormController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, fn () => $definition->validate($request));
+            return $this->validatePrecognitive($request, fn (): array => $definition->validate($request));
         }
 
         $definition->validate($request);

--- a/src/Support/Testing/InteractsWithLatticeComponents.php
+++ b/src/Support/Testing/InteractsWithLatticeComponents.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Support\Testing;
 
+use Closure;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Http\Request;
 use Illuminate\Testing\TestResponse;
@@ -53,7 +54,7 @@ trait InteractsWithLatticeComponents
      */
     public function submitForm(string $form, array $data = [], array $context = []): LatticeTestResponse
     {
-        $component = $this->sealLatticeComponent(Form::use($form, $context));
+        $component = $this->sealLatticeComponent(fn (): Form => Form::use($form, $context));
 
         return $this->latticeRequest(
             $component['props']['method'] ?? 'post',
@@ -71,7 +72,7 @@ trait InteractsWithLatticeComponents
      */
     public function callAction(string $action, array $data = [], array $context = []): LatticeTestResponse
     {
-        $component = $this->sealLatticeComponent(Action::use($action, $context));
+        $component = $this->sealLatticeComponent(fn (): Action => Action::use($action, $context));
 
         return $this->latticeRequest(
             $component['props']['method'] ?? 'post',
@@ -92,7 +93,7 @@ trait InteractsWithLatticeComponents
      */
     public function callBulkAction(string $bulkAction, array $data = [], array $context = []): LatticeTestResponse
     {
-        $component = $this->sealLatticeComponent(BulkAction::use($bulkAction, $context));
+        $component = $this->sealLatticeComponent(fn (): BulkAction => BulkAction::use($bulkAction, $context));
 
         return $this->latticeRequest(
             $component['props']['method'] ?? 'post',
@@ -110,7 +111,7 @@ trait InteractsWithLatticeComponents
      */
     public function loadTable(string $table, array $query = [], array $context = []): LatticeTestResponse
     {
-        $component = $this->sealLatticeComponent(Table::use($table, $context));
+        $component = $this->sealLatticeComponent(fn (): Table => Table::use($table, $context));
         $url = $component['props']['endpoint'];
 
         if ($query !== []) {
@@ -129,7 +130,7 @@ trait InteractsWithLatticeComponents
      */
     public function loadFragment(string $fragment, array $context = []): LatticeTestResponse
     {
-        $component = $this->sealLatticeComponent(Fragment::lazy($fragment, $context));
+        $component = $this->sealLatticeComponent(fn (): Fragment => Fragment::lazy($fragment, $context));
 
         return $this->latticeTestResponse(
             $this->getJson(
@@ -253,13 +254,20 @@ trait InteractsWithLatticeComponents
     }
 
     /**
+     * Builds the component only after the request identity is refreshed. The
+     * component must not be built by the caller: a `can` declared on its
+     * attribute is resolved against the container's request at build time, and
+     * the stale request a previous dispatch left bound carries no user — the
+     * gate would deny and the component would come back hidden.
+     *
+     * @param  Closure(): mixed  $build
      * @return array<string, mixed>
      */
-    private function sealLatticeComponent(mixed $component): array
+    private function sealLatticeComponent(Closure $build): array
     {
         $this->refreshLatticeRequestIdentity();
 
-        return Wire::toArray($component);
+        return Wire::toArray($build());
     }
 
     /**

--- a/tests/Feature/Authorization/DeclaredAbilityTest.php
+++ b/tests/Feature/Authorization/DeclaredAbilityTest.php
@@ -223,6 +223,19 @@ final class DeclaredAbilityAttributePage extends Page
     }
 }
 
+test('the test helpers reach a can-gated definition', function (): void {
+    allowAbilities('manage-widgets');
+
+    $this->loadTable(DeclaredAbilityTable::class)->assertOk();
+    $this->callAction(DeclaredAbilityAction::class)->assertOk();
+});
+
+test('the test helpers still refuse a denied can-gated definition', function (): void {
+    allowAbilities();
+
+    $this->loadDeniedTable(DeclaredAbilityTable::class)->assertForbidden();
+});
+
 #[AsAction('declared.action', can: 'manage-widgets')]
 final class DeclaredAbilityAction extends ActionDefinition
 {


### PR DESCRIPTION
`can:` (0.28) is unusable through Lattice's own test helpers.

The helpers passed an already-built component in as an argument:

```php
$component = $this->sealLatticeComponent(Table::use($table, $context));
```

PHP evaluates that argument before `sealLatticeComponent()` runs, so the component is built **before** `refreshLatticeRequestIdentity()`. A declared `can` resolves against the container's request at build time, and the stale request a previous dispatch leaves bound carries no user — so the gate denies, the component comes back hidden, and `Wire::toArray()` throws *"must not serialize: shouldRender() is false"*.

Every `can`-gated definition was unreachable through `loadTable()`, `callAction()`, `submitForm()`, `callBulkAction()` and `loadFragment()`. Tests only — a real request carries its own user.

`sealLatticeComponent()` now takes the builder as a closure, so the refresh provably happens first and the ordering can't regress.

Two tests cover it; both fail on `main` and pass here.

Found while adopting 0.28 in the saas-starter-kit, where it broke 19 admin tests.

## Second commit: the red PHP Static job

`AddArrowFunctionReturnTypeRector` wants a return type on the precognitive validate closure in `ActionController`, `BulkActionController` and `FormController`. That is pre-existing on `main` and is what fails the PHP Static job there today — unrelated to this fix, but it blocks any PR, so it's fixed here in its own commit.

Full gate green: Pint, PHPStan, Rector, 1371 tests.