### PR TITLE
feat: callout retraction, full-page reload, and client-side date formatting

### DIFF
--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -31,6 +31,7 @@ return ActionResult::success()
 | ------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `->toast($message, $variant)`                           | Shows a toast. Variant defaults to success.                                  |
 | `->callout($callout)`                                   | Shows a persistent in-flow banner in the layout's callout slot.              |
+| `->retractCallout($key)`                                | Drops a keyed callout, even on a same-URL visit.                             |
 | `->reloadComponent($id)`                                | Re-fetches a single component (e.g. the table the action changed).           |
 | `->reloadPage()`                                        | Reloads the current page's props.                                            |
 | `->to($url)` / `->toRoute($name, $params)` / `->back()` | Navigates to a URL, a named route, or the previous page.                     |
@@ -121,6 +122,25 @@ just be undone on the next matching request.
 This is what makes a standing condition — a failing payment, a maintenance window, a read-only mode —
 expressible. Flashing an unkeyed callout on every request instead would stack a fresh copy per
 navigation, because the layout that hosts the slot persists across visits.
+
+**Retracting a keyed callout**
+
+The same-URL cases described above — `router.reload()`, `redirect()->back()` to the same URL,
+polling, and partial reloads — have no way to clear a keyed callout just by omitting it.
+`Callout::retract($key)` states explicitly that the key no longer applies; the client drops any
+callout carrying it regardless of visit type.
+
+The natural place to assert or retract a keyed callout is middleware that runs on every request, so
+the callout always reflects current state:
+
+```php
+Effects::flash($callout ?? Callout::retract('billing.state'));
+```
+
+Here `$callout` is `null` when the condition (a failing payment, say) no longer holds, so the
+middleware falls back to retracting the key instead of asserting a `Callout`. `ActionResult` and
+`LatticeResponse` expose the same behavior as `->retractCallout($key)`, for when the clearing
+condition is detected inside an action rather than middleware.
 
 Callouts hold no server-side state. A message that needs identity, a recipient, and read/unread
 tracking is a [notification](/components/notifications/), not a callout.

--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -33,7 +33,7 @@ return ActionResult::success()
 | `->callout($callout)`                                   | Shows a persistent in-flow banner in the layout's callout slot.              |
 | `->retractCallout($key)`                                | Drops a keyed callout, even on a same-URL visit.                             |
 | `->reloadComponent($id)`                                | Re-fetches a single component (e.g. the table the action changed).           |
-| `->reloadPage()`                                        | Reloads the current page's props.                                            |
+| `->reloadPage($full = false)`                           | Reloads the current page. `full` does a real browser reload.                 |
 | `->to($url)` / `->toRoute($name, $params)` / `->back()` | Navigates to a URL, a named route, or the previous page.                     |
 | `->download($url)`                                      | Triggers a file download.                                                    |
 | `->openModal($id)` / `->closeModal($id)`                | Opens or closes a modal by id (`closeModal()` closes the current modal).     |
@@ -189,6 +189,19 @@ component re-fetches:
 
 ```php
 return ActionResult::success()->reloadComponent('app.products');
+```
+
+`->reloadPage()` re-fetches the current page's props with an Inertia visit — the layout and its
+client state (open menus, form drafts, scroll position) stay mounted. That is the right default for
+almost every server-side change, including a stale callout that should just disappear: use
+`Callout::retract()` for that, not a page reload.
+
+Pass `true` for a full browser reload (`window.location.reload()`) when the change invalidates the
+whole shell and an Inertia revisit is not enough — starting or stopping impersonation, a role change
+that reshapes navigation, or an asset/version bump:
+
+```php
+return ActionResult::success()->reloadPage(full: true);
 ```
 
 ## Flashing effects without an action

--- a/docs/content/docs/actions/effects.mdx
+++ b/docs/content/docs/actions/effects.mdx
@@ -251,6 +251,10 @@ Effects::flash(
 );
 ```
 
+`->with()` also accepts `DateTimeInterface` values, formatted client-side in the reader's own
+locale — see [`Translatable` and `rt()`](/core/i18n/#translatable-and-rt) for how dates travel over
+the wire and render.
+
 Effects built inside a normal request already run in the user's locale, so plain `__()` strings
 remain the default there.
 

--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -185,6 +185,50 @@ translate("app", "save", "Save");
 
 Both take the English fallback inline, so they are safe to call before any translations have loaded.
 
+## `Translatable` and `rt()`
+
+Some strings can't be translated at the point they're produced — a queued listener flashing a
+callout, a [realtime toast](/core/realtime/) broadcast to many subscribers, or a notification
+stored today and read tomorrow by someone in a different locale. `rt()` builds a `Translatable`: an
+i18next key plus replacements, resolved through `t()` on the **client**, in the reader's locale, at
+render time — instead of a finished string baked into the sender's locale:
+
+```php
+rt('billing:subscription-ends')->with(['plan' => 'Pro']);
+```
+
+`->with()` accepts scalars and `DateTimeInterface` instances. A date is serialized to an ISO 8601
+string on the wire — the wire stays flat scalars, never a typed date marker — and formatted
+client-side, in the reader's locale, by Lattice's `datetime` formatter (a superset of i18next's
+built-in one), using its normal format syntax in the translation string:
+
+```php
+use Carbon\CarbonImmutable;
+
+rt('billing:subscription-ends')->with([
+    'plan' => 'Pro',
+    'date' => CarbonImmutable::parse($subscription->ends_at),
+]);
+```
+
+```php
+// lang/en/billing.php
+return ['subscription-ends' => 'Your {{plan}} plan ends on {{date, datetime(dateStyle: long)}}'];
+
+// lang/de/billing.php
+return ['subscription-ends' => 'Ihr {{plan}}-Plan endet am {{date, datetime(dateStyle: long)}}'];
+```
+
+Same stored payload, each reader gets their own date: an English reader sees "Your Pro plan ends on
+March 6, 2026", a German reader sees "Ihr Pro-Plan endet am 6. März 2026". The full
+`Intl.DateTimeFormat` option surface is available through the `datetime(...)` format — see
+[i18next's formatting docs](https://www.i18next.com/translation-function/formatting) for the option
+syntax. A replacement that isn't a valid date (or isn't a date at all) renders as its raw value
+instead of throwing.
+
+`rt()` is used by [callout and toast effects](/actions/effects/#deferred-translation-with-rt) and
+[notifications](/components/notifications/#localized-notifications).
+
 ## Language detection
 
 The frontend picks its initial language from `localStorage.locale`, the `locale` cookie, the

--- a/resources/js/core/event-names.ts
+++ b/resources/js/core/event-names.ts
@@ -5,6 +5,7 @@
  */
 export const LATTICE_EVENT = {
   callout: "lattice:callout",
+  retractCallout: "lattice:retract-callout",
   toast: "lattice:toast",
   reloadComponent: "lattice:reload-component",
   openModal: "lattice:open-modal",

--- a/resources/js/effects/registry.test.ts
+++ b/resources/js/effects/registry.test.ts
@@ -117,6 +117,19 @@ describe("builtinEffectHandlers", () => {
     expect(received[0]).toMatchObject({ message: "Hi" });
   });
 
+  it("retract-callout bridges to the lattice:retract-callout DOM event with the props as detail", () => {
+    const received: unknown[] = [];
+    const listener = (event: Event) => received.push((event as CustomEvent).detail);
+    window.addEventListener(LATTICE_EVENT.retractCallout, listener);
+
+    builtinEffectHandlers["retract-callout"](
+      effect("retract-callout", { unique: "billing.state" }),
+    );
+
+    window.removeEventListener(LATTICE_EVENT.retractCallout, listener);
+    expect(received).toEqual([{ unique: "billing.state" }]);
+  });
+
   it("reloadComponent bridges to the lattice:reload-component DOM event", () => {
     const listener = vi.fn<(event: Event) => void>();
     window.addEventListener(LATTICE_EVENT.reloadComponent, listener);

--- a/resources/js/effects/registry.test.ts
+++ b/resources/js/effects/registry.test.ts
@@ -20,12 +20,23 @@ afterEach(() => {
   router.visit.mockReset();
   setLocale.mockReset();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("builtinEffectHandlers", () => {
-  it("reloadPage calls router.reload()", () => {
-    builtinEffectHandlers["reload-page"](effect("reload-page", {}));
+  it("reloadPage calls router.reload() by default", () => {
+    builtinEffectHandlers["reload-page"](effect("reload-page", { full: false }));
     expect(router.reload).toHaveBeenCalledOnce();
+  });
+
+  it("reloadPage calls window.location.reload() when full is set", () => {
+    const reload = vi.fn();
+    vi.stubGlobal("location", { ...window.location, reload });
+
+    builtinEffectHandlers["reload-page"](effect("reload-page", { full: true }));
+
+    expect(reload).toHaveBeenCalledOnce();
+    expect(router.reload).not.toHaveBeenCalled();
   });
 
   it("redirect visits the url", () => {
@@ -64,7 +75,7 @@ describe("builtinEffectHandlers", () => {
     window.addEventListener("lattice:download", listener);
     window.addEventListener(LATTICE_EVENT.localeChange, listener);
 
-    builtinEffectHandlers["reload-page"](effect("reload-page", {}));
+    builtinEffectHandlers["reload-page"](effect("reload-page", { full: false }));
     builtinEffectHandlers.redirect(effect("redirect", { url: "/x" }));
     builtinEffectHandlers.download(effect("download", { url: "/f.csv" }));
     builtinEffectHandlers["locale-change"](effect("locale-change", { locale: "fr" }));

--- a/resources/js/effects/registry.ts
+++ b/resources/js/effects/registry.ts
@@ -56,6 +56,7 @@ const typedBuiltinHandlers: { [K in keyof EffectPropsMap]: EffectHandler<K> } = 
   "locale-change": (effect) => setLocale(effect.props.locale),
   toast: bridge<"toast">(LATTICE_EVENT.toast),
   callout: bridge<"callout">(LATTICE_EVENT.callout),
+  "retract-callout": bridge<"retract-callout">(LATTICE_EVENT.retractCallout),
   "reload-component": bridge<"reload-component">(LATTICE_EVENT.reloadComponent),
   "open-modal": bridge<"open-modal">(LATTICE_EVENT.openModal),
   "close-modal": bridge<"close-modal">(LATTICE_EVENT.closeModal),

--- a/resources/js/effects/registry.ts
+++ b/resources/js/effects/registry.ts
@@ -50,7 +50,7 @@ function bridge<TType extends keyof EffectPropsMap & string>(event: string): Eff
  * effectHandler performs.
  */
 const typedBuiltinHandlers: { [K in keyof EffectPropsMap]: EffectHandler<K> } = {
-  "reload-page": () => router.reload(),
+  "reload-page": (effect) => (effect.props.full ? window.location.reload() : router.reload()),
   redirect: (effect) => router.visit(effect.props.url),
   download: (effect) => triggerDownload(effect.props.url),
   "locale-change": (effect) => setLocale(effect.props.locale),

--- a/resources/js/format/date-time.test.ts
+++ b/resources/js/format/date-time.test.ts
@@ -1,5 +1,47 @@
 import { describe, expect, it } from "vitest";
-import { formatDateValue, preciseDateTime } from "./date-time";
+import { formatDateValue, preciseDateTime, toDate } from "./date-time";
+
+describe("toDate", () => {
+  it("parses an ISO string", () => {
+    expect(toDate("2026-06-18T00:30:00Z")).toEqual(new Date("2026-06-18T00:30:00Z"));
+  });
+
+  it("parses a numeric timestamp", () => {
+    const timestamp = new Date("2026-06-18T00:30:00Z").getTime();
+
+    expect(toDate(timestamp)).toEqual(new Date(timestamp));
+  });
+
+  it("passes through a valid Date instance", () => {
+    const date = new Date("2026-06-18T00:30:00Z");
+
+    expect(toDate(date)).toBe(date);
+  });
+
+  it("returns null for an unparseable string", () => {
+    expect(toDate("not-a-date")).toBeNull();
+  });
+
+  it("returns null for an invalid Date instance", () => {
+    expect(toDate(new Date("not-a-date"))).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(toDate(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(toDate(undefined)).toBeNull();
+  });
+
+  it("returns null for a plain object", () => {
+    expect(toDate({})).toBeNull();
+  });
+
+  it("returns null for a boolean", () => {
+    expect(toDate(true)).toBeNull();
+  });
+});
 
 describe("preciseDateTime", () => {
   it("includes the IANA zone id and a year", () => {

--- a/resources/js/format/date-time.ts
+++ b/resources/js/format/date-time.ts
@@ -40,6 +40,17 @@ export function formatDateValue(value: unknown, date: DateConfig, options?: Form
   return new Intl.DateTimeFormat(options?.locale, intl).format(parsed);
 }
 
+export function toDate(value: unknown): Date | null {
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === "string" || typeof value === "number"
+        ? new Date(value)
+        : null;
+
+  return date && !Number.isNaN(date.getTime()) ? date : null;
+}
+
 export function preciseDateTime(value: unknown, options?: FormatOptions): string {
   const date = new Date(String(value));
 

--- a/resources/js/i18n/date-time-formatter.test.ts
+++ b/resources/js/i18n/date-time-formatter.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureI18n, i18n, translate } from "./instance";
+import { setTimezone } from "./timezone";
+
+const namespace = "date-time-formatter-test";
+const key = "subscription-ends";
+const iso = "2026-03-06T00:00:00+00:00";
+
+function addBundles(format: string): void {
+  for (const locale of ["en", "de"]) {
+    if (i18n.hasResourceBundle(locale, namespace)) {
+      i18n.removeResourceBundle(locale, namespace);
+    }
+  }
+
+  i18n.addResourceBundle(
+    "en",
+    namespace,
+    { [key]: `Your subscription ends on {{date, ${format}}}` },
+    true,
+    true,
+  );
+  i18n.addResourceBundle(
+    "de",
+    namespace,
+    { [key]: `Ihr Abonnement endet am {{date, ${format}}}` },
+    true,
+    true,
+  );
+}
+
+describe("datetime formatter", () => {
+  beforeEach(async () => {
+    await ensureI18n();
+    setTimezone("UTC");
+    addBundles("datetime(dateStyle: long)");
+    await i18n.changeLanguage("en");
+  });
+
+  afterEach(() => {
+    setTimezone("");
+  });
+
+  it("formats an ISO string in the reader's locale", async () => {
+    const english = translate(namespace, key, key, { date: iso });
+    expect(english).toBe("Your subscription ends on March 6, 2026");
+
+    await i18n.changeLanguage("de");
+    const german = translate(namespace, key, key, { date: iso });
+    expect(german).toBe("Ihr Abonnement endet am 6. März 2026");
+
+    expect(english).not.toBe(german);
+  });
+
+  it("formats a numeric timestamp the same way as its equivalent ISO string", () => {
+    const timestamp = new Date(iso).getTime();
+
+    expect(translate(namespace, key, key, { date: timestamp })).toBe(
+      translate(namespace, key, key, { date: iso }),
+    );
+  });
+
+  it("still formats a Date instance", () => {
+    expect(translate(namespace, key, key, { date: new Date(iso) })).toBe(
+      "Your subscription ends on March 6, 2026",
+    );
+  });
+
+  it("degrades an unparseable string to its raw value instead of throwing", () => {
+    expect(() => translate(namespace, key, key, { date: "not-a-date" })).not.toThrow();
+    expect(translate(namespace, key, key, { date: "not-a-date" })).toBe(
+      "Your subscription ends on not-a-date",
+    );
+  });
+
+  it("degrades an already-invalid Date instance to the literal 'Invalid Date'", () => {
+    const invalid = new Date("nonsense");
+
+    expect(() => translate(namespace, key, key, { date: invalid })).not.toThrow();
+    expect(translate(namespace, key, key, { date: invalid })).toBe(
+      "Your subscription ends on Invalid Date",
+    );
+  });
+
+  it("formats in Lattice's currentTimezone(), not the host's local zone", () => {
+    setTimezone("America/New_York");
+
+    expect(translate(namespace, key, key, { date: iso })).toBe(
+      "Your subscription ends on March 5, 2026",
+    );
+  });
+
+  it("lets an explicit timeZone in the translation string's format options override currentTimezone()", () => {
+    addBundles("datetime(dateStyle: long; timeZone: 'America/New_York')");
+
+    expect(translate(namespace, key, key, { date: iso })).toBe(
+      "Your subscription ends on March 5, 2026",
+    );
+  });
+
+  it("re-reads currentTimezone() on every call, so setTimezone() takes effect immediately", () => {
+    const beforeSwitch = translate(namespace, key, key, { date: iso });
+    expect(beforeSwitch).toBe("Your subscription ends on March 6, 2026");
+
+    setTimezone("America/New_York");
+    const afterSwitch = translate(namespace, key, key, { date: iso });
+    expect(afterSwitch).toBe("Your subscription ends on March 5, 2026");
+
+    expect(beforeSwitch).not.toBe(afterSwitch);
+  });
+});

--- a/resources/js/i18n/date-time-formatter.ts
+++ b/resources/js/i18n/date-time-formatter.ts
@@ -1,0 +1,26 @@
+import type { i18n as I18nInstance } from "i18next";
+import { toDate } from "@lattice-php/lattice/format/date-time";
+import { currentTimezone } from "./timezone";
+
+/**
+ * i18next's built-in `datetime` formatter throws on a string, and
+ * `Translatable::with()` sends dates over the wire as ISO 8601 strings, so
+ * coercion to `Date` is required first.
+ *
+ * Replaces i18next's built-in `datetime` formatter on the shared instance,
+ * for every consumer of it — not just Lattice's own translations.
+ *
+ * Pins the formatter to Lattice's own {@link currentTimezone}, the same
+ * source `<DateTime>` renders through, so both agree on calendar day.
+ */
+export function registerDateTimeFormatter(instance: I18nInstance): void {
+  instance.services.formatter?.add("datetime", (value, lng, options) => {
+    const date = toDate(value);
+
+    if (!date) {
+      return String(value ?? "");
+    }
+
+    return new Intl.DateTimeFormat(lng, { timeZone: currentTimezone(), ...options }).format(date);
+  });
+}

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -1,6 +1,7 @@
 import i18next, { type i18n as I18nInstance, type InitOptions } from "i18next";
 import { useCallback, useSyncExternalStore } from "react";
 import { useConfig } from "./config";
+import { registerDateTimeFormatter } from "./date-time-formatter";
 import { currentLocale, subscribeLocale, useLocale } from "./locale";
 
 export const DEFAULT_NAMESPACE = "lattice";
@@ -66,6 +67,8 @@ export function ensureI18n(extend?: (base: InitOptions) => InitOptions): Promise
     };
 
     initialization = i18n.init(extend ? extend(base) : base);
+    // `services.formatter` only exists once `init()` has run, so this must follow it.
+    registerDateTimeFormatter(i18n);
   }
 
   return initialization;

--- a/resources/js/layout/components/callouts.test.tsx
+++ b/resources/js/layout/components/callouts.test.tsx
@@ -54,6 +54,16 @@ function emitCallout(
   });
 }
 
+function retractCallout(unique: string): void {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(LATTICE_EVENT.retractCallout, {
+        detail: { unique },
+      }),
+    );
+  });
+}
+
 describe("Callouts slot", () => {
   beforeEach(() => {
     navigateListeners.length = 0;
@@ -163,6 +173,50 @@ describe("Callouts slot", () => {
     navigate();
 
     expect(screen.queryByText("Payment failed")).not.toBeInTheDocument();
+    expect(screen.getByText("Archived.")).toBeInTheDocument();
+  });
+
+  it("drops a keyed callout when its key is retracted", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    emitCallout("Payment failed", { unique: "billing.state" });
+
+    retractCallout("billing.state");
+
+    expect(screen.queryByText("Payment failed")).not.toBeInTheDocument();
+  });
+
+  it("leaves a different key alone when retracting", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    emitCallout("Payment failed", { unique: "billing.state" });
+    emitCallout("Read-only mode", { unique: "maintenance.mode" });
+
+    retractCallout("billing.state");
+
+    expect(screen.queryByText("Payment failed")).not.toBeInTheDocument();
+    expect(screen.getByText("Read-only mode")).toBeInTheDocument();
+  });
+
+  it("leaves an unkeyed callout alone when retracting", () => {
+    render(
+      <Provider toaster={false}>
+        <Renderer nodes={[fakeNode({ type: "callouts", id: "c", props: {} })]} />
+      </Provider>,
+    );
+
+    emitCallout("Archived.");
+
+    retractCallout("billing.state");
+
     expect(screen.getByText("Archived.")).toBeInTheDocument();
   });
 });

--- a/resources/js/layout/components/callouts.tsx
+++ b/resources/js/layout/components/callouts.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { RenderNode } from "@lattice-php/lattice/core/renderer";
 import type { Callout } from "@lattice-php/lattice/types/generated";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
-import { onCallout } from "@lattice-php/lattice/toast";
+import { onCallout, onRetractCallout } from "@lattice-php/lattice/toast";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { useT } from "@lattice-php/lattice/i18n";
 import { resolveText } from "@lattice-php/lattice/i18n/translatable";
@@ -23,7 +23,8 @@ let nextId = 0;
  * `replace` instead and never fires it, so the callout survives until the
  * server overwrites or drops it. On these URL-changing visits, `navigate`
  * fires before `flash`, so re-assertion always wins over the clear and no
- * ordering guard is needed.
+ * ordering guard is needed. A `retract-callout` effect clears one on a
+ * same-URL response too.
  */
 const Callouts: RendererComponent<"callouts"> = () => {
   const { t } = useT("lattice");
@@ -47,6 +48,14 @@ const Callouts: RendererComponent<"callouts"> = () => {
     () =>
       router.on("navigate", () => {
         setCallouts((current) => current.filter((callout) => !callout.unique));
+      }),
+    [],
+  );
+
+  useEffect(
+    () =>
+      onRetractCallout((unique) => {
+        setCallouts((current) => current.filter((callout) => callout.unique !== unique));
       }),
     [],
   );

--- a/resources/js/toast/callout.ts
+++ b/resources/js/toast/callout.ts
@@ -1,4 +1,4 @@
-import type { Callout } from "@lattice-php/lattice/types/generated";
+import type { Callout, RetractCallout } from "@lattice-php/lattice/types/generated";
 import { LATTICE_EVENT } from "@lattice-php/lattice/core/event-names";
 import { isTranslatable } from "@lattice-php/lattice/i18n/translatable";
 import { isVariant } from "./toast";
@@ -43,4 +43,18 @@ export function onCallout(callback: (callout: Callout) => void): () => void {
   window.addEventListener(LATTICE_EVENT.callout, listener);
 
   return () => window.removeEventListener(LATTICE_EVENT.callout, listener);
+}
+
+export function onRetractCallout(callback: (unique: string) => void): () => void {
+  const listener = (event: Event): void => {
+    const unique = (event as CustomEvent<RetractCallout>).detail?.unique;
+
+    if (typeof unique === "string") {
+      callback(unique);
+    }
+  };
+
+  window.addEventListener(LATTICE_EVENT.retractCallout, listener);
+
+  return () => window.removeEventListener(LATTICE_EVENT.retractCallout, listener);
 }

--- a/resources/js/toast/index.ts
+++ b/resources/js/toast/index.ts
@@ -1,4 +1,4 @@
-export { normalizeCallout, onCallout } from "./callout";
+export { normalizeCallout, onCallout, onRetractCallout } from "./callout";
 export type { Callout } from "./callout";
 export { Toaster } from "./toaster";
 export { onToast } from "./toast";

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -679,6 +679,7 @@ export type EffectPropsMap = {
   "reload-component": ReloadComponent;
   "reload-page": ReloadPage;
   "reset-form": ResetForm;
+  "retract-callout": RetractCallout;
   toast: Toast;
   "toggle-sidebar": ToggleSidebar;
 };
@@ -1277,6 +1278,9 @@ export type ResolveResponse = {
   readonly fields: Record<string, Node>;
   readonly prefill: Record<string, unknown>;
   readonly values: Record<string, unknown>;
+};
+export type RetractCallout = {
+  readonly unique: string;
 };
 export type RichEditor = {
   columnWidth: ColumnWidth;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1233,7 +1233,9 @@ export type Redirect = {
 export type ReloadComponent = {
   readonly component: string;
 };
-export type ReloadPage = Record<string, never>;
+export type ReloadPage = {
+  readonly full: boolean;
+};
 export type RemoteAccess = {
   readonly audience: string;
   readonly nodeId: string;

--- a/src/Effects/Builtin/Callout.php
+++ b/src/Effects/Builtin/Callout.php
@@ -72,4 +72,13 @@ final class Callout extends Effect
 
         return $this;
     }
+
+    /**
+     * States that the keyed callout `$key` no longer applies. Pair it with
+     * the asserting `Callout`: `Effects::flash($callout ?? Callout::retract('billing.state'))`.
+     */
+    public static function retract(string $key): RetractCallout
+    {
+        return new RetractCallout($key);
+    }
 }

--- a/src/Effects/Builtin/ReloadPage.php
+++ b/src/Effects/Builtin/ReloadPage.php
@@ -6,5 +6,17 @@ namespace Lattice\Lattice\Effects\Builtin;
 use Lattice\Lattice\Effects\Attributes\AsEffect;
 use Lattice\Lattice\Effects\Effect;
 
+/**
+ * Reloads the current page. By default this is an Inertia visit
+ * (`router.reload()`): props re-fetch but the persistent layout stays
+ * mounted. Set `full` for a shell-invalidating change that needs a real
+ * browser reload (`window.location.reload()`) — not for a stale callout,
+ * which `Callout::retract()` handles instead.
+ */
 #[AsEffect('reload-page')]
-final class ReloadPage extends Effect {}
+final class ReloadPage extends Effect
+{
+    public function __construct(
+        public readonly bool $full = false,
+    ) {}
+}

--- a/src/Effects/Builtin/RetractCallout.php
+++ b/src/Effects/Builtin/RetractCallout.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Effects\Builtin;
+
+use Lattice\Lattice\Effects\Attributes\AsEffect;
+use Lattice\Lattice\Effects\Effect;
+
+/**
+ * States that a keyed callout no longer applies. A keyed callout is
+ * otherwise only dropped on a URL-changing navigation, so a same-URL
+ * response has no way to clear one.
+ */
+#[AsEffect('retract-callout')]
+final class RetractCallout extends Effect
+{
+    public function __construct(
+        public readonly string $unique,
+    ) {}
+}

--- a/src/Effects/Concerns/QueuesEffects.php
+++ b/src/Effects/Concerns/QueuesEffects.php
@@ -24,6 +24,11 @@ trait QueuesEffects
         return $this->effect($callout);
     }
 
+    public function retractCallout(string $key): static
+    {
+        return $this->effect(Callout::retract($key));
+    }
+
     public function reloadComponent(string $component): static
     {
         return $this->effect(Effects::reloadComponent($component));

--- a/src/Effects/Concerns/QueuesEffects.php
+++ b/src/Effects/Concerns/QueuesEffects.php
@@ -34,9 +34,9 @@ trait QueuesEffects
         return $this->effect(Effects::reloadComponent($component));
     }
 
-    public function reloadPage(): static
+    public function reloadPage(bool $full = false): static
     {
-        return $this->effect(Effects::reloadPage());
+        return $this->effect(Effects::reloadPage($full));
     }
 
     public function openModal(string $modal): static

--- a/src/Effects/EffectRegistry.php
+++ b/src/Effects/EffectRegistry.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Effects\Builtin\Redirect;
 use Lattice\Lattice\Effects\Builtin\ReloadComponent;
 use Lattice\Lattice\Effects\Builtin\ReloadPage;
 use Lattice\Lattice\Effects\Builtin\ResetForm;
+use Lattice\Lattice\Effects\Builtin\RetractCallout;
 use Lattice\Lattice\Effects\Builtin\Toast;
 use Lattice\Lattice\Effects\Builtin\ToggleSidebar;
 use Lattice\Lattice\Support\WireTypeRegistry;
@@ -37,6 +38,7 @@ final class EffectRegistry extends WireTypeRegistry
         ReloadComponent::class,
         ReloadPage::class,
         ResetForm::class,
+        RetractCallout::class,
         Toast::class,
         ToggleSidebar::class,
     ];

--- a/src/Facades/Effects.php
+++ b/src/Facades/Effects.php
@@ -36,9 +36,9 @@ final class Effects extends Facade
         return new ReloadComponent($component);
     }
 
-    public static function reloadPage(): ReloadPage
+    public static function reloadPage(bool $full = false): ReloadPage
     {
-        return new ReloadPage;
+        return new ReloadPage($full);
     }
 
     public static function redirect(string $url): Redirect

--- a/src/I18n/Values/Translatable.php
+++ b/src/I18n/Values/Translatable.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\I18n\Values;
 
+use DateTimeInterface;
 use JsonSerializable;
 use Lattice\Lattice\Attributes\TypeScript;
 use Lattice\Lattice\Support\Wire;
@@ -20,7 +21,12 @@ final class Translatable implements JsonSerializable
     /** @var array<string, string> */
     public array $payload = [];
 
-    /** @var array<string, string|int|float|bool> */
+    /**
+     * Only guaranteed scalar (no `DateTimeInterface`) when built through
+     * {@see with()} — direct assignment or {@see fromWire()} bypasses that.
+     *
+     * @var array<string, string|int|float|bool>
+     */
     public array $replacements = [];
 
     private function __construct(public string $key) {}
@@ -70,11 +76,22 @@ final class Translatable implements JsonSerializable
     }
 
     /**
-     * @param  array<string, string|int|float|bool>  $replacements
+     * Wire stays flat scalars so a date is formatted client-side, in the
+     * reader's locale, instead of being fixed into English prose here.
+     *
+     * @param  array<string, string|int|float|bool|DateTimeInterface>  $replacements
      */
     public function with(array $replacements): self
     {
-        $this->replacements = [...$this->replacements, ...$replacements];
+        $this->replacements = [
+            ...$this->replacements,
+            ...array_map(
+                static fn (mixed $value): mixed => $value instanceof DateTimeInterface
+                    ? $value->format(DateTimeInterface::ATOM)
+                    : $value,
+                $replacements,
+            ),
+        ];
 
         return $this;
     }

--- a/src/Support/Testing/LatticeTestResponse.php
+++ b/src/Support/Testing/LatticeTestResponse.php
@@ -60,9 +60,9 @@ final class LatticeTestResponse extends TestResponse
         return $this->assertEffect(new OpenModal($modal));
     }
 
-    public function assertReloadsPage(): static
+    public function assertReloadsPage(bool $full = false): static
     {
-        return $this->assertEffect(new ReloadPage);
+        return $this->assertEffect(new ReloadPage($full));
     }
 
     public function assertNoEffects(): static

--- a/tests/Feature/Actions/EffectSerializationTest.php
+++ b/tests/Feature/Actions/EffectSerializationTest.php
@@ -52,14 +52,23 @@ test('action results expose the full effect vocabulary', function (): void {
         ->localeChange('de');
 
     expect(wire($result)['effects'])->toBe([
-        ['type' => 'reload-page', 'props' => []],
+        ['type' => 'reload-page', 'props' => ['full' => false]],
         ['type' => 'redirect', 'props' => ['url' => '/dashboard']],
         ['type' => 'download', 'props' => ['url' => '/exports/report.csv']],
         ['type' => 'reset-form', 'props' => ['form' => 'teams.create']],
         ['type' => 'locale-change', 'props' => ['locale' => 'de']],
     ])
         ->and(wire(Effects::resetForm()))->toBe(['type' => 'reset-form', 'props' => ['form' => null]])
-        ->and(wire(Effects::reloadPage()))->toBe(['type' => 'reload-page', 'props' => []]);
+        ->and(wire(Effects::reloadPage()))->toBe(['type' => 'reload-page', 'props' => ['full' => false]]);
+});
+
+test('reloadPage serializes full both ways, and the facade and ActionResult helper pass it through', function (): void {
+    expect(wire(Effects::reloadPage(true)))->toBe(['type' => 'reload-page', 'props' => ['full' => true]])
+        ->and(wire(Effects::reloadPage(false)))->toBe(['type' => 'reload-page', 'props' => ['full' => false]])
+        ->and(wire(ActionResult::success()->reloadPage(true))['effects'][0])->toBe([
+            'type' => 'reload-page',
+            'props' => ['full' => true],
+        ]);
 });
 
 test('action result navigation verbs emit a redirect effect', function (): void {

--- a/tests/Feature/Actions/EffectSerializationTest.php
+++ b/tests/Feature/Actions/EffectSerializationTest.php
@@ -132,6 +132,22 @@ test('a callout without a unique key serializes it as null', function (): void {
     expect($wire['props']['unique'])->toBeNull();
 });
 
+test('a retract-callout effect serializes its key', function (): void {
+    $wire = wire(Callout::retract('billing.state'));
+
+    expect($wire['type'])->toBe('retract-callout')
+        ->and($wire['props'])->toBe(['unique' => 'billing.state']);
+});
+
+test('action results expose the retract callout effect', function (): void {
+    $result = ActionResult::success()->retractCallout('billing.state');
+
+    expect(wire($result)['effects'][0])->toBe([
+        'type' => 'retract-callout',
+        'props' => ['unique' => 'billing.state'],
+    ]);
+});
+
 test('action groups serialize grouped child actions', function (): void {
     $group = wire(ActionGroup::make('workbench.user-actions')
         ->label('Manage user')

--- a/tests/Feature/Support/EndpointTestingHelpersTest.php
+++ b/tests/Feature/Support/EndpointTestingHelpersTest.php
@@ -75,6 +75,32 @@ test('typed effect assertions match action response effects regardless of order'
         ->assertReloadsPage();
 });
 
+test('assertReloadsPage(true) matches a full-page reload effect', function (): void {
+    Lattice::actions([HelperFullReloadEffectsAction::class]);
+
+    $response = $this->callAction(HelperFullReloadEffectsAction::class);
+
+    $response->assertOk()->assertReloadsPage(full: true);
+});
+
+test('assertReloadsPage discriminates between a default and a full reload in both directions', function (): void {
+    Route::get('/helper/projects/{project}', fn (string $project): string => $project)
+        ->name('helper.projects.show');
+    Lattice::actions([HelperEffectsAction::class, HelperFullReloadEffectsAction::class]);
+
+    expect(fn () => $this->callAction(HelperEffectsAction::class)->assertReloadsPage(full: true))
+        ->toThrow(
+            AssertionFailedError::class,
+            'Expected Lattice effect [reload-page] with props {"full":true}. Received effects:',
+        );
+
+    expect(fn () => $this->callAction(HelperFullReloadEffectsAction::class)->assertReloadsPage())
+        ->toThrow(
+            AssertionFailedError::class,
+            'Expected Lattice effect [reload-page] with props {"full":false}. Received effects:',
+        );
+});
+
 test('typed effect assertion failures identify the expected and received effects', function (): void {
     Route::get('/helper/projects/{project}', fn (string $project): string => $project)
         ->name('helper.projects.show');
@@ -260,5 +286,19 @@ final class HelperEffectsAction extends ActionDefinition
             ->reloadPage()
             ->toRoute('helper.projects.show', 'lattice')
             ->reloadComponent('profile.passkeys');
+    }
+}
+
+#[AsAction('helper.full-reload')]
+final class HelperFullReloadEffectsAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Full reload');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success()->reloadPage(true);
     }
 }

--- a/tests/Unit/Core/Values/TranslatableTest.php
+++ b/tests/Unit/Core/Values/TranslatableTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
 use Lattice\Lattice\I18n\Values\Translatable;
 
 test('it serializes key, payload paths, and static replacements', function (): void {
@@ -41,4 +42,38 @@ test('it rehydrates from its wire shape', function (): void {
     ];
 
     expect(Translatable::fromWire($wire)->jsonSerialize())->toBe($wire);
+});
+
+test('a DateTimeInterface replacement serializes to an ISO 8601 string, scalars unchanged', function (): void {
+    $date = CarbonImmutable::parse('2026-03-06T00:00:00+00:00');
+
+    $translatable = Translatable::make('billing.subscription-ends')
+        ->with(['date' => $date, 'plan' => 'Pro', 'seats' => 5]);
+
+    expect($translatable->jsonSerialize())->toEqual([
+        'key' => 'billing.subscription-ends',
+        'payload' => (object) [],
+        'replacements' => [
+            'date' => '2026-03-06T00:00:00+00:00',
+            'plan' => 'Pro',
+            'seats' => 5,
+        ],
+    ]);
+});
+
+test('a serialized date round-trips through fromWire as a plain string', function (): void {
+    $wire = Translatable::make('billing.subscription-ends')
+        ->with(['date' => CarbonImmutable::parse('2026-03-06T00:00:00+00:00')])
+        ->jsonSerialize();
+
+    expect(Translatable::fromWire($wire)->jsonSerialize())->toEqual($wire);
+});
+
+test('with() still merges a non-scalar, non-DateTimeInterface value without throwing', function (): void {
+    /** @var array<string, mixed> $replacement */
+    $replacement = ['x' => null];
+
+    $translatable = Translatable::make('k')->with($replacement);
+
+    expect($translatable->jsonSerialize()['replacements'])->toBe(['x' => null]);
 });


### PR DESCRIPTION
Three related follow-ups to the keyed callouts added in 0.30, each independently useful.

## `Callout::retract($key)`

A keyed callout is a projection of server state, dropped on `navigate` unless re-asserted. But Inertia treats a **same-URL visit as a `replace` and never fires `navigate`** — so `router.reload()`, a same-URL `redirect()->back()`, polling and partial reloads never retract. A server that stops asserting had no way to say so, and a stale banner outlived its condition.

```php
Effects::flash($callout ?? Callout::retract('billing.state'));
```

The server now always states the truth: a callout, or its absence. Retraction is selective — it removes only callouts sharing the key, never an unkeyed one.

## `reloadPage(full: true)`

`ReloadPage` maps to `router.reload()`, an Inertia visit that keeps the persistent layout and its client state alive. That stays the default. `full` makes it a real browser reload, for the cases where the whole shell is invalid — impersonation start/stop, a role change that reshapes navigation, an asset bump.

It is deliberately *not* the answer to a stale callout — that is what `Callout::retract()` is for, and the docs say so. `assertReloadsPage(bool $full = false)` covers both.

## Client-side date formatting

`Translatable` exists so a string resolves client-side under the reader's locale — but any interpolated date was formatted server-side into a fixed string first, so the sentence localized and the date did not. A German reader got *"Ihr Abonnement endet am 6 March 2026"*.

`Translatable::with()` now accepts a `DateTimeInterface` and sends it as ISO 8601; the translation string declares intent with i18next's own syntax:

```php
rt('billing:state.canceling.message')->with(['date' => $subscription->ends_at])
```
```json
{ "message": "Your subscription ends on {{date, datetime(dateStyle: long)}}" }
```

**The wire stays flat scalars** — no typed date marker. `Translatable::fromWire()` rehydrates stored database-notification payloads, so a shape change would ripple into data already at rest.

A `datetime` formatter is registered that coerces ISO strings and numeric timestamps to `Date` before delegating to `Intl`. This is required, not cosmetic: i18next's built-in is `new Intl.DateTimeFormat(lng, opt)` then `val => formatter.format(val)`, and `format()` throws `RangeError: Invalid time value` on a string. The override is a strict superset — a `Date` passes through unchanged, and the full `Intl.DateTimeFormat` option surface still works.

It pins to `currentTimezone()`, the same source `<DateTime>` renders through, so one instant cannot render as two different calendar days depending on which path drew it. An explicit `timeZone:` in a translation string still wins. The timezone is resolved per call rather than cached, matching `formatDateValue`, so `setTimezone()` takes effect immediately.

## Notes

- `with()` widened its merge closure to `mixed` rather than a union, so `->with(['x' => null])` keeps merging instead of throwing under `strict_types`.
- `datetime-formatter.test.ts` pins its timezone explicitly and passes identically under `TZ=UTC` and `TZ=America/New_York`.

`composer check` (1381 tests, PHPStan clean) and `npm run check` (189 files, 1139 tests, tsc/oxlint/type-coverage/build) both green.