### PR TITLE
fix(rich-editor): run validation and casting for object-shaped submissions

### DIFF
--- a/src/Forms/Components/RichEditor.php
+++ b/src/Forms/Components/RichEditor.php
@@ -209,8 +209,7 @@ class RichEditor extends Field
             array_values($this->activeExtensions()),
         );
 
-        $value = $props['value'] ?? null;
-        $document = is_array($value) ? $value : RichContent::decodeDocument($value);
+        $document = RichContent::decodeDocument($props['value'] ?? null);
 
         if ($document !== null) {
             $props['value'] = RichContent::make($document, $this->allowedServerTypes(), $this->editorExtensionInstances())->toPreparedArray();

--- a/src/Forms/RichContent.php
+++ b/src/Forms/RichContent.php
@@ -115,12 +115,18 @@ final class RichContent
 
     /**
      * The submitted form value as a document array, or null when it isn't one
-     * (not a string, empty, or not valid JSON for an array).
+     * (neither an array nor a non-empty JSON string decoding to an array).
+     * Accepting already-decoded arrays keeps object-shaped JSON submissions on
+     * the same validation/cast pipeline as the string wire format.
      *
      * @return array<string, mixed>|null
      */
     public static function decodeDocument(mixed $value): ?array
     {
+        if (is_array($value)) {
+            return $value;
+        }
+
         if (! is_string($value) || $value === '') {
             return null;
         }

--- a/tests/Feature/Forms/RichContentExtensionsTest.php
+++ b/tests/Feature/Forms/RichContentExtensionsTest.php
@@ -189,6 +189,26 @@ it('passes validation for resolvable references', function (): void {
     expect(Validator::make(['body' => $doc], ['body' => $rules])->fails())->toBeFalse();
 });
 
+it('surfaces validateDocument messages for object-shaped submissions', function (): void {
+    $field = RichEditor::make('body')->withExtensions(CalloutExtension::make());
+    $doc = ['type' => 'doc', 'content' => [['type' => 'callout', 'attrs' => ['id' => 999, 'tone' => null]]]];
+
+    $rules = $field->resolveRules(FormData::make(['body' => $doc]), request());
+    $validator = Validator::make(['body' => $doc], ['body' => $rules]);
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('body'))->toBe('Callout 999 does not exist.');
+});
+
+it('strips disallowed nodes from object-shaped submissions on cast', function (): void {
+    $field = RichEditor::make('body');
+
+    $cast = $field->castValue(calloutDoc());
+
+    $types = array_map(static fn (array $node): string => $node['type'], $cast['content']);
+    expect($types)->not->toContain('callout');
+});
+
 it('renders registered package nodes through the bare display path', function (): void {
     app(EditorExtensionRegistry::class)->register(CalloutExtension::class);
 


### PR DESCRIPTION
## What

`RichContent::decodeDocument()` returned `null` for any non-string, and neither caller treated that as a failure: `ValidatesEditorDocument` silently no-opped and `RichEditor::castValue()` returned the value unchanged. Posting a rich-editor field as a parsed JSON object (`"body": {"type":"doc",...}` in a JSON request body) instead of the string wire format therefore stored the raw document verbatim — disallowed node types survived the schema filter, outbound-only ephemeral attrs survived the scrub, and every extension's `validateDocument()` seam (including extension-level authorization such as the media extension's `Gate::allows('attach', ...)` check) was skipped.

## Fix

`decodeDocument()` now returns already-decoded arrays as-is, so object-shaped submissions flow through the exact same pipeline as string ones. This one guard at the shared choke point covers all three callers; `decorateProps` had its own inline array branch which is now redundant and was removed.

Regression tests: object-shaped submission fails `validateDocument()` validation, and disallowed nodes are stripped on cast.