### PR TITLE
feat: server-side seams for rich-editor extensions

### DIFF
--- a/docs/content/docs/extending/component-packages.mdx
+++ b/docs/content/docs/extending/component-packages.mdx
@@ -259,3 +259,7 @@ an actionable message when the workbench Vite build is missing or a stale dev-se
 behind, and widens Playwright's timeout for CI runners.
 
 See [Registry and types](/extending/registry-and-types/) for how the `type` string couples the two sides, and how generated types keep `node.props` sound.
+
+A package that adds a rich-editor node follows the same PHP-class-plus-client-definition shape, plus
+server-side seams of its own for rendering, sanitizing, and validating that node — see
+[Server-side extensions](/forms/fields/rich-editor/#server-side-extensions).

--- a/docs/content/docs/forms/fields/rich-editor.mdx
+++ b/docs/content/docs/forms/fields/rich-editor.mdx
@@ -5,6 +5,7 @@ description: A formatted-text editor that stores a structured document, not raw 
 
 import ComponentExample from "@components/ComponentExample.astro";
 import Info from "@components/Info.astro";
+import Warning from "@components/Warning.astro";
 
 The rich editor lets the user write formatted text — headings, lists, links, tables, and more. It
 stores a structured TipTap document rather than raw HTML, which keeps the stored value safe to render.
@@ -181,6 +182,168 @@ string — `->extensions([Bold::make(), 'mention'])` — and it serializes as `{
 Unknown types the client has no definition for are skipped (with a console warning in dev). See
 [Registry and types](/extending/registry-and-types/) for how generated types and the
 `EditorExtensionProps` augmentation give `props` a concrete shape on the client.
+
+## Server-side extensions
+
+An extension that adds its own document nodes — not just toolbar behavior — needs a server-side
+counterpart too: something has to teach `RichContent` how to render the node, decide what's safe to
+keep in a stored document, and validate any references it holds. `EditorExtension` exposes five
+seams for that, each with a no-op default so a toolbar-only extension can ignore all of them:
+
+- **`serverExtensions()`** — contributes tiptap-php schema classes, so `RichContent` can parse the
+  node and render it to HTML via their `renderHTML()`.
+- **`prepareDocument()`** — transforms a document once on its way out of the server (prefill and
+  display), the place to batch-resolve stored references into human-readable attrs.
+- **`ephemeralAttributes()`** — declares which node attrs are outbound-only display data, not part
+  of the canonical stored document.
+- **`configureSanitizer()`** — extends the HTML sanitizer with the elements/attrs the extension's
+  `renderHTML()` emits.
+- **`validateDocument()`** — validates the extension's nodes in a submitted document (e.g. that a
+  referenced id still exists); returned messages become field errors.
+
+Take a `callout` extension — a `{id, tone}` node that renders as an `<aside>` and resolves `id` to a
+label pulled from wherever those labels live:
+
+```php
+use Illuminate\Support\Collection;
+use Lattice\Lattice\Forms\RichContent;
+use Lattice\Lattice\Forms\RichEditor\Attributes\AsEditorExtension;
+use Lattice\Lattice\Forms\RichEditor\EditorExtension;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
+
+#[AsEditorExtension('callout')]
+final class Callout extends EditorExtension
+{
+    protected array $serverTypes = ['callout'];
+
+    public function serverExtensions(): array
+    {
+        return [new CalloutNode];
+    }
+
+    public function ephemeralAttributes(): array
+    {
+        return ['callout' => ['resolvedLabel']];
+    }
+
+    public function prepareDocument(array $document): array
+    {
+        $ids = array_column(array_column(RichContent::make($document)->nodes('callout'), 'attrs'), 'id');
+        $labels = Topic::whereIn('id', array_unique($ids))->pluck('name', 'id');
+
+        return $this->injectLabels($document, $labels);
+    }
+
+    public function configureSanitizer(HtmlSanitizerConfig $config): HtmlSanitizerConfig
+    {
+        return $config->allowElement('aside', ['data-callout', 'data-tone']);
+    }
+
+    public function validateDocument(array $document): array
+    {
+        $ids = array_column(array_column(RichContent::make($document)->nodes('callout'), 'attrs'), 'id');
+        $missing = array_diff($ids, Topic::whereIn('id', $ids)->pluck('id')->all());
+
+        return array_map(fn (int $id): string => "Callout {$id} does not exist.", $missing);
+    }
+
+    private function injectLabels(array $node, Collection $labels): array
+    {
+        if (($node['type'] ?? null) === 'callout') {
+            $node['attrs']['resolvedLabel'] = $labels[$node['attrs']['id']] ?? '—';
+        }
+
+        if (isset($node['content'])) {
+            $node['content'] = array_map(fn (array $child): array => $this->injectLabels($child, $labels), $node['content']);
+        }
+
+        return $node;
+    }
+}
+```
+
+`Topic` above is your own model — the extension only knows the id a user picked; resolving it to a
+label is application logic, and `->nodes('callout')` is what lets it happen once per document
+instead of once per node.
+
+`serverExtensions()` returns the matching tiptap-php `Node`, which owns the attrs schema and the
+HTML it renders to:
+
+```php
+use Tiptap\Core\Node;
+use Tiptap\Utils\HTML;
+
+final class CalloutNode extends Node
+{
+    public static $name = 'callout';
+
+    public function addAttributes(): array
+    {
+        return ['id' => ['default' => null], 'tone' => ['default' => null]];
+    }
+
+    public function renderHTML($node, $HTMLAttributes = []): array
+    {
+        return ['aside', HTML::mergeAttributes($HTMLAttributes, [
+            'data-callout' => (string) ($node->attrs->id ?? ''),
+            'data-tone' => $node->attrs->tone ?? null,
+        ]), 0];
+    }
+}
+```
+
+Register it like any extension (see [Custom extensions](#custom-extensions)) and activate it on a
+field with `->withExtensions(Callout::make())`.
+
+### The ephemeral-attr contract
+
+`resolvedLabel` above never reaches storage. Declare it in `ephemeralAttributes()`, inject it in
+`prepareDocument()`, and `toArray()` — the canonical form `RichEditor` casts submitted values into —
+strips it back out before the document is persisted:
+
+<Info>
+  Declaring the attr matters even though `prepareDocument()` only runs on the way out. tiptap-php
+  round-trips attrs it doesn't recognize untouched, so a resolved label a user never edited would
+  otherwise re-enter the document unchanged on the next submit — `toArray()`'s scrub is what keeps
+  it out.
+</Info>
+
+### Sanitizing custom HTML
+
+`toHtml()` sanitizes its output with Symfony's `HtmlSanitizer`, which strips anything it wasn't
+explicitly told to keep.
+
+<Warning>
+  A custom node's `renderHTML()` output is sanitized like everything else — an element or attribute
+  your `configureSanitizer()` doesn't allow is silently dropped from the rendered HTML, not an
+  error. Allow exactly what `renderHTML()` emits, as `CalloutNode` does for `aside` and its two
+  `data-*` attrs above.
+</Warning>
+
+### Rendering without a field
+
+`RichContent::make($document)->toHtml()` needs no `$extensions` argument — called bare, it renders
+every extension [registered](#custom-extensions) app-wide via `EditorExtensionRegistry`, which is
+the usual way to display a stored document outside the context of the `RichEditor` field that
+produced it (an index page, an email, an API response):
+
+```php
+use Lattice\Lattice\Forms\RichContent;
+
+$html = RichContent::make($storedDocument)->toHtml();
+```
+
+`->nodes('callout')` walks the canonical document depth-first and returns every node of that type —
+what `prepareDocument()` and `validateDocument()` use above to batch-resolve and check ids, and what
+application code reaches for to sync references (e.g. attaching the callout's target as a related
+model) without hand-rolling the tree walk.
+
+<Info>
+  Extension labels — toolbar tooltips, validation messages a client-side UI might also render —
+  translate the same way a component package's do: register a namespace with
+  `Lattice::translations()`. See [Translations](/extending/component-packages/#translations) for the
+  full pattern.
+</Info>
 
 ## Common options
 

--- a/docs/content/docs/forms/fields/rich-editor.mdx
+++ b/docs/content/docs/forms/fields/rich-editor.mdx
@@ -264,7 +264,11 @@ final class Callout extends EditorExtension
 
 `Topic` above is your own model — the extension only knows the id a user picked; resolving it to a
 label is application logic, and `->nodes('callout')` is what lets it happen once per document
-instead of once per node.
+instead of once per node. `nodes()` walks the schema-filtered document, so `callout` only survives
+the walk when the extension is either passed to `RichContent::make(...)` or registered app-wide —
+here it's the latter, since these methods run on the `Callout` extension itself once it's
+[registered](#custom-extensions); an unregistered, unpassed extension's `->nodes()` call always
+returns an empty list.
 
 `serverExtensions()` returns the matching tiptap-php `Node`, which owns the attrs schema and the
 HTML it renders to:

--- a/docs/content/docs/forms/fields/rich-editor.mdx
+++ b/docs/content/docs/forms/fields/rich-editor.mdx
@@ -228,7 +228,7 @@ final class Callout extends EditorExtension
 
     public function prepareDocument(array $document): array
     {
-        $ids = array_column(array_column(RichContent::make($document)->nodes('callout'), 'attrs'), 'id');
+        $ids = array_column(array_column(RichContent::make($document, extensions: [$this])->nodes('callout'), 'attrs'), 'id');
         $labels = Topic::whereIn('id', array_unique($ids))->pluck('name', 'id');
 
         return $this->injectLabels($document, $labels);
@@ -241,7 +241,7 @@ final class Callout extends EditorExtension
 
     public function validateDocument(array $document): array
     {
-        $ids = array_column(array_column(RichContent::make($document)->nodes('callout'), 'attrs'), 'id');
+        $ids = array_column(array_column(RichContent::make($document, extensions: [$this])->nodes('callout'), 'attrs'), 'id');
         $missing = array_diff($ids, Topic::whereIn('id', $ids)->pluck('id')->all());
 
         return array_map(fn (int $id): string => "Callout {$id} does not exist.", $missing);
@@ -264,11 +264,11 @@ final class Callout extends EditorExtension
 
 `Topic` above is your own model — the extension only knows the id a user picked; resolving it to a
 label is application logic, and `->nodes('callout')` is what lets it happen once per document
-instead of once per node. `nodes()` walks the schema-filtered document, so `callout` only survives
-the walk when the extension is either passed to `RichContent::make(...)` or registered app-wide —
-here it's the latter, since these methods run on the `Callout` extension itself once it's
-[registered](#custom-extensions); an unregistered, unpassed extension's `->nodes()` call always
-returns an empty list.
+instead of once per node. `nodes()` walks the schema-filtered document, so pass the extension along
+with `extensions: [$this]` as above: it works whether the extension is field-scoped or
+[registered](#custom-extensions) app-wide. A bare `RichContent::make($document)` falls back to the
+app-wide registry instead — for a field-scoped extension the registry doesn't know, the schema
+filter strips its nodes and `->nodes()` silently returns an empty list.
 
 `serverExtensions()` returns the matching tiptap-php `Node`, which owns the attrs schema and the
 HTML it renders to:

--- a/src/Forms/Components/RichEditor.php
+++ b/src/Forms/Components/RichEditor.php
@@ -155,7 +155,18 @@ class RichEditor extends Field
             return $value;
         }
 
-        return RichContent::make($decoded, $this->allowedServerTypes())->toArray();
+        return RichContent::make($decoded, $this->allowedServerTypes(), $this->editorExtensionInstances())->toArray();
+    }
+
+    /**
+     * @return list<EditorExtension>
+     */
+    protected function editorExtensionInstances(): array
+    {
+        return array_values(array_filter(
+            $this->activeExtensions(),
+            static fn (EditorExtension|string $extension): bool => $extension instanceof EditorExtension,
+        ));
     }
 
     /**

--- a/src/Forms/Components/RichEditor.php
+++ b/src/Forms/Components/RichEditor.php
@@ -205,6 +205,10 @@ class RichEditor extends Field
             array_values($this->activeExtensions()),
         );
 
+        if (isset($props['value']) && is_array($props['value'])) {
+            $props['value'] = RichContent::make($props['value'], $this->allowedServerTypes(), $this->editorExtensionInstances())->toPreparedArray();
+        }
+
         return $props;
     }
 

--- a/src/Forms/Components/RichEditor.php
+++ b/src/Forms/Components/RichEditor.php
@@ -27,6 +27,7 @@ use Lattice\Lattice\Forms\RichEditor\Extensions\Strike;
 use Lattice\Lattice\Forms\RichEditor\Extensions\Table;
 use Lattice\Lattice\Forms\RichEditor\Extensions\TextAlign;
 use Lattice\Lattice\Forms\RichEditor\Extensions\Underline;
+use Lattice\Lattice\Forms\RichEditor\ValidatesEditorDocument;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Concerns\HasPlaceholder;
 
@@ -156,6 +157,15 @@ class RichEditor extends Field
         }
 
         return RichContent::make($decoded, $this->allowedServerTypes(), $this->editorExtensionInstances())->toArray();
+    }
+
+    #[\Override]
+    protected function defaultRules(): array
+    {
+        return [
+            ...parent::defaultRules(),
+            new ValidatesEditorDocument($this->editorExtensionInstances()),
+        ];
     }
 
     /**

--- a/src/Forms/Components/RichEditor.php
+++ b/src/Forms/Components/RichEditor.php
@@ -215,8 +215,14 @@ class RichEditor extends Field
             array_values($this->activeExtensions()),
         );
 
-        if (isset($props['value']) && is_array($props['value'])) {
-            $props['value'] = RichContent::make($props['value'], $this->allowedServerTypes(), $this->editorExtensionInstances())->toPreparedArray();
+        $value = $props['value'] ?? null;
+
+        if (is_string($value) && $value !== '') {
+            $value = json_decode($value, true);
+        }
+
+        if (is_array($value)) {
+            $props['value'] = RichContent::make($value, $this->allowedServerTypes(), $this->editorExtensionInstances())->toPreparedArray();
         }
 
         return $props;

--- a/src/Forms/Components/RichEditor.php
+++ b/src/Forms/Components/RichEditor.php
@@ -146,13 +146,9 @@ class RichEditor extends Field
     #[\Override]
     public function castValue(mixed $value): mixed
     {
-        if (! is_string($value) || $value === '') {
-            return $value;
-        }
+        $decoded = RichContent::decodeDocument($value);
 
-        $decoded = json_decode($value, true);
-
-        if (! is_array($decoded)) {
+        if ($decoded === null) {
             return $value;
         }
 
@@ -190,10 +186,8 @@ class RichEditor extends Field
     {
         $types = [];
 
-        foreach ($this->activeExtensions() as $extension) {
-            if ($extension instanceof EditorExtension) {
-                $types = [...$types, ...$extension->serverTypes()];
-            }
+        foreach ($this->editorExtensionInstances() as $extension) {
+            $types = [...$types, ...$extension->serverTypes()];
         }
 
         return array_values(array_unique($types));
@@ -216,13 +210,10 @@ class RichEditor extends Field
         );
 
         $value = $props['value'] ?? null;
+        $document = is_array($value) ? $value : RichContent::decodeDocument($value);
 
-        if (is_string($value) && $value !== '') {
-            $value = json_decode($value, true);
-        }
-
-        if (is_array($value)) {
-            $props['value'] = RichContent::make($value, $this->allowedServerTypes(), $this->editorExtensionInstances())->toPreparedArray();
+        if ($document !== null) {
+            $props['value'] = RichContent::make($document, $this->allowedServerTypes(), $this->editorExtensionInstances())->toPreparedArray();
         }
 
         return $props;

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -72,20 +72,20 @@ final class RichContent
     /**
      * @param  array<string, mixed>|string|null  $document
      * @param  list<string>|null  $allowedTypes  Schema type names to keep beyond the baseline; null keeps the full built-in schema.
-     * @param  iterable<EditorExtension>  $extensions
+     * @param  iterable<EditorExtension>|null  $extensions  Null falls back to the app-wide registry; an explicit iterable (including empty) is used as-is.
      */
     public function __construct(
         private readonly array|string|null $document,
         private readonly ?array $allowedTypes = null,
-        private readonly iterable $extensions = [],
+        private readonly ?iterable $extensions = null,
     ) {}
 
     /**
      * @param  array<string, mixed>|string|null  $document
      * @param  list<string>|null  $allowedTypes
-     * @param  iterable<EditorExtension>  $extensions
+     * @param  iterable<EditorExtension>|null  $extensions
      */
-    public static function make(array|string|null $document, ?array $allowedTypes = null, iterable $extensions = []): self
+    public static function make(array|string|null $document, ?array $allowedTypes = null, ?iterable $extensions = null): self
     {
         return new self($document, $allowedTypes, $extensions);
     }
@@ -166,9 +166,12 @@ final class RichContent
     }
 
     /**
-     * The active extension set: what was given, or — when nothing was given,
-     * whether omitted or passed as an explicit empty iterable — the app-wide
-     * registry defaults. Narrow with $allowedTypes, not an explicit `[]` here.
+     * The active extension set: exactly what was given, including an explicit
+     * empty iterable (a field that activates none of them must strip their
+     * nodes everywhere — display, validation, and cast alike). Only an
+     * omitted argument (null) falls back to the app-wide registry defaults —
+     * the bare display path `RichContent::make($doc)`. Narrow with
+     * $allowedTypes, not an explicit `[]` here.
      *
      * @return list<EditorExtension>
      */
@@ -178,11 +181,13 @@ final class RichContent
             return $this->resolvedExtensions;
         }
 
-        $given = is_array($this->extensions) ? $this->extensions : iterator_to_array($this->extensions);
+        if ($this->extensions === null) {
+            return $this->resolvedExtensions = app(EditorExtensionRegistry::class)->instances();
+        }
 
-        return $this->resolvedExtensions = $given === []
-            ? app(EditorExtensionRegistry::class)->instances()
-            : array_values($given);
+        return $this->resolvedExtensions = is_array($this->extensions)
+            ? array_values($this->extensions)
+            : array_values(iterator_to_array($this->extensions));
     }
 
     private function editor(): Editor

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -104,6 +104,30 @@ final class RichContent
         return $this->editor()->getDocument();
     }
 
+    /**
+     * Matching nodes from the canonical document, depth-first. The typed
+     * traversal consumers would otherwise hand-roll (e.g. collecting media
+     * references for attachment sync).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function nodes(string $type): array
+    {
+        $collect = static function (array $node) use (&$collect, $type): array {
+            $matches = ($node['type'] ?? null) === $type ? [$node] : [];
+
+            foreach (is_array($node['content'] ?? null) ? $node['content'] : [] as $child) {
+                if (is_array($child)) {
+                    $matches = [...$matches, ...$collect($child)];
+                }
+            }
+
+            return $matches;
+        };
+
+        return $collect($this->toArray());
+    }
+
     private function editor(): Editor
     {
         if ($this->editor instanceof Editor) {

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -343,7 +343,7 @@ final class RichContent
         if (isset($node['content']) && is_array($node['content'])) {
             $node['content'] = array_values(array_map(
                 fn (array $child): array => $this->withoutAttributes($child, $ephemeral),
-                array_filter($node['content'], 'is_array'),
+                array_filter($node['content'], is_array(...)),
             ));
         }
 

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -96,7 +96,7 @@ final class RichContent
             return '';
         }
 
-        return $this->sanitize(new Editor(['extensions' => $this->schema()])->setContent($this->toPreparedArray())->getHTML());
+        return $this->sanitize($this->preparedEditor()->getHTML());
     }
 
     public function toText(): string
@@ -105,7 +105,29 @@ final class RichContent
             return '';
         }
 
-        return new Editor(['extensions' => $this->schema()])->setContent($this->toPreparedArray())->getText();
+        return $this->preparedEditor()->getText();
+    }
+
+    private function preparedEditor(): Editor
+    {
+        return new Editor(['extensions' => $this->schema()])->setContent($this->toPreparedArray());
+    }
+
+    /**
+     * The submitted form value as a document array, or null when it isn't one
+     * (not a string, empty, or not valid JSON for an array).
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function decodeDocument(mixed $value): ?array
+    {
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
     }
 
     /**
@@ -187,7 +209,7 @@ final class RichContent
 
         return $this->resolvedExtensions = is_array($this->extensions)
             ? array_values($this->extensions)
-            : array_values(iterator_to_array($this->extensions));
+            : iterator_to_array($this->extensions, false);
     }
 
     private function editor(): Editor

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -345,6 +345,10 @@ final class RichContent
             ->allowElement('summary')
             ->allowAttribute('style', ['p', 'h1', 'h2', 'h3']);
 
+        foreach ($this->extensions as $extension) {
+            $config = $extension->configureSanitizer($config);
+        }
+
         return new HtmlSanitizer($config)->sanitize($html);
     }
 }

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Forms;
 
+use Lattice\Lattice\Forms\RichEditor\EditorExtension;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Tiptap\Core\Extension;
@@ -55,19 +56,22 @@ final class RichContent
     /**
      * @param  array<string, mixed>|string|null  $document
      * @param  list<string>|null  $allowedTypes  Schema type names to keep beyond the baseline; null keeps the full built-in schema.
+     * @param  iterable<EditorExtension>  $extensions
      */
     public function __construct(
         private readonly array|string|null $document,
         private readonly ?array $allowedTypes = null,
+        private readonly iterable $extensions = [],
     ) {}
 
     /**
      * @param  array<string, mixed>|string|null  $document
      * @param  list<string>|null  $allowedTypes
+     * @param  iterable<EditorExtension>  $extensions
      */
-    public static function make(array|string|null $document, ?array $allowedTypes = null): self
+    public static function make(array|string|null $document, ?array $allowedTypes = null, iterable $extensions = []): self
     {
-        return new self($document, $allowedTypes);
+        return new self($document, $allowedTypes, $extensions);
     }
 
     public function toHtml(): string
@@ -191,16 +195,30 @@ final class RichContent
             new DetailsContent,
         ];
 
-        if ($this->allowedTypes === null) {
-            return $extensions;
+        $allowed = [...self::BASELINE_TYPES, ...$this->allowedTypes ?? []];
+
+        $builtin = $this->allowedTypes === null
+            ? $extensions
+            : array_values(array_filter(
+                $extensions,
+                static fn (Extension $extension): bool => in_array($extension::$name, $allowed, true),
+            ));
+
+        return [...$builtin, ...$this->contributedExtensions()];
+    }
+
+    /**
+     * @return list<Extension>
+     */
+    private function contributedExtensions(): array
+    {
+        $contributed = [];
+
+        foreach ($this->extensions as $extension) {
+            $contributed = [...$contributed, ...$extension->serverExtensions()];
         }
 
-        $allowed = [...self::BASELINE_TYPES, ...$this->allowedTypes];
-
-        return array_values(array_filter(
-            $extensions,
-            static fn (Extension $extension): bool => in_array($extension::$name, $allowed, true),
-        ));
+        return $contributed;
     }
 
     private function isEmpty(): bool

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -101,7 +101,7 @@ final class RichContent
             return ['type' => 'doc', 'content' => []];
         }
 
-        return $this->editor()->getDocument();
+        return $this->scrubEphemeral($this->editor()->getDocument());
     }
 
     /**
@@ -243,6 +243,50 @@ final class RichContent
         }
 
         return $contributed;
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     * @return array<string, mixed>
+     */
+    private function scrubEphemeral(array $node): array
+    {
+        $ephemeral = [];
+
+        foreach ($this->extensions as $extension) {
+            foreach ($extension->ephemeralAttributes() as $type => $attributes) {
+                $ephemeral[$type] = [...$ephemeral[$type] ?? [], ...$attributes];
+            }
+        }
+
+        return $ephemeral === [] ? $node : $this->withoutAttributes($node, $ephemeral);
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     * @param  array<string, list<string>>  $ephemeral
+     * @return array<string, mixed>
+     */
+    private function withoutAttributes(array $node, array $ephemeral): array
+    {
+        $type = $node['type'] ?? null;
+
+        if (is_string($type) && isset($ephemeral[$type], $node['attrs']) && is_array($node['attrs'])) {
+            $node['attrs'] = array_diff_key($node['attrs'], array_flip($ephemeral[$type]));
+
+            if ($node['attrs'] === []) {
+                unset($node['attrs']);
+            }
+        }
+
+        if (isset($node['content']) && is_array($node['content'])) {
+            $node['content'] = array_values(array_map(
+                fn (array $child): array => $this->withoutAttributes($child, $ephemeral),
+                array_filter($node['content'], 'is_array'),
+            ));
+        }
+
+        return $node;
     }
 
     private function isEmpty(): bool

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -54,6 +54,11 @@ final class RichContent
     private ?Editor $editor = null;
 
     /**
+     * @var list<Extension>|null
+     */
+    private ?array $schema = null;
+
+    /**
      * @param  array<string, mixed>|string|null  $document
      * @param  list<string>|null  $allowedTypes  Schema type names to keep beyond the baseline; null keeps the full built-in schema.
      * @param  iterable<EditorExtension>  $extensions
@@ -80,7 +85,7 @@ final class RichContent
             return '';
         }
 
-        return $this->sanitize($this->editor()->getHTML());
+        return $this->sanitize(new Editor(['extensions' => $this->schema()])->setContent($this->toPreparedArray())->getHTML());
     }
 
     public function toText(): string
@@ -89,7 +94,7 @@ final class RichContent
             return '';
         }
 
-        return $this->editor()->getText();
+        return new Editor(['extensions' => $this->schema()])->setContent($this->toPreparedArray())->getText();
     }
 
     /**
@@ -102,6 +107,23 @@ final class RichContent
         }
 
         return $this->scrubEphemeral($this->editor()->getDocument());
+    }
+
+    /**
+     * The display/editing form: canonical document with every extension's
+     * outbound preparation applied (ephemeral attrs injected).
+     *
+     * @return array<string, mixed>
+     */
+    public function toPreparedArray(): array
+    {
+        $document = $this->toArray();
+
+        foreach ($this->extensions as $extension) {
+            $document = $extension->prepareDocument($document);
+        }
+
+        return $document;
     }
 
     /**
@@ -190,6 +212,10 @@ final class RichContent
      */
     private function schema(): array
     {
+        if ($this->schema !== null) {
+            return $this->schema;
+        }
+
         $extensions = [
             new Document,
             new Paragraph,
@@ -228,7 +254,7 @@ final class RichContent
                 static fn (Extension $extension): bool => in_array($extension::$name, $allowed, true),
             ));
 
-        return [...$builtin, ...$this->contributedExtensions()];
+        return $this->schema = [...$builtin, ...$this->contributedExtensions()];
     }
 
     /**

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -59,6 +59,11 @@ final class RichContent
     private ?array $schema = null;
 
     /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $preparedDocument = null;
+
+    /**
      * @param  array<string, mixed>|string|null  $document
      * @param  list<string>|null  $allowedTypes  Schema type names to keep beyond the baseline; null keeps the full built-in schema.
      * @param  iterable<EditorExtension>  $extensions
@@ -117,13 +122,17 @@ final class RichContent
      */
     public function toPreparedArray(): array
     {
+        if ($this->preparedDocument !== null) {
+            return $this->preparedDocument;
+        }
+
         $document = $this->toArray();
 
         foreach ($this->extensions as $extension) {
             $document = $extension->prepareDocument($document);
         }
 
-        return $document;
+        return $this->preparedDocument = $document;
     }
 
     /**

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Forms;
 
 use Lattice\Lattice\Forms\RichEditor\EditorExtension;
+use Lattice\Lattice\Forms\RichEditor\EditorExtensionRegistry;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Tiptap\Core\Extension;
@@ -62,6 +63,11 @@ final class RichContent
      * @var array<string, mixed>|null
      */
     private ?array $preparedDocument = null;
+
+    /**
+     * @var list<EditorExtension>|null
+     */
+    private ?array $resolvedExtensions = null;
 
     /**
      * @param  array<string, mixed>|string|null  $document
@@ -128,7 +134,7 @@ final class RichContent
 
         $document = $this->toArray();
 
-        foreach ($this->extensions as $extension) {
+        foreach ($this->activeExtensions() as $extension) {
             $document = $extension->prepareDocument($document);
         }
 
@@ -157,6 +163,26 @@ final class RichContent
         };
 
         return $collect($this->toArray());
+    }
+
+    /**
+     * The active extension set: what was given, or — when nothing was given,
+     * whether omitted or passed as an explicit empty iterable — the app-wide
+     * registry defaults. Narrow with $allowedTypes, not an explicit `[]` here.
+     *
+     * @return list<EditorExtension>
+     */
+    private function activeExtensions(): array
+    {
+        if ($this->resolvedExtensions !== null) {
+            return $this->resolvedExtensions;
+        }
+
+        $given = is_array($this->extensions) ? $this->extensions : iterator_to_array($this->extensions);
+
+        return $this->resolvedExtensions = $given === []
+            ? app(EditorExtensionRegistry::class)->instances()
+            : array_values($given);
     }
 
     private function editor(): Editor
@@ -273,7 +299,7 @@ final class RichContent
     {
         $contributed = [];
 
-        foreach ($this->extensions as $extension) {
+        foreach ($this->activeExtensions() as $extension) {
             $contributed = [...$contributed, ...$extension->serverExtensions()];
         }
 
@@ -288,7 +314,7 @@ final class RichContent
     {
         $ephemeral = [];
 
-        foreach ($this->extensions as $extension) {
+        foreach ($this->activeExtensions() as $extension) {
             foreach ($extension->ephemeralAttributes() as $type => $attributes) {
                 $ephemeral[$type] = [...$ephemeral[$type] ?? [], ...$attributes];
             }
@@ -345,7 +371,7 @@ final class RichContent
             ->allowElement('summary')
             ->allowAttribute('style', ['p', 'h1', 'h2', 'h3']);
 
-        foreach ($this->extensions as $extension) {
+        foreach ($this->activeExtensions() as $extension) {
             $config = $extension->configureSanitizer($config);
         }
 

--- a/src/Forms/RichEditor/EditorExtension.php
+++ b/src/Forms/RichEditor/EditorExtension.php
@@ -7,6 +7,7 @@ use JsonSerializable;
 use Lattice\Lattice\Forms\RichEditor\Attributes\AsEditorExtension;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Concerns\SerializesToWire;
+use Tiptap\Core\Extension;
 
 /**
  * A rich-editor extension: a `{type, props}` wire value whose props are the
@@ -41,6 +42,18 @@ abstract class EditorExtension implements JsonSerializable
     public function serverTypes(): array
     {
         return $this->serverTypes;
+    }
+
+    /**
+     * tiptap-php extensions contributed to RichContent's schema: the node/mark
+     * survives sanitization and renders to HTML via its own renderHTML. Types
+     * covered here need no serverTypes entry.
+     *
+     * @return list<Extension>
+     */
+    public function serverExtensions(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Forms/RichEditor/EditorExtension.php
+++ b/src/Forms/RichEditor/EditorExtension.php
@@ -57,6 +57,18 @@ abstract class EditorExtension implements JsonSerializable
     }
 
     /**
+     * Outbound-only attrs by node type — injected by prepareDocument() for
+     * display/editing, stripped from the canonical storage form. Needed
+     * because tiptap-php round-trips undeclared attrs untouched.
+     *
+     * @return array<string, list<string>>
+     */
+    public function ephemeralAttributes(): array
+    {
+        return [];
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toWire(): array

--- a/src/Forms/RichEditor/EditorExtension.php
+++ b/src/Forms/RichEditor/EditorExtension.php
@@ -7,6 +7,7 @@ use JsonSerializable;
 use Lattice\Lattice\Forms\RichEditor\Attributes\AsEditorExtension;
 use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Concerns\SerializesToWire;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Tiptap\Core\Extension;
 
 /**
@@ -79,6 +80,16 @@ abstract class EditorExtension implements JsonSerializable
     public function prepareDocument(array $document): array
     {
         return $document;
+    }
+
+    /**
+     * Extend the display sanitizer with the elements/attributes this
+     * extension's renderHTML emits — the sanitizer strips everything it was
+     * not explicitly told about.
+     */
+    public function configureSanitizer(HtmlSanitizerConfig $config): HtmlSanitizerConfig
+    {
+        return $config;
     }
 
     /**

--- a/src/Forms/RichEditor/EditorExtension.php
+++ b/src/Forms/RichEditor/EditorExtension.php
@@ -69,6 +69,19 @@ abstract class EditorExtension implements JsonSerializable
     }
 
     /**
+     * Transform a document on its way out of the server — form prefill and
+     * HTML/text rendering. The place to batch-resolve stored references into
+     * displayable ephemeral attrs; runs once per document, so resolve in bulk.
+     *
+     * @param  array<string, mixed>  $document
+     * @return array<string, mixed>
+     */
+    public function prepareDocument(array $document): array
+    {
+        return $document;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toWire(): array

--- a/src/Forms/RichEditor/EditorExtension.php
+++ b/src/Forms/RichEditor/EditorExtension.php
@@ -93,6 +93,18 @@ abstract class EditorExtension implements JsonSerializable
     }
 
     /**
+     * Validate this extension's nodes in a submitted document — e.g. can the
+     * user reference this id. Returned messages become field errors.
+     *
+     * @param  array<string, mixed>  $document
+     * @return list<string>
+     */
+    public function validateDocument(array $document): array
+    {
+        return [];
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toWire(): array

--- a/src/Forms/RichEditor/EditorExtensionRegistry.php
+++ b/src/Forms/RichEditor/EditorExtensionRegistry.php
@@ -69,6 +69,20 @@ final class EditorExtensionRegistry extends WireTypeRegistry
         return $registry;
     }
 
+    /**
+     * One configured-with-defaults instance per registered extension class —
+     * the app-wide set the bare RichContent display path renders with.
+     *
+     * @return list<EditorExtension>
+     */
+    public function instances(): array
+    {
+        return array_map(
+            static fn (string $class): EditorExtension => $class::make(),
+            array_values($this->all()),
+        );
+    }
+
     #[\Override]
     public static function attribute(): string
     {

--- a/src/Forms/RichEditor/ValidatesEditorDocument.php
+++ b/src/Forms/RichEditor/ValidatesEditorDocument.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
  * Decodes a submitted rich-editor document and runs each active extension's
  * validateDocument() over it, failing with every message returned.
  */
-final class ValidatesEditorDocument implements ValidationRule
+final readonly class ValidatesEditorDocument implements ValidationRule
 {
     /**
      * @param  list<EditorExtension>  $extensions

--- a/src/Forms/RichEditor/ValidatesEditorDocument.php
+++ b/src/Forms/RichEditor/ValidatesEditorDocument.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Forms\RichEditor;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Decodes a submitted rich-editor document and runs each active extension's
+ * validateDocument() over it, failing with every message returned.
+ */
+final class ValidatesEditorDocument implements ValidationRule
+{
+    /**
+     * @param  list<EditorExtension>  $extensions
+     */
+    public function __construct(private array $extensions) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $document = json_decode($value, true);
+
+        if (! is_array($document)) {
+            return;
+        }
+
+        foreach ($this->extensions as $extension) {
+            foreach ($extension->validateDocument($document) as $message) {
+                $fail($message);
+            }
+        }
+    }
+}

--- a/src/Forms/RichEditor/ValidatesEditorDocument.php
+++ b/src/Forms/RichEditor/ValidatesEditorDocument.php
@@ -5,6 +5,7 @@ namespace Lattice\Lattice\Forms\RichEditor;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Lattice\Lattice\Forms\RichContent;
 
 /**
  * Decodes a submitted rich-editor document and runs each active extension's
@@ -19,13 +20,9 @@ final readonly class ValidatesEditorDocument implements ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! is_string($value) || $value === '') {
-            return;
-        }
+        $document = RichContent::decodeDocument($value);
 
-        $document = json_decode($value, true);
-
-        if (! is_array($document)) {
+        if ($document === null) {
             return;
         }
 

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -18,10 +18,11 @@ function calloutDoc(): array
     ];
 }
 
-it('keeps extension nodes in the schema when the extension is active', function (): void {
-    $array = RichContent::make(calloutDoc(), extensions: [CalloutExtension::make()])->toArray();
+it('renders extension nodes to html when the extension is active', function (): void {
+    $html = RichContent::make(calloutDoc(), extensions: [CalloutExtension::make()])->toHtml();
 
-    expect($array['content'][1]['type'])->toBe('callout');
+    expect($html)->toContain('<aside')
+        ->and($html)->toContain('data-callout="7"');
 });
 
 it('strips extension nodes from the schema without the extension', function (): void {
@@ -142,4 +143,13 @@ it('wires the prepared document as the rich editor value prop', function (): voi
     $wire = wire($field);
 
     expect($wire['props']['value']['content'][0]['attrs']['resolvedLabel'] ?? null)->toBe('callout-7');
+});
+
+it('lets extensions extend the html sanitizer', function (): void {
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => 'info']]]];
+
+    $html = RichContent::make($doc, extensions: [CalloutExtension::make()])->toHtml();
+
+    expect($html)->toContain('data-callout="7"')
+        ->and($html)->toContain('data-tone="info"');
 });

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -7,6 +7,7 @@ use Lattice\Lattice\Forms\Components\RichEditor;
 use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\RichContent;
 use Lattice\Lattice\Forms\RichEditor\EditorExtension;
+use Lattice\Lattice\Forms\RichEditor\EditorExtensionRegistry;
 use Lattice\Lattice\Tests\Fixtures\RichEditor\CalloutExtension;
 
 function calloutDoc(): array
@@ -174,4 +175,12 @@ it('passes validation for resolvable references', function (): void {
     $rules = $field->resolveRules(FormData::make(['body' => $doc]), request());
 
     expect(Validator::make(['body' => $doc], ['body' => $rules])->fails())->toBeFalse();
+});
+
+it('renders registered package nodes through the bare display path', function (): void {
+    app(EditorExtensionRegistry::class)->register(CalloutExtension::class);
+
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => 'info']]]];
+
+    expect(RichContent::make($doc)->toHtml())->toContain('data-callout="7"');
 });

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Lattice\Lattice\Forms\Components\RichEditor;
 use Lattice\Lattice\Forms\RichContent;
+use Lattice\Lattice\Forms\RichEditor\EditorExtension;
 use Lattice\Lattice\Tests\Fixtures\RichEditor\CalloutExtension;
 
 function calloutDoc(): array
@@ -109,6 +110,29 @@ it('keeps toArray canonical while toPreparedArray carries ephemeral attrs', func
 
     expect($content->toArray()['content'][0]['attrs'] ?? [])->not->toHaveKey('resolvedLabel')
         ->and($content->toPreparedArray()['content'][0]['attrs'])->toHaveKey('resolvedLabel');
+});
+
+it('prepares the document once per instance across toHtml, toText, and toPreparedArray', function (): void {
+    $extension = new class extends EditorExtension
+    {
+        public int $calls = 0;
+
+        public function prepareDocument(array $document): array
+        {
+            $this->calls++;
+
+            return $document;
+        }
+    };
+
+    $doc = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'hi']]]]];
+    $content = RichContent::make($doc, extensions: [$extension]);
+
+    $content->toHtml();
+    $content->toText();
+    $content->toPreparedArray();
+
+    expect($extension->calls)->toBe(1);
 });
 
 it('wires the prepared document as the rich editor value prop', function (): void {

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -46,3 +46,24 @@ it('strips extension nodes on submit when the field does not activate the extens
     $types = array_map(static fn (array $node): string => $node['type'], $cast['content']);
     expect($types)->not->toContain('callout');
 });
+
+it('collects nodes of a type depth-first', function (): void {
+    $doc = [
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'callout', 'attrs' => ['id' => 1, 'tone' => null]],
+            ['type' => 'blockquote', 'content' => [
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'quoted']]],
+                ['type' => 'callout', 'attrs' => ['id' => 2, 'tone' => 'warn']],
+            ]],
+        ],
+    ];
+
+    $nodes = RichContent::make($doc, extensions: [CalloutExtension::make()])->nodes('callout');
+
+    expect(array_column(array_column($nodes, 'attrs'), 'id'))->toBe([1, 2]);
+});
+
+it('collects no nodes from an empty document', function (): void {
+    expect(RichContent::make(null)->nodes('callout'))->toBe([]);
+});

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Validator;
 use Lattice\Lattice\Forms\Components\RichEditor;
+use Lattice\Lattice\Forms\FormData;
 use Lattice\Lattice\Forms\RichContent;
 use Lattice\Lattice\Forms\RichEditor\EditorExtension;
 use Lattice\Lattice\Tests\Fixtures\RichEditor\CalloutExtension;
@@ -152,4 +154,24 @@ it('lets extensions extend the html sanitizer', function (): void {
 
     expect($html)->toContain('data-callout="7"')
         ->and($html)->toContain('data-tone="info"');
+});
+
+it('surfaces validateDocument messages as field validation errors', function (): void {
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make());
+    $doc = json_encode(['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 999, 'tone' => null]]]]);
+
+    $rules = $field->resolveRules(FormData::make(['body' => $doc]), request());
+    $validator = Validator::make(['body' => $doc], ['body' => $rules]);
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('body'))->toBe('Callout 999 does not exist.');
+});
+
+it('passes validation for resolvable references', function (): void {
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make());
+    $doc = json_encode(['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => null]]]]);
+
+    $rules = $field->resolveRules(FormData::make(['body' => $doc]), request());
+
+    expect(Validator::make(['body' => $doc], ['body' => $rules])->fails())->toBeFalse();
 });

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -151,6 +151,15 @@ it('wires the prepared document as the rich editor value prop', function (): voi
     expect($wire['props']['value']['content'][0]['attrs']['resolvedLabel'] ?? null)->toBe('callout-7');
 });
 
+it('wires the prepared document as the rich editor value prop for a string value', function (): void {
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => null]]]];
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make())->value(json_encode($doc));
+
+    $wire = wire($field);
+
+    expect($wire['props']['value']['content'][0]['attrs']['resolvedLabel'] ?? null)->toBe('callout-7');
+});
+
 it('lets extensions extend the html sanitizer', function (): void {
     $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => 'info']]]];
 
@@ -186,4 +195,15 @@ it('renders registered package nodes through the bare display path', function ()
     $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => 'info']]]];
 
     expect(RichContent::make($doc)->toHtml())->toContain('data-callout="7"');
+});
+
+it('strips registered package nodes when a field activates none of them', function (): void {
+    app(EditorExtensionRegistry::class)->register(CalloutExtension::class);
+
+    $field = RichEditor::make('body')->extensions(['some-client-only-type']);
+
+    $cast = $field->castValue(json_encode(calloutDoc()));
+
+    $types = array_map(static fn (array $node): string => $node['type'], $cast['content']);
+    expect($types)->not->toContain('callout');
 });

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -67,3 +67,30 @@ it('collects nodes of a type depth-first', function (): void {
 it('collects no nodes from an empty document', function (): void {
     expect(RichContent::make(null)->nodes('callout'))->toBe([]);
 });
+
+it('scrubs ephemeral attrs from the canonical array', function (): void {
+    $doc = [
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => 'info', 'resolvedLabel' => 'Seven']],
+        ],
+    ];
+
+    $array = RichContent::make($doc, extensions: [CalloutExtension::make()])->toArray();
+
+    expect($array['content'][0]['attrs'])->toBe(['id' => 7, 'tone' => 'info']);
+});
+
+it('scrubs ephemeral attrs on the rich editor submit cast', function (): void {
+    $doc = [
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => null, 'resolvedLabel' => 'Seven']],
+        ],
+    ];
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make());
+
+    $cast = $field->castValue(json_encode($doc));
+
+    expect($cast['content'][0]['attrs'] ?? [])->not->toHaveKey('resolvedLabel');
+});

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Lattice\Lattice\Forms\Components\RichEditor;
+use Lattice\Lattice\Forms\RichContent;
+use Lattice\Lattice\Tests\Fixtures\RichEditor\CalloutExtension;
+
+function calloutDoc(): array
+{
+    return [
+        'type' => 'doc',
+        'content' => [
+            ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'before']]],
+            ['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => 'info']],
+        ],
+    ];
+}
+
+it('keeps extension nodes in the schema when the extension is active', function (): void {
+    $array = RichContent::make(calloutDoc(), extensions: [CalloutExtension::make()])->toArray();
+
+    expect($array['content'][1]['type'])->toBe('callout');
+});
+
+it('strips extension nodes from the schema without the extension', function (): void {
+    $array = RichContent::make(calloutDoc())->toArray();
+
+    $types = array_map(static fn (array $node): string => $node['type'], $array['content']);
+    expect($types)->not->toContain('callout');
+});
+
+it('keeps extension nodes through the rich editor submit cast', function (): void {
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make());
+
+    $cast = $field->castValue(json_encode(calloutDoc()));
+
+    expect($cast['content'][1]['type'] ?? null)->toBe('callout');
+});
+
+it('strips extension nodes on submit when the field does not activate the extension', function (): void {
+    $field = RichEditor::make('body');
+
+    $cast = $field->castValue(json_encode(calloutDoc()));
+
+    $types = array_map(static fn (array $node): string => $node['type'], $cast['content']);
+    expect($types)->not->toContain('callout');
+});

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -94,3 +94,28 @@ it('scrubs ephemeral attrs on the rich editor submit cast', function (): void {
 
     expect($cast['content'][0]['attrs'] ?? [])->not->toHaveKey('resolvedLabel');
 });
+
+it('prepares the document for display rendering', function (): void {
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => null]]]];
+
+    $prepared = RichContent::make($doc, extensions: [CalloutExtension::make()])->toPreparedArray();
+
+    expect($prepared['content'][0]['attrs']['resolvedLabel'])->toBe('callout-7');
+});
+
+it('keeps toArray canonical while toPreparedArray carries ephemeral attrs', function (): void {
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => null]]]];
+    $content = RichContent::make($doc, extensions: [CalloutExtension::make()]);
+
+    expect($content->toArray()['content'][0]['attrs'] ?? [])->not->toHaveKey('resolvedLabel')
+        ->and($content->toPreparedArray()['content'][0]['attrs'])->toHaveKey('resolvedLabel');
+});
+
+it('wires the prepared document as the rich editor value prop', function (): void {
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 7, 'tone' => null]]]];
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make())->value($doc);
+
+    $wire = wire($field);
+
+    expect($wire['props']['value']['content'][0]['attrs']['resolvedLabel'] ?? null)->toBe('callout-7');
+});

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -10,6 +10,9 @@ use Lattice\Lattice\Forms\RichEditor\EditorExtension;
 use Lattice\Lattice\Forms\RichEditor\EditorExtensionRegistry;
 use Lattice\Lattice\Tests\Fixtures\RichEditor\CalloutExtension;
 
+/**
+ * @return array<string, mixed>
+ */
 function calloutDoc(): array
 {
     return [

--- a/tests/Fixtures/RichEditor/CalloutExtension.php
+++ b/tests/Fixtures/RichEditor/CalloutExtension.php
@@ -6,6 +6,7 @@ namespace Lattice\Lattice\Tests\Fixtures\RichEditor;
 
 use Lattice\Lattice\Forms\RichEditor\Attributes\AsEditorExtension;
 use Lattice\Lattice\Forms\RichEditor\EditorExtension;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 
 #[AsEditorExtension('callout')]
 final class CalloutExtension extends EditorExtension
@@ -37,5 +38,10 @@ final class CalloutExtension extends EditorExtension
         };
 
         return $walk($document);
+    }
+
+    public function configureSanitizer(HtmlSanitizerConfig $config): HtmlSanitizerConfig
+    {
+        return $config->allowElement('aside', ['data-callout', 'data-tone']);
     }
 }

--- a/tests/Fixtures/RichEditor/CalloutExtension.php
+++ b/tests/Fixtures/RichEditor/CalloutExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\RichEditor;
+
+use Lattice\Lattice\Forms\RichEditor\Attributes\AsEditorExtension;
+use Lattice\Lattice\Forms\RichEditor\EditorExtension;
+
+#[AsEditorExtension('callout')]
+final class CalloutExtension extends EditorExtension
+{
+    protected array $serverTypes = ['callout'];
+
+    public function serverExtensions(): array
+    {
+        return [new CalloutNode];
+    }
+}

--- a/tests/Fixtures/RichEditor/CalloutExtension.php
+++ b/tests/Fixtures/RichEditor/CalloutExtension.php
@@ -13,16 +13,19 @@ final class CalloutExtension extends EditorExtension
 {
     protected array $serverTypes = ['callout'];
 
+    #[\Override]
     public function serverExtensions(): array
     {
         return [new CalloutNode];
     }
 
+    #[\Override]
     public function ephemeralAttributes(): array
     {
         return ['callout' => ['resolvedLabel']];
     }
 
+    #[\Override]
     public function prepareDocument(array $document): array
     {
         $walk = static function (array $node) use (&$walk): array {
@@ -40,11 +43,13 @@ final class CalloutExtension extends EditorExtension
         return $walk($document);
     }
 
+    #[\Override]
     public function configureSanitizer(HtmlSanitizerConfig $config): HtmlSanitizerConfig
     {
         return $config->allowElement('aside', ['data-callout', 'data-tone']);
     }
 
+    #[\Override]
     public function validateDocument(array $document): array
     {
         $messages = [];

--- a/tests/Fixtures/RichEditor/CalloutExtension.php
+++ b/tests/Fixtures/RichEditor/CalloutExtension.php
@@ -44,4 +44,25 @@ final class CalloutExtension extends EditorExtension
     {
         return $config->allowElement('aside', ['data-callout', 'data-tone']);
     }
+
+    public function validateDocument(array $document): array
+    {
+        $messages = [];
+
+        $walk = static function (array $node) use (&$walk, &$messages): void {
+            if (($node['type'] ?? null) === 'callout' && ($node['attrs']['id'] ?? 0) >= 100) {
+                $messages[] = 'Callout '.$node['attrs']['id'].' does not exist.';
+            }
+
+            foreach (is_array($node['content'] ?? null) ? $node['content'] : [] as $child) {
+                if (is_array($child)) {
+                    $walk($child);
+                }
+            }
+        };
+
+        $walk($document);
+
+        return $messages;
+    }
 }

--- a/tests/Fixtures/RichEditor/CalloutExtension.php
+++ b/tests/Fixtures/RichEditor/CalloutExtension.php
@@ -21,4 +21,21 @@ final class CalloutExtension extends EditorExtension
     {
         return ['callout' => ['resolvedLabel']];
     }
+
+    public function prepareDocument(array $document): array
+    {
+        $walk = static function (array $node) use (&$walk): array {
+            if (($node['type'] ?? null) === 'callout') {
+                $node['attrs']['resolvedLabel'] = 'callout-'.($node['attrs']['id'] ?? '?');
+            }
+
+            if (isset($node['content']) && is_array($node['content'])) {
+                $node['content'] = array_map($walk, $node['content']);
+            }
+
+            return $node;
+        };
+
+        return $walk($document);
+    }
 }

--- a/tests/Fixtures/RichEditor/CalloutExtension.php
+++ b/tests/Fixtures/RichEditor/CalloutExtension.php
@@ -16,4 +16,9 @@ final class CalloutExtension extends EditorExtension
     {
         return [new CalloutNode];
     }
+
+    public function ephemeralAttributes(): array
+    {
+        return ['callout' => ['resolvedLabel']];
+    }
 }

--- a/tests/Fixtures/RichEditor/CalloutNode.php
+++ b/tests/Fixtures/RichEditor/CalloutNode.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\RichEditor;
+
+use Tiptap\Core\Node;
+use Tiptap\Utils\HTML;
+
+final class CalloutNode extends Node
+{
+    public static $name = 'callout';
+
+    public function addAttributes(): array
+    {
+        return [
+            'id' => ['default' => null],
+            'tone' => ['default' => null],
+        ];
+    }
+
+    public function renderHTML($node, $HTMLAttributes = []): array
+    {
+        return [
+            'aside',
+            HTML::mergeAttributes($HTMLAttributes, [
+                'data-callout' => (string) ($node->attrs->id ?? ''),
+                'data-tone' => $node->attrs->tone ?? null,
+            ]),
+            0,
+        ];
+    }
+}

--- a/tests/Fixtures/RichEditor/CalloutNode.php
+++ b/tests/Fixtures/RichEditor/CalloutNode.php
@@ -9,8 +9,13 @@ use Tiptap\Utils\HTML;
 
 final class CalloutNode extends Node
 {
+    /** @var string */
     public static $name = 'callout';
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    #[\Override]
     public function addAttributes(): array
     {
         return [
@@ -19,6 +24,11 @@ final class CalloutNode extends Node
         ];
     }
 
+    /**
+     * @param  mixed  $node
+     * @param  array<string, mixed>  $HTMLAttributes
+     * @return array{0: string, 1: array<string, mixed>, 2: int}
+     */
     public function renderHTML($node, $HTMLAttributes = []): array
     {
         return [


### PR DESCRIPTION
Gives `EditorExtension` five optional server-side seams so packages (first consumer: lattice-php/media) can ship rich-editor nodes that render, validate, and store references correctly:

- `serverExtensions()` — contribute tiptap-php nodes to `RichContent`'s schema: the node survives sanitization and renders to HTML via its own `renderHTML`.
- `prepareDocument()` — outbound transform (prefill + display) for batch-resolving stored references into ephemeral attrs; runs once per `RichContent` instance.
- `ephemeralAttributes()` — declares outbound-only attrs; `toArray()` (the storage form) scrubs them, since tiptap-php round-trips undeclared attrs untouched.
- `configureSanitizer()` — allow the elements/attrs a custom node emits (the sanitizer strips everything undeclared).
- `validateDocument()` — submit-time validation surfaced as field errors via a `ValidatesEditorDocument` rule.

Plus `RichContent::toPreparedArray()`, a `->nodes($type)` walker for reference collection, and registry-backed defaults so bare `RichContent::make($doc)->toHtml()` renders app-registered package nodes. A `null`-vs-empty sentinel keeps field-scoped extension sets authoritative: a given set (even empty) never falls back to the registry, so package nodes can't bypass their `validateDocument` gate on fields that don't activate them.

All seams default to no-ops; the 17 built-ins and existing `RichContent` callers are unchanged. Documented in forms/fields/rich-editor. The media-side extension (picker toolbar, temp-URL resolution, attachment sync) follows in lattice-php/media.