### PR TITLE
feat(js): shared upload transport for signed and multipart flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
       "types": "./dist/core/types.d.ts",
       "import": "./dist/core/types.js"
     },
+    "./core/upload": {
+      "types": "./dist/core/upload.d.ts",
+      "import": "./dist/core/upload.js"
+    },
     "./dnd": {
       "types": "./dist/dnd/index.d.ts",
       "import": "./dist/dnd/index.js"

--- a/resources/js/core/upload.test.ts
+++ b/resources/js/core/upload.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { requestSignedUpload, xhrTransfer } from "./upload";
+
+type Progress = { lengthComputable: boolean; loaded: number; total: number };
+
+class FakeUploadRequest {
+  static instances: FakeUploadRequest[] = [];
+
+  body: unknown = null;
+
+  headers: Record<string, string> = {};
+
+  method = "";
+
+  onerror: (() => void) | null = null;
+
+  onload: (() => void) | null = null;
+
+  responseText = "";
+
+  status = 200;
+
+  upload: { onprogress: ((event: Progress) => void) | null } = { onprogress: null };
+
+  url = "";
+
+  constructor() {
+    FakeUploadRequest.instances.push(this);
+  }
+
+  open(method: string, url: string): void {
+    this.method = method;
+    this.url = url;
+  }
+
+  send(body: unknown): void {
+    this.body = body;
+  }
+
+  setRequestHeader(key: string, value: string): void {
+    this.headers[key] = value;
+  }
+}
+
+function startTransfer(onProgress?: (percent: number) => void): {
+  request: FakeUploadRequest;
+  transfer: Promise<Response>;
+} {
+  const transfer = xhrTransfer({
+    url: "https://rustfs.test/tmp/lamp.jpg?signature=1",
+    method: "PUT",
+    body: new File(["image-data"], "lamp.jpg", { type: "image/jpeg" }),
+    headers: { "x-amz-acl": "private", "content-length": 10 },
+    onProgress,
+  });
+
+  return { request: FakeUploadRequest.instances[0] as FakeUploadRequest, transfer };
+}
+
+describe("xhrTransfer", () => {
+  beforeEach(() => {
+    FakeUploadRequest.instances = [];
+    vi.stubGlobal("XMLHttpRequest", FakeUploadRequest);
+  });
+
+  it("opens the signed request with stringified headers and the raw body", () => {
+    const { request } = startTransfer();
+
+    expect(request.method).toBe("PUT");
+    expect(request.url).toBe("https://rustfs.test/tmp/lamp.jpg?signature=1");
+    expect(request.headers).toEqual({ "x-amz-acl": "private", "content-length": "10" });
+    expect(request.body).toBeInstanceOf(File);
+  });
+
+  it("reports integer progress only while the length is computable", async () => {
+    const percents: number[] = [];
+    const { request, transfer } = startTransfer((percent) => percents.push(percent));
+
+    request.upload.onprogress?.({ lengthComputable: true, loaded: 1, total: 3 });
+    request.upload.onprogress?.({ lengthComputable: false, loaded: 2, total: 3 });
+    request.onload?.();
+    await transfer;
+
+    expect(percents).toEqual([33]);
+  });
+
+  it("resolves a response carrying the transport status and body", async () => {
+    const { request, transfer } = startTransfer();
+
+    request.status = 200;
+    request.responseText = JSON.stringify({ key: "tmp/lamp.jpg" });
+    request.onload?.();
+
+    const response = await transfer;
+
+    expect(response.ok).toBe(true);
+    expect(await response.json()).toEqual({ key: "tmp/lamp.jpg" });
+  });
+
+  it("maps a status of zero to a 500 response instead of hanging", async () => {
+    const { request, transfer } = startTransfer();
+
+    request.status = 0;
+    request.onload?.();
+
+    const response = await transfer;
+
+    expect(response.status).toBe(500);
+    expect(response.ok).toBe(false);
+  });
+
+  it("rejects when the transport fails", async () => {
+    const { request, transfer } = startTransfer();
+
+    request.onerror?.();
+
+    await expect(transfer).rejects.toThrow(
+      "Upload to https://rustfs.test/tmp/lamp.jpg?signature=1 failed",
+    );
+  });
+});
+
+describe("requestSignedUpload", () => {
+  it("posts the upload envelope with the caller's form values spread in", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await requestSignedUpload("/forms/products", {
+      ref: "sealed-ref",
+      target: "items.0.images",
+      filename: "lamp.jpg",
+      contentType: "image/jpeg",
+      values: { sku: "LMP-001", images: [] },
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({ "X-Lattice-Ref": "sealed-ref" });
+    expect(init.body).toBe(
+      JSON.stringify({
+        sku: "LMP-001",
+        images: [],
+        _sub: "upload",
+        _target: "items.0.images",
+        filename: "lamp.jpg",
+        contentType: "image/jpeg",
+      }),
+    );
+  });
+
+  it("omits the values spread and hands a rejected sign back to the caller", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 422 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await requestSignedUpload("/media/library", {
+      ref: "sealed-ref",
+      target: "files",
+      filename: "lamp.jpg",
+      contentType: "image/jpeg",
+    });
+
+    expect(response.status).toBe(422);
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).body).toBe(
+      JSON.stringify({
+        _sub: "upload",
+        _target: "files",
+        filename: "lamp.jpg",
+        contentType: "image/jpeg",
+      }),
+    );
+  });
+});

--- a/resources/js/core/upload.ts
+++ b/resources/js/core/upload.ts
@@ -1,0 +1,73 @@
+import { apiFetch } from "./api";
+
+export type Transfer = {
+  url: string;
+  method: string;
+  body: FormData | File | Blob;
+  headers: Record<string, unknown>;
+  onProgress?: (percent: number) => void;
+};
+
+export type SignedUploadRequest = {
+  ref: string;
+  target: string;
+  filename: string;
+  contentType: string;
+  values?: Record<string, unknown>;
+};
+
+/**
+ * XHR rather than fetch because only XHR reports upload progress. A transport
+ * failure leaves `status` at 0, which `new Response` rejects as out of range, so
+ * it is mapped to 500 — otherwise the promise never settles and the upload hangs.
+ */
+export function xhrTransfer({
+  url,
+  method,
+  body,
+  headers,
+  onProgress,
+}: Transfer): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+
+    request.open(method, url, true);
+    Object.entries(headers).forEach(([key, value]) => request.setRequestHeader(key, String(value)));
+    request.upload.onprogress = (event) => {
+      if (event.lengthComputable) {
+        onProgress?.(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+    request.onload = () => {
+      try {
+        resolve(new Response(request.responseText || null, { status: request.status || 500 }));
+      } catch {
+        reject(new Error(`Upload to ${url} returned an unusable response`));
+      }
+    };
+    request.onerror = () => reject(new Error(`Upload to ${url} failed`));
+    request.send(body);
+  });
+}
+
+/**
+ * Asks the component for a signed upload. Form fields spread their live values
+ * in so the server-side schema walk can find the field inside repeater rows.
+ */
+export function requestSignedUpload(
+  endpoint: string,
+  { ref, target, filename, contentType, values }: SignedUploadRequest,
+): Promise<Response> {
+  return apiFetch(endpoint, {
+    method: "POST",
+    ref,
+    body: JSON.stringify({
+      ...values,
+      _sub: "upload",
+      _target: target,
+      filename,
+      contentType,
+    }),
+    throwOnError: false,
+  });
+}

--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -1,5 +1,5 @@
-import { apiFetch } from "@lattice-php/lattice/core/api";
 import { testIdentity } from "@lattice-php/lattice/core/test-id";
+import { requestSignedUpload, xhrTransfer } from "@lattice-php/lattice/core/upload";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
 import type { SignedUpload } from "@lattice-php/lattice/types/generated";
 import { IconButton } from "@lattice-php/lattice/ui/icon-button";
@@ -146,66 +146,55 @@ export const FileUploadComponent: RendererComponent<"field.file-upload"> = ({ no
   }
 
   async function signAndUpload(item: Item, file: File): Promise<void> {
-    const response = await apiFetch(action, {
-      method: "POST",
-      ref: componentRef,
-      body: JSON.stringify({
-        ...values,
-        _sub: "upload",
-        _target: uploadKey,
-        filename: file.name,
-        contentType: file.type,
-      }),
-      throwOnError: false,
-    });
-
-    if (!response.ok) {
+    const markFailed = (): void => {
       setItems((prev) =>
         prev.map((entry) => (entry.id === item.id ? { ...entry, status: "error" } : entry)),
       );
+    };
+
+    const response = await requestSignedUpload(action, {
+      ref: componentRef,
+      target: uploadKey,
+      filename: file.name,
+      contentType: file.type,
+      values,
+    });
+
+    if (!response.ok) {
+      markFailed();
 
       return;
     }
 
     const sign = (await response.json()) as SignedUpload;
 
-    await new Promise<void>((resolve) => {
-      const request = new XMLHttpRequest();
-      request.open(sign.method.toUpperCase(), sign.url, true);
-      Object.entries(sign.headers).forEach(([key, value]) =>
-        request.setRequestHeader(key, String(value)),
-      );
-      request.upload.onprogress = (event) => {
-        if (event.lengthComputable) {
-          const progress = Math.round((event.loaded / event.total) * 100);
+    try {
+      const put = await xhrTransfer({
+        url: sign.url,
+        method: sign.method.toUpperCase(),
+        body: file,
+        headers: sign.headers,
+        onProgress: (progress) =>
           setItems((prev) =>
             prev.map((entry) => (entry.id === item.id ? { ...entry, progress } : entry)),
-          );
-        }
-      };
-      request.onload = () => {
-        setItems((prev) =>
-          prev.map((entry) =>
-            entry.id === item.id
-              ? {
-                  ...entry,
-                  status: request.status < 300 ? "ready" : "error",
-                  key: sign.key,
-                  progress: 100,
-                }
-              : entry,
           ),
-        );
-        resolve();
-      };
-      request.onerror = () => {
-        setItems((prev) =>
-          prev.map((entry) => (entry.id === item.id ? { ...entry, status: "error" } : entry)),
-        );
-        resolve();
-      };
-      request.send(file);
-    });
+      });
+
+      setItems((prev) =>
+        prev.map((entry) =>
+          entry.id === item.id
+            ? {
+                ...entry,
+                status: put.ok ? "ready" : "error",
+                key: sign.key,
+                progress: 100,
+              }
+            : entry,
+        ),
+      );
+    } catch {
+      markFailed();
+    }
   }
 
   function addFiles(fileList: FileList | null): void {


### PR DESCRIPTION
Follow-up to #332. The signed-upload client transport was duplicated between core's FileUpload field and the media package's upload hook; it now lives in `resources/js/core/upload.ts` (exported as `./core/upload`) with two functions: `xhrTransfer` (progress-reporting XHR, maps a status of 0 to a 500 response so a failed transfer cannot hang) and `requestSignedUpload` (the `_sub: "upload"` envelope over `apiFetch`, with an optional form-values spread for fields inside repeater rows).

`FileUpload` now calls both; its test suite is unchanged, so the state transitions are provably identical apart from the status-0 guard it gains.