### PR TITLE
feat: package DX — Lattice::translations() and shipped Testbench base cases

### DIFF
--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -190,11 +190,20 @@ const Signature: RendererComponent<"signature"> = ({ node }) => {
 };
 ```
 
-`createLatticeApp` merges every plugin's namespace into the [i18n bootstrap](/core/i18n/), so when the app enables the translation backend the namespace loads from `/locales/{lng}/acme-signature.json` like any other — serve the package's lang files by registering them on the translation loader in the package's service provider:
+`createLatticeApp` merges every plugin's namespace into the [i18n bootstrap](/core/i18n/), so when the app enables the translation backend the namespace loads from `/locales/{lng}/acme-signature.json` like any other — serve the package's lang files by registering them in the package's service provider:
 
 ```php
-$this->app->make('translation.loader')->addNamespace('acme-signature', __DIR__.'/../lang');
+use Lattice\Lattice\Facades\Lattice;
+
+Lattice::translations('acme-signature', __DIR__.'/../lang');
 ```
+
+<Warning>
+  Do not use Laravel's `loadTranslationsFrom()` here: it registers the namespace in a deferred
+  callback the i18next JSON route never triggers, so the translations silently fail to appear.
+  `Lattice::translations()` registers on the translation loader directly, which both the translator
+  and the route read.
+</Warning>
 
 <Info>
   The inline defaults are the no-backend fallback: apps that never enable the translation backend
@@ -219,5 +228,34 @@ import {
 A Composer package has no way to deliver npm dependencies into the consumer's bundle, so core owns
 the dependency and republishes it under its export map, the same way core owns i18next behind
 `.../i18n` above.
+
+## Testing the package
+
+Extend `Lattice\Lattice\Support\Testing\PackageTestCase` instead of hand-writing a Testbench
+`TestCase`: it boots Inertia and Lattice around the package's own providers on an in-memory sqlite
+app, applies the package's config overrides before boot, pulls in the
+[Lattice component assertions](/testing/overview/), and wires the conventional `workbench/` view and
+migration paths when they exist:
+
+```php
+use Lattice\Lattice\Support\Testing\PackageTestCase;
+
+abstract class TestCase extends PackageTestCase
+{
+    protected function packageProviders(): array
+    {
+        return [AcmeSignatureServiceProvider::class];
+    }
+
+    protected function packageConfig(): array
+    {
+        return ['lattice.discover' => [__DIR__.'/../workbench/app']];
+    }
+}
+```
+
+For Pest browser suites, extend `PackageBrowserTestCase` instead — it additionally fails fast with
+an actionable message when the workbench Vite build is missing or a stale dev-server marker is left
+behind, and widens Playwright's timeout for CI runners.
 
 See [Registry and types](/extending/registry-and-types/) for how the `type` string couples the two sides, and how generated types keep `node.props` sound.

--- a/src/Facades/Lattice.php
+++ b/src/Facades/Lattice.php
@@ -21,6 +21,7 @@ use Lattice\Lattice\LatticeRegistry;
  * @method static \Lattice\Lattice\Remote\RemoteSourceRegistry remoteSourceRegistry()
  * @method static void extend(string $name, \Closure $factory, int $priority = 0)
  * @method static void theme(\Lattice\Lattice\Theme\Theme|\Closure $theme)
+ * @method static void translations(string $namespace, string $path)
  *
  * @see LatticeRegistry
  */

--- a/src/LatticeRegistry.php
+++ b/src/LatticeRegistry.php
@@ -38,7 +38,19 @@ final readonly class LatticeRegistry
         private RemoteSourceRegistry $remoteSources,
         private SlotRegistry $slots,
         private ThemeRenderer $themeRenderer,
+        private Container $container,
     ) {}
+
+    /**
+     * Register a package's lang directory under a namespace, visible to both
+     * the translator and the i18next JSON route. Registered on the loader
+     * directly because that route resolves only the translation loader, so the
+     * deferred loadTranslationsFrom() callback would never fire for it.
+     */
+    public function translations(string $namespace, string $path): void
+    {
+        $this->container->make('translation.loader')->addNamespace($namespace, $path);
+    }
 
     /**
      * @param  class-string<FormDefinition>|array<int, class-string<FormDefinition>>  $forms

--- a/src/LatticeServiceProvider.php
+++ b/src/LatticeServiceProvider.php
@@ -148,11 +148,10 @@ final class LatticeServiceProvider extends PackageServiceProvider
         // namespace so consumers get them (and i18next /locales/{lng}/lattice.json)
         // without copying any files. Each lang group is its own file so the
         // i18next keys stay un-prefixed (e.g. `editor.bold`, not `lattice.editor.bold`).
-        // Registered directly on the loader rather than via loadTranslationsFrom():
-        // the i18next route resolves only the translation loader, never the
-        // translator, so the deferred loadTranslationsFrom() callback would never fire.
-        $translationLoader = $this->app->make('translation.loader');
-        $translationLoader->addNamespace(self::$name, __DIR__.'/../lang');
+        // Registered on the loader (not loadTranslationsFrom) for the reason
+        // documented on LatticeRegistry::translations(); resolved directly to
+        // keep the registry graph out of the boot path.
+        $this->app->make('translation.loader')->addNamespace(self::$name, __DIR__.'/../lang');
 
         $this->callAfterResolving(Kernel::class, function (Kernel $kernel): void {
             if ($kernel instanceof HttpKernel) {

--- a/src/Support/Testing/ChecksWorkbenchAssets.php
+++ b/src/Support/Testing/ChecksWorkbenchAssets.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing;
+
+use RuntimeException;
+
+use function Orchestra\Testbench\package_path;
+
+trait ChecksWorkbenchAssets
+{
+    private static bool $checkedWorkbenchManifest = false;
+
+    /**
+     * The browser serves whatever the last `npm run build` produced; a missing
+     * manifest or a leftover dev-server marker would fail every test with
+     * blank pages, so fail fast with an actionable message instead.
+     */
+    protected function assertWorkbenchManifestExists(): void
+    {
+        if (self::$checkedWorkbenchManifest) {
+            return;
+        }
+
+        $public = package_path('vendor/orchestra/testbench-core/laravel/public');
+        $manifest = $public.'/build/manifest.json';
+        $hot = $public.'/hot';
+
+        if (! is_file($manifest)) {
+            throw new RuntimeException("Missing workbench Vite manifest [{$manifest}]. Run `npm run build` before the browser suite.");
+        }
+
+        if (is_file($hot)) {
+            throw new RuntimeException("Stale Vite hot file [{$hot}]. Delete it (a `composer serve` leftover), then rerun the browser suite.");
+        }
+
+        self::$checkedWorkbenchManifest = true;
+    }
+}

--- a/src/Support/Testing/PackageBrowserTestCase.php
+++ b/src/Support/Testing/PackageBrowserTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing;
+
+use Pest\Browser\Playwright\Playwright;
+
+abstract class PackageBrowserTestCase extends PackageTestCase
+{
+    use ChecksWorkbenchAssets;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assertWorkbenchManifestExists();
+
+        // CI runners are slower than Playwright's tight 5s default, which
+        // intermittently trips browser actions/assertions under load.
+        Playwright::setTimeout(15_000);
+    }
+}

--- a/src/Support/Testing/PackageTestCase.php
+++ b/src/Support/Testing/PackageTestCase.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Support\Testing;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\ServiceProvider;
+use Inertia\ServiceProvider as InertiaServiceProvider;
+use Lattice\Lattice\LatticeServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+use function Orchestra\Testbench\package_path;
+
+/**
+ * Base TestCase for Lattice component packages: boots Inertia and Lattice
+ * around the package's own providers on an in-memory sqlite app, applies the
+ * package's config overrides before boot, and wires the conventional
+ * workbench/ view and migration paths when they exist.
+ */
+abstract class PackageTestCase extends BaseTestCase
+{
+    use InteractsWithLatticeComponents;
+    use RefreshDatabase;
+
+    /**
+     * @return array<int, class-string<ServiceProvider>>
+     */
+    abstract protected function packageProviders(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function packageConfig(): array
+    {
+        return [];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite.database', ':memory:');
+
+        foreach ($this->packageConfig() as $key => $value) {
+            $app['config']->set($key, $value);
+        }
+
+        $views = package_path('workbench/resources/views');
+
+        if (is_dir($views)) {
+            $app['config']->set('view.paths', [
+                ...$app['config']->get('view.paths', []),
+                $views,
+            ]);
+        }
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            InertiaServiceProvider::class,
+            LatticeServiceProvider::class,
+            ...$this->packageProviders(),
+        ];
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        $migrations = package_path('workbench/database/migrations');
+
+        if (is_dir($migrations)) {
+            $this->loadMigrationsFrom($migrations);
+        }
+    }
+}

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Tests;
 
+use Lattice\Lattice\Support\Testing\ChecksWorkbenchAssets;
 use Lattice\Lattice\Tests\Browser\Support\ReverbServer;
 use Pest\Browser\Api\ArrayablePendingAwaitablePage;
 use Pest\Browser\Api\PendingAwaitablePage;
 use Pest\Browser\Playwright\Playwright;
 
-use function Orchestra\Testbench\package_path;
-
 class BrowserTestCase extends TestCase
 {
-    private static ?ReverbServer $reverb = null;
+    use ChecksWorkbenchAssets;
 
-    private static bool $checkedWorkbenchManifest = false;
+    private static ?ReverbServer $reverb = null;
 
     #[\Override]
     protected function setUp(): void
@@ -33,29 +32,6 @@ class BrowserTestCase extends TestCase
         // missing key mid-suite would leave junk behind. No browser test
         // needs the dump — keep it off.
         config(['i18next.save_missing.enabled' => false]);
-    }
-
-    private function assertWorkbenchManifestExists(): void
-    {
-        if (self::$checkedWorkbenchManifest) {
-            return;
-        }
-
-        $public = package_path('vendor/orchestra/testbench-core/laravel/public');
-        $manifest = $public.'/build/manifest.json';
-        $hot = $public.'/hot';
-
-        if (! is_file($manifest)) {
-            throw new \RuntimeException("Missing workbench Vite manifest [{$manifest}]. Run `npm run build` before `composer test:browser`.");
-        }
-
-        // A leftover dev-server marker makes every page load assets from a dead
-        // server, which renders blank pages and times out interactive tests.
-        if (is_file($hot)) {
-            throw new \RuntimeException("Stale Vite hot file [{$hot}]. Delete it (a `composer serve` leftover), then rerun the browser suite.");
-        }
-
-        self::$checkedWorkbenchManifest = true;
     }
 
     protected function bootReverb(): void

--- a/tests/Feature/I18n/PackageTranslationsTest.php
+++ b/tests/Feature/I18n/PackageTranslationsTest.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Facades\Lattice;
+
+use function Pest\Laravel\getJson;
+
+it('registers a package lang namespace for the translator and the i18next route', function (): void {
+    Lattice::translations('zzpkg', dirname(__DIR__, 2).'/Fixtures/I18n/lang');
+
+    expect(__('zzpkg::messages.greeting'))->toBe('Hello from the package');
+
+    getJson('/locales/en/zzpkg::messages.json')
+        ->assertOk()
+        ->assertJsonPath('greeting', 'Hello from the package');
+});

--- a/tests/Feature/Testing/PackageTestCaseTest.php
+++ b/tests/Feature/Testing/PackageTestCaseTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+use Inertia\ServiceProvider as InertiaServiceProvider;
+use Lattice\Lattice\LatticeServiceProvider;
+use Lattice\Lattice\Support\Testing\PackageTestCase;
+use Workbench\App\Providers\WorkbenchServiceProvider;
+
+use function Orchestra\Testbench\package_path;
+
+function fakePackageTestCase(): PackageTestCase
+{
+    return new class('noop') extends PackageTestCase
+    {
+        protected function packageProviders(): array
+        {
+            return [WorkbenchServiceProvider::class];
+        }
+
+        protected function packageConfig(): array
+        {
+            return ['lattice.i18n.locales' => ['en', 'zz']];
+        }
+    };
+}
+
+it('boots inertia and lattice ahead of the package providers', function (): void {
+    $case = fakePackageTestCase();
+
+    $providers = (fn (): array => $this->getPackageProviders(app()))->call($case);
+
+    expect($providers)->toBe([
+        InertiaServiceProvider::class,
+        LatticeServiceProvider::class,
+        WorkbenchServiceProvider::class,
+    ]);
+});
+
+it('applies the sqlite app defaults, package config, and workbench view path', function (): void {
+    $case = fakePackageTestCase();
+    config()->set('database.default', 'mysql');
+    config()->set('view.paths', ['/existing']);
+
+    $app = $this->app;
+    (fn () => $this->getEnvironmentSetUp($app))->call($case);
+
+    expect(config('database.default'))->toBe('sqlite')
+        ->and(config('database.connections.sqlite.database'))->toBe(':memory:')
+        ->and((string) config('app.key'))->toStartWith('base64:')
+        ->and(config('lattice.i18n.locales'))->toBe(['en', 'zz'])
+        ->and(config('view.paths'))->toBe([
+            '/existing',
+            package_path('workbench/resources/views'),
+        ]);
+});

--- a/tests/Fixtures/I18n/lang/en/messages.php
+++ b/tests/Fixtures/I18n/lang/en/messages.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'greeting' => 'Hello from the package',
+];


### PR DESCRIPTION
Two seams every satellite package (tree, media) had to hand-write, now owned by core:

- `Lattice::translations('ns', $path)` registers a package lang directory on the translation loader, visible to both the translator and the i18next JSON route. Laravel's `loadTranslationsFrom()` silently fails there (its deferred callback never fires for the route), which every package worked around with the same copied loader poke.
- `Support\Testing\PackageTestCase` / `PackageBrowserTestCase`: the Testbench harness satellites re-derive — Inertia + Lattice providers around the package's own, in-memory sqlite, pre-boot config overrides, conventional workbench view/migration paths, and the browser suite's stale-build guard (now a shared trait, reused by this repo's own `BrowserTestCase`).

Docs updated in extending/component-packages.