### PR TITLE
feat(ui): add code block display options

### DIFF
--- a/resources/js/types/generated.ts
+++ b/resources/js/types/generated.ts
@@ -380,6 +380,8 @@ export type CodeBlock = {
   code: string;
   copyable: boolean;
   language: CodeBlockLanguage;
+  lineNumbers: boolean;
+  maxHeight: number | null;
   wrap: boolean;
 };
 export type CodeBlockLanguage = "text" | "json" | "javascript" | "shell" | "php";

--- a/resources/js/ui/code-block-view.tsx
+++ b/resources/js/ui/code-block-view.tsx
@@ -5,7 +5,7 @@ import { php } from "@codemirror/lang-php";
 import { HighlightStyle, StreamLanguage, syntaxHighlighting } from "@codemirror/language";
 import { shell } from "@codemirror/legacy-modes/mode/shell";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
+import { EditorView, lineNumbers as showLineNumbers } from "@codemirror/view";
 import { tags } from "@lezer/highlight";
 import type { CodeBlockLanguage, CodeBlockViewProps } from "./code-block";
 
@@ -46,7 +46,14 @@ const copyableTheme = EditorView.theme({
   ".cm-content": { padding: "2.75rem 0.75rem 0.75rem" },
 });
 
-function CodeBlockView({ children, copyable, language, wrap }: CodeBlockViewProps) {
+function CodeBlockView({
+  children,
+  copyable,
+  language,
+  lineNumbers,
+  maxHeight,
+  wrap,
+}: CodeBlockViewProps) {
   const container = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -68,6 +75,12 @@ function CodeBlockView({ children, copyable, language, wrap }: CodeBlockViewProp
         syntaxHighlighting(highlightStyle),
         codeBlockTheme,
         copyable ? copyableTheme : [],
+        lineNumbers ? showLineNumbers() : [],
+        maxHeight === null
+          ? []
+          : EditorView.theme({
+              "&": { maxHeight: `${maxHeight}px` },
+            }),
         wrap ? EditorView.lineWrapping : [],
       ],
     });
@@ -91,7 +104,7 @@ function CodeBlockView({ children, copyable, language, wrap }: CodeBlockViewProp
       active = false;
       view.destroy();
     };
-  }, [children, copyable, language, wrap]);
+  }, [children, copyable, language, lineNumbers, maxHeight, wrap]);
 
   return <div ref={container} />;
 }

--- a/resources/js/ui/code-block-view.tsx
+++ b/resources/js/ui/code-block-view.tsx
@@ -55,6 +55,9 @@ function CodeBlockView({
   wrap,
 }: CodeBlockViewProps) {
   const container = useRef<HTMLDivElement>(null);
+  const content = useRef(children);
+  const editor = useRef<EditorView>(null);
+  content.current = children;
 
   useEffect(() => {
     if (!container.current) {
@@ -65,7 +68,7 @@ function CodeBlockView({
     const customLanguage = typeof language === "function" ? language : null;
     const initialLanguage = typeof language === "function" ? [] : languages[language];
     const view = new EditorView({
-      doc: children,
+      doc: content.current,
       parent: container.current,
       extensions: [
         EditorState.readOnly.of(true),
@@ -84,6 +87,7 @@ function CodeBlockView({
         wrap ? EditorView.lineWrapping : [],
       ],
     });
+    editor.current = view;
     let active = true;
 
     if (customLanguage) {
@@ -102,9 +106,20 @@ function CodeBlockView({
 
     return () => {
       active = false;
+      editor.current = null;
       view.destroy();
     };
-  }, [children, copyable, language, lineNumbers, maxHeight, wrap]);
+  }, [copyable, language, lineNumbers, maxHeight, wrap]);
+
+  useEffect(() => {
+    const view = editor.current;
+
+    if (!view || view.state.doc.toString() === children) {
+      return;
+    }
+
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: children } });
+  }, [children]);
 
   return <div ref={container} />;
 }

--- a/resources/js/ui/code-block-view.tsx
+++ b/resources/js/ui/code-block-view.tsx
@@ -44,21 +44,11 @@ const codeBlockTheme = EditorView.theme({
     borderRightColor: "var(--lt-border)",
     color: "var(--lt-muted-fg)",
   },
+  ".cm-lineNumbers .cm-gutterElement": { padding: "0 0.75rem" },
   ".cm-line": { padding: "0" },
 });
 
-const copyableTheme = EditorView.theme({
-  ".cm-content": { padding: "2.75rem 0.75rem 0.75rem" },
-});
-
-function CodeBlockView({
-  children,
-  copyable,
-  language,
-  lineNumbers,
-  maxHeight,
-  wrap,
-}: CodeBlockViewProps) {
+function CodeBlockView({ children, language, lineNumbers, maxHeight, wrap }: CodeBlockViewProps) {
   const container = useRef<HTMLDivElement>(null);
   const content = useRef(children);
   const editor = useRef<EditorView>(null);
@@ -81,7 +71,6 @@ function CodeBlockView({
         EditorView.contentAttributes.of({ role: "code" }),
         languageCompartment.of(initialLanguage),
         syntaxHighlighting(highlightStyle),
-        copyable ? copyableTheme : [],
         codeBlockTheme,
         lineNumbers ? showLineNumbers() : [],
         maxHeight === null
@@ -114,7 +103,7 @@ function CodeBlockView({
       editor.current = null;
       view.destroy();
     };
-  }, [copyable, language, lineNumbers, maxHeight, wrap]);
+  }, [language, lineNumbers, maxHeight, wrap]);
 
   useEffect(() => {
     const view = editor.current;

--- a/resources/js/ui/code-block-view.tsx
+++ b/resources/js/ui/code-block-view.tsx
@@ -39,6 +39,11 @@ const codeBlockTheme = EditorView.theme({
     overflow: "auto",
   },
   ".cm-content": { padding: "0.75rem" },
+  ".cm-gutters": {
+    backgroundColor: "transparent",
+    borderRightColor: "var(--lt-border)",
+    color: "var(--lt-muted-fg)",
+  },
   ".cm-line": { padding: "0" },
 });
 
@@ -76,8 +81,8 @@ function CodeBlockView({
         EditorView.contentAttributes.of({ role: "code" }),
         languageCompartment.of(initialLanguage),
         syntaxHighlighting(highlightStyle),
-        codeBlockTheme,
         copyable ? copyableTheme : [],
+        codeBlockTheme,
         lineNumbers ? showLineNumbers() : [],
         maxHeight === null
           ? []

--- a/resources/js/ui/code-block.browser.test.tsx
+++ b/resources/js/ui/code-block.browser.test.tsx
@@ -20,4 +20,26 @@ describe("CodeBlock in a browser", () => {
     expect(screen.getByRole("region", { name: "PHP example" })).toBeVisible();
     expect(screen.getByText("<?php echo 'Hello';")).toBeVisible();
   });
+
+  it("keeps the fallback and CodeMirror chrome aligned", async () => {
+    const screen = await render(
+      <CodeBlock aria-label="Code example" copyable lineNumbers maxHeight={100}>
+        {"one\ntwo\nthree\nfour\nfive\nsix\nseven"}
+      </CodeBlock>,
+    );
+
+    await expect.poll(() => document.querySelector(".cm-editor")).not.toBeNull();
+
+    const content = document.querySelector<HTMLElement>(".cm-content");
+    const gutters = document.querySelector<HTMLElement>(".cm-gutters");
+    const button = screen.getByRole("button", { name: "Copy Code example" }).element();
+    const block = button.closest<HTMLElement>('[data-slot="code-block"]');
+
+    expect(content).not.toBeNull();
+    expect(gutters).not.toBeNull();
+    expect(block).not.toBeNull();
+    expect(getComputedStyle(content!).paddingTop).toBe("44px");
+    expect(getComputedStyle(gutters!).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(block!.getBoundingClientRect().right - button.getBoundingClientRect().right).toBe(20);
+  });
 });

--- a/resources/js/ui/code-block.browser.test.tsx
+++ b/resources/js/ui/code-block.browser.test.tsx
@@ -32,14 +32,19 @@ describe("CodeBlock in a browser", () => {
 
     const content = document.querySelector<HTMLElement>(".cm-content");
     const gutters = document.querySelector<HTMLElement>(".cm-gutters");
+    const gutterElement = document.querySelector<HTMLElement>(".cm-gutterElement");
     const button = screen.getByRole("button", { name: "Copy Code example" }).element();
     const block = button.closest<HTMLElement>('[data-slot="code-block"]');
 
     expect(content).not.toBeNull();
     expect(gutters).not.toBeNull();
+    expect(gutterElement).not.toBeNull();
     expect(block).not.toBeNull();
-    expect(getComputedStyle(content!).paddingTop).toBe("44px");
+    expect(getComputedStyle(content!).paddingTop).toBe("12px");
     expect(getComputedStyle(gutters!).backgroundColor).toBe("rgba(0, 0, 0, 0)");
-    expect(block!.getBoundingClientRect().right - button.getBoundingClientRect().right).toBe(20);
+    expect(getComputedStyle(gutterElement!).paddingLeft).toBe("12px");
+    expect(getComputedStyle(gutterElement!).paddingRight).toBe("12px");
+    expect(button.getBoundingClientRect().top - block!.getBoundingClientRect().top).toBe(12);
+    expect(block!.getBoundingClientRect().right - button.getBoundingClientRect().right).toBe(24);
   });
 });

--- a/resources/js/ui/code-block.test.tsx
+++ b/resources/js/ui/code-block.test.tsx
@@ -29,6 +29,22 @@ describe("CodeBlock", () => {
     expect(html).toContain('style="max-height:240px"');
   });
 
+  it("server-renders line numbers on the fallback", () => {
+    const html = renderToString(<CodeBlock lineNumbers>{"one\ntwo"}</CodeBlock>);
+    const container = document.createElement("div");
+    container.innerHTML = html;
+
+    expect(
+      Array.from(container.querySelectorAll('[aria-hidden="true"]'), (line) => line.textContent),
+    ).toEqual(["1", "2"]);
+  });
+
+  it("makes a height-limited fallback vertically scrollable", () => {
+    const html = renderToString(<CodeBlock maxHeight={240}>one\ntwo</CodeBlock>);
+
+    expect(html).toContain("overflow-auto");
+  });
+
   it("renders serialized node props", async () => {
     const node = fakeNode({
       type: "code-block",
@@ -69,6 +85,24 @@ describe("CodeBlock", () => {
     expect(container.querySelector(".cm-content")).toHaveAttribute("role", "code");
     expect(container.querySelector(".cm-content")).toHaveTextContent("<?php echo 'Hello';");
     expect(container.querySelector(".cm-content span")).toBeInTheDocument();
+  });
+
+  it("updates content without recreating the CodeMirror view", async () => {
+    const { container, rerender } = render(<CodeBlock>one\ntwo\nthree</CodeBlock>);
+
+    await waitFor(() => expect(container.querySelector(".cm-editor")).toBeInTheDocument());
+
+    const editor = container.querySelector(".cm-editor");
+    const scroller = container.querySelector<HTMLElement>(".cm-scroller");
+    expect(scroller).not.toBeNull();
+    scroller!.scrollTop = 24;
+
+    rerender(<CodeBlock>four\nfive\nsix</CodeBlock>);
+
+    await waitFor(() => expect(container.querySelector(".cm-content")).toHaveTextContent("four"));
+    expect(container.querySelector(".cm-editor")).toBe(editor);
+    expect(container.querySelector(".cm-scroller")).toBe(scroller);
+    expect(scroller).toHaveProperty("scrollTop", 24);
   });
 
   it("loads custom languages through the public lazy loader", async () => {

--- a/resources/js/ui/code-block.test.tsx
+++ b/resources/js/ui/code-block.test.tsx
@@ -23,6 +23,12 @@ describe("CodeBlock", () => {
     expect(html).toContain("&lt;?php echo &#x27;Hello&#x27;;");
   });
 
+  it("server-renders the maximum height on the fallback", () => {
+    const html = renderToString(<CodeBlock maxHeight={240}>one\ntwo</CodeBlock>);
+
+    expect(html).toContain('style="max-height:240px"');
+  });
+
   it("renders serialized node props", async () => {
     const node = fakeNode({
       type: "code-block",
@@ -30,6 +36,8 @@ describe("CodeBlock", () => {
         code: "<?php echo 'Hello';",
         language: "php",
         copyable: false,
+        lineNumbers: true,
+        maxHeight: 240,
         wrap: true,
       },
     });
@@ -38,6 +46,8 @@ describe("CodeBlock", () => {
     await waitFor(() => expect(container.querySelector(".cm-editor")).toBeInTheDocument());
 
     expect(container.querySelector(".cm-content")).toHaveTextContent("<?php echo 'Hello';");
+    expect(container.querySelector(".cm-gutters")).toBeInTheDocument();
+    expect(container.querySelector(".cm-editor")).toHaveStyle({ maxHeight: "240px" });
     expect(container.querySelector(".cm-lineWrapping")).toBeInTheDocument();
     expect(container.querySelector(".cm-content span")).toBeInTheDocument();
   });

--- a/resources/js/ui/code-block.test.tsx
+++ b/resources/js/ui/code-block.test.tsx
@@ -13,7 +13,7 @@ afterEach(() => {
 describe("CodeBlock", () => {
   it("server-renders an accessible pre while CodeMirror loads", () => {
     const html = renderToString(
-      <CodeBlock aria-label="PHP example" language="php">
+      <CodeBlock aria-label="PHP example" copyable language="php">
         {"<?php echo 'Hello';"}
       </CodeBlock>,
     );
@@ -21,6 +21,7 @@ describe("CodeBlock", () => {
     expect(html).toContain("<pre");
     expect(html).toContain('aria-label="PHP example"');
     expect(html).toContain("&lt;?php echo &#x27;Hello&#x27;;");
+    expect(html).not.toContain("pt-11");
   });
 
   it("server-renders the maximum height on the fallback", () => {

--- a/resources/js/ui/code-block.tsx
+++ b/resources/js/ui/code-block.tsx
@@ -85,7 +85,7 @@ function CodeBlock({
           value={children}
           label={ariaLabel ?? "code"}
           iconOnly
-          className="absolute top-2 right-2 z-10 bg-lt-bg/80 hover:bg-lt-bg"
+          className="absolute top-2 right-5 z-10 bg-lt-bg/80 hover:bg-lt-bg"
         />
       ) : null}
       <Suspense fallback={fallback}>

--- a/resources/js/ui/code-block.tsx
+++ b/resources/js/ui/code-block.tsx
@@ -14,6 +14,8 @@ interface CodeBlockProps extends Omit<ComponentProps<"div">, "children"> {
   children: string;
   copyable?: boolean;
   language?: CodeBlockLanguage | CodeBlockLanguageLoader;
+  lineNumbers?: boolean;
+  maxHeight?: number | null;
   wrap?: boolean;
 }
 
@@ -21,6 +23,8 @@ interface CodeBlockViewProps {
   children: string;
   copyable: boolean;
   language: CodeBlockLanguage | CodeBlockLanguageLoader;
+  lineNumbers: boolean;
+  maxHeight: number | null;
   wrap: boolean;
 }
 
@@ -30,6 +34,8 @@ function CodeBlock({
   className,
   copyable = false,
   language = "text",
+  lineNumbers = false,
+  maxHeight = null,
   role = ariaLabel ? "region" : undefined,
   wrap = false,
   ...props
@@ -41,6 +47,7 @@ function CodeBlock({
         wrap && "whitespace-pre-wrap wrap-anywhere",
         copyable && "pt-11",
       )}
+      style={{ maxHeight: maxHeight ?? undefined }}
     >
       {children}
     </pre>
@@ -66,7 +73,13 @@ function CodeBlock({
         />
       ) : null}
       <Suspense fallback={fallback}>
-        <CodeBlockView copyable={copyable} language={language} wrap={wrap}>
+        <CodeBlockView
+          copyable={copyable}
+          language={language}
+          lineNumbers={lineNumbers}
+          maxHeight={maxHeight}
+          wrap={wrap}
+        >
           {children}
         </CodeBlockView>
       </Suspense>
@@ -75,7 +88,13 @@ function CodeBlock({
 }
 
 const CodeBlockComponent: RendererComponent<"code-block"> = ({ node }) => (
-  <CodeBlock copyable={node.props.copyable} language={node.props.language} wrap={node.props.wrap}>
+  <CodeBlock
+    copyable={node.props.copyable}
+    language={node.props.language}
+    lineNumbers={node.props.lineNumbers}
+    maxHeight={node.props.maxHeight}
+    wrap={node.props.wrap}
+  >
     {node.props.code}
   </CodeBlock>
 );

--- a/resources/js/ui/code-block.tsx
+++ b/resources/js/ui/code-block.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { Fragment, lazy, Suspense } from "react";
 import type { ComponentProps } from "react";
 import type { Extension } from "@codemirror/state";
 import type { RendererComponent } from "@lattice-php/lattice/core/types";
@@ -43,13 +43,29 @@ function CodeBlock({
   const fallback = (
     <pre
       className={cn(
-        "max-w-full overflow-x-auto p-3 font-lt-mono text-xs",
+        "max-w-full overflow-auto p-3 font-lt-mono text-xs",
         wrap && "whitespace-pre-wrap wrap-anywhere",
         copyable && "pt-11",
       )}
       style={{ maxHeight: maxHeight ?? undefined }}
     >
-      {children}
+      {lineNumbers ? (
+        <code className="grid grid-cols-[auto_1fr]">
+          {children.split("\n").map((line, index) => (
+            <Fragment key={index}>
+              <span
+                aria-hidden="true"
+                className="mr-3 border-r border-lt-border pr-3 text-right text-lt-muted-fg select-none"
+              >
+                {index + 1}
+              </span>
+              <span>{line || "\u200b"}</span>
+            </Fragment>
+          ))}
+        </code>
+      ) : (
+        children
+      )}
     </pre>
   );
 

--- a/resources/js/ui/code-block.tsx
+++ b/resources/js/ui/code-block.tsx
@@ -21,7 +21,6 @@ interface CodeBlockProps extends Omit<ComponentProps<"div">, "children"> {
 
 interface CodeBlockViewProps {
   children: string;
-  copyable: boolean;
   language: CodeBlockLanguage | CodeBlockLanguageLoader;
   lineNumbers: boolean;
   maxHeight: number | null;
@@ -45,7 +44,6 @@ function CodeBlock({
       className={cn(
         "max-w-full overflow-auto p-3 font-lt-mono text-xs",
         wrap && "whitespace-pre-wrap wrap-anywhere",
-        copyable && "pt-11",
       )}
       style={{ maxHeight: maxHeight ?? undefined }}
     >
@@ -85,12 +83,11 @@ function CodeBlock({
           value={children}
           label={ariaLabel ?? "code"}
           iconOnly
-          className="absolute top-2 right-5 z-10 bg-lt-bg/80 hover:bg-lt-bg"
+          className="absolute top-3 right-6 z-10 bg-lt-bg/80 hover:bg-lt-bg"
         />
       ) : null}
       <Suspense fallback={fallback}>
         <CodeBlockView
-          copyable={copyable}
           language={language}
           lineNumbers={lineNumbers}
           maxHeight={maxHeight}

--- a/src/Ui/Components/CodeBlock.php
+++ b/src/Ui/Components/CodeBlock.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Lattice\Ui\Components;
 
+use InvalidArgumentException;
 use Lattice\Lattice\Attributes\AsComponent;
 use Lattice\Lattice\Ui\Components\Concerns\HasPrimaryBinding;
 use Lattice\Lattice\Ui\Concerns\HasCopyable;
@@ -18,6 +19,10 @@ class CodeBlock extends Component
 
     public CodeBlockLanguage $language = CodeBlockLanguage::Text;
 
+    public bool $lineNumbers = false;
+
+    public ?int $maxHeight = null;
+
     public bool $wrap = false;
 
     public static function make(string $code, ?string $key = null): static
@@ -31,6 +36,24 @@ class CodeBlock extends Component
     public function language(CodeBlockLanguage $language): static
     {
         $this->language = $language;
+
+        return $this;
+    }
+
+    public function lineNumbers(bool $lineNumbers = true): static
+    {
+        $this->lineNumbers = $lineNumbers;
+
+        return $this;
+    }
+
+    public function maxHeight(?int $maxHeight): static
+    {
+        if ($maxHeight !== null && $maxHeight <= 0) {
+            throw new InvalidArgumentException('Code block maximum height must be greater than zero.');
+        }
+
+        $this->maxHeight = $maxHeight;
 
         return $this;
     }

--- a/tests/Feature/Workbench/CodeBlocksPageTest.php
+++ b/tests/Feature/Workbench/CodeBlocksPageTest.php
@@ -6,6 +6,7 @@ use Workbench\App\Pages\Components\CodeBlocksPage;
 
 test('the workbench code blocks page renders JSON and PHP examples', function (): void {
     $schema = wire((new CodeBlocksPage)->render(PageSchema::make())->renderable());
+    $phpExample = $schema[0]['schema'][4];
 
     expect($schema[0]['schema'][2])->toMatchArray([
         'type' => 'code-block',
@@ -23,23 +24,16 @@ JSON,
             'maxHeight' => null,
             'wrap' => false,
         ],
-    ])->and($schema[0]['schema'][4])->toMatchArray([
-        'type' => 'code-block',
-        'key' => 'code-block-php',
-        'props' => [
-            'code' => <<<'PHP'
-<?php
-
-CodeBlock::make('echo "Hello, Lattice!";')
-    ->language(CodeBlockLanguage::Php)
-    ->copyable()
-    ->wrap();
-PHP,
-            'language' => 'php',
-            'copyable' => true,
-            'lineNumbers' => false,
-            'maxHeight' => null,
-            'wrap' => true,
-        ],
-    ]);
+    ])->and($phpExample['type'])->toBe('code-block')
+        ->and($phpExample['key'])->toBe('code-block-php')
+        ->and($phpExample['props']['language'])->toBe('php')
+        ->and($phpExample['props']['copyable'])->toBeTrue()
+        ->and($phpExample['props']['lineNumbers'])->toBeTrue()
+        ->and($phpExample['props']['maxHeight'])->toBe(320)
+        ->and($phpExample['props']['wrap'])->toBeTrue()
+        ->and($phpExample['props']['code'])->toContain(
+            'final class CodeBlocksPage extends WorkbenchPage',
+            '->lineNumbers()',
+            '->maxHeight(320)',
+        );
 });

--- a/tests/Feature/Workbench/CodeBlocksPageTest.php
+++ b/tests/Feature/Workbench/CodeBlocksPageTest.php
@@ -19,6 +19,8 @@ test('the workbench code blocks page renders JSON and PHP examples', function ()
 JSON,
             'language' => 'json',
             'copyable' => false,
+            'lineNumbers' => false,
+            'maxHeight' => null,
             'wrap' => false,
         ],
     ])->and($schema[0]['schema'][4])->toMatchArray([
@@ -35,6 +37,8 @@ CodeBlock::make('echo "Hello, Lattice!";')
 PHP,
             'language' => 'php',
             'copyable' => true,
+            'lineNumbers' => false,
+            'maxHeight' => null,
             'wrap' => true,
         ],
     ]);

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -111,6 +111,8 @@ test('code blocks serialize their code and presentation configuration', function
     expect(wire(CodeBlock::make('<?php echo "Hello";')
         ->language(CodeBlockLanguage::Php)
         ->copyable()
+        ->lineNumbers()
+        ->maxHeight(320)
         ->wrap()))
         ->toMatchArray([
             'type' => 'code-block',
@@ -118,6 +120,8 @@ test('code blocks serialize their code and presentation configuration', function
                 'code' => '<?php echo "Hello";',
                 'language' => 'php',
                 'copyable' => true,
+                'lineNumbers' => true,
+                'maxHeight' => 320,
                 'wrap' => true,
             ],
         ])
@@ -125,11 +129,17 @@ test('code blocks serialize their code and presentation configuration', function
         ->toMatchArray([
             'language' => 'text',
             'copyable' => false,
+            'lineNumbers' => false,
+            'maxHeight' => null,
             'wrap' => false,
         ])
         ->and(wire(CodeBlock::bound('snippet'))['props']['dataBindings'])
         ->toBe(['code' => 'snippet']);
 });
+
+test('code blocks reject non-positive maximum heights', function (): void {
+    CodeBlock::make('plain')->maxHeight(0);
+})->throws(InvalidArgumentException::class);
 
 test('separators default to horizontal and serialize their orientation', function (): void {
     expect(wire(Separator::make()))

--- a/workbench/app/Pages/Components/CodeBlocksPage.php
+++ b/workbench/app/Pages/Components/CodeBlocksPage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Pages\Components;
 
+use Illuminate\Support\Facades\File;
 use Lattice\Lattice\Attributes\AsPage;
 use Lattice\Lattice\Core\PageSchema;
 use Lattice\Lattice\Ui\Components\CodeBlock;
@@ -35,16 +36,11 @@ final class CodeBlocksPage extends WorkbenchPage
 }
 JSON, 'code-block-json')->language(CodeBlockLanguage::Json),
                     Heading::make(__('workbench.pages.components.code-blocks.php'), 2),
-                    CodeBlock::make(<<<'PHP'
-<?php
-
-CodeBlock::make('echo "Hello, Lattice!";')
-    ->language(CodeBlockLanguage::Php)
-    ->copyable()
-    ->wrap();
-PHP, 'code-block-php')
+                    CodeBlock::make(File::get(__FILE__), 'code-block-php')
                         ->language(CodeBlockLanguage::Php)
                         ->copyable()
+                        ->lineNumbers()
+                        ->maxHeight(320)
                         ->wrap(),
                 ]),
         ]);


### PR DESCRIPTION
Adds opt-in `lineNumbers` and pixel-based `maxHeight` options to the PHP and React CodeBlock APIs. CodeMirror uses its native gutter and scrolls within the configured height; the SSR fallback receives the same limit.

Before: code blocks always rendered without gutters and expanded to full content height.
After: `->lineNumbers()->maxHeight(320)` or `<CodeBlock lineNumbers maxHeight={320}>` enables numbered, internally scrolling blocks.

Verified with `composer check`, `npm run check`, and the CodeBlock browser test.