### PR TITLE
feat(js): export the form field-scope hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,10 @@
       "types": "./dist/form/hooks/context.d.ts",
       "import": "./dist/form/hooks/context.js"
     },
+    "./form/hooks/field-scope": {
+      "types": "./dist/form/hooks/field-scope.d.ts",
+      "import": "./dist/form/hooks/field-scope.js"
+    },
     "./form/hooks/values": {
       "types": "./dist/form/hooks/values.d.ts",
       "import": "./dist/form/hooks/values.js"


### PR DESCRIPTION
## Summary
- Exports `./form/hooks/field-scope` (`FieldScopeProvider`, `useFieldScope`) alongside the existing `./form/hooks/context` entry, same dist/types path pattern.
- The media package's picker fields need `FieldScopeProvider` to scope per-item fields.

No other changes: `vite.config.ts`'s library entries are auto-discovered from `resources/js`, so the existing source file is already picked up by the build.