### PR TITLE
feat(tables): per-page select with dynamic infinite pagination

### DIFF
--- a/docs/content/docs/tables/sorting-and-pagination.mdx
+++ b/docs/content/docs/tables/sorting-and-pagination.mdx
@@ -65,13 +65,15 @@ A [custom data source](/tables/data-sources/) chooses its own `TableResult` buil
 ### Page size options
 
 Declare `perPageOptions()` to render a page-size select in the pagination bar. Numeric entries offer
-fixed page sizes; the string `'infinite'` lets the user switch the table to infinite pagination on
+fixed page sizes; `PaginationType::Infinite` lets the user switch the table to infinite pagination on
 the fly — and back to numbered pages.
 
 ```php
+use Lattice\Lattice\Tables\Enums\PaginationType;
+
 public function perPageOptions(): array
 {
-    return [10, 25, 50, 100, 'infinite'];
+    return [10, 25, 50, 100, PaginationType::Infinite];
 }
 ```
 

--- a/docs/content/docs/tables/sorting-and-pagination.mdx
+++ b/docs/content/docs/tables/sorting-and-pagination.mdx
@@ -61,3 +61,19 @@ A [custom data source](/tables/data-sources/) chooses its own `TableResult` buil
 `fromPaginator()` for a full pager, `fromSimplePaginator()` for infinite scroll-to-load, or
 `fromSimplePaginator($paginator, PaginationType::Simple)` for previous/next. The
 [Eloquent source](/tables/eloquent-tables/) picks the right one from the mode automatically.
+
+### Page size options
+
+Declare `perPageOptions()` to render a page-size select in the pagination bar. Numeric entries offer
+fixed page sizes; the string `'infinite'` lets the user switch the table to infinite pagination on
+the fly — and back to numbered pages.
+
+```php
+public function perPageOptions(): array
+{
+    return [10, 25, 50, 100, 'infinite'];
+}
+```
+
+The endpoint accepts only declared sizes and falls back to `perPage()` for anything else. Tables
+without options keep their fixed page size and mode.

--- a/docs/fixtures/table.badge.json
+++ b/docs/fixtures/table.badge.json
@@ -101,8 +101,10 @@
                 "to": 3,
                 "total": 3
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.boolean.json
+++ b/docs/fixtures/table.boolean.json
@@ -96,8 +96,10 @@
                 "to": 3,
                 "total": 3
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -136,8 +136,10 @@
                 "to": 3,
                 "total": 3
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.icon.json
+++ b/docs/fixtures/table.icon.json
@@ -80,8 +80,10 @@
                 "to": 2,
                 "total": 2
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.image.json
+++ b/docs/fixtures/table.image.json
@@ -86,8 +86,10 @@
                 "to": 2,
                 "total": 2
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.money.json
+++ b/docs/fixtures/table.money.json
@@ -90,8 +90,10 @@
                 "to": 2,
                 "total": 2
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.number.json
+++ b/docs/fixtures/table.number.json
@@ -93,8 +93,10 @@
                 "to": 3,
                 "total": 3
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -160,8 +160,10 @@
                 "to": 3,
                 "total": 3
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.search.json
+++ b/docs/fixtures/table.search.json
@@ -96,8 +96,10 @@
                 "to": 3,
                 "total": 3
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.stack.json
+++ b/docs/fixtures/table.stack.json
@@ -97,8 +97,10 @@
                 "to": 2,
                 "total": 2
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.text.json
+++ b/docs/fixtures/table.text.json
@@ -97,8 +97,10 @@
                 "to": 2,
                 "total": 2
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/docs/fixtures/table.toggleable.json
+++ b/docs/fixtures/table.toggleable.json
@@ -111,8 +111,10 @@
                 "to": 2,
                 "total": 2
             },
+            "perPageOptions": [],
             "query": {
                 "filters": [],
+                "mode": null,
                 "page": 1,
                 "perPage": 25,
                 "search": "",

--- a/lang/de/table.php
+++ b/lang/de/table.php
@@ -17,6 +17,8 @@ return [
         'loading' => 'Lädt...',
         'previous' => 'Zurück',
         'next' => 'Weiter',
+        'per-page' => 'Zeilen pro Seite',
+        'infinite' => 'Unendlich',
     ],
     'bulk' => [
         'selected' => ':count ausgewählt',

--- a/lang/en/table.php
+++ b/lang/en/table.php
@@ -17,6 +17,8 @@ return [
         'loading' => 'Loading...',
         'previous' => 'Previous',
         'next' => 'Next',
+        'per-page' => 'Rows per page',
+        'infinite' => 'Infinite',
     ],
     'bulk' => [
         'selected' => ':count selected',

--- a/resources/js/table/components/pagination.tsx
+++ b/resources/js/table/components/pagination.tsx
@@ -1,7 +1,9 @@
 import type { RefObject } from "react";
 import { Button } from "@lattice-php/lattice/ui/button";
+import { NativeSelect } from "@lattice-php/lattice/ui/native-select";
 import { useT } from "@lattice-php/lattice/i18n";
 import type { PaginationType } from "@lattice-php/lattice/types/generated";
+import type { PerPageOption } from "@lattice-php/lattice/table/lib/payload";
 import type { TablePagination as TablePaginationData } from "@lattice-php/lattice/table/types";
 
 export function TablePagination({
@@ -12,6 +14,9 @@ export function TablePagination({
   hasNextPage,
   visiblePages,
   infiniteLoaderRef,
+  perPageOptions,
+  perPageValue,
+  onPerPage,
   onPage,
   onLoadMore,
 }: {
@@ -22,6 +27,9 @@ export function TablePagination({
   hasNextPage: boolean;
   visiblePages: number[];
   infiniteLoaderRef: RefObject<HTMLDivElement | null>;
+  perPageOptions: PerPageOption[];
+  perPageValue: PerPageOption;
+  onPerPage: (option: PerPageOption) => void;
   onPage: (page: number) => void;
   onLoadMore: () => void;
 }) {
@@ -32,15 +40,40 @@ export function TablePagination({
       data-slot="table-pagination"
       className="flex items-center justify-between gap-3 border-t border-lt-border p-4 text-sm"
     >
-      <span>
-        {pagination.total == null
-          ? t("table.pagination.page", "Page {{page}}", { page: currentPage })
-          : t("table.pagination.showing", "Showing {{from}}-{{to}} of {{total}}", {
-              from: pagination.from ?? 0,
-              to: pagination.to ?? 0,
-              total: pagination.total,
-            })}
-      </span>
+      <div className="flex items-center gap-4">
+        <span>
+          {pagination.total == null
+            ? t("table.pagination.page", "Page {{page}}", { page: currentPage })
+            : t("table.pagination.showing", "Showing {{from}}-{{to}} of {{total}}", {
+                from: pagination.from ?? 0,
+                to: pagination.to ?? 0,
+                total: pagination.total,
+              })}
+        </span>
+        {perPageOptions.length > 0 && mode !== "none" && (
+          <label className="flex items-center gap-2">
+            <span className="text-lt-muted-fg">
+              {t("table.pagination.per-page", "Rows per page")}
+            </span>
+            <NativeSelect
+              data-test="pagination-per-page"
+              disabled={processing}
+              value={String(perPageValue)}
+              onChange={(event) =>
+                onPerPage(
+                  event.target.value === "infinite" ? "infinite" : Number(event.target.value),
+                )
+              }
+            >
+              {perPageOptions.map((option) => (
+                <option key={String(option)} value={String(option)}>
+                  {option === "infinite" ? t("table.pagination.infinite", "Infinite") : option}
+                </option>
+              ))}
+            </NativeSelect>
+          </label>
+        )}
+      </div>
       {mode === "infinite" ? (
         <div ref={infiniteLoaderRef} className="flex items-center gap-2">
           {pagination.hasMore ? (

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -984,3 +984,154 @@ describe("Lattice table component", () => {
     );
   });
 });
+
+describe("per-page options", () => {
+  function perPageNode(overrides: Partial<TableNode["props"]> = {}): TableNode {
+    return {
+      id: "workbench.users",
+      props: {
+        columns: [col({ key: "name", label: "Name", sortable: true })],
+        data: [{ id: 1, name: "Taylor" }],
+        endpoint: "/lattice/tables/workbench.users",
+        perPageOptions: [25, 50, "infinite"],
+        pagination: pagination({
+          mode: "table",
+          currentPage: 1,
+          lastPage: 1,
+          perPage: 25,
+          total: 1,
+        }),
+        query: tableQuery(),
+        ...overrides,
+      },
+      type: "table",
+    } satisfies TableNode;
+  }
+
+  it("hides the select when no options are declared", () => {
+    render(<TableComponent node={perPageNode({ perPageOptions: [] })}>{null}</TableComponent>);
+
+    expect(screen.queryByLabelText("Rows per page")).not.toBeInTheDocument();
+  });
+
+  it("changes the page size through the per-page select", async () => {
+    const fetch = tableFetch({
+      data: [{ id: 2, name: "Ada" }],
+      pagination: pagination({ mode: "table", currentPage: 1, lastPage: 1, perPage: 50, total: 1 }),
+      query: tableQuery({ perPage: 50 }),
+    });
+
+    render(<TableComponent node={perPageNode()}>{null}</TableComponent>);
+
+    fireEvent.change(screen.getByLabelText("Rows per page"), { target: { value: "50" } });
+
+    await screen.findByRole("cell", { name: "Ada" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/lattice/tables/workbench.users?page=1&per_page=50",
+      requestOptions(),
+    );
+  });
+
+  it("switches to infinite pagination, keeps it across reloads, and switches back", async () => {
+    const fetch = tableFetch(
+      {
+        data: [{ id: 2, name: "Ada" }],
+        pagination: pagination({
+          mode: "infinite",
+          currentPage: 1,
+          perPage: 25,
+          hasMore: true,
+          nextPage: 2,
+        }),
+        query: tableQuery({ mode: "infinite" }),
+      },
+      {
+        data: [{ id: 3, name: "Grace" }],
+        pagination: pagination({
+          mode: "infinite",
+          currentPage: 1,
+          perPage: 25,
+          hasMore: true,
+          nextPage: 2,
+        }),
+        query: tableQuery({ mode: "infinite", sorts: [{ key: "name", direction: "asc" }] }),
+      },
+      {
+        data: [{ id: 4, name: "Maya" }],
+        pagination: pagination({
+          mode: "table",
+          currentPage: 1,
+          lastPage: 1,
+          perPage: 25,
+          total: 1,
+        }),
+        query: tableQuery(),
+      },
+    );
+
+    render(<TableComponent node={perPageNode()}>{null}</TableComponent>);
+
+    fireEvent.change(screen.getByLabelText("Rows per page"), { target: { value: "infinite" } });
+
+    await screen.findByRole("cell", { name: "Ada" });
+
+    expect(screen.queryByRole("cell", { name: "Taylor" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Load more" })).toBeVisible();
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "/lattice/tables/workbench.users?page=1&per_page=25&mode=infinite",
+      requestOptions(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort Name" }));
+
+    await screen.findByRole("cell", { name: "Grace" });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "/lattice/tables/workbench.users?sort=name&page=1&per_page=25&mode=infinite",
+      requestOptions(),
+    );
+
+    fireEvent.change(screen.getByLabelText("Rows per page"), { target: { value: "25" } });
+
+    await screen.findByRole("cell", { name: "Maya" });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      "/lattice/tables/workbench.users?sort=name&page=1&per_page=25",
+      requestOptions(),
+    );
+  });
+
+  it("requests numbered pagination when a size is picked on an infinite table", async () => {
+    const fetch = tableFetch({
+      data: [{ id: 2, name: "Ada" }],
+      pagination: pagination({ mode: "table", currentPage: 1, lastPage: 1, perPage: 25, total: 1 }),
+      query: tableQuery(),
+    });
+
+    const node = perPageNode({
+      pagination: pagination({
+        mode: "infinite",
+        currentPage: 1,
+        perPage: 25,
+        hasMore: false,
+      }),
+    });
+
+    render(<TableComponent node={node}>{null}</TableComponent>);
+
+    expect(screen.getByLabelText("Rows per page")).toHaveValue("infinite");
+
+    fireEvent.change(screen.getByLabelText("Rows per page"), { target: { value: "25" } });
+
+    await screen.findByRole("cell", { name: "Ada" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/lattice/tables/workbench.users?page=1&per_page=25&mode=table",
+      requestOptions(),
+    );
+  });
+});

--- a/resources/js/table/components/table.tsx
+++ b/resources/js/table/components/table.tsx
@@ -11,7 +11,12 @@ import { Icon } from "@lattice-php/lattice/icons";
 import { alignJustifyItems, alignText } from "@lattice-php/lattice/table/lib/align";
 import type { TableNode } from "@lattice-php/lattice/table/types";
 import { getBulkActions } from "@lattice-php/lattice/table/lib/bulk";
-import { getRowActions, getRowDetail, getRowKey } from "@lattice-php/lattice/table/lib/payload";
+import {
+  getPerPageOptions,
+  getRowActions,
+  getRowDetail,
+  getRowKey,
+} from "@lattice-php/lattice/table/lib/payload";
 import {
   getQueryParams,
   getTableSizingColumns,
@@ -54,6 +59,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
     sort,
     clearSort,
     goToPage,
+    setPerPage,
     loadMore,
   } = useTable(node);
 
@@ -98,6 +104,10 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   const currentPage = pagination.currentPage ?? query.page;
   const lastPage = pagination.lastPage ?? currentPage;
   const mode = pagination.mode ?? "table";
+  const perPageOptions = useMemo(
+    () => getPerPageOptions(node.props?.perPageOptions),
+    [node.props?.perPageOptions],
+  );
   const visiblePages = getVisiblePages(currentPage, lastPage);
   const hasNextPage = pagination.hasMore ?? currentPage < lastPage;
   const hasActions = rowEntries.some((entry) => entry.actions.length > 0);
@@ -416,6 +426,9 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
             hasNextPage={hasNextPage}
             visiblePages={visiblePages}
             infiniteLoaderRef={infiniteLoaderRef}
+            perPageOptions={perPageOptions}
+            perPageValue={mode === "infinite" ? "infinite" : query.perPage}
+            onPerPage={setPerPage}
             onPage={goToPage}
             onLoadMore={loadMore}
           />

--- a/resources/js/table/hooks/use-table.ts
+++ b/resources/js/table/hooks/use-table.ts
@@ -9,6 +9,7 @@ import {
   getPagination,
   getRows,
   getQuery,
+  type PerPageOption,
 } from "@lattice-php/lattice/table/lib/payload";
 import { buildEndpoint, nextSort } from "@lattice-php/lattice/table/lib/query";
 import type {
@@ -183,6 +184,24 @@ export function useTable(node: TableNode) {
     });
   }
 
+  function setPerPage(option: PerPageOption): void {
+    const definitionMode = initialPagination.mode ?? "table";
+    const nextQuery = {
+      ...query,
+      perPage: option === "infinite" ? query.perPage : option,
+      mode:
+        option === "infinite"
+          ? ("infinite" as const)
+          : definitionMode === "infinite"
+            ? ("table" as const)
+            : null,
+      page: 1,
+    };
+
+    setQuery(nextQuery);
+    void load(nextQuery);
+  }
+
   const loadMore = useCallback((): void => {
     if (processing || !pagination.hasMore) {
       return;
@@ -270,6 +289,7 @@ export function useTable(node: TableNode) {
     sort,
     clearSort,
     goToPage,
+    setPerPage,
     loadMore,
   };
 }

--- a/resources/js/table/lib/filter-params.test.ts
+++ b/resources/js/table/lib/filter-params.test.ts
@@ -11,6 +11,7 @@ function query(overrides: Partial<TableQuery>): TableQuery {
     tableFilters: {},
     tableFilterIndicators: [],
     search: "",
+    mode: null,
     ...overrides,
   };
 }

--- a/resources/js/table/lib/payload.ts
+++ b/resources/js/table/lib/payload.ts
@@ -1,4 +1,5 @@
 import type { Node } from "@lattice-php/lattice/core/types";
+import type { PaginationType } from "@lattice-php/lattice/types/generated";
 import type {
   FilterClause,
   FilterIndicator,
@@ -81,6 +82,7 @@ export function getQuery(value: unknown): TableQuery {
       tableFilters: {},
       tableFilterIndicators: [],
       search: "",
+      mode: null,
     };
   }
 
@@ -94,7 +96,28 @@ export function getQuery(value: unknown): TableQuery {
     tableFilters: getTableFilters(query.tableFilters),
     tableFilterIndicators: getTableFilterIndicators(query.tableFilterIndicators),
     search: typeof query.search === "string" ? query.search : "",
+    mode: getPaginationMode(query.mode),
   };
+}
+
+const PAGINATION_MODES = new Set(["none", "simple", "table", "infinite"]);
+
+function getPaginationMode(value: unknown): PaginationType | null {
+  return typeof value === "string" && PAGINATION_MODES.has(value)
+    ? (value as PaginationType)
+    : null;
+}
+
+export type PerPageOption = number | "infinite";
+
+export function getPerPageOptions(value: unknown): PerPageOption[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(
+    (option): option is PerPageOption => typeof option === "number" || option === "infinite",
+  );
 }
 
 /**

--- a/resources/js/table/lib/query.ts
+++ b/resources/js/table/lib/query.ts
@@ -42,6 +42,10 @@ export function buildEndpoint(endpoint: string, query: TableQuery): string {
   url.searchParams.set("page", String(query.page));
   url.searchParams.set("per_page", String(query.perPage));
 
+  if (query.mode != null) {
+    url.searchParams.set("mode", query.mode);
+  }
+
   return `${url.pathname}${url.search}`;
 }
 

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -1407,6 +1407,7 @@ export type Table = {
   filters: FilterNode[];
   layout: string | null;
   lazy: boolean;
+  perPageOptions: (number | string)[];
   ref: string | null;
   resizableColumns: boolean;
   resizeIndicator: boolean;
@@ -1427,6 +1428,7 @@ export type TablePagination = {
 };
 export type TableQuery = {
   readonly filters: FilterClause[];
+  readonly mode: PaginationType | null;
   readonly page: number;
   readonly perPage: number;
   readonly search: string;

--- a/src/Http/Controllers/BulkActionController.php
+++ b/src/Http/Controllers/BulkActionController.php
@@ -69,6 +69,7 @@ final readonly class BulkActionController
                     $tableKey,
                     $table->perPage(),
                     $table->filters(),
+                    $table->perPageOptions(),
                 ),
             );
         }

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -3,11 +3,13 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tables\Components;
 
+use InvalidArgumentException;
 use Lattice\Lattice\Actions\Components\Action;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Attributes\SerializationHook;
 use Lattice\Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Lattice\Tables\Columns\Column;
+use Lattice\Lattice\Tables\Enums\PaginationType;
 use Lattice\Lattice\Tables\Filters\Filter;
 use Lattice\Lattice\Tables\TableDefinition;
 use Lattice\Lattice\Tables\TableQuery;
@@ -127,11 +129,20 @@ class Table extends Component implements InteractiveComponent
     }
 
     /**
-     * @param  array<int, int|string>  $options
+     * @param  array<int, int|PaginationType>  $options
      */
     public function perPageOptions(array $options): static
     {
-        $this->perPageOptions = array_values($options);
+        $this->perPageOptions = array_map(
+            static fn (int|PaginationType $option): int|string => match (true) {
+                is_int($option) => $option,
+                $option === PaginationType::Infinite => $option->value,
+                default => throw new InvalidArgumentException(
+                    "Only PaginationType::Infinite may appear in perPageOptions, {$option->value} given.",
+                ),
+            },
+            array_values($options),
+        );
 
         return $this;
     }

--- a/src/Tables/Components/Table.php
+++ b/src/Tables/Components/Table.php
@@ -35,6 +35,11 @@ class Table extends Component implements InteractiveComponent
      */
     public array $filters = [];
 
+    /**
+     * @var array<int, int|string>
+     */
+    public array $perPageOptions = [];
+
     public ?string $layout = null;
 
     /**
@@ -117,6 +122,16 @@ class Table extends Component implements InteractiveComponent
     public function filters(array $filters): static
     {
         $this->filters = array_values($this->renderableComponents($filters));
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, int|string>  $options
+     */
+    public function perPageOptions(array $options): static
+    {
+        $this->perPageOptions = array_values($options);
 
         return $this;
     }

--- a/src/Tables/Sources/Eloquent/EloquentTableSource.php
+++ b/src/Tables/Sources/Eloquent/EloquentTableSource.php
@@ -56,13 +56,15 @@ final readonly class EloquentTableSource implements TableSource
 
         $project = $this->rowProjector($relations);
 
-        return match ($this->pagination) {
+        $mode = $query->mode ?? $this->pagination;
+
+        return match ($mode) {
             PaginationType::None => TableResult::fromItems(
                 $builder->get()->map($project),
             ),
             PaginationType::Infinite, PaginationType::Simple => TableResult::fromSimplePaginator(
                 $builder->simplePaginate(perPage: $query->perPage, page: $query->page)->through($project),
-                $this->pagination,
+                $mode,
             ),
             PaginationType::Table => TableResult::fromPaginator(
                 $builder->paginate(perPage: $query->perPage, page: $query->page)->through($project),

--- a/src/Tables/TableDefinition.php
+++ b/src/Tables/TableDefinition.php
@@ -36,9 +36,9 @@ abstract class TableDefinition extends Definition
 
     /**
      * Page-size choices offered in the pagination bar; empty hides the control.
-     * The string 'infinite' offers switching to infinite pagination.
+     * `PaginationType::Infinite` offers switching to infinite pagination.
      *
-     * @return array<int, int|string>
+     * @return array<int, int|PaginationType::Infinite>
      */
     public function perPageOptions(): array
     {

--- a/src/Tables/TableDefinition.php
+++ b/src/Tables/TableDefinition.php
@@ -34,6 +34,17 @@ abstract class TableDefinition extends Definition
         return 25;
     }
 
+    /**
+     * Page-size choices offered in the pagination bar; empty hides the control.
+     * The string 'infinite' offers switching to infinite pagination.
+     *
+     * @return array<int, int|string>
+     */
+    public function perPageOptions(): array
+    {
+        return [];
+    }
+
     public function pagination(): PaginationType|string
     {
         return PaginationType::Table;

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -47,7 +47,7 @@ final readonly class TableQuery implements JsonSerializable
     /**
      * @param  array<int, Column>  $columns
      * @param  array<int, Filter>  $filters
-     * @param  array<int, int|string>  $perPageOptions
+     * @param  array<int, int|PaginationType::Infinite>  $perPageOptions
      */
     public static function fromRequest(Request $request, array $columns, string $table, int $defaultPerPage = 25, array $filters = [], array $perPageOptions = []): self
     {
@@ -81,7 +81,7 @@ final readonly class TableQuery implements JsonSerializable
      * Declared options are trusted verbatim; without options the request value
      * is clamped as before.
      *
-     * @param  array<int, int|string>  $options
+     * @param  array<int, int|PaginationType::Infinite>  $options
      */
     private static function resolvePerPage(int $perPage, int $default, array $options): int
     {
@@ -96,14 +96,14 @@ final readonly class TableQuery implements JsonSerializable
 
     /**
      * A mode override is only honored when the declared options offer it:
-     * 'infinite' requires the 'infinite' option, 'table' any options at all.
+     * 'infinite' requires the infinite option, 'table' any options at all.
      *
-     * @param  array<int, int|string>  $options
+     * @param  array<int, int|PaginationType::Infinite>  $options
      */
     private static function resolveMode(mixed $mode, array $options): ?PaginationType
     {
         return match (true) {
-            $mode === 'infinite' && in_array('infinite', $options, true) => PaginationType::Infinite,
+            $mode === 'infinite' && in_array(PaginationType::Infinite, $options, true) => PaginationType::Infinite,
             $mode === 'table' && $options !== [] => PaginationType::Table,
             default => null,
         };

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -45,8 +45,9 @@ final readonly class TableQuery implements JsonSerializable
     /**
      * @param  array<int, Column>  $columns
      * @param  array<int, Filter>  $filters
+     * @param  array<int, int|string>  $perPageOptions
      */
-    public static function fromRequest(Request $request, array $columns, string $table, int $defaultPerPage = 25, array $filters = []): self
+    public static function fromRequest(Request $request, array $columns, string $table, int $defaultPerPage = 25, array $filters = [], array $perPageOptions = []): self
     {
         $clauses = self::parseFilters($request->input('filter'), $table);
         $sorts = self::parseSorts($request->input('sort'));
@@ -61,7 +62,7 @@ final readonly class TableQuery implements JsonSerializable
             $clauses,
             $sorts,
             max(1, $request->integer('page', 1)),
-            self::clampPerPage($request->integer('per_page', $defaultPerPage)),
+            self::resolvePerPage($request->integer('per_page', $defaultPerPage), $defaultPerPage, $perPageOptions),
             $tableFilters,
             $tableFilterIndicators,
             $request->string('q')->trim()->toString(),
@@ -71,6 +72,23 @@ final readonly class TableQuery implements JsonSerializable
     private static function clampPerPage(int $perPage): int
     {
         return max(1, min(100, $perPage));
+    }
+
+    /**
+     * Declared options are trusted verbatim; without options the request value
+     * is clamped as before.
+     *
+     * @param  array<int, int|string>  $options
+     */
+    private static function resolvePerPage(int $perPage, int $default, array $options): int
+    {
+        $numeric = array_filter($options, is_int(...));
+
+        if ($numeric === []) {
+            return self::clampPerPage($perPage);
+        }
+
+        return in_array($perPage, $numeric, true) ? $perPage : self::clampPerPage($default);
     }
 
     /**

--- a/src/Tables/TableQuery.php
+++ b/src/Tables/TableQuery.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Contracts\Filterable;
 use Lattice\Lattice\Tables\Contracts\Sortable;
+use Lattice\Lattice\Tables\Enums\PaginationType;
 use Lattice\Lattice\Tables\Filters\Filter;
 use Lattice\Lattice\Tables\Filters\FilterIndicator;
 use Lattice\Lattice\Tables\Filters\FilterValueValidator;
@@ -35,6 +36,7 @@ final readonly class TableQuery implements JsonSerializable
         public array $tableFilters = [],
         public array $tableFilterIndicators = [],
         public string $search = '',
+        public ?PaginationType $mode = null,
     ) {}
 
     public static function empty(int $defaultPerPage = 25): self
@@ -66,6 +68,7 @@ final readonly class TableQuery implements JsonSerializable
             $tableFilters,
             $tableFilterIndicators,
             $request->string('q')->trim()->toString(),
+            self::resolveMode($request->input('mode'), $perPageOptions),
         );
     }
 
@@ -92,7 +95,22 @@ final readonly class TableQuery implements JsonSerializable
     }
 
     /**
-     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int, tableFilters: array<string, mixed>|stdClass, tableFilterIndicators: list<FilterIndicator>, search: string}
+     * A mode override is only honored when the declared options offer it:
+     * 'infinite' requires the 'infinite' option, 'table' any options at all.
+     *
+     * @param  array<int, int|string>  $options
+     */
+    private static function resolveMode(mixed $mode, array $options): ?PaginationType
+    {
+        return match (true) {
+            $mode === 'infinite' && in_array('infinite', $options, true) => PaginationType::Infinite,
+            $mode === 'table' && $options !== [] => PaginationType::Table,
+            default => null,
+        };
+    }
+
+    /**
+     * @return array{filters: array<int, FilterClause>, sorts: array<int, TableSort>, page: int, perPage: int, tableFilters: array<string, mixed>|stdClass, tableFilterIndicators: list<FilterIndicator>, search: string, mode: PaginationType|null}
      */
     public function jsonSerialize(): array
     {
@@ -104,6 +122,7 @@ final readonly class TableQuery implements JsonSerializable
             'tableFilters' => Wire::map($this->tableFilters),
             'tableFilterIndicators' => $this->tableFilterIndicators,
             'search' => $this->search,
+            'mode' => $this->mode,
         ];
     }
 

--- a/src/Tables/TableRegistry.php
+++ b/src/Tables/TableRegistry.php
@@ -76,6 +76,7 @@ final class TableRegistry extends DefinitionRegistry
                     ->endpoint($this->endpointFor($key))
                     ->columns($columns)
                     ->filters($definition->filters())
+                    ->perPageOptions($definition->perPageOptions())
                     ->searchable($this->hasSearchableColumns($columns))
                     ->layout($definition->layout())
                     ->striped($definition->striped())
@@ -97,7 +98,7 @@ final class TableRegistry extends DefinitionRegistry
     {
         $definition ??= $this->resolve($key);
         $columns = $definition->columns();
-        $query = TableQuery::fromRequest($request, $columns, $key, $definition->perPage(), $definition->filters());
+        $query = TableQuery::fromRequest($request, $columns, $key, $definition->perPage(), $definition->filters(), $definition->perPageOptions());
 
         return $this->decorateResult($definition, $definition->source()->query($query), $columns)->forQuery($query);
     }

--- a/tests/Feature/Tables/Components/TableWireShapeTest.php
+++ b/tests/Feature/Tables/Components/TableWireShapeTest.php
@@ -6,6 +6,7 @@ use Lattice\Lattice\Facades\Lattice;
 use Lattice\Lattice\Tables\Columns\NumberColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
 use Lattice\Lattice\Tables\Components\Table;
+use Lattice\Lattice\Tables\Enums\PaginationType;
 use Lattice\Lattice\Tables\TableQuery;
 use Lattice\Lattice\Tables\TableRegistry;
 use Lattice\Lattice\Tables\TableResult;
@@ -55,6 +56,17 @@ it('serializes the table component wire shape', function (): void {
     expect($payload['props']['bulkActions'])->toBe([]);
     expect($payload['props']['filters'])->toBe([]);
     expect($payload['props']['perPageOptions'])->toBe([]);
+});
+
+it('serializes per-page options with the infinite marker as its wire value', function (): void {
+    $payload = wire(Table::make('demo')->perPageOptions([10, 25, PaginationType::Infinite]));
+
+    expect($payload['props']['perPageOptions'])->toBe([10, 25, 'infinite']);
+});
+
+it('rejects per-page options besides sizes and the infinite marker', function (): void {
+    expect(fn (): Table => Table::make('demo')->perPageOptions([10, PaginationType::Simple]))
+        ->toThrow(InvalidArgumentException::class, 'Only PaginationType::Infinite may appear in perPageOptions');
 });
 
 it('serializes visible resize indicators on table components', function (): void {

--- a/tests/Feature/Tables/Components/TableWireShapeTest.php
+++ b/tests/Feature/Tables/Components/TableWireShapeTest.php
@@ -50,9 +50,11 @@ it('serializes the table component wire shape', function (): void {
         'tableFilters' => [],
         'tableFilterIndicators' => [],
         'search' => '',
+        'mode' => null,
     ]);
     expect($payload['props']['bulkActions'])->toBe([]);
     expect($payload['props']['filters'])->toBe([]);
+    expect($payload['props']['perPageOptions'])->toBe([]);
 });
 
 it('serializes visible resize indicators on table components', function (): void {

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -47,6 +47,7 @@ test('registered tables serialize their configured endpoint columns state and in
                 'actionsLabel' => null,
                 'emptyLabel' => null,
                 'filters' => [],
+                'perPageOptions' => [],
                 'columns' => [
                     [
                         'key' => 'name',
@@ -134,6 +135,7 @@ test('registered tables serialize their configured endpoint columns state and in
                     'tableFilters' => [],
                     'tableFilterIndicators' => [],
                     'search' => '',
+                    'mode' => null,
                 ],
                 'pagination' => null,
             ],
@@ -162,6 +164,7 @@ test('registered tables can serialize lazily without running their query', funct
                 'actionsLabel' => null,
                 'emptyLabel' => null,
                 'filters' => [],
+                'perPageOptions' => [],
                 'columns' => [
                     [
                         'key' => 'name',
@@ -191,6 +194,7 @@ test('registered tables can serialize lazily without running their query', funct
                     'tableFilters' => [],
                     'tableFilterIndicators' => [],
                     'search' => '',
+                    'mode' => null,
                 ],
                 'pagination' => [
                     'mode' => 'table',

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -357,12 +357,12 @@ class WorkbenchPerPageUsersTable extends EloquentTableDefinition
     }
 
     /**
-     * @return array<int, int|string>
+     * @return array<int, int|PaginationType::Infinite>
      */
     #[Override]
     public function perPageOptions(): array
     {
-        return [1, 2, 200, 'infinite'];
+        return [1, 2, 200, PaginationType::Infinite];
     }
 
     public function columns(): array
@@ -400,12 +400,12 @@ class WorkbenchInfiniteSwitchUsersTable extends EloquentTableDefinition
     }
 
     /**
-     * @return array<int, int|string>
+     * @return array<int, int|PaginationType::Infinite>
      */
     #[Override]
     public function perPageOptions(): array
     {
-        return [2, 'infinite'];
+        return [2, PaginationType::Infinite];
     }
 
     public function columns(): array
@@ -431,7 +431,7 @@ class WorkbenchInfiniteSwitchUsersTable extends EloquentTableDefinition
 class WorkbenchNumericPerPageUsersTable extends EloquentTableDefinition
 {
     /**
-     * @return array<int, int|string>
+     * @return array<int, int|PaginationType::Infinite>
      */
     #[Override]
     public function perPageOptions(): array

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -154,6 +154,71 @@ test('per-page options serialize into the table component props', function (): v
     expect($table['props']['perPageOptions'])->toBe([1, 2, 200, 'infinite']);
 });
 
+test('mode=infinite switches a table-mode table to infinite pagination', function (): void {
+    User::query()->delete();
+
+    foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {
+        UserFactory::new()->create([
+            'name' => $name,
+            'email' => str($name)->slug()->append('@example.com')->toString(),
+        ]);
+    }
+
+    Lattice::tables([WorkbenchPerPageUsersTable::class]);
+
+    $this->loadTable(WorkbenchPerPageUsersTable::class, ['per_page' => 2, 'mode' => 'infinite'])
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('pagination.mode', 'infinite')
+        ->assertJsonPath('pagination.total', null)
+        ->assertJsonPath('pagination.hasMore', true)
+        ->assertJsonPath('query.mode', 'infinite');
+});
+
+test('mode=table switches an infinite-mode table to numbered pagination', function (): void {
+    User::query()->delete();
+
+    foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {
+        UserFactory::new()->create([
+            'name' => $name,
+            'email' => str($name)->slug()->append('@example.com')->toString(),
+        ]);
+    }
+
+    Lattice::tables([WorkbenchInfiniteSwitchUsersTable::class]);
+
+    $this->loadTable(WorkbenchInfiniteSwitchUsersTable::class, ['per_page' => 2, 'mode' => 'table'])
+        ->assertOk()
+        ->assertJsonPath('pagination.mode', 'table')
+        ->assertJsonPath('pagination.total', 3)
+        ->assertJsonPath('pagination.lastPage', 2)
+        ->assertJsonPath('query.mode', 'table');
+});
+
+test('mode=infinite is ignored when infinite is not declared', function (): void {
+    User::query()->delete();
+    UserFactory::new()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
+
+    Lattice::tables([WorkbenchNumericPerPageUsersTable::class]);
+
+    $this->loadTable(WorkbenchNumericPerPageUsersTable::class, ['mode' => 'infinite'])
+        ->assertOk()
+        ->assertJsonPath('pagination.mode', 'table')
+        ->assertJsonPath('query.mode', null);
+});
+
+test('mode overrides are ignored when no options are declared', function (): void {
+    User::query()->delete();
+    UserFactory::new()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
+
+    Lattice::tables([WorkbenchDefaultUsersTable::class]);
+
+    $this->loadTable(WorkbenchDefaultUsersTable::class, ['mode' => 'infinite'])
+        ->assertOk()
+        ->assertJsonPath('pagination.mode', 'table')
+        ->assertJsonPath('query.mode', null);
+});
+
 /**
  * @extends EloquentTableDefinition<User>
  */
@@ -298,6 +363,80 @@ class WorkbenchPerPageUsersTable extends EloquentTableDefinition
     public function perPageOptions(): array
     {
         return [1, 2, 200, 'infinite'];
+    }
+
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->label('Name')->sortable(),
+        ];
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    public function builder(TableQuery $query): Builder
+    {
+        return User::query()->select(['id', 'name'])->orderBy('id');
+    }
+}
+
+/**
+ * @extends EloquentTableDefinition<User>
+ */
+#[AsTable('workbench.infinite-switch-users')]
+class WorkbenchInfiniteSwitchUsersTable extends EloquentTableDefinition
+{
+    #[Override]
+    public function pagination(): PaginationType
+    {
+        return PaginationType::Infinite;
+    }
+
+    #[Override]
+    public function perPage(): int
+    {
+        return 2;
+    }
+
+    /**
+     * @return array<int, int|string>
+     */
+    #[Override]
+    public function perPageOptions(): array
+    {
+        return [2, 'infinite'];
+    }
+
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->label('Name')->sortable(),
+        ];
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    public function builder(TableQuery $query): Builder
+    {
+        return User::query()->select(['id', 'name'])->orderBy('id');
+    }
+}
+
+/**
+ * @extends EloquentTableDefinition<User>
+ */
+#[AsTable('workbench.numeric-per-page-users')]
+class WorkbenchNumericPerPageUsersTable extends EloquentTableDefinition
+{
+    /**
+     * @return array<int, int|string>
+     */
+    #[Override]
+    public function perPageOptions(): array
+    {
+        return [1, 2];
     }
 
     public function columns(): array

--- a/tests/Feature/Tables/TablePaginationTest.php
+++ b/tests/Feature/Tables/TablePaginationTest.php
@@ -120,6 +120,40 @@ test('eloquent tables can disable pagination for small datasets', function (): v
         ->assertJsonPath('pagination.hasMore', false);
 });
 
+test('declared per-page options validate the requested page size', function (): void {
+    User::query()->delete();
+
+    foreach (['Ada Lovelace', 'Grace Hopper', 'Maya Chen'] as $name) {
+        UserFactory::new()->create([
+            'name' => $name,
+            'email' => str($name)->slug()->append('@example.com')->toString(),
+        ]);
+    }
+
+    Lattice::tables([WorkbenchPerPageUsersTable::class]);
+
+    $this->loadTable(WorkbenchPerPageUsersTable::class, ['per_page' => 1])
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('query.perPage', 1);
+
+    $this->loadTable(WorkbenchPerPageUsersTable::class, ['per_page' => 7])
+        ->assertOk()
+        ->assertJsonPath('query.perPage', 2);
+
+    $this->loadTable(WorkbenchPerPageUsersTable::class, ['per_page' => 200])
+        ->assertOk()
+        ->assertJsonPath('query.perPage', 200);
+});
+
+test('per-page options serialize into the table component props', function (): void {
+    Lattice::tables([WorkbenchPerPageUsersTable::class]);
+
+    $table = wire(Table::use(WorkbenchPerPageUsersTable::class));
+
+    expect($table['props']['perPageOptions'])->toBe([1, 2, 200, 'infinite']);
+});
+
 /**
  * @extends EloquentTableDefinition<User>
  */
@@ -227,6 +261,43 @@ class WorkbenchSmallUsersTable extends EloquentTableDefinition
     public function pagination(): PaginationType
     {
         return PaginationType::None;
+    }
+
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->label('Name')->sortable(),
+        ];
+    }
+
+    /**
+     * @return Builder<User>
+     */
+    public function builder(TableQuery $query): Builder
+    {
+        return User::query()->select(['id', 'name'])->orderBy('id');
+    }
+}
+
+/**
+ * @extends EloquentTableDefinition<User>
+ */
+#[AsTable('workbench.per-page-users')]
+class WorkbenchPerPageUsersTable extends EloquentTableDefinition
+{
+    #[Override]
+    public function perPage(): int
+    {
+        return 2;
+    }
+
+    /**
+     * @return array<int, int|string>
+     */
+    #[Override]
+    public function perPageOptions(): array
+    {
+        return [1, 2, 200, 'infinite'];
     }
 
     public function columns(): array

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -38,6 +38,15 @@ use Workbench\App\Tables\Columns\StatusBadgeColumn;
 class ProductsTable extends EloquentTableDefinition
 {
     /**
+     * @return array<int, int|string>
+     */
+    #[Override]
+    public function perPageOptions(): array
+    {
+        return [10, 25, 50, 100, 'infinite'];
+    }
+
+    /**
      * @return array<int, Column>
      */
     public function columns(): array

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Tables\Columns\Column;
 use Lattice\Lattice\Tables\Columns\ImageColumn;
 use Lattice\Lattice\Tables\Columns\MoneyColumn;
 use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Enums\PaginationType;
 use Lattice\Lattice\Tables\Filters\DateRangeFilter;
 use Lattice\Lattice\Tables\Filters\Filter;
 use Lattice\Lattice\Tables\Filters\TernaryFilter;
@@ -38,12 +39,12 @@ use Workbench\App\Tables\Columns\StatusBadgeColumn;
 class ProductsTable extends EloquentTableDefinition
 {
     /**
-     * @return array<int, int|string>
+     * @return array<int, int|PaginationType::Infinite>
      */
-    #[Override]
+    #[\Override]
     public function perPageOptions(): array
     {
-        return [10, 25, 50, 100, 'infinite'];
+        return [10, 25, 50, 100, PaginationType::Infinite];
     }
 
     /**


### PR DESCRIPTION
## What

Tables can declare page-size options that render a "Rows per page" select in the pagination bar. Alongside numeric sizes, `PaginationType::Infinite` lets the user switch the table to infinite pagination at runtime — and back to numbered pages (also for tables whose default mode is infinite).

```php
use Lattice\Lattice\Tables\Enums\PaginationType;

/** @return array<int, int|PaginationType::Infinite> */
public function perPageOptions(): array
{
    return [10, 25, 50, 100, PaginationType::Infinite];
}
```

Empty (the default) keeps today's behavior: no select, fixed page size. The docblock uses a PHPStan enum-case type, so any other case fails static analysis; the component setter additionally throws on anything besides ints and `PaginationType::Infinite`. The marker serializes to `'infinite'` only at the wire boundary, where the client narrows it back to the literal union `number | "infinite"`.

## How

- `TableQuery` gains a nullable `mode` override parsed from the request and round-tripped through the serialized query, so the choice survives sorting/filtering/paging. `EloquentTableSource` paginates with `$query->mode ?? definition mode`.
- Requested sizes validate against the declared options (fallback: the definition's `perPage()`); `mode=infinite` is only honored when the infinite option is declared. Undeclared values are silently normalized, matching the existing `per_page` clamp.
- The client UI was already result-mode-driven, so switching modes needed no new rendering paths — just a `NativeSelect` (before: pagination bar showed only "Showing X–Y of Z" + pager; after: a "Rows per page" select sits next to it, `data-test="pagination-per-page"`).
- Demoed on the workbench products table; documented in *Sorting & pagination*; en+de translations; regenerated TS types and docs fixtures.

Covered by Pest feature tests (validation, mode switching both directions, undeclared-mode guards, wire normalization + setter guard) and Vitest component tests (select rendering, size change, infinite round-trip incl. append/replace behavior).