### PR TITLE
feat(tables): support MorphOne/MorphMany relation columns

### DIFF
--- a/src/Tables/Sources/Eloquent/MultipleRelationColumn.php
+++ b/src/Tables/Sources/Eloquent/MultipleRelationColumn.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Lattice\Lattice\Tables\RelationBinding;
 
 /**
@@ -23,13 +24,13 @@ use Lattice\Lattice\Tables\RelationBinding;
 final readonly class MultipleRelationColumn implements RelationProjection
 {
     /**
-     * @param  HasMany<Model, Model>|BelongsToMany<Model, Model>  $relationInstance
+     * @param  HasMany<Model, Model>|BelongsToMany<Model, Model>|MorphMany<Model, Model>  $relationInstance
      */
     private function __construct(
         private string $key,
         private string $labelField,
         private ?string $colorField,
-        private HasMany|BelongsToMany $relationInstance,
+        private HasMany|BelongsToMany|MorphMany $relationInstance,
     ) {}
 
     public static function resolve(Model $model, RelationBinding $binding): ?self
@@ -40,7 +41,7 @@ final readonly class MultipleRelationColumn implements RelationProjection
 
         $instance = $model->{$binding->relation}();
 
-        if (! $instance instanceof HasMany && ! $instance instanceof BelongsToMany) {
+        if (! $instance instanceof HasMany && ! $instance instanceof BelongsToMany && ! $instance instanceof MorphMany) {
             return null;
         }
 

--- a/src/Tables/Sources/Eloquent/RelationColumn.php
+++ b/src/Tables/Sources/Eloquent/RelationColumn.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Lattice\Lattice\Tables\RelationBinding;
 
 /**
@@ -21,13 +23,13 @@ use Lattice\Lattice\Tables\RelationBinding;
 final readonly class RelationColumn implements RelationProjection
 {
     /**
-     * @param  BelongsTo<Model, Model>|HasOne<Model, Model>  $relationInstance
+     * @param  BelongsTo<Model, Model>|HasOne<Model, Model>|MorphOne<Model, Model>  $relationInstance
      */
     private function __construct(
         private string $key,
         private string $relation,
         private string $field,
-        private BelongsTo|HasOne $relationInstance,
+        private BelongsTo|HasOne|MorphOne $relationInstance,
     ) {}
 
     public static function resolve(Model $model, RelationBinding $binding): ?self
@@ -38,7 +40,7 @@ final readonly class RelationColumn implements RelationProjection
 
         $instance = $model->{$binding->relation}();
 
-        if (! $instance instanceof BelongsTo && ! $instance instanceof HasOne) {
+        if (! $instance instanceof BelongsTo && ! $instance instanceof HasOne && ! $instance instanceof MorphOne) {
             return null;
         }
 
@@ -110,29 +112,27 @@ final readonly class RelationColumn implements RelationProjection
     }
 
     /**
+     * Sorts through a correlated subquery built the same way Eloquent builds
+     * `whereHas`: rebuild the relation with its automatic parent-key constraint
+     * suppressed (`Relation::noConstraints()`) so only the relation's own extra
+     * `where()` calls survive (e.g. a `hasOne()->where('channel', 'email')`),
+     * then let the relation compile its own correlation (`getRelationExistenceQuery`)
+     * and merge those extra constraints back in. This also covers `MorphOne`,
+     * whose type constraint `getRelationExistenceQuery` adds automatically.
+     *
      * @param  Builder<*>  $builder
      */
     public function applySort(Builder $builder, string $direction): void
     {
-        $related = $this->relationInstance->getRelated();
-        $baseTable = $builder->getModel()->getTable();
-        $relatedTable = $related->getTable();
+        $model = $builder->getModel();
 
-        $subquery = $related->newQuery()->select($this->field);
+        /** @var BelongsTo<Model, Model>|HasOne<Model, Model>|MorphOne<Model, Model> $relation */
+        $relation = Relation::noConstraints(fn () => $model->{$this->relation}());
 
-        if ($this->relationInstance instanceof BelongsTo) {
-            $subquery->whereColumn(
-                $relatedTable.'.'.$this->relationInstance->getOwnerKeyName(),
-                $baseTable.'.'.$this->relationInstance->getForeignKeyName(),
-            );
-        } else {
-            $subquery
-                ->whereColumn(
-                    $relatedTable.'.'.$this->relationInstance->getForeignKeyName(),
-                    $baseTable.'.'.$this->relationInstance->getLocalKeyName(),
-                )
-                ->limit(1);
-        }
+        $subquery = $relation
+            ->getRelationExistenceQuery($relation->getRelated()->newQueryWithoutRelationships(), $model->newQuery(), [$this->field])
+            ->mergeConstraintsFrom($relation->getQuery())
+            ->limit(1);
 
         $builder->orderBy($subquery, $direction);
     }

--- a/tests/Feature/Tables/MorphRelationColumnTest.php
+++ b/tests/Feature/Tables/MorphRelationColumnTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Lattice\Lattice\Tables\TableQuery;
+use Workbench\App\Models\BusinessPartner;
+use Workbench\App\Tables\MorphRelationColumnsTable;
+
+/**
+ * @param  array<string, string>  $params
+ * @return array<int, array<string, mixed>>
+ */
+function morphRelationRows(array $params = []): array
+{
+    $table = new MorphRelationColumnsTable;
+
+    $query = TableQuery::fromRequest(
+        Request::create('/', 'GET', $params),
+        $table->columns(),
+        'workbench.morph-relation-columns',
+    );
+
+    return $table->source()->query($query)->data;
+}
+
+test('a MorphOne relation column eager-loads its value onto a flat key without N+1', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $globex = BusinessPartner::factory()->create(['name' => 'Globex']);
+    $acme->internalNote()->create(['type' => 'internal', 'body' => 'Acme internal note']);
+    $globex->internalNote()->create(['type' => 'internal', 'body' => 'Globex internal note']);
+
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $rows = morphRelationRows();
+
+    expect($rows)->toHaveCount(2)
+        ->and($rows[0])->toHaveKey('internalNote.body')
+        ->and($rows[0])->not->toHaveKey('internalNote');
+
+    // The table also has a `notes` MultipleRelationColumn, so 2 partners produce
+    // 2 total note queries — one per relation column, not one per row of either.
+    $noteQueries = collect(DB::getQueryLog())
+        ->filter(fn (array $log): bool => str_contains((string) $log['query'], 'notes'))
+        ->count();
+
+    expect($noteQueries)->toBe(2);
+});
+
+test('a MorphOne relation column filters through whereHas honouring both the morph type and the extra where', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $globex = BusinessPartner::factory()->create(['name' => 'Globex']);
+    $acme->internalNote()->create(['type' => 'internal', 'body' => 'needs follow-up']);
+    $globex->notes()->create(['type' => 'external', 'body' => 'needs follow-up']);
+
+    $rows = morphRelationRows(['filter' => 'internalNote.body:contains:follow-up']);
+
+    // Globex's matching note is type=external, outside internalNote()'s scope — it must not match.
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['name'])->toBe('Acme');
+});
+
+test('a MorphOne relation column sorts through a correlated subquery that preserves the extra where', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $globex = BusinessPartner::factory()->create(['name' => 'Globex']);
+
+    // Acme's internal note sorts last alphabetically; its external note (out of
+    // internalNote()'s scope) would sort first if the extra where were dropped.
+    $acme->internalNote()->create(['type' => 'internal', 'body' => 'zzz-internal']);
+    $acme->notes()->create(['type' => 'external', 'body' => 'aaa-external']);
+    $globex->internalNote()->create(['type' => 'internal', 'body' => 'mmm-internal']);
+
+    $rows = morphRelationRows(['sort' => 'internalNote.body']);
+
+    expect(array_column($rows, 'name'))->toBe(['Globex', 'Acme']);
+});
+
+test('a MorphMany relation column lists every related row without N+1', function (): void {
+    $acme = BusinessPartner::factory()->create(['name' => 'Acme']);
+    $acme->notes()->create(['type' => 'internal', 'body' => 'first']);
+    $acme->notes()->create(['type' => 'external', 'body' => 'second']);
+    BusinessPartner::factory()->create(['name' => 'Globex']);
+
+    $rows = morphRelationRows();
+    $acmeRow = collect($rows)->firstWhere('name', 'Acme');
+
+    expect($acmeRow['notes'])->toBe(['first', 'second']);
+});

--- a/workbench/app/Factories/NoteFactory.php
+++ b/workbench/app/Factories/NoteFactory.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Note;
+
+/** @extends Factory<Note> */
+class NoteFactory extends Factory
+{
+    protected $model = Note::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'type' => 'internal',
+            'body' => fake()->sentence(),
+        ];
+    }
+
+    public function external(): static
+    {
+        return $this->state(['type' => 'external']);
+    }
+}

--- a/workbench/app/Models/BusinessPartner.php
+++ b/workbench/app/Models/BusinessPartner.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Workbench\App\Factories\BusinessPartnerFactory;
 
 /**
@@ -19,6 +21,8 @@ use Workbench\App\Factories\BusinessPartnerFactory;
  * @property-read Collection<int, Group> $groups
  * @property-read Collection<int, Address> $addresses
  * @property-read Collection<int, SalesOrder> $salesOrders
+ * @property-read Collection<int, Note> $notes
+ * @property-read Note|null $internalNote
  */
 class BusinessPartner extends Model
 {
@@ -56,6 +60,25 @@ class BusinessPartner extends Model
     public function salesOrders(): HasMany
     {
         return $this->hasMany(SalesOrder::class);
+    }
+
+    /** @return MorphMany<Note, $this> */
+    public function notes(): MorphMany
+    {
+        return $this->morphMany(Note::class, 'notable');
+    }
+
+    /**
+     * Scoped to `type = 'internal'` on purpose — this is the fixture a
+     * {@see RelationColumn} test uses to prove sorting/filtering through a
+     * `MorphOne` preserves an extra `where()` alongside the morph type
+     * constraint, not just the polymorphic wiring itself.
+     *
+     * @return MorphOne<Note, $this>
+     */
+    public function internalNote(): MorphOne
+    {
+        return $this->morphOne(Note::class, 'notable')->where('type', 'internal');
     }
 
     protected static function newFactory(): BusinessPartnerFactory

--- a/workbench/app/Models/Note.php
+++ b/workbench/app/Models/Note.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Workbench\App\Factories\NoteFactory;
+
+/**
+ * @property string $notable_type
+ * @property int $notable_id
+ * @property string $type
+ * @property string $body
+ */
+class Note extends Model
+{
+    /** @use HasFactory<NoteFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = ['notable_type', 'notable_id', 'type', 'body'];
+
+    /** @return MorphTo<Model, $this> */
+    public function notable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    protected static function newFactory(): NoteFactory
+    {
+        return NoteFactory::new();
+    }
+}

--- a/workbench/app/Tables/MorphRelationColumnsTable.php
+++ b/workbench/app/Tables/MorphRelationColumnsTable.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Tables;
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Lattice\Attributes\AsTable;
+use Lattice\Lattice\Tables\Columns\Column;
+use Lattice\Lattice\Tables\Columns\TextColumn;
+use Lattice\Lattice\Tables\Sources\Eloquent\EloquentTableDefinition;
+use Lattice\Lattice\Tables\TableQuery;
+use Workbench\App\Models\BusinessPartner;
+
+/**
+ * @extends EloquentTableDefinition<BusinessPartner>
+ */
+#[AsTable('workbench.morph-relation-columns')]
+class MorphRelationColumnsTable extends EloquentTableDefinition
+{
+    /**
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->label('Name'),
+            TextColumn::make('internalNote.body')->label('Internal note')->searchable()->sortable()->filterable(),
+            TextColumn::make('notes')->multiple('body')->label('Notes'),
+        ];
+    }
+
+    /**
+     * @return Builder<BusinessPartner>
+     */
+    public function builder(TableQuery $query): Builder
+    {
+        $builder = BusinessPartner::query();
+
+        if ($query->sorts === []) {
+            $builder->orderBy('name');
+        }
+
+        return $builder;
+    }
+}

--- a/workbench/database/migrations/2026_08_02_000000_create_notes_table.php
+++ b/workbench/database/migrations/2026_08_02_000000_create_notes_table.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notes', function (Blueprint $table): void {
+            $table->id();
+            $table->morphs('notable');
+            $table->string('type');
+            $table->text('body');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notes');
+    }
+};


### PR DESCRIPTION
## Summary

- Dotted-key relation columns (`businessPartner.name`) only recognized `BelongsTo`/`HasOne` (to-one) and `HasMany`/`BelongsToMany` (to-many). A polymorphic relation (`MorphOne`/`MorphMany`) silently fell through to the plain-attribute path instead, which breaks for a non-column key like `contactChannel.value` — `RelationColumn`/`MultipleRelationColumn` now also accept `MorphOne`/`MorphMany`.
- `RelationColumn::applySort()` built its correlated subquery from a bare `$related->newQuery()`, which drops any extra `where()` calls the relation itself adds (e.g. `hasOne(...)->where('channel', 'email')`) — a pre-existing bug for any scoped to-one relation, not just morphs, and a blocker for `MorphOne` specifically since its morph-type constraint is exactly that kind of extra `where()`. Rewritten to rebuild the relation under `Relation::noConstraints()` and compile the subquery via `getRelationExistenceQuery()` + `mergeConstraintsFrom()` — the same building blocks Eloquent's own `whereHas()`/`has()` use internally.

## Test plan

- New `tests/Feature/Tables/MorphRelationColumnTest.php`: eager-load without N+1, filter/search through `whereHas` honoring both the morph type and an extra `where()`, sort through the corrected correlated subquery, and a `MorphMany` list column.
- New workbench fixture (`notes` polymorphic table, `Note` model, `BusinessPartner::internalNote()`/`notes()`) to exercise a scoped `MorphOne` and a `MorphMany`.
- Full suite: 1541 passed, PHPStan clean (845 files), Pint clean, Rector clean.