### PR TITLE
fix(typescript): stop lattice:typescript scanning package test scaffolding

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,4 +7,6 @@ parameters:
         - src
         - tests
         - workbench/app
+    excludePaths:
+        - tests/Fixtures/TypeScript/Unloadable/BrokenExtendsMissingClass.php
     level: 6

--- a/src/Support/Discovery/ClassWalker.php
+++ b/src/Support/Discovery/ClassWalker.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Lattice\Support\Discovery;
 
 use Spatie\StructureDiscoverer\Discover;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * The single Spatie structure-discoverer entry point used across the package.
@@ -35,17 +37,41 @@ final class ClassWalker
     /**
      * Every discovered structure, including enums (`->classes()` drops them).
      *
+     * @param  list<string>  $ignoreDirectories
      * @return list<class-string>
      */
-    public static function all(string $path): array
+    public static function all(string $path, array $ignoreDirectories = []): array
     {
         if (! is_dir($path)) {
             return [];
         }
 
         /** @var list<class-string> $classes */
-        $classes = new Discover(directories: [$path])->get();
+        $classes = new Discover(
+            directories: [$path],
+            ignoredFiles: self::phpFilesIn($ignoreDirectories),
+        )->get();
 
         return $classes;
+    }
+
+    /**
+     * @param  list<string>  $directories
+     * @return list<string>
+     */
+    private static function phpFilesIn(array $directories): array
+    {
+        $directories = array_filter($directories, is_dir(...));
+
+        if ($directories === []) {
+            return [];
+        }
+
+        $files = (new Finder)->files()->name('*.php')->in($directories);
+
+        return array_values(array_map(
+            fn (SplFileInfo $file): string => $file->getPathname(),
+            iterator_to_array($files),
+        ));
     }
 }

--- a/src/Support/TypeScript/AugmentProfile.php
+++ b/src/Support/TypeScript/AugmentProfile.php
@@ -108,7 +108,7 @@ final readonly class AugmentProfile implements TypeScriptProfile
     {
         $byCategory = ['component' => [], 'column' => [], 'filter' => []];
 
-        foreach ($this->discovery->discover(dirname(__DIR__, 2))->components as $component) {
+        foreach ($this->discovery->discover(dirname(__DIR__, 2), [dirname(__DIR__).'/Testing'])->components as $component) {
             $byCategory[$component->category][$component->class] = $component->type;
         }
 

--- a/src/Support/TypeScript/WireTypeDiscovery.php
+++ b/src/Support/TypeScript/WireTypeDiscovery.php
@@ -22,7 +22,12 @@ use Spatie\Attributes\Attributes;
  */
 final class WireTypeDiscovery
 {
-    public function discover(string $path): WireTypeManifest
+    /**
+     * @param  list<string>  $ignoreDirectories  paths skipped entirely (e.g. test scaffolding
+     *                                           that can never be a wire type) so they're
+     *                                           never autoloaded during the walk
+     */
+    public function discover(string $path, array $ignoreDirectories = []): WireTypeManifest
     {
         if (! is_dir($path)) {
             return new WireTypeManifest([], [], [], []);
@@ -33,8 +38,15 @@ final class WireTypeDiscovery
         $components = [];
         $families = [];
 
-        foreach (ClassWalker::all($path) as $class) {
-            $abstract = new ReflectionClass($class)->isAbstract();
+        foreach (ClassWalker::all($path, $ignoreDirectories) as $class) {
+            try {
+                $abstract = new ReflectionClass($class)->isAbstract();
+            } catch (\Throwable) {
+                // A discovered class can fail to autoload when it depends on an
+                // optional (e.g. require-dev) package that isn't installed in the
+                // consuming app. It can't be a wire type either way, so skip it.
+                continue;
+            }
 
             if ($this->collectFamilyMember($class, $abstract, $families)) {
                 continue;

--- a/tests/Feature/TypeScript/WireTypeDiscoveryTest.php
+++ b/tests/Feature/TypeScript/WireTypeDiscoveryTest.php
@@ -13,6 +13,7 @@ use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleDualMarkedA;
 use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleDualMarkedB;
 use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleEditorExtension;
 use Lattice\Lattice\Tests\Fixtures\TypeScript\SampleUnattributed;
+use Lattice\Lattice\Tests\Fixtures\TypeScript\Unloadable\LoadableSibling;
 use Lattice\Lattice\Ui\Components\Card;
 use Lattice\Lattice\Ui\Enums\Align;
 use Lattice\Lattice\Ui\Enums\Variant;
@@ -172,6 +173,21 @@ it('classifies AsRemoteComponent with correct precedence in components', functio
     expect($dataList->type)->toBe('remote.data-list')
         ->and($dataList->category)->toBe('component')
         ->and($manifest->valueObjects)->not->toContain(DataList::class);
+});
+
+it('skips a class that fails to autoload during discovery instead of throwing', function (): void {
+    $manifest = new WireTypeDiscovery()->discover(__DIR__.'/../../Fixtures/TypeScript/Unloadable');
+
+    expect($manifest->valueObjects)->toContain(LoadableSibling::class);
+});
+
+it('excludes classes under an ignored directory from discovery', function (): void {
+    $manifest = new WireTypeDiscovery()->discover(
+        __DIR__.'/../../Fixtures/TypeScript/Unloadable',
+        [__DIR__.'/../../Fixtures/TypeScript/Unloadable'],
+    );
+
+    expect($manifest->valueObjects)->toBe([]);
 });
 
 it('resolves a domain for every discovered src component', function (): void {

--- a/tests/Fixtures/TypeScript/Unloadable/BrokenExtendsMissingClass.php
+++ b/tests/Fixtures/TypeScript/Unloadable/BrokenExtendsMissingClass.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\TypeScript\Unloadable;
+
+use Lattice\Lattice\Tests\Fixtures\TypeScript\Unloadable\NonInstalledDependency\MissingBase;
+
+/**
+ * Simulates a class whose parent lives in an optional (e.g. require-dev)
+ * dependency that isn't installed — autoloading it throws a fatal Error.
+ */
+class BrokenExtendsMissingClass extends MissingBase {}

--- a/tests/Fixtures/TypeScript/Unloadable/LoadableSibling.php
+++ b/tests/Fixtures/TypeScript/Unloadable/LoadableSibling.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Lattice\Tests\Fixtures\TypeScript\Unloadable;
+
+use Lattice\Lattice\Attributes\TypeScript;
+
+#[TypeScript]
+class LoadableSibling {}


### PR DESCRIPTION
## Summary
- `lattice:typescript` fatals in any consuming app without `orchestra/testbench`: `AugmentProfile` scans the package's own `src/` for built-in wire types, which reaches `Support/Testing/PackageTestCase.php` (extends `Orchestra\Testbench\TestCase`, a require-dev-only dependency) and autoloads it during discovery.
- Exclude `Support/Testing` from that self-scan — it can never contain wire types — via a new `$ignoreDirectories` param on `ClassWalker::all()`/`WireTypeDiscovery::discover()`.
- Make `WireTypeDiscovery::discover()` tolerate any class that fails to autoload (catch and skip) as defense-in-depth against similar cases.

## Test plan
- [x] Added regression tests: discovery skips an unloadable class without throwing, and honors `$ignoreDirectories`. Confirmed they fail with the original error when the fix is reverted.
- [x] Reproduced the fatal against a real consuming app missing `orchestra/testbench`, verified the patched package generates types successfully there.
- [x] `composer check` (Pint, PHPStan, Rector, Pest) and `npm run check` pass via the pre-push gate.