### PR TITLE
feat(grid): breakpoint-mapped columns, track-list templates, and column spans

### DIFF
--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -20,6 +20,7 @@ layout primitives.
 <EnumTable
   enums={[
     "Align",
+    "Breakpoint",
     "Justify",
     "Gap",
     "Width",

--- a/docs/content/docs/components/layout.mdx
+++ b/docs/content/docs/components/layout.mdx
@@ -33,16 +33,33 @@ Tune the layout with enum-typed options (see the [enums reference](/advanced/enu
 
 ## Grid
 
-`Grid::make()->columns(n)` lays children out in `n` equal columns.
+`Grid::make()->columns(…)` lays children out in a responsive CSS grid:
+
+- `->columns(3)` — three equal columns from the `md` breakpoint up, one column below.
+- `->columns(['default' => 1, 'md' => 2, 'xl' => 4])` — an explicit count per breakpoint
+  (`default`, `sm`, `md`, `lg`, `xl`, `2xl`), mobile-first: each value applies from its
+  breakpoint up until a larger breakpoint overrides it.
+- `->columns('2fr 1fr 1fr 1fr')` — a raw
+  [`grid-template-columns`](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
+  track list for unequal columns, e.g. one wide plus three narrow. Track lists work inside
+  breakpoint maps too.
+
+Any child component or field controls how many columns it covers with `->columnSpan(n)`
+(from `md` up), a breakpoint map, or `->columnSpanFull()` to stretch across the whole row.
 
 <ComponentExample
   php={`Grid::make()->columns(3)->schema([
-    Badge::make('First'),
-    Badge::make('Second'),
-    Badge::make('Third'),
+    Badge::make('Wide')->columnSpan(2),
+    Badge::make('Narrow'),
+    Badge::make('Full width')->columnSpanFull(),
 ]);`}
   fixture="components.grid"
 />
+
+<Info>
+  A span larger than the active column count overflows the grid — pair breakpoint-mapped spans with
+  matching `columns` maps when a grid gets narrow.
+</Info>
 
 ## Card
 

--- a/docs/fixtures/components.grid.json
+++ b/docs/fixtures/components.grid.json
@@ -1,27 +1,35 @@
 [
     {
         "props": {
-            "columns": 3
+            "columns": {
+                "md": 3
+            }
         },
         "schema": [
             {
                 "props": {
                     "color": null,
-                    "label": "First"
+                    "columnSpan": {
+                        "md": 2
+                    },
+                    "label": "Wide"
                 },
                 "type": "badge"
             },
             {
                 "props": {
                     "color": null,
-                    "label": "Second"
+                    "label": "Narrow"
                 },
                 "type": "badge"
             },
             {
                 "props": {
                     "color": null,
-                    "label": "Third"
+                    "columnSpan": {
+                        "default": "full"
+                    },
+                    "label": "Full width"
                 },
                 "type": "badge"
             }

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -455,6 +455,36 @@
         "name": "Align",
         "namespace": "Lattice\\Lattice\\Ui\\Enums"
     },
+    "Lattice\\Lattice\\Ui\\Enums\\Breakpoint": {
+        "cases": [
+            {
+                "name": "Default",
+                "value": "default"
+            },
+            {
+                "name": "Sm",
+                "value": "sm"
+            },
+            {
+                "name": "Md",
+                "value": "md"
+            },
+            {
+                "name": "Lg",
+                "value": "lg"
+            },
+            {
+                "name": "Xl",
+                "value": "xl"
+            },
+            {
+                "name": "Xxl",
+                "value": "2xl"
+            }
+        ],
+        "name": "Breakpoint",
+        "namespace": "Lattice\\Lattice\\Ui\\Enums"
+    },
     "Lattice\\Lattice\\Ui\\Enums\\ButtonType": {
         "cases": [
             {

--- a/resources/css/lattice.css
+++ b/resources/css/lattice.css
@@ -355,6 +355,95 @@
   z-index: var(--lt-z-toast);
 }
 
+/*
+ * Responsive grid templates and spans driven by CSS variables the Grid
+ * component sets inline (mobile-first fallback chains, so only the breakpoints
+ * a grid declares need a variable). Variables instead of generated utility
+ * classes so arbitrary column counts and track lists survive Tailwind's static
+ * class scanning and the prebuilt standalone bundle.
+ */
+@utility lt-grid {
+  grid-template-columns: var(--lt-grid-cols-default, none);
+
+  & > [data-slot="grid-item"] {
+    grid-column: var(--lt-col-span-default, auto);
+    min-width: 0;
+  }
+
+  /* A child renderer that returns null (e.g. a condition-hidden field) must
+     not leave an empty cell behind. */
+  & > [data-slot="grid-item"]:empty {
+    display: none;
+  }
+
+  @media (width >= theme(--breakpoint-sm)) {
+    grid-template-columns: var(--lt-grid-cols-sm, var(--lt-grid-cols-default, none));
+
+    & > [data-slot="grid-item"] {
+      grid-column: var(--lt-col-span-sm, var(--lt-col-span-default, auto));
+    }
+  }
+
+  @media (width >= theme(--breakpoint-md)) {
+    grid-template-columns: var(
+      --lt-grid-cols-md,
+      var(--lt-grid-cols-sm, var(--lt-grid-cols-default, none))
+    );
+
+    & > [data-slot="grid-item"] {
+      grid-column: var(--lt-col-span-md, var(--lt-col-span-sm, var(--lt-col-span-default, auto)));
+    }
+  }
+
+  @media (width >= theme(--breakpoint-lg)) {
+    grid-template-columns: var(
+      --lt-grid-cols-lg,
+      var(--lt-grid-cols-md, var(--lt-grid-cols-sm, var(--lt-grid-cols-default, none)))
+    );
+
+    & > [data-slot="grid-item"] {
+      grid-column: var(
+        --lt-col-span-lg,
+        var(--lt-col-span-md, var(--lt-col-span-sm, var(--lt-col-span-default, auto)))
+      );
+    }
+  }
+
+  @media (width >= theme(--breakpoint-xl)) {
+    grid-template-columns: var(
+      --lt-grid-cols-xl,
+      var(--lt-grid-cols-lg, var(--lt-grid-cols-md, var(--lt-grid-cols-sm, var(--lt-grid-cols-default, none))))
+    );
+
+    & > [data-slot="grid-item"] {
+      grid-column: var(
+        --lt-col-span-xl,
+        var(--lt-col-span-lg, var(--lt-col-span-md, var(--lt-col-span-sm, var(--lt-col-span-default, auto))))
+      );
+    }
+  }
+
+  @media (width >= theme(--breakpoint-2xl)) {
+    grid-template-columns: var(
+      --lt-grid-cols-2xl,
+      var(
+        --lt-grid-cols-xl,
+        var(--lt-grid-cols-lg, var(--lt-grid-cols-md, var(--lt-grid-cols-sm, var(--lt-grid-cols-default, none))))
+      )
+    );
+
+    & > [data-slot="grid-item"] {
+      grid-column: var(
+        --lt-col-span-2xl,
+        var(
+          --lt-col-span-xl,
+          var(--lt-col-span-lg, var(--lt-col-span-md, var(--lt-col-span-sm, var(--lt-col-span-default, auto))))
+        )
+      );
+    }
+  }
+}
+
 @keyframes lt-toast-in {
   from {
     opacity: 0;

--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -8,6 +8,7 @@
 export type NodeProps = Record<string, unknown>;
 
 export type CommonNodeProps = {
+  columnSpan?: Record<string, number | string> | null;
   dataBindings?: Record<string, string> | null;
   hideWhenCollapsed?: boolean | null;
 };
@@ -217,6 +218,7 @@ export type Breadcrumb = {
   readonly title: string;
 };
 export type Breadcrumbs = Record<string, never>;
+export type Breakpoint = "default" | "sm" | "md" | "lg" | "xl" | "2xl";
 export type BrowserToken = {
   readonly accessToken: string;
   readonly audience: string;
@@ -833,7 +835,7 @@ export type FragmentResponse = {
 };
 export type Gap = "none" | "xs" | "sm" | "md" | "lg" | "xl";
 export type Grid = {
-  columns: number | null;
+  columns: Record<string, number | string> | null;
 };
 export type Heading = {
   copyable: boolean;

--- a/resources/js/ui/grid.test.tsx
+++ b/resources/js/ui/grid.test.tsx
@@ -1,27 +1,100 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { fakeNode } from "@lattice-php/lattice/test-support";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core/registry";
+import { Renderer } from "@lattice-php/lattice/core/renderer";
+import { renderWithRegistry } from "@lattice-php/lattice/test/render";
+import type { Node, RendererComponent } from "@lattice-php/lattice/core/types";
 import GridComponent from "./grid";
 
-function renderGrid(columns: number | null, key?: string) {
-  const node = fakeNode({ type: "grid", key, props: { columns } });
-  return render(
-    <GridComponent node={node}>
-      <span>child</span>
-    </GridComponent>,
+const TextProbe: RendererComponent<"text"> = ({ node }) => <span>{String(node.props?.text)}</span>;
+
+function renderGrid(
+  props: Record<string, unknown>,
+  children: Record<string, unknown>[] = [{ text: "child" }],
+  key?: string,
+) {
+  const registry = createRegistry({
+    components: {
+      grid: eagerComponent(GridComponent),
+      text: eagerComponent(TextProbe),
+    },
+    name: "test/grid",
+  });
+
+  const { container } = renderWithRegistry(
+    <Renderer
+      nodes={[
+        {
+          schema: children.map((childProps) => ({ props: childProps, type: "text" })),
+          key,
+          props,
+          type: "grid",
+        } as Node,
+      ]}
+    />,
+    registry,
   );
+
+  const grid = container.querySelector("[data-slot=grid]");
+  const items = [...container.querySelectorAll("[data-slot=grid-item]")];
+
+  return { container, grid, items };
 }
 
 describe("GridComponent", () => {
-  it("renders its children inside a grid container", () => {
-    renderGrid(2);
+  it("wraps each child in a grid item", () => {
+    const { grid, items } = renderGrid({ columns: { md: 2 } }, [
+      { text: "first" },
+      { text: "second" },
+    ]);
 
-    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.getByText("first")).toBeInTheDocument();
+    expect(items).toHaveLength(2);
+    expect(items[0]?.parentElement).toBe(grid);
   });
 
   it("exposes the node identity for component targeting", () => {
-    const { container } = renderGrid(1, "summary");
+    const { grid } = renderGrid({ columns: { md: 2 } }, undefined, "summary");
 
-    expect(container.firstElementChild).toHaveAttribute("data-lattice-component", "summary");
+    expect(grid).toHaveAttribute("data-lattice-component", "summary");
+  });
+
+  it("turns integer column counts into equal-track template variables per breakpoint", () => {
+    const { grid } = renderGrid({ columns: { default: 1, md: 3 } });
+
+    expect(grid?.getAttribute("style")).toContain(
+      "--lt-grid-cols-default: repeat(1, minmax(0, 1fr))",
+    );
+    expect(grid?.getAttribute("style")).toContain("--lt-grid-cols-md: repeat(3, minmax(0, 1fr))");
+  });
+
+  it("passes string track lists through as raw template variables", () => {
+    const { grid } = renderGrid({ columns: { md: "2fr 1fr 1fr 1fr" } });
+
+    expect(grid?.getAttribute("style")).toContain("--lt-grid-cols-md: 2fr 1fr 1fr 1fr");
+  });
+
+  it("renders no template variables without columns", () => {
+    const { grid } = renderGrid({ columns: null });
+
+    expect(grid?.getAttribute("style")).toBeNull();
+  });
+
+  it("sets span variables on items from the child column span", () => {
+    const { items } = renderGrid({ columns: { md: 4 } }, [
+      { text: "wide", columnSpan: { md: 2 } },
+      { text: "narrow" },
+    ]);
+
+    expect(items[0]?.getAttribute("style")).toContain("--lt-col-span-md: span 2 / span 2");
+    expect(items[1]?.getAttribute("style")).toBeNull();
+  });
+
+  it("turns full spans into a full-row placement", () => {
+    const { items } = renderGrid({ columns: { md: 3 } }, [
+      { text: "banner", columnSpan: { default: "full" } },
+    ]);
+
+    expect(items[0]?.getAttribute("style")).toContain("--lt-col-span-default: 1 / -1");
   });
 });

--- a/resources/js/ui/grid.tsx
+++ b/resources/js/ui/grid.tsx
@@ -1,22 +1,54 @@
+import type { CSSProperties } from "react";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
-import { cn } from "@lattice-php/lattice/lib/utils";
+import { RenderNode } from "@lattice-php/lattice/core/renderer";
+import { nodeKey } from "@lattice-php/lattice/core/nodes";
 import { nodeIdentity } from "@lattice-php/lattice/core/test-id";
 
-const GridComponent: RendererComponent<"grid"> = ({ children, node }) => {
-  const columns = Math.min(Math.max(node.props.columns ?? 1, 1), 4);
+type BreakpointMap = Record<string, number | string>;
 
+function breakpointVars(
+  map: BreakpointMap | null | undefined,
+  prefix: string,
+  toValue: (value: number | string) => string,
+): CSSProperties | undefined {
+  const entries = Object.entries(map ?? {});
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(
+    entries.map(([breakpoint, value]) => [`${prefix}-${breakpoint}`, toValue(value)]),
+  ) as CSSProperties;
+}
+
+const trackList = (value: number | string): string =>
+  typeof value === "number" ? `repeat(${value}, minmax(0, 1fr))` : value;
+
+const gridColumn = (value: number | string): string =>
+  value === "full" ? "1 / -1" : `span ${value} / span ${value}`;
+
+const GridComponent: RendererComponent<"grid"> = ({ node }) => {
   return (
     <div
       data-slot="grid"
       data-lattice-component={nodeIdentity(node)}
-      className={cn(
-        "grid gap-x-4 gap-y-6",
-        columns >= 2 && "md:grid-cols-2",
-        columns >= 3 && "lg:grid-cols-3",
-        columns >= 4 && "xl:grid-cols-4",
-      )}
+      className="lt-grid grid gap-x-4 gap-y-6"
+      style={breakpointVars(node.props.columns, "--lt-grid-cols", trackList)}
     >
-      {children}
+      {(node.schema ?? []).map((child, index) => (
+        <div
+          key={nodeKey(child, index)}
+          data-slot="grid-item"
+          style={breakpointVars(
+            child.props?.columnSpan as BreakpointMap | undefined,
+            "--lt-col-span",
+            gridColumn,
+          )}
+        >
+          <RenderNode node={child} />
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/Support/TypeScript/stubs/envelopes.ts
+++ b/src/Support/TypeScript/stubs/envelopes.ts
@@ -8,6 +8,7 @@
 export type NodeProps = Record<string, unknown>;
 
 export type CommonNodeProps = {
+  columnSpan?: Record<string, number | string> | null;
   dataBindings?: Record<string, string> | null;
   hideWhenCollapsed?: boolean | null;
 };

--- a/src/Ui/Components/Component.php
+++ b/src/Ui/Components/Component.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Ui\Components;
 
+use InvalidArgumentException;
 use JsonSerializable;
 use Lattice\Lattice\Attributes\WireEnvelope;
+use Lattice\Lattice\Support\Wire;
 use Lattice\Lattice\Ui\Components\Concerns\HasDataBindings;
 use Lattice\Lattice\Ui\Components\Concerns\SerializesWireNode;
 use Lattice\Lattice\Ui\Concerns\GatesRendering;
 use Lattice\Lattice\Ui\Contracts\Renderable;
 use Lattice\Lattice\Ui\Contracts\SchemaEntry;
+use Lattice\Lattice\Ui\Enums\Breakpoint;
 
 /**
  * @phpstan-consistent-constructor
@@ -22,6 +25,13 @@ abstract class Component implements JsonSerializable, Renderable, SchemaEntry
     use SerializesWireNode;
 
     protected bool $hideWhenCollapsed = false;
+
+    /**
+     * Breakpoint => span toward the nearest Grid ancestor.
+     *
+     * @var array<string, int|string>|null
+     */
+    protected ?array $columnSpan = null;
 
     public function __construct(protected ?string $key = null) {}
 
@@ -42,6 +52,39 @@ abstract class Component implements JsonSerializable, Renderable, SchemaEntry
         $this->hideWhenCollapsed = $hide;
 
         return $this;
+    }
+
+    /**
+     * A bare integer applies from the `md` breakpoint up; `'full'` spans the
+     * whole row at every breakpoint; a map sets each breakpoint explicitly.
+     *
+     * @param  int|string|array<string, int|string>  $span
+     */
+    public function columnSpan(int|string|array $span): static
+    {
+        if (! is_array($span)) {
+            $span = $span === 'full' ? ['default' => 'full'] : ['md' => $span];
+        }
+
+        foreach ($span as $breakpoint => $value) {
+            Breakpoint::validateKey($breakpoint);
+
+            if ((! is_int($value) || $value < 1) && $value !== 'full') {
+                throw new InvalidArgumentException(sprintf(
+                    'Column span for "%s" must be a positive integer or "full".',
+                    $breakpoint,
+                ));
+            }
+        }
+
+        $this->columnSpan = $span;
+
+        return $this;
+    }
+
+    public function columnSpanFull(): static
+    {
+        return $this->columnSpan('full');
     }
 
     /**
@@ -81,6 +124,10 @@ abstract class Component implements JsonSerializable, Renderable, SchemaEntry
 
         if ($this->hideWhenCollapsed) {
             $props['hideWhenCollapsed'] = true;
+        }
+
+        if ($this->columnSpan !== null) {
+            $props['columnSpan'] = Wire::map($this->columnSpan);
         }
 
         return $props;

--- a/src/Ui/Components/Grid.php
+++ b/src/Ui/Components/Grid.php
@@ -3,20 +3,51 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Ui\Components;
 
+use InvalidArgumentException;
 use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Attributes\WireMap;
+use Lattice\Lattice\Ui\Enums\Breakpoint;
 
 #[AsComponent('grid')]
 class Grid extends ContainerComponent
 {
-    public ?int $columns = null;
+    /**
+     * Breakpoint => column count or grid-template-columns track list.
+     *
+     * @var array<string, int|string>|null
+     */
+    #[WireMap]
+    public ?array $columns = null;
 
     public static function make(?string $key = null): static
     {
         return new static($key);
     }
 
-    public function columns(int $columns): static
+    /**
+     * A bare value applies from the `md` breakpoint up (one column below);
+     * a map sets each breakpoint explicitly. Integer values are equal-width
+     * column counts, strings are raw `grid-template-columns` track lists.
+     *
+     * @param  int|string|array<string, int|string>  $columns
+     */
+    public function columns(int|string|array $columns): static
     {
+        if (! is_array($columns)) {
+            $columns = ['md' => $columns];
+        }
+
+        foreach ($columns as $breakpoint => $value) {
+            Breakpoint::validateKey($breakpoint);
+
+            if ((is_int($value) && $value < 1) || (is_string($value) && trim($value) === '')) {
+                throw new InvalidArgumentException(sprintf(
+                    'Grid columns for "%s" must be a positive integer or a grid-template-columns track list.',
+                    $breakpoint,
+                ));
+            }
+        }
+
         $this->columns = $columns;
 
         return $this;

--- a/src/Ui/Enums/Breakpoint.php
+++ b/src/Ui/Enums/Breakpoint.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Ui\Enums;
+
+use InvalidArgumentException;
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+enum Breakpoint: string
+{
+    case Default = 'default';
+    case Sm = 'sm';
+    case Md = 'md';
+    case Lg = 'lg';
+    case Xl = 'xl';
+    case Xxl = '2xl';
+
+    public static function validateKey(int|string $key): void
+    {
+        if (! is_string($key) || self::tryFrom($key) === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Unknown breakpoint "%s". Valid breakpoints: %s.',
+                $key,
+                implode(', ', array_column(self::cases(), 'value')),
+            ));
+        }
+    }
+}

--- a/tests/Browser/Components/GridTest.php
+++ b/tests/Browser/Components/GridTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+it('applies breakpoint columns and child spans in a real grid', function (): void {
+    $page = $this->visitAsWorkbenchUser('/components/containers');
+
+    $grid = $page->script(<<<'JS'
+        () => {
+            const grid = document.querySelector('[data-lattice-component="containers-grid"]');
+            const items = [...grid.querySelectorAll(':scope > [data-slot=grid-item]')].map(
+                (item) => getComputedStyle(item),
+            );
+
+            return {
+                tracks: getComputedStyle(grid).gridTemplateColumns.split(' ').length,
+                wide: items[0].gridColumnStart,
+                narrow: items[1].gridColumnStart,
+                full: `${items[2].gridColumnStart} / ${items[2].gridColumnEnd}`,
+            };
+        }
+    JS);
+
+    expect($grid['tracks'])->toBe(3)
+        ->and($grid['wide'])->toBe('span 2')
+        ->and($grid['narrow'])->toBe('auto')
+        ->and($grid['full'])->toBe('1 / -1');
+
+    $page->assertNoSmoke();
+});

--- a/tests/Feature/Docs/ComponentDocsTest.php
+++ b/tests/Feature/Docs/ComponentDocsTest.php
@@ -58,9 +58,9 @@ describe('docs fixtures', function (): void {
     it('matches the grid example fixture', function (): void {
         assertFixtureMatches('components.grid', Wire::toWire([
             Grid::make()->columns(3)->schema([
-                Badge::make('First'),
-                Badge::make('Second'),
-                Badge::make('Third'),
+                Badge::make('Wide')->columnSpan(2),
+                Badge::make('Narrow'),
+                Badge::make('Full width')->columnSpanFull(),
             ]),
         ]));
     });

--- a/tests/Feature/Http/PageTest.php
+++ b/tests/Feature/Http/PageTest.php
@@ -135,7 +135,7 @@ test('workbench pages serialize package component trees for inertia', function (
             ->component(Heading::class, tap: fn ($heading) => $heading->assertProp('text', 'Workbench page')))
         ->component('card', tap: fn ($card) => $card->assertProp('title', 'Components'))
         ->component('grid', 'workbench-charts', fn ($charts) => $charts
-            ->assertProp('columns', 3)
+            ->assertProp('columns', ['md' => 3])
             ->component(Fragment::class, 'workbench.revenue-trend-chart', fn ($chart) => $chart
                 ->assertProps(['lazy' => true, 'size' => 'lg']))
             ->component(Fragment::class, 'workbench.sales-mix-chart', fn ($chart) => $chart

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -377,3 +377,36 @@ test('bound accepts an explicit component key', function (): void {
     expect(wire(Text::bound('email', 'contact-email')))
         ->toMatchArray(['key' => 'contact-email']);
 });
+
+test('grids normalize bare column values to the md breakpoint', function (): void {
+    expect(wire(Grid::make()->columns(3))['props']['columns'])->toBe(['md' => 3])
+        ->and(wire(Grid::make()->columns('2fr 1fr 1fr 1fr'))['props']['columns'])->toBe(['md' => '2fr 1fr 1fr 1fr']);
+});
+
+test('grids serialize breakpoint column maps as given', function (): void {
+    expect(wire(Grid::make()->columns(['default' => 1, 'md' => 2, 'xl' => 4]))['props']['columns'])
+        ->toBe(['default' => 1, 'md' => 2, 'xl' => 4]);
+});
+
+test('grids reject unknown breakpoints', function (): void {
+    Grid::make()->columns(['tablet' => 2]);
+})->throws(InvalidArgumentException::class);
+
+test('grids reject non-positive column counts', function (): void {
+    Grid::make()->columns(0);
+})->throws(InvalidArgumentException::class);
+
+test('components serialize their column span only when set', function (): void {
+    expect(wire(Text::make('hello'))['props'])->not->toHaveKey('columnSpan')
+        ->and(wire(Text::make('hello')->columnSpan(2))['props']['columnSpan'])->toBe(['md' => 2])
+        ->and(wire(Text::make('hello')->columnSpan(['default' => 2, 'xl' => 3]))['props']['columnSpan'])->toBe(['default' => 2, 'xl' => 3]);
+});
+
+test('full column spans normalize to the default breakpoint', function (): void {
+    expect(wire(Text::make('hello')->columnSpanFull())['props']['columnSpan'])->toBe(['default' => 'full'])
+        ->and(wire(Text::make('hello')->columnSpan('full'))['props']['columnSpan'])->toBe(['default' => 'full']);
+});
+
+test('column spans reject values that are neither positive integers nor full', function (): void {
+    Text::make('hello')->columnSpan('wide');
+})->throws(InvalidArgumentException::class);

--- a/workbench/app/Pages/Components/ContainersPage.php
+++ b/workbench/app/Pages/Components/ContainersPage.php
@@ -42,10 +42,10 @@ final class ContainersPage extends WorkbenchPage
                             Text::make(__('workbench.pages.components.containers.card-body')),
                             Badge::make(__('workbench.pages.components.containers.card-badge')),
                         ]),
-                    Grid::make('containers-grid')->columns(3)->schema([
-                        Badge::make(__('workbench.pages.components.containers.grid-first')),
+                    Grid::make('containers-grid')->columns(['default' => 1, 'md' => 3])->schema([
+                        Badge::make(__('workbench.pages.components.containers.grid-first'))->columnSpan(2),
                         Badge::make(__('workbench.pages.components.containers.grid-second')),
-                        Badge::make(__('workbench.pages.components.containers.grid-third')),
+                        Badge::make(__('workbench.pages.components.containers.grid-third'))->columnSpanFull(),
                     ]),
                     Section::make(__('workbench.pages.components.containers.section-title'), __('workbench.pages.components.containers.section-description'))
                         ->collapsible()


### PR DESCRIPTION
Consumer feedback: a "one wide + three narrow in a single row" layout was impossible — Grid rendered only equal-width columns capped at 4, and children had no span option.

## What changed

- `Grid::columns()` accepts an int (applies from `md` up), a raw `grid-template-columns` track list, or a per-breakpoint map (keys validated by the new `Breakpoint` enum):
  ```php
  Grid::make()->columns('2fr 1fr 1fr 1fr');                    // one wide + three narrow
  Grid::make()->columns(['default' => 1, 'md' => 2, 'xl' => 4]);
  ```
- Every component/field gains `->columnSpan(int|'full'|map)` and `->columnSpanFull()`, wired as an optional cross-cutting prop (same seam as `hideWhenCollapsed`).
- Rendering switched to Filament-v4-style CSS variables: the grid emits `--lt-grid-cols-{bp}` / `--lt-col-span-{bp}` inline, and a static `lt-grid` utility applies them per breakpoint via mobile-first `var()` fallback chains. No dynamic Tailwind classes, so arbitrary counts and unequal tracks survive consumer builds and the standalone bundle. An `:empty` rule collapses cells of condition-hidden fields.

## Breaking

- `columns(3)` now renders 3 columns from `md` up; the stepped 2@md/3@lg/4@xl behavior and the cap of 4 are gone.
- Grid children are wrapped in a `[data-slot=grid-item]` div; the `columns` wire prop is now a breakpoint map.

## Verification

New serialization + vitest coverage (TDD), and a browser test asserting *computed* styles on the workbench containers page: 3 tracks, `span 2`, `auto`, `1 / -1`. Docs, enum reference, and fixtures regenerated.