### PR TITLE
fix: make Inertia SSR work end to end

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -12,6 +12,29 @@
           }
         ]
       }
+    },
+    {
+      "files": ["resources/js/**/*.{ts,tsx}"],
+      "excludeFiles": [
+        "resources/js/test/browser-setup.ts",
+        "resources/js/ui/**",
+        "resources/js/form/rich-editor/toolbar-button.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": ["../**"],
+            "paths": [
+              {
+                "name": "react",
+                "importNames": ["useLayoutEffect"],
+                "message": "Import the SSR-safe useLayoutEffect from @lattice-php/lattice/lib/use-layout-effect instead."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -200,6 +200,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: "Security", link: "/advanced/security/" },
+            { label: "Server-side rendering", link: "/advanced/ssr/" },
             { label: "Remote components", link: "/advanced/remote/" },
             { label: "Bundle size", link: "/advanced/bundle-size/" },
             { label: "Enums reference", link: "/advanced/enums/" },

--- a/docs/content/docs/advanced/ssr.md
+++ b/docs/content/docs/advanced/ssr.md
@@ -1,0 +1,89 @@
+---
+title: Server-side rendering
+description: Render Lattice pages to HTML on the server with Inertia SSR and hydrate them in place on the client.
+---
+
+Lattice works with [Inertia SSR](https://inertiajs.com/server-side-rendering): the first visit is
+rendered to full HTML on the server and the client hydrates it in place. Same pages, same
+components — SSR is a deployment choice, not a different way of building.
+
+## The SSR entry
+
+`@inertiajs/vite` normally generates the SSR bootstrap by detecting a literal `createInertiaApp`
+call — which a Lattice app doesn't have. The package ships the equivalent for `createLatticeApp`:
+**`createLatticeSsr`**, on its own `@lattice-php/lattice/ssr` subpath. Create `resources/js/ssr.tsx`
+next to your `app.tsx` and pass it the **same options**:
+
+```tsx
+// resources/js/ssr.tsx
+import createServer from "@inertiajs/react/server";
+import { createLatticeSsr } from "@lattice-php/lattice/ssr";
+import plugins from "virtual:lattice/plugins";
+import sprite from "virtual:svg-sprite";
+
+createServer(
+  createLatticeSsr({
+    plugins,
+    sprite,
+    pages: import.meta.glob("./Pages/**/*.tsx"),
+  }),
+);
+```
+
+`@inertiajs/vite` finds `resources/js/ssr.tsx` on its own and rewrites the `createServer` call into
+the development endpoint and the production HTTP bootstrap — one file covers both. Keep the options
+in sync with [`createLatticeApp`](/introduction/installation/#register-the-inertia-renderer) (or
+extract them into a shared module); browser-only options such as `boot` never run on the server, so
+sharing one options object is safe.
+
+:::note
+`createLatticeSsr` lives on its own subpath on purpose: it imports `react-dom/server`, which has no
+business in a client bundle. Import it only from the SSR entry, never from `app.tsx`.
+:::
+
+## Development
+
+Nothing else to start. With the entry in place and `inertia.ssr.enabled` on (the default), the
+Laravel adapter renders through the Vite dev server directly — no separate Node process.
+
+## Production
+
+Build the SSR bundle alongside the client build and run the SSR server. With the Laravel Vite
+plugin, point its `ssr` option at the same entry so `vite build --ssr` emits
+`bootstrap/ssr/ssr.mjs` where the adapter expects it:
+
+```ts
+// vite.config.ts
+laravel({
+  input: ["resources/css/app.css", "resources/js/app.tsx"],
+  ssr: "resources/js/ssr.tsx",
+}),
+```
+
+```bash
+vite build && vite build --ssr
+php artisan inertia:start-ssr
+```
+
+## What the server renders
+
+- The full page — layout, navigation, and every eagerly registered component. Components registered
+  with `lazyComponent()` render their loading fallback on the server and stream in after hydration;
+  register a component with `eagerComponent()` if its markup should be part of the server HTML.
+- The theme. Lattice shares the `appearance` cookie with the server render, so a user who picked
+  dark mode gets dark-mode HTML instead of a flash of the default.
+- `boot` and the rest of the client bootstrap run after hydration. On a server-rendered page the
+  first client render intentionally does not wait for them — hydration must match the HTML the
+  server produced.
+
+## SSR-safe custom components
+
+Anything you register yourself ([custom fields](/extending/custom-fields/),
+[component packages](/extending/component-packages/)) renders on the server too. Two rules keep a
+component SSR-safe:
+
+- Don't touch `window`, `document`, or other browser globals during render — move that work into an
+  effect, or guard it with `typeof window === "undefined"`.
+- Import `useLayoutEffect` from `@lattice-php/lattice/lib/use-layout-effect` instead of `react`.
+  It is the same hook in the browser and substitutes `useEffect` on the server, where React's own
+  `useLayoutEffect` warns.

--- a/package.json
+++ b/package.json
@@ -162,6 +162,10 @@
       "types": "./dist/remote/index.d.ts",
       "import": "./dist/remote/index.js"
     },
+    "./ssr": {
+      "types": "./dist/ssr.d.ts",
+      "import": "./dist/ssr.js"
+    },
     "./table": {
       "types": "./dist/table/index.d.ts",
       "import": "./dist/table/index.js"

--- a/package.json
+++ b/package.json
@@ -138,6 +138,10 @@
       "types": "./dist/lib/use-debounced-callback.d.ts",
       "import": "./dist/lib/use-debounced-callback.js"
     },
+    "./lib/use-layout-effect": {
+      "types": "./dist/lib/use-layout-effect.d.ts",
+      "import": "./dist/lib/use-layout-effect.js"
+    },
     "./lib/utils": {
       "types": "./dist/lib/utils.d.ts",
       "import": "./dist/lib/utils.js"

--- a/resources/js/appearance/index.test.tsx
+++ b/resources/js/appearance/index.test.tsx
@@ -45,6 +45,25 @@ function stubColorScheme(initialMatches: boolean) {
   };
 }
 
+it("serves the seeded appearance to server renders and ignores unknown values", async () => {
+  const { seedAppearance, useAppearance } = await import(".");
+  const { renderToString } = await import("react-dom/server");
+
+  function Probe() {
+    return <span>{useAppearance().appearance}</span>;
+  }
+
+  expect(renderToString(<Probe />)).toContain("system");
+
+  seedAppearance("dark");
+
+  expect(renderToString(<Probe />)).toContain("dark");
+
+  seedAppearance("sepia");
+
+  expect(renderToString(<Probe />)).toContain("dark");
+});
+
 it("updates subscribers when the system theme changes in system mode", async () => {
   const colorScheme = stubColorScheme(false);
   localStorage.setItem("appearance", "system");

--- a/resources/js/appearance/index.ts
+++ b/resources/js/appearance/index.ts
@@ -14,6 +14,19 @@ export type UseAppearanceReturn = {
 
 const listeners = new Set<() => void>();
 let currentAppearance: Appearance = "system";
+let serverAppearance: Appearance = "system";
+
+/**
+ * Seed the SSR/hydration snapshot from the backend-shared `lattice.appearance`
+ * prop (the `appearance` cookie). Both the server render and the client's
+ * hydration pass read this snapshot, so components branching on the appearance
+ * hydrate against the same value the server rendered instead of "system".
+ */
+export function seedAppearance(value: unknown): void {
+  if (isAppearance(value)) {
+    serverAppearance = value;
+  }
+}
 
 export function isAppearance(value: unknown): value is Appearance {
   return appearances.some((appearance) => appearance === value);
@@ -115,7 +128,7 @@ export function useAppearance(): UseAppearanceReturn {
   const appearance: Appearance = useSyncExternalStore(
     subscribe,
     () => currentAppearance,
-    () => "system",
+    () => serverAppearance,
   );
   const systemAppearance: ResolvedAppearance = useSyncExternalStore(
     subscribe,

--- a/resources/js/appearance/index.ts
+++ b/resources/js/appearance/index.ts
@@ -18,9 +18,8 @@ let serverAppearance: Appearance = "system";
 
 /**
  * Seed the SSR/hydration snapshot from the backend-shared `lattice.appearance`
- * prop (the `appearance` cookie). Both the server render and the client's
- * hydration pass read this snapshot, so components branching on the appearance
- * hydrate against the same value the server rendered instead of "system".
+ * prop. The server render and the client's hydration pass must read the same
+ * value, or components branching on the appearance mismatch on hydration.
  */
 export function seedAppearance(value: unknown): void {
   if (isAppearance(value)) {

--- a/resources/js/create-app.test.tsx
+++ b/resources/js/create-app.test.tsx
@@ -1,6 +1,8 @@
 import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
+import { hydrateRoot, type Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createInertiaApp = vi.hoisted(() => vi.fn<(options?: unknown) => void>());
@@ -19,6 +21,7 @@ vi.mock("@inertiajs/react", async () =>
 );
 vi.mock("./i18n/page-props", () => ({ configureI18nFromPageProps }));
 
+import { useAppearance } from "./appearance";
 import { createLatticeApp } from "./create-app";
 import { pageComponentName } from "./inertia";
 import Page from "./page";
@@ -71,6 +74,7 @@ afterEach(() => {
   createInertiaApp.mockReset();
   configureI18nFromPageProps.mockClear();
   localStorage.clear();
+  document.getElementById("app")?.remove();
 });
 
 describe("createLatticeApp", () => {
@@ -281,6 +285,70 @@ describe("createLatticeApp", () => {
 
     resolveBoot();
     await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+  });
+
+  it("hydrates server-rendered markup immediately without a mismatch", async () => {
+    let resolveConfigure = (): void => {};
+    configureI18nFromPageProps.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveConfigure = resolve;
+      }),
+    );
+
+    const page = fakePage(i18nProps);
+
+    createLatticeApp();
+
+    const options = captureOptions();
+    const html = renderToString(
+      options.withApp(<div data-test="app">hello</div>, { ssr: true, page }),
+    );
+
+    const el = document.createElement("div");
+    el.id = "app";
+    el.setAttribute("data-server-rendered", "true");
+    el.innerHTML = html;
+    document.body.append(el);
+
+    const onRecoverableError = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let root: Root | undefined;
+
+    await act(async () => {
+      root = hydrateRoot(
+        el,
+        options.withApp(<div data-test="app">hello</div>, { ssr: false, page }),
+        { onRecoverableError },
+      );
+    });
+
+    expect(screen.getByTestId("app")).toHaveTextContent("hello");
+    expect(onRecoverableError).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(configureI18nFromPageProps).toHaveBeenCalledWith(i18nProps, {});
+
+    resolveConfigure();
+    await act(async () => {});
+
+    root?.unmount();
+    consoleError.mockRestore();
+  });
+
+  it("seeds the server-rendered appearance from the shared prop", () => {
+    function Probe() {
+      return <span>{useAppearance().appearance}</span>;
+    }
+
+    createLatticeApp();
+
+    const html = renderToString(
+      captureOptions().withApp(<Probe />, {
+        ssr: true,
+        page: fakePage({ lattice: { appearance: "dark" } }),
+      }),
+    );
+
+    expect(html).toContain("dark");
   });
 
   it("skips boot and the i18n bootstrap on the server render", () => {

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -50,10 +50,10 @@ export type CreateLatticeAppOptions = Omit<
   /**
    * Lattice's i18n bootstrap, on by default: when the backend shares the
    * `lattice.i18n` prop, the first render waits for the translation setup (no
-   * flash of untranslated fallbacks — except when hydrating a server-rendered
-   * page, which renders immediately to match the SSR'd HTML and swaps
-   * client-only strings in once ready), `LocaleReload` re-fetches the page after
-   * a locale switch, and every visit carries the locale/timezone headers. The
+   * flash of untranslated fallbacks; a server-rendered page instead hydrates
+   * immediately and swaps strings in once ready), `LocaleReload` re-fetches the
+   * page after a locale switch, and every visit carries the locale/timezone
+   * headers. The
    * i18next chunk only loads when the backend actually shares the prop. Pass
    * `false` to opt out entirely.
    */
@@ -217,10 +217,8 @@ export function createLatticeApp({
       }
 
       // A hydration pass must render what the server rendered — gating on the
-      // bootstrap would hydrate null against the SSR'd markup and force a full
-      // client re-render. The hold still lets the i18n backend win the init
-      // race; translated strings swap in once the bootstrap resolves (the
-      // server-driven ones are already translated in PHP).
+      // bootstrap would hydrate null against the SSR'd markup. The hold still
+      // lets the i18n backend win the init race; strings swap in once it resolves.
       if (hydrating) {
         holdI18nInit(Promise.all(pending));
 

--- a/resources/js/create-app.tsx
+++ b/resources/js/create-app.tsx
@@ -1,13 +1,13 @@
 import type { Page as InertiaPage, VisitOptions } from "@inertiajs/core";
 import { createInertiaApp } from "@inertiajs/react";
 import { useEffect, useState, type ReactElement, type ReactNode } from "react";
-import { initializeAppearance } from "./appearance";
+import { initializeAppearance, seedAppearance } from "./appearance";
 import { setRefRefreshEndpoint } from "./core/api";
 import { isRecord } from "./core/materialize";
 import { extendRegistry, type Plugin, type PluginI18n, type Registry } from "./core/registry";
 import { setDefaultRegistry } from "./core/registry-context";
 import type { SpriteValue } from "./icons/sprite";
-import { DEFAULT_NAMESPACE } from "./i18n/instance";
+import { DEFAULT_NAMESPACE, holdI18nInit } from "./i18n/instance";
 import { LocaleReload } from "./i18n/locale-reload";
 import { i18nConfigFromPageProps } from "./i18n/shared-props";
 import {
@@ -50,7 +50,9 @@ export type CreateLatticeAppOptions = Omit<
   /**
    * Lattice's i18n bootstrap, on by default: when the backend shares the
    * `lattice.i18n` prop, the first render waits for the translation setup (no
-   * flash of untranslated fallbacks), `LocaleReload` re-fetches the page after
+   * flash of untranslated fallbacks — except when hydrating a server-rendered
+   * page, which renders immediately to match the SSR'd HTML and swaps
+   * client-only strings in once ready), `LocaleReload` re-fetches the page after
    * a locale switch, and every visit carries the locale/timezone headers. The
    * i18next chunk only loads when the backend actually shares the prop. Pass
    * `false` to opt out entirely.
@@ -59,7 +61,8 @@ export type CreateLatticeAppOptions = Omit<
   /**
    * App bootstrap that needs the initial page — e.g. `configureEcho` from a
    * shared connection prop. Runs on the client before the first render; a
-   * returned promise delays that render until it resolves.
+   * returned promise delays that render until it resolves, except when
+   * hydrating a server-rendered page (hydration must match the SSR'd HTML).
    */
   boot?: (context: { page: InertiaPage }) => void | Promise<void>;
   /**
@@ -154,9 +157,18 @@ export function createLatticeApp({
     layout: createLayoutResolver({ defaultLayout }),
     withApp: (node: ReactElement, { ssr, page }: { ssr: boolean; page: InertiaPage }) => {
       const pending: Promise<unknown>[] = [];
+      const shared = page.props.lattice;
+      let hydrating = false;
+
+      if (isRecord(shared)) {
+        seedAppearance(shared.appearance);
+      }
 
       if (!ssr) {
-        const shared = page.props.lattice;
+        hydrating =
+          document
+            .getElementById(inertiaOptions.id ?? "app")
+            ?.hasAttribute("data-server-rendered") === true;
 
         if (
           isRecord(shared) &&
@@ -200,11 +212,22 @@ export function createLatticeApp({
         </ProviderBase>
       );
 
-      return pending.length > 0 ? (
-        <AwaitReady ready={Promise.all(pending)}>{shell}</AwaitReady>
-      ) : (
-        shell
-      );
+      if (pending.length === 0) {
+        return shell;
+      }
+
+      // A hydration pass must render what the server rendered — gating on the
+      // bootstrap would hydrate null against the SSR'd markup and force a full
+      // client re-render. The hold still lets the i18n backend win the init
+      // race; translated strings swap in once the bootstrap resolves (the
+      // server-driven ones are already translated in PHP).
+      if (hydrating) {
+        holdI18nInit(Promise.all(pending));
+
+        return shell;
+      }
+
+      return <AwaitReady ready={Promise.all(pending)}>{shell}</AwaitReady>;
     },
   });
 

--- a/resources/js/form/components/fields/use-flip-reorder.ts
+++ b/resources/js/form/components/fields/use-flip-reorder.ts
@@ -1,4 +1,5 @@
-import { useCallback, useLayoutEffect, useRef } from "react";
+import { useCallback, useRef } from "react";
+import { useIsomorphicLayoutEffect } from "@lattice-php/lattice/lib/use-isomorphic-layout-effect";
 
 const DURATION_MS = 180;
 
@@ -26,7 +27,7 @@ export function useFlipReorder(
     }
   }, []);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const handles: number[] = [];
     const next = new Map<string, DOMRect>();
     elements.current.forEach((el, key) => {

--- a/resources/js/form/components/fields/use-flip-reorder.ts
+++ b/resources/js/form/components/fields/use-flip-reorder.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from "react";
-import { useIsomorphicLayoutEffect } from "@lattice-php/lattice/lib/use-isomorphic-layout-effect";
+import { useLayoutEffect } from "@lattice-php/lattice/lib/use-layout-effect";
 
 const DURATION_MS = 180;
 
@@ -27,7 +27,7 @@ export function useFlipReorder(
     }
   }, []);
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     const handles: number[] = [];
     const next = new Map<string, DOMRect>();
     elements.current.forEach((el, key) => {

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,4 +1,5 @@
-import { useCallback, useLayoutEffect } from "react";
+import { useCallback } from "react";
+import { useIsomorphicLayoutEffect } from "@lattice-php/lattice/lib/use-isomorphic-layout-effect";
 import { useFieldScope } from "@lattice-php/lattice/form/hooks/field-scope";
 import { useFormValue, useSetFormValue } from "@lattice-php/lattice/form/hooks/values";
 import {
@@ -29,7 +30,7 @@ export function useRowCollection(name: string, defaultItems: number): RowCollect
   const raw: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
   const rows = ensureRowIds(raw);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (rows !== raw) {
       setValue(path, rows);
     }

--- a/resources/js/form/components/fields/use-row-collection.ts
+++ b/resources/js/form/components/fields/use-row-collection.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useIsomorphicLayoutEffect } from "@lattice-php/lattice/lib/use-isomorphic-layout-effect";
+import { useLayoutEffect } from "@lattice-php/lattice/lib/use-layout-effect";
 import { useFieldScope } from "@lattice-php/lattice/form/hooks/field-scope";
 import { useFormValue, useSetFormValue } from "@lattice-php/lattice/form/hooks/values";
 import {
@@ -30,7 +30,7 @@ export function useRowCollection(name: string, defaultItems: number): RowCollect
   const raw: RepeaterRow[] = Array.isArray(stored) ? stored : seedRows(stored, defaultItems);
   const rows = ensureRowIds(raw);
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     if (rows !== raw) {
       setValue(path, rows);
     }

--- a/resources/js/form/hooks/use-form-resolver.test.tsx
+++ b/resources/js/form/hooks/use-form-resolver.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
-import { useLayoutEffect } from "react";
+import { useLayoutEffect } from "@lattice-php/lattice/lib/use-layout-effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Node } from "@lattice-php/lattice/core/types";
 import { fakeNode } from "@lattice-php/lattice/test-support";

--- a/resources/js/form/hooks/use-form-resolver.ts
+++ b/resources/js/form/hooks/use-form-resolver.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useIsomorphicLayoutEffect } from "@lattice-php/lattice/lib/use-isomorphic-layout-effect";
 import type { Node } from "@lattice-php/lattice/core/types";
 import type { ResolveResponse } from "@lattice-php/lattice/types/generated";
 import { walkFields } from "@lattice-php/lattice/form/lib/field-props";
@@ -41,7 +42,7 @@ export function useFormResolver(
   const targetsRef = useRef(targets);
   targetsRef.current = targets;
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const liveOverrideKeys = new Set(targets.map((target) => target.overrideKey));
     seededOverrideKeys.current = new Set(
       [...seededOverrideKeys.current].filter((overrideKey) => liveOverrideKeys.has(overrideKey)),

--- a/resources/js/form/hooks/use-form-resolver.ts
+++ b/resources/js/form/hooks/use-form-resolver.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useIsomorphicLayoutEffect } from "@lattice-php/lattice/lib/use-isomorphic-layout-effect";
+import { useLayoutEffect } from "@lattice-php/lattice/lib/use-layout-effect";
 import type { Node } from "@lattice-php/lattice/core/types";
 import type { ResolveResponse } from "@lattice-php/lattice/types/generated";
 import { walkFields } from "@lattice-php/lattice/form/lib/field-props";
@@ -42,7 +42,7 @@ export function useFormResolver(
   const targetsRef = useRef(targets);
   targetsRef.current = targets;
 
-  useIsomorphicLayoutEffect(() => {
+  useLayoutEffect(() => {
     const liveOverrideKeys = new Set(targets.map((target) => target.overrideKey));
     seededOverrideKeys.current = new Set(
       [...seededOverrideKeys.current].filter((overrideKey) => liveOverrideKeys.has(overrideKey)),

--- a/resources/js/i18n/instance.test.tsx
+++ b/resources/js/i18n/instance.test.tsx
@@ -67,6 +67,41 @@ describe("i18n instance", () => {
     loadLanguages.mockRestore();
   });
 
+  it("holds component-driven init so a pending bootstrap can register its backend", async () => {
+    vi.resetModules();
+    const fresh = await import("./instance");
+
+    let releaseBootstrap = (): void => {};
+    fresh.holdI18nInit(
+      new Promise<void>((resolve) => {
+        releaseBootstrap = resolve;
+      }),
+    );
+
+    const deferred = fresh.ensureI18n();
+
+    expect(fresh.i18n.isInitialized).toBeFalsy();
+
+    await fresh.ensureI18n((base) => ({ ...base, ns: ["backend-ns"] }));
+
+    releaseBootstrap();
+    await deferred;
+
+    expect(fresh.i18n.isInitialized).toBe(true);
+    expect(fresh.i18n.options.ns).toEqual(["backend-ns"]);
+  });
+
+  it("releases the hold and initializes plainly when the bootstrap fails", async () => {
+    vi.resetModules();
+    const fresh = await import("./instance");
+
+    fresh.holdI18nInit(Promise.reject(new Error("bootstrap failed")));
+
+    await fresh.ensureI18n();
+
+    expect(fresh.i18n.isInitialized).toBe(true);
+  });
+
   it("returns locale controls and configured locales from useT", async () => {
     await configureI18n({
       enabled: false,

--- a/resources/js/i18n/instance.ts
+++ b/resources/js/i18n/instance.ts
@@ -24,6 +24,7 @@ type TranslationResult = {
 export const i18n: I18nInstance = i18next.createInstance();
 
 let initialization: Promise<unknown> | undefined;
+let hold: Promise<unknown> | undefined;
 let revision = 0;
 
 function subscribe(onStoreChange: () => void): () => void {
@@ -52,11 +53,33 @@ function snapshot(): number {
 }
 
 /**
+ * Defer component-driven initialization until `until` settles — for shells
+ * that render before the i18n bootstrap has loaded (SSR hydration), where the
+ * first rendered `useT` would otherwise win the init race and lock the HTTP
+ * backend out. Configuring callers (those passing `extend` to {@link ensureI18n})
+ * bypass the hold; a failed bootstrap releases it, so init stays fail-open.
+ */
+export function holdI18nInit(until: Promise<unknown>): void {
+  const release = (): void => {
+    hold = undefined;
+  };
+  const released = until.then(release, release);
+
+  if (!initialization) {
+    hold = released;
+  }
+}
+
+/**
  * Initialize the instance exactly once. The first caller wins — a rendered
  * component (inline English, zero config) or `enableBackend()`, which registers
  * its backend first because i18next can only wire a backend during `init`.
  */
 export function ensureI18n(extend?: (base: InitOptions) => InitOptions): Promise<unknown> {
+  if (!initialization && hold && !extend) {
+    return hold.then(() => ensureI18n());
+  }
+
   if (!initialization) {
     const base: InitOptions = {
       lng: currentLocale(),

--- a/resources/js/lib/use-isomorphic-layout-effect.ts
+++ b/resources/js/lib/use-isomorphic-layout-effect.ts
@@ -1,8 +1,0 @@
-import { useEffect, useLayoutEffect } from "react";
-
-/**
- * `useLayoutEffect` warns under `renderToString`; effects never run there, so
- * the server-side substitution is free.
- */
-export const useIsomorphicLayoutEffect =
-  typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/resources/js/lib/use-isomorphic-layout-effect.ts
+++ b/resources/js/lib/use-isomorphic-layout-effect.ts
@@ -1,0 +1,8 @@
+import { useEffect, useLayoutEffect } from "react";
+
+/**
+ * `useLayoutEffect` warns under `renderToString`; effects never run there, so
+ * the server-side substitution is free.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/resources/js/lib/use-layout-effect.ts
+++ b/resources/js/lib/use-layout-effect.ts
@@ -3,7 +3,6 @@ import { useEffect, useLayoutEffect as reactUseLayoutEffect } from "react";
 
 /**
  * Drop-in for React's `useLayoutEffect`, which warns under `renderToString`;
- * effects never run there, so the server-side substitution is free. Lint bans
- * the React import — always import the hook from here.
+ * effects never run there, so the server-side substitution is free.
  */
 export const useLayoutEffect = typeof window === "undefined" ? useEffect : reactUseLayoutEffect;

--- a/resources/js/lib/use-layout-effect.ts
+++ b/resources/js/lib/use-layout-effect.ts
@@ -1,0 +1,9 @@
+// oxlint-disable-next-line no-restricted-imports -- the one place the real hook may be imported
+import { useEffect, useLayoutEffect as reactUseLayoutEffect } from "react";
+
+/**
+ * Drop-in for React's `useLayoutEffect`, which warns under `renderToString`;
+ * effects never run there, so the server-side substitution is free. Lint bans
+ * the React import — always import the hook from here.
+ */
+export const useLayoutEffect = typeof window === "undefined" ? useEffect : reactUseLayoutEffect;

--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -5,7 +5,7 @@ import { createLatticeApp, type CreateLatticeAppOptions } from "./create-app";
 /**
  * Build an SSR entry's render function from the same options as `createLatticeApp`.
  * `@inertiajs/vite` only auto-wraps literal `createInertiaApp` calls, so a Lattice
- * app declares its own ssr entry (`inertia({ ssr: "resources/js/ssr.tsx" })`):
+ * app declares its own `resources/js/ssr.tsx`:
  *
  *     import createServer from "@inertiajs/react/server";
  *     import { createLatticeSsr } from "@lattice-php/lattice/ssr";
@@ -13,8 +13,8 @@ import { createLatticeApp, type CreateLatticeAppOptions } from "./create-app";
  *     createServer(createLatticeSsr({ ...same options as app.tsx }));
  *
  * The plugin rewrites that `createServer` call into the dev-server default
- * export plus the production HTTP bootstrap. Where the bootstrap is unwanted
- * (e.g. a test harness), `export default createLatticeSsr(...)` works as-is.
+ * export plus the production HTTP bootstrap; where the bootstrap is unwanted,
+ * `export default createLatticeSsr(...)` works as-is.
  *
  * Own subpath on purpose: importing react-dom/server from the client bundle
  * would drag the server renderer into the app.

--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -1,0 +1,36 @@
+import type { InertiaAppSSRResponse, Page } from "@inertiajs/core";
+import { renderToString } from "react-dom/server";
+import { createLatticeApp, type CreateLatticeAppOptions } from "./create-app";
+
+/**
+ * Build an SSR entry's render function from the same options as `createLatticeApp`.
+ * `@inertiajs/vite` only auto-wraps literal `createInertiaApp` calls, so a Lattice
+ * app declares its own ssr entry (`inertia({ ssr: "resources/js/ssr.tsx" })`):
+ *
+ *     import createServer from "@inertiajs/react/server";
+ *     import { createLatticeSsr } from "@lattice-php/lattice/ssr";
+ *
+ *     createServer(createLatticeSsr({ ...same options as app.tsx }));
+ *
+ * The plugin rewrites that `createServer` call into the dev-server default
+ * export plus the production HTTP bootstrap. Where the bootstrap is unwanted
+ * (e.g. a test harness), `export default createLatticeSsr(...)` works as-is.
+ *
+ * Own subpath on purpose: importing react-dom/server from the client bundle
+ * would drag the server renderer into the app.
+ */
+export function createLatticeSsr(
+  options: CreateLatticeAppOptions = {},
+): (page: Page) => Promise<InertiaAppSSRResponse> {
+  const app = createLatticeApp(options);
+
+  return async (page: Page): Promise<InertiaAppSSRResponse> => {
+    const render = await app;
+
+    if (typeof render !== "function") {
+      throw new Error("[lattice] createLatticeSsr requires a server environment without a DOM.");
+    }
+
+    return render(page, renderToString);
+  };
+}

--- a/resources/js/test/setup.ts
+++ b/resources/js/test/setup.ts
@@ -21,7 +21,7 @@ if (!globalThis.ResizeObserver) {
 // scrolls the selection throws asynchronously — tests still pass, but Vitest
 // exits non-zero on the unhandled error. An empty list is enough: ProseMirror
 // falls back to getBoundingClientRect when there are no rects.
-if (!Range.prototype.getClientRects) {
+if (typeof Range !== "undefined" && !Range.prototype.getClientRects) {
   Range.prototype.getClientRects = (): DOMRectList =>
     Object.assign([], { item: () => null }) as unknown as DOMRectList;
   Range.prototype.getBoundingClientRect = (): DOMRect => new DOMRect();

--- a/resources/js/test/ssr-entry.tsx
+++ b/resources/js/test/ssr-entry.tsx
@@ -1,0 +1,8 @@
+import { createLatticeApp } from "@lattice-php/lattice";
+import { renderToString } from "react-dom/server";
+
+export { createLatticeApp };
+
+export function render(): string {
+  return renderToString(<div data-lattice-ssr>lattice-ssr</div>);
+}

--- a/resources/js/vite-ssr.test.ts
+++ b/resources/js/vite-ssr.test.ts
@@ -6,8 +6,7 @@ import type { ViteDevServer } from "vite";
 import { describe, expect, it } from "vitest";
 import { lattice } from "./vite";
 
-// Node environment on purpose: jsdom would provide the browser globals whose
-// absence these tests are meant to prove Lattice can live without.
+// jsdom would supply the browser globals these tests prove Lattice can live without.
 
 function ssrServer(): Promise<ViteDevServer> {
   const appRoot = process.cwd();
@@ -24,10 +23,6 @@ function ssrServer(): Promise<ViteDevServer> {
 }
 
 describe("lattice Vite helper under SSR", () => {
-  // Regression: aliasing react to an absolute path defeated Vite's SSR
-  // externalization (only bare specifiers externalize), inlining react's CJS
-  // into the module runner — `module is not defined` the moment anything
-  // SSR-loaded an entry importing Lattice (e.g. @inertiajs/vite's warm-up).
   it("ssr-loads an entry importing @lattice-php/lattice", async () => {
     const server = await ssrServer();
 

--- a/resources/js/vite-ssr.test.ts
+++ b/resources/js/vite-ssr.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import path from "node:path";
+import type { Page } from "@inertiajs/core";
+import { createServer } from "vite";
+import type { ViteDevServer } from "vite";
+import { describe, expect, it } from "vitest";
+import { lattice } from "./vite";
+
+// Node environment on purpose: jsdom would provide the browser globals whose
+// absence these tests are meant to prove Lattice can live without.
+
+function ssrServer(): Promise<ViteDevServer> {
+  const appRoot = process.cwd();
+
+  return createServer({
+    configFile: false,
+    logLevel: "silent",
+    server: { middlewareMode: true },
+    plugins: lattice({ appRoot, icons: { dts: false }, typescript: false }),
+    resolve: {
+      alias: { "@lattice-php/lattice": path.resolve(appRoot, "resources/js") },
+    },
+  });
+}
+
+describe("lattice Vite helper under SSR", () => {
+  // Regression: aliasing react to an absolute path defeated Vite's SSR
+  // externalization (only bare specifiers externalize), inlining react's CJS
+  // into the module runner — `module is not defined` the moment anything
+  // SSR-loaded an entry importing Lattice (e.g. @inertiajs/vite's warm-up).
+  it("ssr-loads an entry importing @lattice-php/lattice", async () => {
+    const server = await ssrServer();
+
+    try {
+      const entry = await server.ssrLoadModule(
+        path.resolve(process.cwd(), "resources/js/test/ssr-entry.tsx"),
+      );
+
+      expect(entry.createLatticeApp).toBeTypeOf("function");
+      expect(entry.render()).toContain("lattice-ssr");
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+
+  it("server-renders a lattice page through the workbench ssr entry", async () => {
+    const server = await ssrServer();
+
+    try {
+      const entry = await server.ssrLoadModule(
+        path.resolve(process.cwd(), "workbench/resources/js/ssr.tsx"),
+      );
+      const page = {
+        component: "lattice/page",
+        props: {
+          errors: {},
+          lattice: {
+            breadcrumbs: [{ label: "Dashboard", href: "/" }],
+            container: "default",
+            layout: { key: "app", schema: [] },
+            listeners: [],
+            schema: [
+              { type: "heading", props: { text: "SSR proof" } },
+              { type: "text", props: { text: "Rendered on the server" } },
+            ],
+            title: "SSR proof",
+          },
+        },
+        url: "/",
+        version: "",
+      } as unknown as Page;
+
+      const { body } = await entry.default(page);
+
+      expect(body).toContain('data-server-rendered="true"');
+      expect(body).toContain("SSR proof");
+      expect(body).toContain("Rendered on the server");
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+});

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -59,13 +59,14 @@ function typescriptPlugin(options: Parameters<typeof lattice>[0] = {}): Plugin {
 describe("lattice Vite helper", () => {
   it("configures package-link mode without reading an environment variable", () => {
     const appRoot = path.resolve("/tmp/lattice-app");
+    const config = latticeConfig({ appRoot });
 
-    expect(latticeConfig({ appRoot })).toMatchObject({
+    // No react alias: an absolute-path alias would defeat SSR externalization
+    // and inline react's CJS into the SSR module runner. dedupe covers the
+    // single-React-copy concern.
+    expect(config.resolve).not.toHaveProperty("alias");
+    expect(config).toMatchObject({
       resolve: {
-        alias: {
-          react: path.resolve(appRoot, "node_modules/react"),
-          "react-dom": path.resolve(appRoot, "node_modules/react-dom"),
-        },
         dedupe: ["@inertiajs/react", "react", "react-dom"],
       },
       test: {

--- a/resources/js/vite.test.ts
+++ b/resources/js/vite.test.ts
@@ -61,9 +61,6 @@ describe("lattice Vite helper", () => {
     const appRoot = path.resolve("/tmp/lattice-app");
     const config = latticeConfig({ appRoot });
 
-    // No react alias: an absolute-path alias would defeat SSR externalization
-    // and inline react's CJS into the SSR module runner. dedupe covers the
-    // single-React-copy concern.
     expect(config.resolve).not.toHaveProperty("alias");
     expect(config).toMatchObject({
       resolve: {

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -190,11 +190,9 @@ export function latticeConfig(options: LatticeViteOptions = {}): ConfigWithTest 
 
   return {
     resolve: {
-      // No react alias here: aliasing react to an absolute path defeats Vite's
-      // SSR externalization (it only recognizes bare specifiers), inlining
-      // react's CJS into the SSR module runner — `module is not defined` on
-      // any ssrLoadModule of an entry importing Lattice. `dedupe` alone keeps
-      // the app on a single React copy, symlinked package installs included.
+      // A react alias would break SSR: Vite only externalizes bare specifiers,
+      // so an absolute path inlines react's CJS into the SSR module runner.
+      // `dedupe` alone keeps the app on a single React copy, symlinks included.
       ...(options.source
         ? {
             alias: {

--- a/resources/js/vite.ts
+++ b/resources/js/vite.ts
@@ -190,15 +190,19 @@ export function latticeConfig(options: LatticeViteOptions = {}): ConfigWithTest 
 
   return {
     resolve: {
-      alias: options.source
+      // No react alias here: aliasing react to an absolute path defeats Vite's
+      // SSR externalization (it only recognizes bare specifiers), inlining
+      // react's CJS into the SSR module runner — `module is not defined` on
+      // any ssrLoadModule of an entry importing Lattice. `dedupe` alone keeps
+      // the app on a single React copy, symlinked package installs included.
+      ...(options.source
         ? {
-            "@lattice-php/lattice/css": path.resolve(root, "resources/css/lattice.css"),
-            "@lattice-php/lattice": path.resolve(root, "resources/js"),
+            alias: {
+              "@lattice-php/lattice/css": path.resolve(root, "resources/css/lattice.css"),
+              "@lattice-php/lattice": path.resolve(root, "resources/js"),
+            },
           }
-        : {
-            react: path.resolve(appRoot, "node_modules/react"),
-            "react-dom": path.resolve(appRoot, "node_modules/react-dom"),
-          },
+        : {}),
       dedupe: ["@inertiajs/react", "react", "react-dom"],
     },
     server: options.source

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -142,7 +142,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
     public function packageBooted(): void
     {
-        EncryptCookies::except('locale');
+        EncryptCookies::except(['locale', 'appearance']);
 
         // Serve Lattice's built-in chrome translations under the `lattice`
         // namespace so consumers get them (and i18next /locales/{lng}/lattice.json)
@@ -161,8 +161,22 @@ final class LatticeServiceProvider extends PackageServiceProvider
         });
 
         $this->callAfterResolving(ResponseFactory::class, function (ResponseFactory $inertia): void {
-            $inertia->share('lattice.urls', fn (): array => [
-                'refreshRef' => route('lattice.refs.refresh', absolute: false),
+            // Array form on purpose: share('lattice.urls', ...) Arr::sets a real
+            // nested `lattice` array, which a Lattice page's own `lattice` prop
+            // then clobbers wholesale. A literal dotted key survives the merge
+            // and is expanded into the nested position at resolve time.
+            $inertia->share([
+                'lattice.urls' => fn (): array => [
+                    'refreshRef' => route('lattice.refs.refresh', absolute: false),
+                ],
+                // The client stores the theme in this plain cookie; sharing it
+                // back lets the SSR render (and the hydration pass) start from
+                // the user's appearance instead of "system".
+                'lattice.appearance' => function (): ?string {
+                    $appearance = request()->cookies->get('appearance');
+
+                    return in_array($appearance, ['light', 'dark', 'system'], true) ? $appearance : null;
+                },
             ]);
         });
 

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -169,9 +169,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
                 'lattice.urls' => fn (): array => [
                     'refreshRef' => route('lattice.refs.refresh', absolute: false),
                 ],
-                // The client stores the theme in this plain cookie; sharing it
-                // back lets the SSR render (and the hydration pass) start from
-                // the user's appearance instead of "system".
+                // Lets the SSR render start from the user's theme instead of "system".
                 'lattice.appearance' => function (): ?string {
                     $appearance = request()->cookies->get('appearance');
 

--- a/tests/Feature/Http/AppearanceSharingTest.php
+++ b/tests/Feature/Http/AppearanceSharingTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Inertia\Testing\AssertableInertia;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Ui\Components\Text;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+beforeEach(function (): void {
+    Route::get('appearance-probe', [AppearanceProbePage::class, 'render'])->middleware('web')->name('appearance-probe.show');
+
+    withoutVite();
+});
+
+it('shares the plain appearance cookie so the server render can match the theme', function (): void {
+    $this->withCredentials()->withUnencryptedCookie('appearance', 'dark');
+
+    get('/appearance-probe')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->where('lattice.appearance', 'dark')
+            ->where('lattice.urls.refreshRef', route('lattice.refs.refresh', absolute: false))
+        );
+});
+
+it('shares null when no appearance cookie is present', function (): void {
+    get('/appearance-probe')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->where('lattice.appearance', null)
+        );
+});
+
+it('ignores appearance cookie values outside the known modes', function (): void {
+    $this->withCredentials()->withUnencryptedCookie('appearance', 'sepia');
+
+    get('/appearance-probe')
+        ->assertOk()
+        ->assertInertia(fn (AssertableInertia $page): AssertableInertia => $page
+            ->where('lattice.appearance', null)
+        );
+});
+
+final class AppearanceProbePage extends Page
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Appearance probe'));
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -233,7 +233,7 @@ export default defineConfig(({ mode }) => {
               buildDirectory: "build",
               refresh: ["workbench/resources/**", "workbench/routes/**", "resources/js/**"],
             }),
-            inertia(),
+            inertia({ ssr: "workbench/resources/js/ssr.tsx" }),
             // The workbench acts as a Lattice consumer: auto-discover component
             // packages installed via Composer and expose them as
             // `virtual:lattice/plugins` (external apps get this from `lattice()`).

--- a/workbench/resources/js/ssr.tsx
+++ b/workbench/resources/js/ssr.tsx
@@ -1,0 +1,26 @@
+import type { Page } from "@inertiajs/core";
+import { createLatticeApp } from "@lattice-php/lattice";
+import { renderToString } from "react-dom/server";
+import sprite from "virtual:svg-sprite";
+import plugins from "virtual:lattice/plugins";
+import { appColumns } from "./columns";
+import { WORKBENCH_I18N_NAMESPACE } from "./i18n";
+
+// On the server (no `page`/`render` options) createLatticeApp resolves to
+// Inertia's SSR render function; `@inertiajs/vite` only auto-wraps literal
+// `createInertiaApp` calls, so a Lattice app exports the wrapper itself.
+const app = createLatticeApp({
+  plugins: [appColumns, ...plugins],
+  sprite,
+  i18n: { namespaces: ["lattice", WORKBENCH_I18N_NAMESPACE] },
+});
+
+export default async function render(page: Page) {
+  const ssr = await app;
+
+  if (typeof ssr !== "function") {
+    throw new Error("createLatticeApp did not return an SSR render function");
+  }
+
+  return ssr(page, renderToString);
+}

--- a/workbench/resources/js/ssr.tsx
+++ b/workbench/resources/js/ssr.tsx
@@ -4,9 +4,8 @@ import plugins from "virtual:lattice/plugins";
 import { appColumns } from "./columns";
 import { WORKBENCH_I18N_NAMESPACE } from "./i18n";
 
-// Plain default export instead of the consumer-facing `createServer(...)`
-// bootstrap: the workbench only server-renders through the dev endpoint and
-// the vitest SSR proof, never as a standalone production process.
+// Plain default export: the workbench only server-renders through the dev
+// endpoint and the vitest SSR proof, never as a standalone production process.
 export default createLatticeSsr({
   plugins: [appColumns, ...plugins],
   sprite,

--- a/workbench/resources/js/ssr.tsx
+++ b/workbench/resources/js/ssr.tsx
@@ -1,26 +1,14 @@
-import type { Page } from "@inertiajs/core";
-import { createLatticeApp } from "@lattice-php/lattice";
-import { renderToString } from "react-dom/server";
+import { createLatticeSsr } from "@lattice-php/lattice/ssr";
 import sprite from "virtual:svg-sprite";
 import plugins from "virtual:lattice/plugins";
 import { appColumns } from "./columns";
 import { WORKBENCH_I18N_NAMESPACE } from "./i18n";
 
-// On the server (no `page`/`render` options) createLatticeApp resolves to
-// Inertia's SSR render function; `@inertiajs/vite` only auto-wraps literal
-// `createInertiaApp` calls, so a Lattice app exports the wrapper itself.
-const app = createLatticeApp({
+// Plain default export instead of the consumer-facing `createServer(...)`
+// bootstrap: the workbench only server-renders through the dev endpoint and
+// the vitest SSR proof, never as a standalone production process.
+export default createLatticeSsr({
   plugins: [appColumns, ...plugins],
   sprite,
   i18n: { namespaces: ["lattice", WORKBENCH_I18N_NAMESPACE] },
 });
-
-export default async function render(page: Page) {
-  const ssr = await app;
-
-  if (typeof ssr !== "function") {
-    throw new Error("createLatticeApp did not return an SSR render function");
-  }
-
-  return ssr(page, renderToString);
-}


### PR DESCRIPTION
Server-side rendering a Lattice app crashed at module load and then mismatched on hydration. This makes SSR work end to end, gives consumers a real entry point, and proves it in CI.

- **Vite plugin**: the package-mode `react`/`react-dom` absolute-path aliases defeated Vite's SSR externalization (only bare specifiers externalize), inlining react's CJS into the module runner — `module is not defined` on any `ssrLoadModule` of an entry importing Lattice. Dropped in favor of the existing `resolve.dedupe`, which already guarantees a single React copy for symlinked installs.
- **createLatticeApp**: the `AwaitReady` null gate hydrated `null` against the server-rendered shell. Hydration passes (detected via Inertia's `data-server-rendered` marker) now render immediately; a new `holdI18nInit()` defers component-driven i18next init so the HTTP backend still wins the one-shot init race. CSR pages keep the existing no-flash gate and boot delay; public API unchanged.
- **`@lattice-php/lattice/ssr`**: new subpath exporting `createLatticeSsr(options)` — same options as `createLatticeApp`, returns the `(page) => {head, body}` render function `@inertiajs/vite`'s dev endpoint and `createServer` bootstrap expect (the plugin only auto-wraps literal `createInertiaApp` calls, so Lattice consumers need an explicit entry). Own subpath so client bundles never see `react-dom/server`. A consumer's `ssr.tsx` is now: `createServer(createLatticeSsr({ ...same options as app.tsx }))`.
- **Appearance**: the backend shares the plain `appearance` cookie as `lattice.appearance` and `seedAppearance()` feeds the `useAppearance` server snapshot, so SSR renders the user's theme instead of `"system"`. This surfaced a latent bug: `share('lattice.urls', ...)` built a nested `lattice` array that every Lattice page's own `lattice` prop clobbered — both shares now use literal dotted keys (regression-tested).
- **useLayoutEffect**: SSR-safe drop-in exported as `useLayoutEffect` from `lib/use-layout-effect`; lint bans importing the hook from react so the safe variant is the only one in play (star-import ui primitives excluded — the rule flags any namespace import).
- **Proof**: the workbench `ssr.tsx` consumes `createLatticeSsr` and is wired into dev SSR warm-up; node-environment Vitest tests cover the module-runner regression and a full server-driven page render through the entry, plus a jsdom `renderToString` → `hydrateRoot` test asserting zero hydration errors.

Deferred: shipping translations via page props to remove the English text swap for client-side strings on SSR'd pages.