### PR TITLE
feat: keyed callouts as state projections

### DIFF
--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -85,12 +85,34 @@ return ActionResult::success()
 
 The `Callout` builder options:
 
-| Method                            | Effect                                                                  |
-| --------------------------------- | ----------------------------------------------------------------------- |
-| `->title($string)`                | Optional heading above the message.                                     |
-| `->dismissible(bool)`             | Show or hide the close button (default: dismissible).                   |
-| `->link($label, $href, $method?)` | Render a link in the callout (`$method` defaults to `HttpMethod::Get`). |
-| `->action($component)`            | Render an action instead of a link.                                     |
+| Method                            | Effect                                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------------ |
+| `->title($string)`                | Optional heading above the message.                                                  |
+| `->dismissible(bool)`             | Show or hide the close button (default: dismissible).                                |
+| `->link($label, $href, $method?)` | Render a link in the callout (`$method` defaults to `HttpMethod::Get`).              |
+| `->action($component)`            | Render an action instead of a link.                                                  |
+| `->unique($key)`                  | Treat the callout as a projection of server state under `$key` rather than an event. |
+
+**Callout lifetimes**
+
+Without a key, a callout is an **event**: emitted once, it stays until the user dismisses it.
+
+With a key it is a **projection of state**. The client replaces any callout sharing the key, and
+drops it on navigation unless the server asserts it again — so a keyed callout must be re-emitted on
+every request for which it still holds, typically from middleware:
+
+```php
+Callout::make(__('billing.past-due'), Variant::Danger)
+    ->unique('billing.state')
+    ->dismissible(false);
+```
+
+This is what makes a standing condition — a failing payment, a maintenance window, a read-only mode —
+expressible. Flashing an unkeyed callout on every request instead would stack a fresh copy per
+navigation, because the layout that hosts the slot persists across visits.
+
+Callouts hold no server-side state. A message that needs identity, a recipient, and read/unread
+tracking is a [notification](/components/notifications/), not a callout.
 
 **Placing the slot in your layout**
 

--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -65,9 +65,9 @@ defaulting to success: `->toast('Saved.')`, `->toast('Could not save.', Variant:
 
 A callout is a persistent in-flow banner — appropriate for warnings, trials, subscription notices, or
 any message that should stay visible until the user acts. Unlike a toast, a callout is not transient:
-it appears in the layout where the `Callouts` slot is placed and stays until the user dismisses it.
-There is no duration or auto-dismiss, and navigating between pages within the same layout does not
-clear it.
+it appears in the layout where the `Callouts` slot is placed. There is no duration or auto-dismiss.
+An unkeyed callout stays until the user dismisses it, and navigating between pages within the same
+layout does not clear it; a keyed callout follows the lifetime described below instead.
 
 Build a `Callout` value object and pass it to `->callout()`:
 
@@ -99,13 +99,24 @@ Without a key, a callout is an **event**: emitted once, it stays until the user 
 
 With a key it is a **projection of state**. The client replaces any callout sharing the key, and
 drops it on navigation unless the server asserts it again — so a keyed callout must be re-emitted on
-every request for which it still holds, typically from middleware:
+every request for which it still holds, typically from middleware.
+
+Retraction only happens on a navigation that **changes the URL**. A same-URL `router.reload()`, a
+`redirect()->back()` to the same URL, polling, and partial reloads do not clear a keyed callout — the
+server must overwrite it explicitly if the condition no longer holds. Browser back/forward is its own
+case: Inertia restores those pages from a history snapshot that carries no flash data, so a keyed
+callout disappears on back/forward regardless of whether the condition still holds, until the next
+request re-asserts it.
 
 ```php
 Callout::make(__('billing.past-due'), Variant::Danger)
     ->unique('billing.state')
     ->dismissible(false);
 ```
+
+The example above disables dismissal: dismissing is a client-only action, and the next re-assertion of
+the same key brings the callout straight back, so letting the user dismiss a standing condition would
+just be undone on the next matching request.
 
 This is what makes a standing condition — a failing payment, a maintenance window, a read-only mode —
 expressible. Flashing an unkeyed callout on every request instead would stack a fresh copy per

--- a/resources/js/effects/registry.test.ts
+++ b/resources/js/effects/registry.test.ts
@@ -107,6 +107,7 @@ describe("builtinEffectHandlers", () => {
         dismissible: true,
         message: "Hi",
         title: null,
+        unique: null,
         variant: "info",
       }),
     );

--- a/resources/js/layout/components/callouts.test.tsx
+++ b/resources/js/layout/components/callouts.test.tsx
@@ -6,13 +6,37 @@ import { Provider } from "@lattice-php/lattice/provider";
 import { Renderer } from "@lattice-php/lattice/core/renderer";
 import { fakeNode } from "@lattice-php/lattice/test-support";
 
-vi.mock("@inertiajs/react", async () =>
-  (await import("@lattice-php/lattice/test/inertia-mock")).inertiaMock(),
-);
+const navigateListeners: Array<() => void> = [];
+
+vi.mock("@inertiajs/react", async () => {
+  const { inertiaMock } = await import("@lattice-php/lattice/test/inertia-mock");
+
+  return inertiaMock({
+    router: {
+      on: (event: string, listener: () => void) => {
+        if (event === "navigate") {
+          navigateListeners.push(listener);
+        }
+
+        return () => undefined;
+      },
+      reload: vi.fn(),
+      visit: vi.fn(),
+    },
+  });
+});
+
+function navigate(): void {
+  act(() => {
+    for (const listener of navigateListeners) {
+      listener();
+    }
+  });
+}
 
 function emitCallout(
   message: string,
-  options: { dismissible?: boolean; action?: unknown } = {},
+  options: { dismissible?: boolean; action?: unknown; unique?: string } = {},
 ): void {
   act(() => {
     window.dispatchEvent(
@@ -23,6 +47,7 @@ function emitCallout(
           message,
           dismissible: options.dismissible ?? true,
           action: options.action ?? null,
+          unique: options.unique ?? null,
         },
       }),
     );
@@ -92,5 +117,48 @@ describe("Callouts slot", () => {
     });
 
     expect(screen.getByRole("link", { name: "Undo" })).toHaveAttribute("href", "/undo");
+  });
+
+  it("replaces a keyed callout instead of stacking it", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    emitCallout("Payment failed", { unique: "billing.state" });
+    emitCallout("Payment failed", { unique: "billing.state" });
+    emitCallout("Payment failed", { unique: "billing.state" });
+
+    expect(screen.getAllByText("Payment failed")).toHaveLength(1);
+  });
+
+  it("keeps unkeyed callouts stacking", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    emitCallout("Archived.");
+    emitCallout("Archived.");
+
+    expect(screen.getAllByText("Archived.")).toHaveLength(2);
+  });
+
+  it("drops keyed callouts on navigation and keeps unkeyed ones", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    emitCallout("Payment failed", { unique: "billing.state" });
+    emitCallout("Archived.");
+
+    navigate();
+
+    expect(screen.queryByText("Payment failed")).not.toBeInTheDocument();
+    expect(screen.getByText("Archived.")).toBeInTheDocument();
   });
 });

--- a/resources/js/layout/components/callouts.test.tsx
+++ b/resources/js/layout/components/callouts.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { vi } from "vitest";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
 import { Provider } from "@lattice-php/lattice/provider";
@@ -55,6 +55,10 @@ function emitCallout(
 }
 
 describe("Callouts slot", () => {
+  beforeEach(() => {
+    navigateListeners.length = 0;
+  });
+
   it("renders callouts emitted on the bus and dismisses them", () => {
     render(
       <Provider toaster={false}>

--- a/resources/js/layout/components/callouts.tsx
+++ b/resources/js/layout/components/callouts.tsx
@@ -16,10 +16,14 @@ let nextId = 0;
 
 /**
  * Renders callouts emitted on the bus. A keyed callout is a projection of
- * server state: it replaces any callout sharing its key, and is dropped on
- * navigation unless the server re-asserts it. Inertia fires `navigate` before
- * `flash` on both initial load and every visit, so re-assertion always wins
- * over the clear and no ordering guard is needed.
+ * server state: it replaces any callout sharing its key, and is dropped when
+ * `navigate` fires. Inertia only fires `navigate` for a URL-changing visit
+ * (initial load included); a same-URL visit — `router.reload()`,
+ * `redirect()->back()` to the same URL, polling, partial reloads — sets
+ * `replace` instead and never fires it, so the callout survives until the
+ * server overwrites or drops it. On these URL-changing visits, `navigate`
+ * fires before `flash`, so re-assertion always wins over the clear and no
+ * ordering guard is needed.
  */
 const Callouts: RendererComponent<"callouts"> = () => {
   const { t } = useT("lattice");

--- a/resources/js/layout/components/callouts.tsx
+++ b/resources/js/layout/components/callouts.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@lattice-php/lattice/icons";
+import { router } from "@inertiajs/react";
 import { useEffect, useState } from "react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import type { Callout } from "@lattice-php/lattice/types/generated";
@@ -13,6 +14,13 @@ type CalloutItem = Callout & { id: number };
 
 let nextId = 0;
 
+/**
+ * Renders callouts emitted on the bus. A keyed callout is a projection of
+ * server state: it replaces any callout sharing its key, and is dropped on
+ * navigation unless the server re-asserts it. Inertia fires `navigate` before
+ * `flash` on both initial load and every visit, so re-assertion always wins
+ * over the clear and no ordering guard is needed.
+ */
 const Callouts: RendererComponent<"callouts"> = () => {
   const { t } = useT("lattice");
   const [callouts, setCallouts] = useState<CalloutItem[]>([]);
@@ -20,7 +28,21 @@ const Callouts: RendererComponent<"callouts"> = () => {
   useEffect(
     () =>
       onCallout((callout) => {
-        setCallouts((current) => [...current, { ...callout, id: nextId++ }]);
+        setCallouts((current) => {
+          const kept = callout.unique
+            ? current.filter((existing) => existing.unique !== callout.unique)
+            : current;
+
+          return [...kept, { ...callout, id: nextId++ }];
+        });
+      }),
+    [],
+  );
+
+  useEffect(
+    () =>
+      router.on("navigate", () => {
+        setCallouts((current) => current.filter((callout) => !callout.unique));
       }),
     [],
   );

--- a/resources/js/toast/callout.test.ts
+++ b/resources/js/toast/callout.test.ts
@@ -16,6 +16,7 @@ describe("normalizeCallout", () => {
       message: "Ends soon",
       dismissible: false,
       action: null,
+      unique: null,
     });
   });
 
@@ -37,5 +38,13 @@ describe("normalizeCallout", () => {
     const callout = normalizeCallout({ message: "Hi" });
     expect(callout?.variant).toBe("info");
     expect(callout?.dismissible).toBe(true);
+  });
+
+  it("normalizes the unique key and defaults it to null", () => {
+    expect(normalizeCallout({ message: "Hi", unique: "billing.state" })?.unique).toBe(
+      "billing.state",
+    );
+    expect(normalizeCallout({ message: "Hi" })?.unique).toBeNull();
+    expect(normalizeCallout({ message: "Hi", unique: 42 })?.unique).toBeNull();
   });
 });

--- a/resources/js/toast/callout.ts
+++ b/resources/js/toast/callout.ts
@@ -26,6 +26,7 @@ export function normalizeCallout(detail: unknown): Callout | null {
     message,
     title:
       typeof callout.title === "string" || isTranslatable(callout.title) ? callout.title : null,
+    unique: typeof callout.unique === "string" ? callout.unique : null,
     variant: isVariant(callout.variant) ? callout.variant : "info",
   };
 }

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -281,6 +281,7 @@ export type Callout = {
   dismissible: boolean;
   message: Translatable | string;
   title: Translatable | string | null;
+  unique: string | null;
   variant: Variant;
 };
 export type Callouts = Record<string, never>;

--- a/src/Effects/Builtin/Callout.php
+++ b/src/Effects/Builtin/Callout.php
@@ -15,6 +15,12 @@ use Lattice\Lattice\Ui\Enums\Variant;
  * A callout: a prominent, persistent banner rendered in a layout's Callouts
  * slot. A heading plus body and variant, with an optional dismiss button and
  * an action (a link or a full Action).
+ *
+ * Without a unique key a callout is an event: emitted once, it stays until the
+ * user dismisses it. With one it is a projection of server state — the client
+ * replaces any callout sharing the key and drops it on navigation unless the
+ * server asserts it again, so a keyed callout must be re-emitted on every
+ * request for which it still holds.
  */
 #[AsEffect('callout')]
 final class Callout extends Effect
@@ -25,6 +31,7 @@ final class Callout extends Effect
         public string|Translatable|null $title = null,
         public bool $dismissible = true,
         public ?Component $action = null,
+        public ?string $unique = null,
     ) {}
 
     public static function make(string|Translatable $message, Variant $variant = Variant::Info): self
@@ -42,6 +49,13 @@ final class Callout extends Effect
     public function dismissible(bool $dismissible = true): self
     {
         $this->dismissible = $dismissible;
+
+        return $this;
+    }
+
+    public function unique(string $key): self
+    {
+        $this->unique = $key;
 
         return $this;
     }

--- a/src/Effects/Builtin/Callout.php
+++ b/src/Effects/Builtin/Callout.php
@@ -18,9 +18,10 @@ use Lattice\Lattice\Ui\Enums\Variant;
  *
  * Without a unique key a callout is an event: emitted once, it stays until the
  * user dismisses it. With one it is a projection of server state — the client
- * replaces any callout sharing the key and drops it on navigation unless the
- * server asserts it again, so a keyed callout must be re-emitted on every
- * request for which it still holds.
+ * replaces any callout sharing the key and drops it on a URL-changing
+ * navigation unless the server asserts it again (a same-URL reload, back(),
+ * or poll does not retract it; browser back/forward always drops it), so a
+ * keyed callout must be re-emitted on every request for which it still holds.
  */
 #[AsEffect('callout')]
 final class Callout extends Effect

--- a/tests/Feature/Actions/EffectSerializationTest.php
+++ b/tests/Feature/Actions/EffectSerializationTest.php
@@ -118,6 +118,20 @@ test('action results expose the callout effect', function (): void {
         ->and(wire($result)['effects'][0]['props']['variant'])->toBe('info');
 });
 
+test('a callout carries its unique key on the wire', function (): void {
+    $wire = wire(
+        Callout::make('Your payment failed.', Variant::Danger)->unique('billing.state'),
+    );
+
+    expect($wire['props']['unique'])->toBe('billing.state');
+});
+
+test('a callout without a unique key serializes it as null', function (): void {
+    $wire = wire(Callout::make('Saved as draft.', Variant::Info));
+
+    expect($wire['props']['unique'])->toBeNull();
+});
+
 test('action groups serialize grouped child actions', function (): void {
     $group = wire(ActionGroup::make('workbench.user-actions')
         ->label('Manage user')


### PR DESCRIPTION
Adds `Callout::unique($key)`. A keyed callout is a projection of server state rather than an event:
the client replaces any callout sharing the key, and drops it on navigation unless the server asserts
it again.

Without this, a callout re-flashed on every request stacks a fresh copy per navigation — `SchemaLayout`
is a persistent Inertia layout, so `Callouts` state survives visits. A flash channel also cannot
retract, so a banner outlives the condition that produced it.

## Retraction boundary

Retraction happens on a navigation that **changes the URL** (initial load included). Inertia treats a
same-URL visit as a `replace` and never fires `navigate` for it, so `router.reload()`, a
`redirect()->back()` to the same URL, polling, and partial reloads do **not** retract a keyed callout —
it survives until the server overwrites or drops it on a later URL-changing visit. Browser back/forward
does fire `navigate`, but history entries are stored with the flash bag stripped, so a keyed callout
disappears there until the next server visit regardless of whether the condition still holds.

This is documented in `docs/content/docs/actions/effects.mdx`. Stacking is fixed unconditionally;
retraction is a strict improvement over the previous state, in which it was impossible everywhere.

Unkeyed callouts are unchanged.

## Note for consumers

`unique: null` now appears on the wire for every serialized callout, since `SerializesToWire` reflects
public properties — a downstream strict `toEqual`/snapshot on callout props will need updating.