### PR TITLE
feat: expose public client primitives

### DIFF
--- a/resources/js/form/components/base/field.test.tsx
+++ b/resources/js/form/components/base/field.test.tsx
@@ -1,46 +1,69 @@
-import { expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { FormFieldFrame } from "./field";
+import { expect, it } from "vitest";
+import { FormFieldFrame as PublicFormFieldFrame } from "@lattice-php/lattice/form";
 import { TableCellProvider } from "@lattice-php/lattice/form/hooks/row-layout-context";
+import { FormFieldFrame } from "./field";
 
-it("renders the label and error in normal (stack) context", () => {
+it("is exported from the form entry point", () => {
+  expect(PublicFormFieldFrame).toBe(FormFieldFrame);
+});
+
+it("connects a standalone control to its label, helper text, and error", () => {
   render(
-    <FormFieldFrame label="Qty" name="qty" error="bad">
-      <input aria-label="qty" />
+    <FormFieldFrame
+      id="qty"
+      label="Qty"
+      helperText="Whole numbers only"
+      error="Invalid quantity"
+      required
+      className="min-w-0"
+      data-test="qty-frame"
+    >
+      {(controlProps) => <input {...controlProps} />}
     </FormFieldFrame>,
   );
-  expect(screen.getByText("Qty")).toBeInTheDocument();
-  expect(screen.getByText("bad")).toBeInTheDocument();
+
+  const input = screen.getByLabelText("Qty");
+
+  expect(input).not.toHaveAttribute("required");
+  expect(input).toHaveAttribute("aria-required", "true");
+  expect(input).toHaveAttribute("aria-invalid", "true");
+  expect(input).toHaveAttribute("aria-describedby", "qty-helper qty-error");
+  expect(screen.getByText("Whole numbers only")).toHaveAttribute("id", "qty-helper");
+  expect(screen.getByText("Invalid quantity")).toHaveAttribute("id", "qty-error");
+  expect(input.closest("[data-test='qty-frame']")).toHaveClass("min-w-0");
 });
 
 it("keeps a visually-hidden accessible label inside a table cell", () => {
   render(
     <TableCellProvider>
-      <FormFieldFrame label="Qty" name="qty" error="bad">
-        {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-        <input id="qty" />
+      <FormFieldFrame id="qty" label="Qty" error="bad">
+        {(controlProps) => <input {...controlProps} />}
       </FormFieldFrame>
     </TableCellProvider>,
   );
+
   expect(screen.getByLabelText("Qty")).toBeInTheDocument();
-  expect(screen.getByText("bad")).toBeInTheDocument();
+  expect(screen.getByText("bad")).toHaveAttribute("id", "qty-error");
   expect(screen.getByText("Qty")).toHaveClass("sr-only");
 });
 
 it("renders a tooltip trigger when a tooltip is provided", () => {
   render(
-    <FormFieldFrame label="Qty" name="qty" tooltip="How many units">
-      <input aria-label="qty" />
+    <FormFieldFrame id="qty" label="Qty" tooltip="How many units">
+      {(controlProps) => <input {...controlProps} />}
     </FormFieldFrame>,
   );
+
   expect(screen.getByRole("button", { name: "More information" })).toBeInTheDocument();
 });
 
 it("renders no tooltip trigger when no tooltip is provided", () => {
   render(
-    <FormFieldFrame label="Qty" name="qty">
-      <input aria-label="qty" />
+    <FormFieldFrame id="qty" label="Qty">
+      {(controlProps) => <input {...controlProps} />}
     </FormFieldFrame>,
   );
+
   expect(screen.queryByRole("button", { name: "More information" })).not.toBeInTheDocument();
 });

--- a/resources/js/form/components/base/field.tsx
+++ b/resources/js/form/components/base/field.tsx
@@ -3,45 +3,72 @@ import { InfoTooltip } from "@lattice-php/lattice/ui/info-tooltip";
 import { TextLink } from "@lattice-php/lattice/ui/link";
 import { Label } from "@lattice-php/lattice/ui/label";
 import { useInTableCell } from "@lattice-php/lattice/form/hooks/row-layout-context";
+import { cn } from "@lattice-php/lattice/lib/utils";
 import type { LabelAction } from "@lattice-php/lattice/form/types";
+import type { ComponentProps, ReactNode } from "react";
+
+export type FormFieldControlProps = {
+  id: string;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+  "aria-labelledby"?: string;
+  "aria-required"?: boolean;
+};
+
+type FormFieldFrameProps = Omit<ComponentProps<"div">, "children" | "id"> & {
+  children: (controlProps: FormFieldControlProps) => ReactNode;
+  error?: string;
+  helperText?: string;
+  id: string;
+  label: string;
+  labelAction?: LabelAction;
+  required?: boolean;
+  tooltip?: string;
+};
 
 export function FormFieldFrame({
   children,
+  className,
   error,
   helperText,
+  id,
   label,
   labelAction,
-  name,
   required,
   tooltip,
-}: {
-  children: React.ReactNode;
-  error?: string;
-  helperText?: string;
-  label: string;
-  labelAction?: LabelAction;
-  name: string;
-  required?: boolean;
-  tooltip?: string;
-}) {
+  ...props
+}: FormFieldFrameProps): ReactNode {
   const bare = useInTableCell();
+  const labelId = `${id}-label`;
+  const helperTextId = !bare && helperText ? `${id}-helper` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [helperTextId, errorId].filter(Boolean).join(" ") || undefined;
+  const control = children({
+    id,
+    "aria-describedby": describedBy,
+    "aria-invalid": error ? true : undefined,
+    "aria-labelledby": label ? labelId : undefined,
+    "aria-required": required || undefined,
+  });
 
   if (bare) {
     return (
-      <div className="grid gap-1">
-        <Label htmlFor={name} className="sr-only">
+      <div {...props} className={cn("grid gap-1", className)}>
+        <Label id={labelId} htmlFor={id} className="sr-only">
           {label}
         </Label>
-        {children}
-        <InputError message={error} />
+        {control}
+        <InputError id={errorId} message={error} />
       </div>
     );
   }
 
   return (
-    <div className="grid gap-2">
+    <div {...props} className={cn("grid gap-2", className)}>
       <div className="flex min-h-5 items-center">
-        <Label htmlFor={name}>{label}</Label>
+        <Label id={labelId} htmlFor={id}>
+          {label}
+        </Label>
         {required && (
           <span aria-hidden="true" className="ml-0.5 text-lt-danger">
             *
@@ -59,11 +86,15 @@ export function FormFieldFrame({
         )}
       </div>
 
-      {children}
+      {control}
 
-      {helperText && <p className="text-sm text-lt-muted-fg">{helperText}</p>}
+      {helperText && (
+        <p id={helperTextId} className="text-sm text-lt-muted-fg">
+          {helperText}
+        </p>
+      )}
 
-      <InputError message={error} />
+      <InputError id={errorId} message={error} />
     </div>
   );
 }

--- a/resources/js/form/components/fields/builder.tsx
+++ b/resources/js/form/components/fields/builder.tsx
@@ -64,84 +64,86 @@ export const BuilderComponent: RendererComponent<"field.builder"> = ({ node }) =
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={path}
+      id={path}
       required={required}
     >
-      <div className="flex flex-col gap-3">
-        <RowKeyInputs path={path} rows={rows} rowKey={ROW_ID_KEY} />
-        <RowKeyInputs path={path} rows={rows} rowKey="type" />
-        {isTable ? (
-          <>
-            <TableRows
-              base={path}
-              columns={columnsFromSchema(primary?.schema ?? [])}
-              rows={tableRows}
-              reorderable={props.reorderable ?? false}
-              removable={() => !atMin}
-              rowActions={props.rowActions}
-              onField={onField}
-              onMove={onMove}
-              onRemove={onRemove}
-              onDuplicate={onDuplicate}
-              registerRow={registerRow}
-              resizableColumns={props.resizableColumns === true}
-              resizeIndicator={props.resizeIndicator === true}
-            />
-          </>
-        ) : (
-          rows.map((row, index) => {
-            const template = templateFor(row.type);
-            const key = String(row[ROW_ID_KEY] ?? index);
+      {(controlProps) => (
+        <div {...controlProps} className="flex flex-col gap-3" role="group">
+          <RowKeyInputs path={path} rows={rows} rowKey={ROW_ID_KEY} />
+          <RowKeyInputs path={path} rows={rows} rowKey="type" />
+          {isTable ? (
+            <>
+              <TableRows
+                base={path}
+                columns={columnsFromSchema(primary?.schema ?? [])}
+                rows={tableRows}
+                reorderable={props.reorderable ?? false}
+                removable={() => !atMin}
+                rowActions={props.rowActions}
+                onField={onField}
+                onMove={onMove}
+                onRemove={onRemove}
+                onDuplicate={onDuplicate}
+                registerRow={registerRow}
+                resizableColumns={props.resizableColumns === true}
+                resizeIndicator={props.resizeIndicator === true}
+              />
+            </>
+          ) : (
+            rows.map((row, index) => {
+              const template = templateFor(row.type);
+              const key = String(row[ROW_ID_KEY] ?? index);
 
-            return (
-              <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
-                {template ? (
-                  <RowItem
-                    base={path}
-                    index={index}
-                    row={row}
-                    template={template.schema ?? EMPTY_TEMPLATE}
-                    heading={template.label}
-                    reorderable={props.reorderable ?? false}
-                    isFirst={index === 0}
-                    isLast={index === rows.length - 1}
-                    removable={!atMin}
-                    rowActions={props.rowActions}
-                    onField={onField}
-                    onRemove={onRemove}
-                    onMove={onMove}
-                    onDuplicate={onDuplicate}
-                  />
-                ) : (
-                  <div
-                    data-test={`repeater-${name}-row-${index}`}
-                    className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
-                  >
-                    <span>Unknown block: {String(row.type)}</span>
-                    <RowActions
-                      actions={buildRowActions(props.rowActions, {
-                        index,
-                        removable: !atMin,
-                        onRemove,
-                        onDuplicate,
-                        t,
-                      })}
+              return (
+                <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
+                  {template ? (
+                    <RowItem
+                      base={path}
+                      index={index}
+                      row={row}
+                      template={template.schema ?? EMPTY_TEMPLATE}
+                      heading={template.label}
+                      reorderable={props.reorderable ?? false}
+                      isFirst={index === 0}
+                      isLast={index === rows.length - 1}
+                      removable={!atMin}
+                      rowActions={props.rowActions}
+                      onField={onField}
+                      onRemove={onRemove}
+                      onMove={onMove}
+                      onDuplicate={onDuplicate}
                     />
-                  </div>
-                )}
-              </div>
-            );
-          })
-        )}
+                  ) : (
+                    <div
+                      data-test={`repeater-${name}-row-${index}`}
+                      className="flex items-center justify-between rounded-lt border border-dashed border-lt-border p-4 text-sm text-lt-muted-fg"
+                    >
+                      <span>Unknown block: {String(row.type)}</span>
+                      <RowActions
+                        actions={buildRowActions(props.rowActions, {
+                          index,
+                          removable: !atMin,
+                          onRemove,
+                          onDuplicate,
+                          t,
+                        })}
+                      />
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
 
-        {!atMax && (
-          <AddRowMenu
-            addLabel={props.addLabel ?? "Add"}
-            options={options}
-            onSelect={(type) => append({ type })}
-          />
-        )}
-      </div>
+          {!atMax && (
+            <AddRowMenu
+              addLabel={props.addLabel ?? "Add"}
+              options={options}
+              onSelect={(type) => append({ type })}
+            />
+          )}
+        </div>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/choice.tsx
+++ b/resources/js/form/components/fields/choice.tsx
@@ -29,20 +29,25 @@ export const ChoiceComponent: RendererComponent<"field.choice"> = ({ node }) => 
       helperText={node.props.helperText ?? undefined}
       tooltip={node.props.tooltip ?? undefined}
       label={node.props.label ?? ""}
-      name={name}
+      id={name}
       required={required}
     >
-      <input name={name} type="hidden" value={selected} />
-      <SegmentedPills
-        ariaLabel={node.props.label ?? undefined}
-        autoFocus={node.props.autoFocus ?? undefined}
-        disabled={readOnly || disabled}
-        name={testId ?? "segment"}
-        onSelect={commit}
-        options={options}
-        tabIndex={node.props.tabIndex ?? undefined}
-        value={selected}
-      />
+      {(controlProps) => (
+        <>
+          <input name={name} type="hidden" value={selected} />
+          <SegmentedPills
+            {...controlProps}
+            ariaLabel={node.props.label ?? undefined}
+            autoFocus={node.props.autoFocus ?? undefined}
+            disabled={readOnly || disabled}
+            name={testId ?? "segment"}
+            onSelect={commit}
+            options={options}
+            tabIndex={node.props.tabIndex ?? undefined}
+            value={selected}
+          />
+        </>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/color-picker-field.tsx
+++ b/resources/js/form/components/fields/color-picker-field.tsx
@@ -10,7 +10,7 @@ export const ColorPickerFieldComponent: RendererComponent<"field.color-picker"> 
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, value, readOnly, disabled, commit }) => {
+      {({ name, value, readOnly, disabled, commit }, controlProps) => {
         const hex = normalizeHex(value);
 
         return (
@@ -18,10 +18,10 @@ export const ColorPickerFieldComponent: RendererComponent<"field.color-picker"> 
             <input name={name} type="hidden" value={hex ?? ""} />
             <PopoverTrigger asChild>
               <button
+                {...controlProps}
                 className={cn(controlSurface(), "flex items-center gap-2 text-left")}
                 data-test={`color-picker-${name}`}
                 disabled={disabled || readOnly}
-                id={name}
                 type="button"
               >
                 {hex ? (

--- a/resources/js/form/components/fields/date-input.tsx
+++ b/resources/js/form/components/fields/date-input.tsx
@@ -7,8 +7,9 @@ export const DateInputComponent: RendererComponent<"field.date-input"> = ({ node
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, change, blur }) => (
+      {({ name, testId, value, readOnly, disabled, change, blur }, controlProps) => (
         <DatePicker
+          controlProps={controlProps}
           autoFocus={props.autoFocus ?? false}
           disabled={disabled}
           label={props.label ?? props.name}

--- a/resources/js/form/components/fields/date-picker-field.tsx
+++ b/resources/js/form/components/fields/date-picker-field.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@lattice-php/lattice/icons";
 import { useLocale } from "@lattice-php/lattice/i18n";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { Input } from "@lattice-php/lattice/ui/input";
+import type { FormFieldControlProps } from "@lattice-php/lattice/form/components/base/field";
 import {
   formatDateDisplayValue,
   formatDateTimeDisplayValue,
@@ -23,6 +24,7 @@ import { parseTimeString } from "./time-picker-columns";
 
 export type DatePickerFieldProps = {
   mode: "date" | "date-time";
+  controlProps: FormFieldControlProps;
   label: string;
   name: string;
   testId: string;
@@ -41,6 +43,7 @@ export type DatePickerFieldProps = {
 
 export function DatePickerField({
   mode,
+  controlProps,
   label,
   name,
   testId,
@@ -109,11 +112,11 @@ export function DatePickerField({
       <div {...api.getControlProps()} className="flex gap-2">
         <Input
           {...inputProps}
+          {...controlProps}
           aria-label={label}
           autoFocus={autoFocus}
           data-test={testId}
           disabled={disabled}
-          id={name}
           onInput={(event) => {
             onInput?.(event);
 

--- a/resources/js/form/components/fields/date-time-input.tsx
+++ b/resources/js/form/components/fields/date-time-input.tsx
@@ -9,8 +9,9 @@ export const DateTimeInputComponent: RendererComponent<"field.date-time-input"> 
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, change, blur }) => (
+      {({ name, testId, value, readOnly, disabled, change, blur }, controlProps) => (
         <DatePicker
+          controlProps={controlProps}
           autoFocus={props.autoFocus ?? false}
           disabled={disabled}
           label={props.label ?? props.name}

--- a/resources/js/form/components/fields/file-upload.tsx
+++ b/resources/js/form/components/fields/file-upload.tsx
@@ -259,107 +259,111 @@ export const FileUploadComponent: RendererComponent<"field.file-upload"> = ({ no
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={name}
+      id={inputId}
       required={required}
     >
-      <div
-        className="flex flex-col gap-3 rounded-lt-sm border border-dashed border-lt-border bg-lt-surface px-4 py-6"
-        data-test={testIdentity(name)}
-        onDragOver={(event) => event.preventDefault()}
-        onDrop={(event) => {
-          event.preventDefault();
-          addFiles(event.dataTransfer.files);
-        }}
-      >
-        <button
-          className="text-sm text-lt-muted-fg"
-          disabled={locked}
-          onClick={() => fileInputRef.current?.click()}
-          type="button"
-        >
-          {t("form.file-upload.dropzone", "Drop files here or click to browse")}
-        </button>
-
-        <ul
-          className={props.image ? "grid grid-cols-1 gap-3 sm:grid-cols-2" : "flex flex-col gap-2"}
-        >
-          {items.map((item) => (
-            <li
-              className={
-                props.image
-                  ? "flex min-w-0 items-center gap-3 rounded-lt-sm border border-lt-border bg-lt-bg p-2 text-sm"
-                  : "flex items-center justify-between gap-3 text-sm"
-              }
-              key={item.id}
-            >
-              {props.image && item.url ? (
-                <img
-                  alt={item.name}
-                  className="size-16 shrink-0 rounded-lt-sm border border-lt-border object-cover"
-                  data-test={testIdentity(`${name}-preview`)}
-                  src={item.url}
-                />
-              ) : null}
-              <div className="min-w-0 flex-1">
-                <span className="block truncate" data-test={testIdentity(`${name}-item`)}>
-                  {item.name}
-                </span>
-                {item.status === "uploading" && (
-                  <span className="text-xs text-lt-muted-fg">{item.progress}%</span>
-                )}
-                {item.status === "error" && (
-                  <span className="text-xs text-lt-danger">
-                    {t("form.file-upload.failed", "Failed")}
-                  </span>
-                )}
-              </div>
-              {(!item.existing || !scope) && (
-                <IconButton
-                  size="sm"
-                  icon="x"
-                  label={t("form.file-upload.remove", "Remove {{name}}", { name: item.name })}
-                  data-test={testIdentity(
-                    item.existing ? `${name}-remove-existing` : `${name}-remove`,
-                  )}
-                  disabled={locked}
-                  onClick={() => removeItem(item.id)}
-                />
-              )}
-              {signed && !item.existing && item.key && item.status === "ready" && (
-                <input
-                  data-test={testIdentity(`${name}-uploaded`)}
-                  name={fieldName}
-                  type="hidden"
-                  value={item.key}
-                />
-              )}
-            </li>
-          ))}
-        </ul>
-
-        {!scope &&
-          removedTokens.map((token) => (
-            <input key={token} name={`${name}__removed[]`} type="hidden" value={token} />
-          ))}
-
-        <input
-          accept={props.accept ?? undefined}
-          aria-label={props.label ?? name}
-          className="sr-only"
-          data-test={testIdentity(`${name}-input`)}
-          id={inputId}
-          multiple={multiple}
-          name={signed ? undefined : fieldName}
-          onChange={(event) => {
-            addFiles(event.target.files);
-            if (signed) {
-              event.target.value = "";
-            }
+      {(controlProps) => (
+        <div
+          className="flex flex-col gap-3 rounded-lt-sm border border-dashed border-lt-border bg-lt-surface px-4 py-6"
+          data-test={testIdentity(name)}
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={(event) => {
+            event.preventDefault();
+            addFiles(event.dataTransfer.files);
           }}
-          ref={fileInputRef}
-          type="file"
-        />
-      </div>
+        >
+          <button
+            className="text-sm text-lt-muted-fg"
+            disabled={locked}
+            onClick={() => fileInputRef.current?.click()}
+            type="button"
+          >
+            {t("form.file-upload.dropzone", "Drop files here or click to browse")}
+          </button>
+
+          <ul
+            className={
+              props.image ? "grid grid-cols-1 gap-3 sm:grid-cols-2" : "flex flex-col gap-2"
+            }
+          >
+            {items.map((item) => (
+              <li
+                className={
+                  props.image
+                    ? "flex min-w-0 items-center gap-3 rounded-lt-sm border border-lt-border bg-lt-bg p-2 text-sm"
+                    : "flex items-center justify-between gap-3 text-sm"
+                }
+                key={item.id}
+              >
+                {props.image && item.url ? (
+                  <img
+                    alt={item.name}
+                    className="size-16 shrink-0 rounded-lt-sm border border-lt-border object-cover"
+                    data-test={testIdentity(`${name}-preview`)}
+                    src={item.url}
+                  />
+                ) : null}
+                <div className="min-w-0 flex-1">
+                  <span className="block truncate" data-test={testIdentity(`${name}-item`)}>
+                    {item.name}
+                  </span>
+                  {item.status === "uploading" && (
+                    <span className="text-xs text-lt-muted-fg">{item.progress}%</span>
+                  )}
+                  {item.status === "error" && (
+                    <span className="text-xs text-lt-danger">
+                      {t("form.file-upload.failed", "Failed")}
+                    </span>
+                  )}
+                </div>
+                {(!item.existing || !scope) && (
+                  <IconButton
+                    size="sm"
+                    icon="x"
+                    label={t("form.file-upload.remove", "Remove {{name}}", { name: item.name })}
+                    data-test={testIdentity(
+                      item.existing ? `${name}-remove-existing` : `${name}-remove`,
+                    )}
+                    disabled={locked}
+                    onClick={() => removeItem(item.id)}
+                  />
+                )}
+                {signed && !item.existing && item.key && item.status === "ready" && (
+                  <input
+                    data-test={testIdentity(`${name}-uploaded`)}
+                    name={fieldName}
+                    type="hidden"
+                    value={item.key}
+                  />
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {!scope &&
+            removedTokens.map((token) => (
+              <input key={token} name={`${name}__removed[]`} type="hidden" value={token} />
+            ))}
+
+          <input
+            {...controlProps}
+            accept={props.accept ?? undefined}
+            aria-label={props.label ?? name}
+            className="sr-only"
+            data-test={testIdentity(`${name}-input`)}
+            multiple={multiple}
+            name={signed ? undefined : fieldName}
+            onChange={(event) => {
+              addFiles(event.target.files);
+              if (signed) {
+                event.target.value = "";
+              }
+            }}
+            ref={fileInputRef}
+            type="file"
+          />
+        </div>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/number-input.tsx
+++ b/resources/js/form/components/fields/number-input.tsx
@@ -8,18 +8,18 @@ export const NumberInputComponent: RendererComponent<"field.number-input"> = ({ 
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, commit }) => {
+      {({ name, testId, value, readOnly, disabled, commit }, controlProps) => {
         const onChange = (event: React.ChangeEvent<HTMLInputElement>): void =>
           commit(event.target.value);
 
         return props.slider ? (
           <div className="flex items-center gap-3">
             <input
+              {...controlProps}
               aria-label={props.label ?? ""}
               className="h-2 w-full cursor-pointer appearance-none rounded-lt-sm bg-lt-muted accent-lt-primary disabled:cursor-not-allowed disabled:accent-lt-disabled"
               data-test={testId}
               disabled={disabled || readOnly}
-              id={name}
               max={props.max ?? undefined}
               min={props.min ?? undefined}
               name={name}
@@ -37,11 +37,11 @@ export const NumberInputComponent: RendererComponent<"field.number-input"> = ({ 
           <AffixGroup prefix={props.prefix} suffix={props.suffix}>
             {(controlClassName) => (
               <Input
+                {...controlProps}
                 autoFocus={props.autoFocus ?? false}
                 className={controlClassName}
                 data-test={testId}
                 disabled={disabled}
-                id={name}
                 max={props.max ?? undefined}
                 min={props.min ?? undefined}
                 name={name}

--- a/resources/js/form/components/fields/otp-input.tsx
+++ b/resources/js/form/components/fields/otp-input.tsx
@@ -7,12 +7,12 @@ export const OtpInputComponent: RendererComponent<"field.otp"> = ({ node }) => {
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, commit }) => (
+      {({ name, testId, value, readOnly, disabled, commit }, controlProps) => (
         <InputOTP
+          {...controlProps}
           autoFocus={props.autoFocus ?? false}
           data-test={testId}
           disabled={disabled || readOnly}
-          id={name}
           length={props.length}
           name={name}
           onChange={(next) => commit(next)}

--- a/resources/js/form/components/fields/password-input.tsx
+++ b/resources/js/form/components/fields/password-input.tsx
@@ -34,53 +34,57 @@ export const PasswordInputComponent: RendererComponent<"field.password-input"> =
         tooltip={props.tooltip ?? undefined}
         label={props.label ?? ""}
         labelAction={props.labelAction ?? undefined}
-        name={field.name}
+        id={field.name}
         required={field.required}
       >
-        <AffixGroup prefix={props.prefix} suffix={props.suffix}>
-          {(controlClassName) => (
-            <PasswordInput
-              autoComplete={props.autoComplete ?? ""}
-              autoFocus={props.autoFocus ?? false}
-              className={controlClassName}
-              data-test={field.testId}
-              disabled={field.disabled}
-              id={field.name}
-              name={field.name}
-              onChange={(event) => {
-                field.commit(event.target.value);
-              }}
-              placeholder={props.placeholder ?? ""}
-              passwordrules={passwordRules}
-              readOnly={field.readOnly}
-              tabIndex={props.tabIndex ?? undefined}
-              value={field.value}
-            />
-          )}
-        </AffixGroup>
+        {(controlProps) => (
+          <AffixGroup prefix={props.prefix} suffix={props.suffix}>
+            {(controlClassName) => (
+              <PasswordInput
+                {...controlProps}
+                autoComplete={props.autoComplete ?? ""}
+                autoFocus={props.autoFocus ?? false}
+                className={controlClassName}
+                data-test={field.testId}
+                disabled={field.disabled}
+                name={field.name}
+                onChange={(event) => {
+                  field.commit(event.target.value);
+                }}
+                placeholder={props.placeholder ?? ""}
+                passwordrules={passwordRules}
+                readOnly={field.readOnly}
+                tabIndex={props.tabIndex ?? undefined}
+                value={field.value}
+              />
+            )}
+          </AffixGroup>
+        )}
       </FormFieldFrame>
 
       {confirmation && (
         <FormFieldFrame
           error={errors[confirmationErrorKey]}
           label={confirmation.label ?? "Confirm password"}
-          name={confirmationName}
+          id={confirmationName}
           required={field.required}
         >
-          <PasswordInput
-            autoComplete="new-password"
-            data-test={testIdentity(confirmationLocalName)}
-            disabled={field.disabled}
-            id={confirmationName}
-            name={confirmationName}
-            onChange={(event) => {
-              commit(confirmationLocalName, event.target.value);
-            }}
-            placeholder={confirmation.placeholder ?? confirmation.label ?? "Confirm password"}
-            passwordrules={passwordRules}
-            readOnly={field.readOnly}
-            tabIndex={props.tabIndex ?? undefined}
-          />
+          {(controlProps) => (
+            <PasswordInput
+              {...controlProps}
+              autoComplete="new-password"
+              data-test={testIdentity(confirmationLocalName)}
+              disabled={field.disabled}
+              name={confirmationName}
+              onChange={(event) => {
+                commit(confirmationLocalName, event.target.value);
+              }}
+              placeholder={confirmation.placeholder ?? confirmation.label ?? "Confirm password"}
+              passwordrules={passwordRules}
+              readOnly={field.readOnly}
+              tabIndex={props.tabIndex ?? undefined}
+            />
+          )}
         </FormFieldFrame>
       )}
     </div>

--- a/resources/js/form/components/fields/repeater.tsx
+++ b/resources/js/form/components/fields/repeater.tsx
@@ -57,65 +57,67 @@ export const RepeaterComponent: RendererComponent<"field.repeater"> = ({ node })
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={path}
+      id={path}
       required={required}
     >
-      <div className="flex flex-col gap-3">
-        <RowKeyInputs path={path} rows={rows} rowKey={ROW_ID_KEY} />
-        {isTable ? (
-          <TableRows
-            base={path}
-            columns={columnsFromSchema(template)}
-            rows={tableRows}
-            reorderable={props.reorderable ?? false}
-            removable={() => !atMin}
-            rowActions={props.rowActions}
-            onField={onField}
-            onMove={onMove}
-            onRemove={onRemove}
-            onDuplicate={onDuplicate}
-            registerRow={registerRow}
-            resizableColumns={props.resizableColumns === true}
-            resizeIndicator={props.resizeIndicator === true}
-          />
-        ) : (
-          rows.map((row, index) => {
-            const key = String(row[ROW_ID_KEY] ?? index);
-            return (
-              <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
-                <RowItem
-                  base={path}
-                  index={index}
-                  row={row}
-                  template={template}
-                  heading={rowHeading(index)}
-                  reorderable={props.reorderable ?? false}
-                  isFirst={index === 0}
-                  isLast={index === rows.length - 1}
-                  removable={!atMin}
-                  rowActions={props.rowActions}
-                  onField={onField}
-                  onRemove={onRemove}
-                  onMove={onMove}
-                  onDuplicate={onDuplicate}
-                />
-              </div>
-            );
-          })
-        )}
+      {(controlProps) => (
+        <div {...controlProps} className="flex flex-col gap-3" role="group">
+          <RowKeyInputs path={path} rows={rows} rowKey={ROW_ID_KEY} />
+          {isTable ? (
+            <TableRows
+              base={path}
+              columns={columnsFromSchema(template)}
+              rows={tableRows}
+              reorderable={props.reorderable ?? false}
+              removable={() => !atMin}
+              rowActions={props.rowActions}
+              onField={onField}
+              onMove={onMove}
+              onRemove={onRemove}
+              onDuplicate={onDuplicate}
+              registerRow={registerRow}
+              resizableColumns={props.resizableColumns === true}
+              resizeIndicator={props.resizeIndicator === true}
+            />
+          ) : (
+            rows.map((row, index) => {
+              const key = String(row[ROW_ID_KEY] ?? index);
+              return (
+                <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
+                  <RowItem
+                    base={path}
+                    index={index}
+                    row={row}
+                    template={template}
+                    heading={rowHeading(index)}
+                    reorderable={props.reorderable ?? false}
+                    isFirst={index === 0}
+                    isLast={index === rows.length - 1}
+                    removable={!atMin}
+                    rowActions={props.rowActions}
+                    onField={onField}
+                    onRemove={onRemove}
+                    onMove={onMove}
+                    onDuplicate={onDuplicate}
+                  />
+                </div>
+              );
+            })
+          )}
 
-        {!atMax && (
-          <button
-            type="button"
-            data-test={`repeater-${name}-add`}
-            className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
-            onClick={() => append({})}
-          >
-            <Icon name="plus" />
-            {props.addLabel ?? "Add"}
-          </button>
-        )}
-      </div>
+          {!atMax && (
+            <button
+              type="button"
+              data-test={`repeater-${name}-add`}
+              className="inline-flex items-center gap-1.5 self-start rounded-lt-sm border border-lt-border px-3 py-1.5 text-sm hover:bg-lt-accent [&_svg]:size-lt-icon-sm"
+              onClick={() => append({})}
+            >
+              <Icon name="plus" />
+              {props.addLabel ?? "Add"}
+            </button>
+          )}
+        </div>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/rich-editor-field.tsx
+++ b/resources/js/form/components/fields/rich-editor-field.tsx
@@ -126,19 +126,25 @@ const RichEditorField: RendererComponent<"field.rich-editor"> = ({ node }) => {
       helperText={node.props.helperText ?? undefined}
       tooltip={node.props.tooltip ?? undefined}
       label={node.props.label ?? ""}
-      name={domName}
+      id={domName}
       required={required}
     >
-      <div
-        className={cn(
-          "overflow-hidden rounded-lt-sm border border-lt-input bg-transparent shadow-lt-xs focus-within:border-lt-ring focus-within:ring-[length:var(--lt-ring-width)] focus-within:ring-lt-ring/50",
-          locked && "opacity-60",
-        )}
-      >
-        {editor && !locked && toolbar.length > 0 && <Toolbar editor={editor} items={toolbar} />}
-        <EditorContent editor={editor} />
-      </div>
-      <input name={domName} type="hidden" value={submittedValue} />
+      {(controlProps) => (
+        <>
+          <div
+            {...controlProps}
+            className={cn(
+              "overflow-hidden rounded-lt-sm border border-lt-input bg-transparent shadow-lt-xs focus-within:border-lt-ring focus-within:ring-[length:var(--lt-ring-width)] focus-within:ring-lt-ring/50",
+              locked && "opacity-60",
+            )}
+            role="group"
+          >
+            {editor && !locked && toolbar.length > 0 && <Toolbar editor={editor} items={toolbar} />}
+            <EditorContent editor={editor} />
+          </div>
+          <input name={domName} type="hidden" value={submittedValue} />
+        </>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/select.tsx
+++ b/resources/js/form/components/fields/select.tsx
@@ -186,103 +186,110 @@ export const SelectComponent: RendererComponent<"field.select"> = ({ node }) => 
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={domName}
+      id={domName}
       required={required}
     >
-      {multiple ? (
-        selected.map((value) => (
-          <input key={value} name={`${domName}[]`} type="hidden" value={value} />
-        ))
-      ) : (
-        <input name={domName} type="hidden" value={selected[0] ?? ""} />
-      )}
-
-      <div>
-        {multiple && selected.length > 0 && (
-          <div className="mb-1.5 flex flex-wrap gap-1">
-            {selected.map((value) => {
-              const color = colorFor(value);
-
-              return (
-                <span
-                  className="inline-flex items-center gap-1 rounded-lt-sm bg-lt-muted px-2 py-0.5 text-xs"
-                  key={value}
-                >
-                  {color && (
-                    <span
-                      aria-hidden="true"
-                      className="size-2 shrink-0 rounded-full"
-                      style={{ background: colorValue(color) }}
-                    />
-                  )}
-                  {labelFor(value)}
-                  {!locked && (
-                    <button
-                      aria-label={t("form.remove-option", "Remove {{label}}", {
-                        label: labelFor(value),
-                      })}
-                      data-test={`select-${name}-remove-${value}`}
-                      className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-xs"
-                      onClick={() => remove(value)}
-                      type="button"
-                    >
-                      <Icon name="x" />
-                    </button>
-                  )}
-                </span>
-              );
-            })}
-          </div>
-        )}
-
-        <Combobox
-          creatable={creatable}
-          emptyLabel={props.emptyLabel ?? undefined}
-          loading={loading}
-          multiple={multiple}
-          onCommit={applyCreated}
-          onCreate={applyCreated}
-          onSearch={searchable ? search : undefined}
-          onSelect={select}
-          open={open && !locked}
-          onOpenChange={(next) => {
-            setOpen(next);
-
-            if (!next) {
-              blur(name);
-            }
-          }}
-          options={options}
-          renderOption={renderOption}
-          searchPlaceholder={props.searchPlaceholder ?? undefined}
-          showSearch={Boolean(searchable || creatable)}
-          selected={selected}
-          testId={`select-${name}`}
-          trigger={
-            <>
-              {!multiple && selected.length > 0 ? (
-                <span>{labelFor(selected[0])}</span>
-              ) : (
-                <span className="text-lt-muted-fg">{placeholder}</span>
-              )}
-              <Icon name="chevrons-up-down" className="size-lt-icon-md shrink-0 text-lt-muted-fg" />
-            </>
-          }
-          triggerClassName={cn(
-            controlSurface(),
-            "flex items-center justify-between gap-2 text-left",
-            locked && "cursor-not-allowed opacity-60",
+      {(controlProps) => (
+        <>
+          {multiple ? (
+            selected.map((value) => (
+              <input key={value} name={`${domName}[]`} type="hidden" value={value} />
+            ))
+          ) : (
+            <input name={domName} type="hidden" value={selected[0] ?? ""} />
           )}
-          triggerProps={{
-            "aria-haspopup": "listbox",
-            autoFocus: props.autoFocus ?? undefined,
-            "data-test": `select-${name}`,
-            disabled: locked,
-            id: domName,
-            tabIndex: props.tabIndex ?? undefined,
-          }}
-        />
-      </div>
+
+          <div>
+            {multiple && selected.length > 0 && (
+              <div className="mb-1.5 flex flex-wrap gap-1">
+                {selected.map((value) => {
+                  const color = colorFor(value);
+
+                  return (
+                    <span
+                      className="inline-flex items-center gap-1 rounded-lt-sm bg-lt-muted px-2 py-0.5 text-xs"
+                      key={value}
+                    >
+                      {color && (
+                        <span
+                          aria-hidden="true"
+                          className="size-2 shrink-0 rounded-full"
+                          style={{ background: colorValue(color) }}
+                        />
+                      )}
+                      {labelFor(value)}
+                      {!locked && (
+                        <button
+                          aria-label={t("form.remove-option", "Remove {{label}}", {
+                            label: labelFor(value),
+                          })}
+                          data-test={`select-${name}-remove-${value}`}
+                          className="text-lt-muted-fg hover:text-lt-fg [&_svg]:size-lt-icon-xs"
+                          onClick={() => remove(value)}
+                          type="button"
+                        >
+                          <Icon name="x" />
+                        </button>
+                      )}
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+
+            <Combobox
+              creatable={creatable}
+              emptyLabel={props.emptyLabel ?? undefined}
+              loading={loading}
+              multiple={multiple}
+              onCommit={applyCreated}
+              onCreate={applyCreated}
+              onSearch={searchable ? search : undefined}
+              onSelect={select}
+              open={open && !locked}
+              onOpenChange={(next) => {
+                setOpen(next);
+
+                if (!next) {
+                  blur(name);
+                }
+              }}
+              options={options}
+              renderOption={renderOption}
+              searchPlaceholder={props.searchPlaceholder ?? undefined}
+              showSearch={Boolean(searchable || creatable)}
+              selected={selected}
+              testId={`select-${name}`}
+              trigger={
+                <>
+                  {!multiple && selected.length > 0 ? (
+                    <span>{labelFor(selected[0])}</span>
+                  ) : (
+                    <span className="text-lt-muted-fg">{placeholder}</span>
+                  )}
+                  <Icon
+                    name="chevrons-up-down"
+                    className="size-lt-icon-md shrink-0 text-lt-muted-fg"
+                  />
+                </>
+              }
+              triggerClassName={cn(
+                controlSurface(),
+                "flex items-center justify-between gap-2 text-left",
+                locked && "cursor-not-allowed opacity-60",
+              )}
+              triggerProps={{
+                ...controlProps,
+                "aria-haspopup": "listbox",
+                autoFocus: props.autoFocus ?? undefined,
+                "data-test": `select-${name}`,
+                disabled: locked,
+                tabIndex: props.tabIndex ?? undefined,
+              }}
+            />
+          </div>
+        </>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/components/fields/simple-field.tsx
+++ b/resources/js/form/components/fields/simple-field.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
 import type { Node } from "@lattice-php/lattice/core/types";
-import { FormFieldFrame } from "@lattice-php/lattice/form/components/base/field";
+import {
+  FormFieldFrame,
+  type FormFieldControlProps,
+} from "@lattice-php/lattice/form/components/base/field";
 import { fieldProps } from "@lattice-php/lattice/form/lib/field-props";
 import {
   type ControlledField,
@@ -14,7 +17,7 @@ export function SimpleField({
 }: {
   node: Node;
   label: string;
-  children: (field: ControlledField) => ReactNode;
+  children: (field: ControlledField, controlProps: FormFieldControlProps) => ReactNode;
 }) {
   const field = useControlledField(node);
 
@@ -28,10 +31,10 @@ export function SimpleField({
       helperText={fieldProps(node).helperText ?? undefined}
       tooltip={fieldProps(node).tooltip ?? undefined}
       label={label}
-      name={field.name}
+      id={field.name}
       required={field.required}
     >
-      {children(field)}
+      {(controlProps) => children(field, controlProps)}
     </FormFieldFrame>
   );
 }

--- a/resources/js/form/components/fields/text-input.test.tsx
+++ b/resources/js/form/components/fields/text-input.test.tsx
@@ -105,7 +105,7 @@ describe("TextInputComponent copy affix", () => {
     expect(screen.queryByRole("button", { name: /Copy/ })).not.toBeInTheDocument();
   });
 
-  it("copies the current input value", () => {
+  it("copies the current input value", async () => {
     const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
 
@@ -122,6 +122,6 @@ describe("TextInputComponent copy affix", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy API key" }));
 
     expect(writeText).toHaveBeenCalledWith("tok_secret");
-    expect(screen.getByRole("button", { name: "Copied API key" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Copied API key" })).toBeInTheDocument();
   });
 });

--- a/resources/js/form/components/fields/text-input.tsx
+++ b/resources/js/form/components/fields/text-input.tsx
@@ -9,7 +9,7 @@ export const TextInputComponent: RendererComponent<"field.text-input"> = ({ node
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, commit }) => (
+      {({ name, testId, value, readOnly, disabled, commit }, controlProps) => (
         <AffixGroup
           prefix={props.prefix}
           suffix={props.suffix}
@@ -26,12 +26,12 @@ export const TextInputComponent: RendererComponent<"field.text-input"> = ({ node
         >
           {(controlClassName) => (
             <Input
+              {...controlProps}
               autoComplete={props.autoComplete ?? ""}
               autoFocus={props.autoFocus ?? false}
               className={controlClassName}
               data-test={testId}
               disabled={disabled}
-              id={name}
               name={name}
               onChange={(event) => commit(event.target.value)}
               placeholder={props.placeholder ?? ""}

--- a/resources/js/form/components/fields/textarea.tsx
+++ b/resources/js/form/components/fields/textarea.tsx
@@ -7,12 +7,12 @@ export const TextareaComponent: RendererComponent<"field.textarea"> = ({ node })
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, commit }) => (
+      {({ name, testId, value, readOnly, disabled, commit }, controlProps) => (
         <Textarea
+          {...controlProps}
           autoFocus={props.autoFocus ?? false}
           data-test={testId}
           disabled={disabled}
-          id={name}
           name={name}
           onChange={(event) => commit(event.target.value)}
           placeholder={props.placeholder ?? ""}

--- a/resources/js/form/components/fields/time-input.tsx
+++ b/resources/js/form/components/fields/time-input.tsx
@@ -14,14 +14,14 @@ export const TimeInputComponent: RendererComponent<"field.time-input"> = ({ node
 
   return (
     <SimpleField node={node} label={props.label ?? ""}>
-      {({ name, testId, value, readOnly, disabled, commit, blur }) => (
+      {({ name, testId, value, readOnly, disabled, commit, blur }, controlProps) => (
         <div className="flex gap-2">
           <Input
+            {...controlProps}
             aria-label={triggerLabel}
             autoFocus={props.autoFocus ?? false}
             data-test={testId}
             disabled={disabled}
-            id={name}
             name={name}
             onBlur={() => {
               const parsed = parseTimeString(value);

--- a/resources/js/form/components/fields/toggle.tsx
+++ b/resources/js/form/components/fields/toggle.tsx
@@ -38,32 +38,36 @@ export const ToggleComponent: RendererComponent<"field.toggle"> = ({ node }) => 
       helperText={props.helperText ?? undefined}
       tooltip={props.tooltip ?? undefined}
       label={props.label ?? ""}
-      name={name}
+      id={name}
       required={required}
     >
-      <input disabled={locked} name={name} type="hidden" value={checked ? "1" : "0"} />
-      <button
-        aria-checked={checked}
-        aria-label={props.label ?? localName}
-        autoFocus={props.autoFocus ?? false}
-        className={cn(
-          "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-lt-muted p-0.5 shadow-lt-xs transition-colors outline-none focus-visible:border-lt-ring focus-visible:ring-[length:var(--lt-ring-width)] focus-visible:ring-lt-ring/50 disabled:cursor-not-allowed disabled:bg-lt-disabled data-[state=checked]:bg-lt-primary disabled:data-[state=checked]:bg-lt-disabled",
-        )}
-        data-state={checked ? "checked" : "unchecked"}
-        data-test={testIdentity(localName)}
-        disabled={locked}
-        id={name}
-        name={name}
-        onClick={() => commit(localName, !checked)}
-        role="switch"
-        tabIndex={props.tabIndex ?? undefined}
-        type="button"
-      >
-        <span
-          className="size-5 rounded-full bg-lt-bg shadow-lt-sm transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
-          data-state={checked ? "checked" : "unchecked"}
-        />
-      </button>
+      {(controlProps) => (
+        <>
+          <input disabled={locked} name={name} type="hidden" value={checked ? "1" : "0"} />
+          <button
+            {...controlProps}
+            aria-checked={checked}
+            aria-label={props.label ?? localName}
+            autoFocus={props.autoFocus ?? false}
+            className={cn(
+              "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-lt-muted p-0.5 shadow-lt-xs transition-colors outline-none focus-visible:border-lt-ring focus-visible:ring-[length:var(--lt-ring-width)] focus-visible:ring-lt-ring/50 disabled:cursor-not-allowed disabled:bg-lt-disabled data-[state=checked]:bg-lt-primary disabled:data-[state=checked]:bg-lt-disabled",
+            )}
+            data-state={checked ? "checked" : "unchecked"}
+            data-test={testIdentity(localName)}
+            disabled={locked}
+            name={name}
+            onClick={() => commit(localName, !checked)}
+            role="switch"
+            tabIndex={props.tabIndex ?? undefined}
+            type="button"
+          >
+            <span
+              className="size-5 rounded-full bg-lt-bg shadow-lt-sm transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+              data-state={checked ? "checked" : "unchecked"}
+            />
+          </button>
+        </>
+      )}
     </FormFieldFrame>
   );
 };

--- a/resources/js/form/index.ts
+++ b/resources/js/form/index.ts
@@ -1,4 +1,5 @@
 export * from "./components";
+export { FormFieldFrame, type FormFieldControlProps } from "./components/base/field";
 export { FormValuesProvider } from "./hooks/values";
 export { formComponents } from "./plugin";
 export type * from "./types";

--- a/resources/js/form/toolkit.ts
+++ b/resources/js/form/toolkit.ts
@@ -2,7 +2,7 @@
  * Entry point for building custom form fields outside the package. Form
  * modules not re-exported here are internal and may change without notice.
  */
-export { FormFieldFrame } from "./components/base/field";
+export { FormFieldFrame, type FormFieldControlProps } from "./components/base/field";
 export { useFormContext } from "./hooks/context";
 export { FieldScopeProvider, useFieldScope } from "./hooks/field-scope";
 export { fieldProps, walkFields } from "./lib/field-props";

--- a/resources/js/table/components/table.test.tsx
+++ b/resources/js/table/components/table.test.tsx
@@ -109,7 +109,12 @@ describe("Lattice table component", () => {
     window.localStorage.clear();
   });
 
-  it("renders columns and rows from server props", () => {
+  it("renders columns and rows from server props", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
     const node = {
       id: "workbench.users",
       props: {
@@ -204,7 +209,7 @@ describe("Lattice table component", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Copy Email" }));
 
-    expect(screen.getByRole("button", { name: "Copied Email" })).toBeVisible();
+    expect(await screen.findByRole("button", { name: "Copied Email" })).toBeVisible();
   });
 
   it("refreshes rows when table data props change", () => {

--- a/resources/js/ui/control-extensions.test.tsx
+++ b/resources/js/ui/control-extensions.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Button } from "./button";
-import { NativeSelect } from "./native-select";
+import { NativeSelect } from "./index";
 
 describe("NativeSelect", () => {
   it("renders a styled native select with its options", () => {

--- a/resources/js/ui/copyable-text.test.tsx
+++ b/resources/js/ui/copyable-text.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { CopyableText, copyToClipboard } from "./copyable-text";
+import { CopyButton, CopyableText, copyToClipboard } from "./copyable-text";
 
 function stubClipboard(writeText: (text: string) => Promise<void>) {
   Object.defineProperty(navigator, "clipboard", {
@@ -26,7 +26,7 @@ describe("CopyableText", () => {
     expect(screen.getByRole("button", { name: "Copy API token" })).toBeInTheDocument();
   });
 
-  it("copies the value and swaps the button label on click", () => {
+  it("copies the value and swaps the button label on click", async () => {
     const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
     stubClipboard(writeText);
 
@@ -35,13 +35,46 @@ describe("CopyableText", () => {
     fireEvent.click(screen.getByRole("button", { name: "Copy API token" }));
 
     expect(writeText).toHaveBeenCalledWith("tok_secret");
-    expect(screen.getByRole("button", { name: "Copied API token" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Copied API token" })).toBeInTheDocument();
   });
 
   it("falls back to the value when no children are given", () => {
     render(<CopyableText value="tok_secret" label="API token" />);
 
     expect(screen.getByText("tok_secret")).toBeInTheDocument();
+  });
+});
+
+describe("CopyButton", () => {
+  it("renders an icon-only button with an accessible label", () => {
+    render(<CopyButton value="tok_secret" label="API token" iconOnly />);
+
+    expect(screen.getByRole("button", { name: "Copy API token" })).not.toHaveTextContent("Copy");
+  });
+
+  it("renders a custom idle label", () => {
+    render(
+      <CopyButton value="tok_secret" label="API token">
+        Copy token
+      </CopyButton>,
+    );
+
+    expect(screen.getByRole("button", { name: "Copy API token" })).toHaveTextContent("Copy token");
+  });
+
+  it("does not report success when copying fails", async () => {
+    const writeText = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockRejectedValue(new Error("denied"));
+    stubClipboard(writeText);
+
+    render(<CopyButton value="tok_secret" label="API token" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy API token" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("tok_secret"));
+    expect(screen.getByRole("button", { name: "Copy API token" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copied API token" })).not.toBeInTheDocument();
   });
 });
 

--- a/resources/js/ui/copyable-text.tsx
+++ b/resources/js/ui/copyable-text.tsx
@@ -1,7 +1,7 @@
 import { useT } from "@lattice-php/lattice/i18n";
-import { Icon } from "@lattice-php/lattice/icons";
-import { cn } from "@lattice-php/lattice/lib/utils";
 import { type ReactNode, useEffect, useState } from "react";
+import { Button } from "./button";
+import { IconButton } from "./icon-button";
 
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (!navigator?.clipboard) {
@@ -22,9 +22,18 @@ interface CopyButtonProps {
   label: string;
   testId?: string;
   className?: string;
+  iconOnly?: boolean;
+  children?: ReactNode;
 }
 
-export function CopyButton({ value, label, testId, className }: CopyButtonProps): ReactNode {
+export function CopyButton({
+  value,
+  label,
+  testId,
+  className,
+  iconOnly = false,
+  children,
+}: CopyButtonProps): ReactNode {
   const { t } = useT("lattice");
   const [copied, setCopied] = useState(false);
 
@@ -38,29 +47,41 @@ export function CopyButton({ value, label, testId, className }: CopyButtonProps)
     return () => window.clearTimeout(timeout);
   }, [copied]);
 
-  function handleCopy(): void {
-    void copyToClipboard(value);
-    setCopied(true);
+  async function handleCopy(): Promise<void> {
+    if (await copyToClipboard(value)) {
+      setCopied(true);
+    }
   }
 
   const ariaLabel = copied
     ? t("common.copied-value", "Copied {{label}}", { label })
     : t("common.copy-value", "Copy {{label}}", { label });
 
+  if (iconOnly) {
+    return (
+      <IconButton
+        icon={copied ? "check" : "copy"}
+        label={ariaLabel}
+        data-test={testId}
+        className={className}
+        onClick={() => void handleCopy()}
+      />
+    );
+  }
+
   return (
-    <button
+    <Button
       type="button"
+      size="sm"
+      emphasis="outline"
+      icon={copied ? "check" : "copy"}
       data-test={testId}
-      className={cn(
-        "inline-flex items-center gap-1 rounded-lt-sm border border-lt-border px-2 py-1 text-xs",
-        className,
-      )}
+      className={className}
       aria-label={ariaLabel}
-      onClick={handleCopy}
+      onClick={() => void handleCopy()}
     >
-      <Icon name={copied ? "check" : "copy"} className="size-lt-icon-xs" />
-      {copied ? t("common.copied", "Copied") : t("common.copy", "Copy")}
-    </button>
+      {copied ? t("common.copied", "Copied") : (children ?? t("common.copy", "Copy"))}
+    </Button>
   );
 }
 

--- a/resources/js/ui/index.ts
+++ b/resources/js/ui/index.ts
@@ -35,6 +35,7 @@ export { Input } from "./input";
 export { default as InputError } from "./input-error";
 export { InputOTP } from "./input-otp";
 export { Label } from "./label";
+export { NativeSelect } from "./native-select";
 export { TextLink } from "./link";
 export { default as PasswordInput } from "./password-input";
 export { Popover, PopoverClose, PopoverContent, PopoverTrigger } from "./popover";

--- a/resources/js/ui/segmented-pills.tsx
+++ b/resources/js/ui/segmented-pills.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { type ComponentProps, useEffect, useRef } from "react";
 import type { Option } from "@lattice-php/lattice/core/types";
 import { cn } from "@lattice-php/lattice/lib/utils";
 import { pillClassName } from "./pill";
@@ -10,13 +10,15 @@ import { pillClassName } from "./pill";
 export function SegmentedPills({
   ariaLabel,
   autoFocus = false,
+  className,
   disabled = false,
   name,
   onSelect,
   options,
   tabIndex,
   value,
-}: {
+  ...props
+}: Omit<ComponentProps<"div">, "children" | "onSelect" | "ref"> & {
   ariaLabel?: string;
   autoFocus?: boolean;
   disabled?: boolean;
@@ -43,8 +45,12 @@ export function SegmentedPills({
 
   return (
     <div
+      {...props}
       aria-label={ariaLabel}
-      className="inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-lt bg-lt-muted p-1"
+      className={cn(
+        "inline-flex w-fit max-w-full gap-1 overflow-x-auto rounded-lt bg-lt-muted p-1",
+        className,
+      )}
       ref={groupRef}
       role="radiogroup"
     >

--- a/tests/Browser/Fields/TextInputTest.php
+++ b/tests/Browser/Fields/TextInputTest.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 
 it('copies a copyable text input value via the copy affix', function (): void {
-    $this->visitAsWorkbenchUser('/form/fields/text?type=copyable')
+    $page = $this->visitAsWorkbenchUser('/form/fields/text?type=copyable');
+    stubSuccessfulClipboard($page);
+
+    $page
         ->click('@referral_code-copy')
         ->assertSee('Copied')
         ->assertNoSmoke();

--- a/tests/Browser/Tables/UsersTableTest.php
+++ b/tests/Browser/Tables/UsersTableTest.php
@@ -24,8 +24,9 @@ it('copies a cell value to the clipboard', function (): void {
     deleteWorkbenchUsersExceptAuthenticated();
     UserFactory::new()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
 
-    $page = visit('/')
-        ->click('@copy-email');
+    $page = visit('/');
+    stubSuccessfulClipboard($page);
+    $page->click('@copy-email');
 
     assertSeeEventually($page, 'Copied');
 

--- a/tests/Support/Browser.php
+++ b/tests/Support/Browser.php
@@ -64,6 +64,11 @@ function assertPresentEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $
     });
 }
 
+function stubSuccessfulClipboard(AwaitableWebpage|PendingAwaitablePage|Webpage $page): void
+{
+    $page->script('Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText: async () => {} } })');
+}
+
 /**
  * The infinite tab's IntersectionObserver auto-fires loadMore() when the
  * sentinel enters its 240px root margin — which can happen before the first


### PR DESCRIPTION
## Summary

- extend `CopyButton` with icon-only and custom-label variants, reporting copied state only after a successful write
- export `NativeSelect` from the main `/ui` entry point
- expose an accessible standalone `FormFieldFrame` from `/form` and migrate built-in fields to its render-prop control contract

These remove local wrappers and repeated label, helper, error, and ARIA wiring in client-generated interfaces such as Spectacular.

## Before / after

Before, consumers needed local compact copy controls, a `NativeSelect` subpath import, and custom field framing. After, they can use `<CopyButton iconOnly />`, import `NativeSelect` from `/ui`, and render controls through the public `FormFieldFrame`.

## Verification

- `composer check`
- `npm run check`
- browser suite: 116 passed, 675 assertions; 2 S3 tests skipped because RustFS was unavailable
