### PR TITLE
fix: parse dates through toDate, and await the standalone boot

### DIFF
--- a/resources/js/format/date-time.test.ts
+++ b/resources/js/format/date-time.test.ts
@@ -54,8 +54,31 @@ describe("preciseDateTime", () => {
     expect(text).toContain("Europe/Berlin");
   });
 
+  it("formats a Date instance the same as its equivalent ISO string", () => {
+    const options = { locale: "en-GB", timeZone: "UTC" };
+
+    expect(preciseDateTime(new Date("2026-06-18T00:30:00Z"), options)).toBe(
+      preciseDateTime("2026-06-18T00:30:00Z", options),
+    );
+  });
+
   it("returns an empty string for an invalid value", () => {
     expect(preciseDateTime("not-a-date", { timeZone: "UTC" })).toBe("");
+  });
+
+  it("returns an empty string for an invalid Date instance", () => {
+    expect(preciseDateTime(new Date("not-a-date"), { timeZone: "UTC" })).toBe("");
+  });
+
+  it("returns an empty string for null, undefined, and an empty string", () => {
+    expect(preciseDateTime(null, { timeZone: "UTC" })).toBe("");
+    expect(preciseDateTime(undefined, { timeZone: "UTC" })).toBe("");
+    expect(preciseDateTime("", { timeZone: "UTC" })).toBe("");
+  });
+
+  it("returns an empty string for an object or a boolean", () => {
+    expect(preciseDateTime({}, { timeZone: "UTC" })).toBe("");
+    expect(preciseDateTime(true, { timeZone: "UTC" })).toBe("");
   });
 });
 
@@ -86,5 +109,57 @@ describe("formatDateValue", () => {
 
     expect(dateOnly).toContain("2026");
     expect(timeOnly).toContain("00:30");
+  });
+
+  it("formats a Date instance the same as its equivalent ISO string", () => {
+    const config = { dateStyle: "medium" as const, timeStyle: "short" as const };
+    const options = { locale: "en-GB", timeZone: "UTC" };
+
+    expect(formatDateValue(new Date("2026-06-18T00:30:00Z"), config, options)).toBe(
+      formatDateValue("2026-06-18T00:30:00Z", config, options),
+    );
+  });
+
+  it("formats a numeric timestamp instead of degrading to its stringified digits", () => {
+    const timestamp = new Date("2026-06-18T00:30:00Z").getTime();
+
+    const formatted = formatDateValue(
+      timestamp,
+      { dateStyle: "medium", timeStyle: null },
+      { locale: "en-GB", timeZone: "UTC" },
+    );
+
+    expect(formatted).toBe(
+      formatDateValue(
+        "2026-06-18T00:30:00Z",
+        { dateStyle: "medium", timeStyle: null },
+        { locale: "en-GB", timeZone: "UTC" },
+      ),
+    );
+    expect(formatted).not.toBe(String(timestamp));
+  });
+
+  it("returns the raw value for an invalid Date instance", () => {
+    const invalid = new Date("not-a-date");
+
+    expect(formatDateValue(invalid, { dateStyle: "medium", timeStyle: null })).toBe(
+      String(invalid),
+    );
+  });
+
+  it("degrades to an empty string for null, undefined, and an empty string", () => {
+    const config = { dateStyle: "medium" as const, timeStyle: null };
+
+    expect(formatDateValue(null, config)).toBe("");
+    expect(formatDateValue(undefined, config)).toBe("");
+    expect(formatDateValue("", config)).toBe("");
+  });
+
+  it("degrades to String(value) for an object or a boolean", () => {
+    const config = { dateStyle: "medium" as const, timeStyle: null };
+
+    expect(formatDateValue({}, config)).toBe("[object Object]");
+    expect(formatDateValue(true, config)).toBe("true");
+    expect(formatDateValue(false, config)).toBe("false");
   });
 });

--- a/resources/js/format/date-time.ts
+++ b/resources/js/format/date-time.ts
@@ -13,9 +13,9 @@ export type DateConfig = {
 };
 
 export function formatDateValue(value: unknown, date: DateConfig, options?: FormatOptions): string {
-  const parsed = new Date(String(value));
+  const parsed = toDate(value);
 
-  if (Number.isNaN(parsed.getTime())) {
+  if (!parsed) {
     return String(value ?? "");
   }
 
@@ -52,9 +52,9 @@ export function toDate(value: unknown): Date | null {
 }
 
 export function preciseDateTime(value: unknown, options?: FormatOptions): string {
-  const date = new Date(String(value));
+  const date = toDate(value);
 
-  if (Number.isNaN(date.getTime())) {
+  if (!date) {
     return "";
   }
 

--- a/resources/js/i18n/date-time.test.tsx
+++ b/resources/js/i18n/date-time.test.tsx
@@ -36,4 +36,19 @@ describe("<DateTime>", () => {
     expect(time?.getAttribute("dateTime")).toBeNull();
     expect(time?.getAttribute("title")).toBeNull();
   });
+
+  it("renders a numeric timestamp the same as its equivalent ISO string", () => {
+    setTimezone("Europe/Berlin");
+    const timestamp = new Date("2026-06-18T00:30:00Z").getTime();
+
+    const { container: fromTimestamp } = render(<DateTime value={timestamp} />);
+    const { container: fromIso } = render(<DateTime value="2026-06-18T00:30:00Z" />);
+
+    const timeFromTimestamp = fromTimestamp.querySelector("time");
+    const timeFromIso = fromIso.querySelector("time");
+
+    expect(timeFromTimestamp?.textContent).toBe(timeFromIso?.textContent);
+    expect(timeFromTimestamp?.getAttribute("dateTime")).toBe("2026-06-18T00:30:00.000Z");
+    expect(timeFromTimestamp?.getAttribute("dateTime")).toBe(timeFromIso?.getAttribute("dateTime"));
+  });
 });

--- a/resources/js/i18n/date-time.tsx
+++ b/resources/js/i18n/date-time.tsx
@@ -3,6 +3,7 @@ import {
   type FormatOptions,
   formatDateValue,
   preciseDateTime,
+  toDate,
 } from "@lattice-php/lattice/format/date-time";
 import type { DateTimeStyle } from "@lattice-php/lattice/types/generated";
 import { useLocale } from "./locale";
@@ -39,7 +40,5 @@ export function DateTime({
 }
 
 function isoOrNull(value: unknown): string | null {
-  const date = new Date(String(value));
-
-  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  return toDate(value)?.toISOString() ?? null;
 }

--- a/resources/js/standalone/main.test.tsx
+++ b/resources/js/standalone/main.test.tsx
@@ -24,9 +24,10 @@ it("boots with no config script", async () => {
   vi.resetModules();
 
   const { withVisitHeaders } = await import("@lattice-php/lattice/inertia");
-  await import("./main");
-  await vi.waitFor(() => expect(createLatticeApp).toHaveBeenCalledOnce());
+  const { booted } = await import("./main");
+  await booted;
 
+  expect(createLatticeApp).toHaveBeenCalledOnce();
   const options = createLatticeApp.mock.calls[0]?.[0];
   expect(options).not.toHaveProperty("sprite");
   expect(options?.defaults?.visitOptions).toBe(withVisitHeaders);
@@ -36,9 +37,10 @@ it("passes the sprite href when the config has a spriteUrl", async () => {
   setConfigScript(JSON.stringify({ spriteUrl: "/vendor/lattice/sprite.svg?v=abc" }));
   vi.resetModules();
 
-  await import("./main");
-  await vi.waitFor(() => expect(createLatticeApp).toHaveBeenCalledOnce());
+  const { booted } = await import("./main");
+  await booted;
 
+  expect(createLatticeApp).toHaveBeenCalledOnce();
   const options = createLatticeApp.mock.calls[0]?.[0];
   expect(options?.sprite).toEqual({ href: "/vendor/lattice/sprite.svg?v=abc" });
 });
@@ -47,9 +49,10 @@ it("configures echo before booting the app", async () => {
   setConfigScript(JSON.stringify({ echo: { broadcaster: "reverb" } }));
   vi.resetModules();
 
-  await import("./main");
-  await vi.waitFor(() => expect(createLatticeApp).toHaveBeenCalledOnce());
+  const { booted } = await import("./main");
+  await booted;
 
+  expect(createLatticeApp).toHaveBeenCalledOnce();
   expect(configureEcho).toHaveBeenCalledExactlyOnceWith({ broadcaster: "reverb" });
   expect(configureEcho.mock.invocationCallOrder[0]).toBeLessThan(
     createLatticeApp.mock.invocationCallOrder[0]!,
@@ -64,9 +67,10 @@ it("warns and still boots the app when configuring echo fails", async () => {
   setConfigScript(JSON.stringify({ echo: { broadcaster: "reverb" } }));
   vi.resetModules();
 
-  await import("./main");
-  await vi.waitFor(() => expect(createLatticeApp).toHaveBeenCalledOnce());
+  const { booted } = await import("./main");
+  await booted;
 
+  expect(createLatticeApp).toHaveBeenCalledOnce();
   expect(warn).toHaveBeenCalledOnce();
 
   warn.mockRestore();

--- a/resources/js/standalone/main.tsx
+++ b/resources/js/standalone/main.tsx
@@ -27,4 +27,4 @@ async function boot(): Promise<void> {
   });
 }
 
-void boot();
+export const booted = boot();


### PR DESCRIPTION
Two independent fixes, one commit each.

## `formatDateValue` mangled numeric timestamps

`toDate()` landed in 0.31 for the i18next `datetime` formatter, but three older near-copies of the same parse-and-degrade dance stayed behind — `formatDateValue`, `preciseDateTime`, and `isoOrNull`. All three built their own `Date` from `new Date(String(value))`, which stringifies a number before parsing:

```js
new Date(String(1772928000000))  // Invalid Date
new Date(1772928000000)          // 2026-03-06T00:00:00.000Z
```

So `<DateTime value={1772928000000} />` rendered nothing useful. Routing all three through `toDate` fixes it and removes the duplication. Every other input — a valid ISO string, a `Date` instance, an already-invalid `Date`, `null`, `undefined`, an empty string, a non-date string, an object, a boolean — degrades exactly as before, and there are tests for each.

## The standalone boot test was flaky under load

`main.tsx` ended with `void boot()`, a floating promise nothing could await, so all four tests in `main.test.tsx` compensated with `vi.waitFor(() => expect(createLatticeApp).toHaveBeenCalledOnce())`.

That is not just slow — it leaks. Two of the tests set `config.echo`, so `boot()` awaits `import("@laravel/echo-react")` before calling `createLatticeApp`. Under load that import can resolve after the test has ended and `afterEach` has run `mockClear()`, so the call lands during a **later** test. Reproduced under full-suite concurrency:

```
FAIL resources/js/standalone/main.test.tsx > warns and still boots the app when configuring echo fails
AssertionError: expected "vi.fn()" to be called once, but got 3 times
```

The three sibling timeouts in that same run are the same cause — `vi.waitFor` polling for a count a leaked call had already corrupted.

`boot()` is now exported as `booted`, and each test awaits its own boot before asserting, so no call can reach a later test. `vi.waitFor` is gone from the file.

To be precise about what this proves: the leakage mechanism is structurally removed, since each test now awaits the promise it depends on. Consistent passes alone would not establish that.

`composer check` (1381 tests), `npm run check` (1163 tests), and `npm run build` all green; the standalone bundle still emits.