### PR TITLE
feat: add Tree as the first workspace package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "laravel/pint": "^1.16",
         "laravel/reverb": "^1.10",
         "lattice-php/signature-example": "@dev",
+        "lattice-php/tree": "@dev",
         "league/flysystem-aws-s3-v3": "^3.34",
         "orchestra/testbench": "^10.0 || ^11.0",
         "pestphp/pest": "^5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
-        "docs"
+        "docs",
+        "packages/*"
       ],
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
@@ -2871,6 +2872,10 @@
     },
     "node_modules/@lattice-php/docs": {
       "resolved": "docs",
+      "link": true
+    },
+    "node_modules/@lattice-php/tree": {
+      "resolved": "packages/tree",
       "link": true
     },
     "node_modules/@lattice-php/vite-svg-sprite": {
@@ -15598,6 +15603,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/tree": {
+      "name": "@lattice-php/tree",
+      "version": "0.38.0",
+      "peerDependencies": {
+        "@lattice-php/lattice": "^0.38.0",
+        "react": "^19.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Manuel Christlieb <manuel@christlieb.eu>",
   "type": "module",
   "workspaces": [
-    "docs"
+    "docs",
+    "packages/*"
   ],
   "homepage": "https://latticephp.com",
   "repository": {
@@ -279,7 +280,8 @@
     "boost:refresh": "php vendor/bin/testbench boost:update --no-interaction",
     "typecheck": "tsc --noEmit",
     "type-coverage": "type-coverage --project tsconfig.json --at-least 99.5",
-    "check": "npm run lint && npm run format:check && npm run typecheck && npm run type-coverage && npm run test && npm run build:lib && npm run check:package",
+    "check": "npm run lint && npm run format:check && npm run typecheck && npm run type-coverage && npm run test && npm run build:plugins && npm run build:lib && npm run check:package",
+    "build:plugins": "npm run build:plugin --workspaces --if-present && git diff --exit-code -- packages/*/dist",
     "check:package": "publint --strict && attw --pack . --profile esm-only --exclude-entrypoints ./css",
     "fix": "npm run lint:fix && npm run format",
     "docs:typecheck": "npm run build:lib && tsc --noEmit -p docs/tsconfig.json",

--- a/packages/tree/.gitattributes
+++ b/packages/tree/.gitattributes
@@ -1,0 +1,16 @@
+/.github export-ignore
+/.ai export-ignore
+/tests export-ignore
+/workbench export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/artisan export-ignore
+/boost.json export-ignore
+/phpunit.xml export-ignore
+/phpstan.neon export-ignore
+/pint.json export-ignore
+/testbench.yaml export-ignore
+/vitest.config.ts export-ignore
+/tsconfig.json export-ignore
+/package.json export-ignore
+/package-lock.json export-ignore

--- a/packages/tree/.gitignore
+++ b/packages/tree/.gitignore
@@ -1,0 +1,10 @@
+/vendor/
+/node_modules/
+composer.lock
+.phpunit.cache/
+.phpunit.result.cache
+/.idea/
+/AGENTS.md
+/CLAUDE.md
+/.claude/
+/.agents/

--- a/packages/tree/README.md
+++ b/packages/tree/README.md
@@ -1,0 +1,131 @@
+# Lattice Tree
+
+Tree view component for [Lattice](https://github.com/lattice-php/lattice) — hierarchy rendering
+from inline nodes, callbacks, or Eloquent adjacency-list sources, with full keyboard navigation
+(roving tabindex, typeahead), per-node icons, badges, links, and actions, and lazy child loading
+over a signed endpoint.
+
+Extracted from the Lattice core package to grow on its own; drag & drop reordering is next on
+the roadmap.
+
+## Installation
+
+```bash
+composer require lattice-php/tree
+```
+
+That is the whole integration: the package ships its React renderer as source and Lattice's
+`lattice()` Vite plugin compiles it into your app's bundle via `virtual:lattice/plugins`. The
+PHP classes are picked up by Lattice's discovery and TypeScript generation automatically.
+
+## Usage
+
+```php
+use Lattice\Tree\Tree;
+use Lattice\Tree\TreeNode;
+
+Tree::make('categories')->nodes([
+    TreeNode::make('electronics', 'Electronics')
+        ->icon('cpu')
+        ->children([
+            TreeNode::make('electronics-laptops', 'Laptops'),
+            TreeNode::make('electronics-phones', 'Phones')->href('/products/phones'),
+        ]),
+])->defaultExpanded(['electronics']);
+```
+
+Nodes compile their conveniences (`->icon()`, `->badge()`, `->href()`, `->action()`/`->actions()`) into a
+canonical body schema of core components — an icon, a text-or-link label, a badge, and an end-floated action
+stack. `->badge($label, $color)` accepts any Lattice color.
+
+### Custom node content
+
+For content the conveniences do not cover, `->schema()` replaces the composed body outright:
+
+```php
+use Lattice\Lattice\Ui\Components\Avatar;
+use Lattice\Lattice\Ui\Components\Badge;
+use Lattice\Lattice\Ui\Components\Text;
+
+TreeNode::make('acme-corp', 'Acme Corp')
+    ->schema([
+        Avatar::make('/avatars/acme.png'),
+        Text::make('Acme Corp'),
+        Badge::make('Pro')->color('purple'),
+    ]);
+```
+
+`->schema()` is an escape hatch, not an addition — it replaces the default body entirely. `label` is still
+required and keeps driving typeahead and aria announcements even when the schema does not render it. On
+Enter/Space, a node without an `href` activates the first button found in its body, so a custom schema should
+put its primary action's button first — or expect it to receive Enter.
+
+Or back it with an Eloquent adjacency list (a self-referencing `parent_id` column):
+
+```php
+use Lattice\Tree\EloquentTreeSource;
+
+Tree::make('categories')->source(
+    EloquentTreeSource::make(Category::class)
+        ->scope(fn ($query) => $query->where('active', true)),
+);
+```
+
+Any other backing store implements the two-method `Lattice\Tree\TreeSource` contract.
+
+## Lazy loading
+
+Serializing a large hierarchy eagerly is wasteful. Register a tree definition and let expansion
+fetch one level per request instead:
+
+```php
+use Lattice\Tree\AsTree;
+use Lattice\Tree\EloquentTreeSource;
+use Lattice\Tree\TreeDefinition;
+use Lattice\Tree\TreeSource;
+
+#[AsTree('categories')]
+class CategoryTree extends TreeDefinition
+{
+    public function source(): TreeSource
+    {
+        return EloquentTreeSource::make(Category::class);
+    }
+}
+```
+
+```php
+Tree::use(CategoryTree::class)->lazy();     // roots eager, deeper levels fetched on expand
+Tree::use(CategoryTree::class)->lazy(2);    // two levels eager
+Tree::use(CategoryTree::class)->lazy(0);    // bare skeleton — even the roots are fetched
+```
+
+The definition is discovered like any Lattice definition (`#[AsTree]` + Lattice's discovery
+paths), and the serialized tree carries a sealed reference — the same signing machinery Lattice
+tables use — that the package's `lattice/trees/{tree}` endpoint verifies before resolving the
+definition again with the identical context. `authorize()` on the definition gates both the
+initial render and every fetch. The route's middleware and path follow Lattice's group
+conventions: `config('lattice.trees.middleware', ['web', 'auth'])` and
+`config('lattice.trees.endpoint', 'lattice/trees/{tree}')`.
+
+An `EloquentTreeSource` behind the endpoint automatically switches to per-level queries
+(`WHERE parent_id = ?` plus a scoped `EXISTS` probe for `hasChildren`) instead of loading the
+whole table. Inline `->nodes()` / `->source()` trees stay eager-only — without a registry key
+there is nothing to seal — so `->lazy()` on them throws.
+
+## Translations
+
+The component's strings ship with inline English defaults. With
+[bambamboole/laravel-i18next](https://github.com/bambamboole/laravel-i18next) enabled, the
+plugin's `tree` namespace is loaded automatically and serves
+the bundled `en`/`de` translations (override them like any Laravel package translation).
+
+## Development
+
+```bash
+composer install && npm install
+composer check          # pint --test, phpstan, pest (Unit + Feature)
+npm run typecheck && npm test
+composer test:browser   # rebuilds the workbench bundle, then runs the Playwright suite
+composer serve          # workbench demo app: /tree (eager) and /tree-lazy (lazy endpoint)
+```

--- a/packages/tree/composer.json
+++ b/packages/tree/composer.json
@@ -1,0 +1,79 @@
+{
+    "name": "lattice-php/tree",
+    "description": "Tree view component for Lattice — hierarchy rendering from callback or Eloquent adjacency-list sources.",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.4",
+        "lattice-php/lattice": "self.version"
+    },
+    "require-dev": {
+        "larastan/larastan": "^3.0",
+        "laravel/boost": "^2.4",
+        "laravel/pint": "^1.16",
+        "mrpunyapal/peststan": "^0.2.12",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-browser": "^4.3",
+        "pestphp/pest-plugin-laravel": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Lattice\\Tree\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Lattice\\Tree\\Tests\\": "tests/",
+            "Workbench\\App\\": "workbench/app/"
+        }
+    },
+    "extra": {
+        "lattice": {
+            "plugin": "resources/js/plugin.ts",
+            "standalone": "dist/plugin.js",
+            "discover": ["src"]
+        },
+        "laravel": {
+            "providers": [
+                "Lattice\\Tree\\TreeServiceProvider"
+            ]
+        }
+    },
+    "scripts": {
+        "post-autoload-dump": [
+            "@php vendor/bin/testbench package:purge-skeleton --ansi",
+            "@php vendor/bin/testbench package:discover --ansi"
+        ],
+        "post-install-cmd": [
+            "@boost:refresh"
+        ],
+        "post-update-cmd": [
+            "@boost:refresh"
+        ],
+        "boost:update": "@php vendor/bin/testbench boost:update --no-interaction",
+        "boost:refresh": "[ -n \"$CI\" ] || [ ! -f vendor/bin/testbench ] || vendor/bin/testbench boost:update --no-interaction",
+        "serve": "@php vendor/bin/testbench serve",
+        "test": "@php vendor/bin/pest --testsuite Unit,Feature",
+        "test:browser": [
+            "npm run build",
+            "@php vendor/bin/pest --testsuite Browser"
+        ],
+        "test:lint": "@php vendor/bin/pint --test",
+        "lint": "@php vendor/bin/pint",
+        "analyse": "@php vendor/bin/phpstan analyse",
+        "check": [
+            "@test:lint",
+            "@analyse",
+            "@test"
+        ]
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/packages/tree/dist/plugin.js
+++ b/packages/tree/dist/plugin.js
@@ -1,0 +1,404 @@
+import { Icon, Renderer, apiJson, cn, lazyComponent, nodeIdentity, router, usePersistentState, useT } from "@lattice-php/lattice/runtime";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { jsx, jsxs } from "react/jsx-runtime";
+//#region \0rolldown/runtime.js
+var __defProp = Object.defineProperty;
+var __esmMin = (fn, res, err) => () => {
+	if (err) throw err[0];
+	try {
+		return fn && (res = fn(fn = 0)), res;
+	} catch (e) {
+		throw err = [e], e;
+	}
+};
+var __exportAll = (all, no_symbols) => {
+	let target = {};
+	for (var name in all) __defProp(target, name, {
+		get: all[name],
+		enumerable: true
+	});
+	if (!no_symbols) __defProp(target, Symbol.toStringTag, { value: "Module" });
+	return target;
+};
+//#endregion
+//#region resources/js/tree-context.tsx
+function useTreeContext() {
+	return useContext(TreeContext);
+}
+function parseExpanded(raw) {
+	const parsed = JSON.parse(raw);
+	if (!Array.isArray(parsed)) throw new Error("expected an array of ids");
+	return new Set(parsed.filter((id) => typeof id === "string"));
+}
+function visibleOrder(registry) {
+	return [...registry.values()].sort((a, b) => a.orderPath.localeCompare(b.orderPath));
+}
+function useTreeState({ activeId: initialActiveId, defaultExpanded, endpoint, componentRef, lazy, nodes, rememberState, storageKey }) {
+	const [expanded, setExpanded] = usePersistentState(storageKey, () => new Set(defaultExpanded), {
+		enabled: rememberState,
+		parse: parseExpanded,
+		serialize: (value) => JSON.stringify([...value])
+	});
+	const [activeId, setActiveId] = useState(initialActiveId);
+	const [focusedId, setFocusedId] = useState(() => nodes[0]?.id ?? null);
+	const registryRef = useRef(/* @__PURE__ */ new Map());
+	const typeAheadRef = useRef({
+		text: "",
+		timestamp: 0
+	});
+	const [loaded, setLoaded] = useState(/* @__PURE__ */ new Map());
+	const [loading, setLoading] = useState(/* @__PURE__ */ new Set());
+	const inFlightRef = useRef(/* @__PURE__ */ new Set());
+	const loadedRef = useRef(loaded);
+	loadedRef.current = loaded;
+	const canLoad = endpoint !== null && endpoint !== "";
+	const toggle = useCallback((id) => {
+		setExpanded((current) => {
+			const next = new Set(current);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	}, [setExpanded]);
+	const activate = useCallback((id) => setActiveId(id), []);
+	const focus = useCallback((id) => {
+		setFocusedId(id);
+		[...registryRef.current.values()].find((candidate) => candidate.id === id)?.ref.current?.focus();
+	}, []);
+	const register = useCallback((entry) => {
+		registryRef.current.set(entry.path, entry);
+	}, []);
+	const unregister = useCallback((path) => {
+		registryRef.current.delete(path);
+	}, []);
+	const moveFocus = useCallback((fromId, direction) => {
+		const order = visibleOrder(registryRef.current);
+		if (order.length === 0) return;
+		const index = order.findIndex((entry) => entry.id === fromId);
+		const current = index === -1 ? void 0 : order[index];
+		let target;
+		switch (direction) {
+			case "next":
+				target = index === -1 ? void 0 : order[index + 1];
+				break;
+			case "prev":
+				target = index === -1 ? void 0 : order[index - 1];
+				break;
+			case "first":
+				target = order[0];
+				break;
+			case "last":
+				target = order[order.length - 1];
+				break;
+			case "parent":
+				target = current ? order.find((entry) => entry.path === current.parentPath) : void 0;
+				break;
+			case "firstChild": target = current ? order.find((entry) => entry.parentPath === current.path) : void 0;
+		}
+		if (target) focus(target.id);
+	}, [focus]);
+	const typeAhead = useCallback((fromId, character) => {
+		const order = visibleOrder(registryRef.current);
+		if (order.length === 0) return;
+		const now = Date.now();
+		const buffer = typeAheadRef.current;
+		const text = now - buffer.timestamp > TYPEAHEAD_IDLE_MS ? character : buffer.text + character;
+		typeAheadRef.current = {
+			text,
+			timestamp: now
+		};
+		const needle = text.toLowerCase();
+		const startIndex = order.findIndex((entry) => entry.id === fromId);
+		const start = startIndex === -1 ? 0 : startIndex;
+		for (let offset = 1; offset <= order.length; offset++) {
+			const candidate = order[(start + offset) % order.length];
+			if (candidate.label.toLowerCase().startsWith(needle)) {
+				focus(candidate.id);
+				return;
+			}
+		}
+	}, [focus]);
+	const loadChildren = useCallback((id) => {
+		if (!canLoad || inFlightRef.current.has(id) || loadedRef.current.has(id)) return;
+		inFlightRef.current.add(id);
+		setLoading((current) => new Set(current).add(id));
+		apiJson(`${endpoint}?parent=${encodeURIComponent(id)}`, { ref: componentRef ?? "" }).then(({ nodes: fetched }) => {
+			setLoaded((current) => new Map(current).set(id, fetched));
+		}).catch(() => {
+			setExpanded((current) => {
+				const next = new Set(current);
+				next.delete(id);
+				return next;
+			});
+		}).finally(() => {
+			inFlightRef.current.delete(id);
+			setLoading((current) => {
+				const next = new Set(current);
+				next.delete(id);
+				return next;
+			});
+		});
+	}, [
+		canLoad,
+		componentRef,
+		endpoint,
+		setExpanded
+	]);
+	const childrenFor = useCallback((id) => loaded.get(id), [loaded]);
+	const isLoading = useCallback((id) => loading.has(id), [loading]);
+	const hasWireNodes = nodes.length > 0;
+	useEffect(() => {
+		if (lazy && !hasWireNodes) loadChildren("");
+	}, [
+		lazy,
+		hasWireNodes,
+		loadChildren
+	]);
+	const firstFetchedRootId = loaded.get("")?.[0]?.id;
+	useEffect(() => {
+		if (focusedId === null && firstFetchedRootId !== void 0) setFocusedId(firstFetchedRootId);
+	}, [focusedId, firstFetchedRootId]);
+	return useMemo(() => ({
+		activate,
+		activeId,
+		canLoad,
+		childrenFor,
+		expanded,
+		focus,
+		focusedId,
+		isLoading,
+		loadChildren,
+		moveFocus,
+		register,
+		toggle,
+		typeAhead,
+		unregister
+	}), [
+		activate,
+		activeId,
+		canLoad,
+		childrenFor,
+		expanded,
+		focus,
+		focusedId,
+		isLoading,
+		loadChildren,
+		moveFocus,
+		register,
+		toggle,
+		typeAhead,
+		unregister
+	]);
+}
+var defaultTreeContext, TreeContext, TYPEAHEAD_IDLE_MS;
+var init_tree_context = __esmMin((() => {
+	defaultTreeContext = {
+		activate: () => {},
+		activeId: null,
+		canLoad: false,
+		childrenFor: () => void 0,
+		expanded: /* @__PURE__ */ new Set(),
+		focus: () => {},
+		focusedId: null,
+		isLoading: () => false,
+		loadChildren: () => {},
+		moveFocus: () => {},
+		register: () => {},
+		toggle: () => {},
+		typeAhead: () => {},
+		unregister: () => {}
+	};
+	TreeContext = createContext(defaultTreeContext);
+	TYPEAHEAD_IDLE_MS = 800;
+}));
+//#endregion
+//#region resources/js/tree.tsx
+var tree_exports = /* @__PURE__ */ __exportAll({ default: () => TreeComponent });
+function isExpandable(node, children, canLoad) {
+	return Boolean(children?.length) || node.hasChildren === true && (canLoad || Boolean(node.children?.length));
+}
+function orderPathSegment(index) {
+	return String(index).padStart(ORDER_PATH_SEGMENT_WIDTH, "0");
+}
+function TreeItem({ depth, node, orderPath, parentPath, siblingCount, siblingIndex }) {
+	const { activate, activeId, canLoad, childrenFor, expanded, focusedId, isLoading, loadChildren, moveFocus, register, toggle, typeAhead, unregister } = useTreeContext();
+	const { t } = useT("tree");
+	const ref = useRef(null);
+	const path = parentPath ? `${parentPath}/${node.id}` : node.id;
+	const isExpanded = expanded.has(node.id);
+	const isActive = activeId === node.id;
+	const isFocused = focusedId === node.id;
+	const isDisabled = node.disabled === true;
+	const children = node.children ?? childrenFor(node.id);
+	const expandable = isExpandable(node, children, canLoad);
+	const loading = isLoading(node.id);
+	const bodyRef = useRef(null);
+	useEffect(() => {
+		if (isExpanded && node.hasChildren === true && !node.children && !children) loadChildren(node.id);
+	}, [
+		isExpanded,
+		node,
+		children,
+		loadChildren
+	]);
+	useEffect(() => {
+		register({
+			id: node.id,
+			label: node.label,
+			orderPath,
+			parentPath,
+			path,
+			ref
+		});
+		return () => unregister(path);
+	}, [
+		node.id,
+		node.label,
+		orderPath,
+		parentPath,
+		path,
+		register,
+		unregister
+	]);
+	useEffect(() => {
+		const container = bodyRef.current;
+		if (!container) return;
+		container.querySelectorAll("button, a[href], [tabindex]").forEach((control) => {
+			control.tabIndex = -1;
+		});
+	}, [node.schema]);
+	function onKeyDown(event) {
+		if (event.target !== event.currentTarget) return;
+		switch (event.key) {
+			case "ArrowDown":
+				event.preventDefault();
+				moveFocus(node.id, "next");
+				return;
+			case "ArrowUp":
+				event.preventDefault();
+				moveFocus(node.id, "prev");
+				return;
+			case "ArrowRight":
+				event.preventDefault();
+				if (expandable && !isExpanded) toggle(node.id);
+				else if (expandable) moveFocus(node.id, "firstChild");
+				return;
+			case "ArrowLeft":
+				event.preventDefault();
+				if (expandable && isExpanded) toggle(node.id);
+				else moveFocus(node.id, "parent");
+				return;
+			case "Home":
+				event.preventDefault();
+				moveFocus(node.id, "first");
+				return;
+			case "End":
+				event.preventDefault();
+				moveFocus(node.id, "last");
+				return;
+			case "Enter":
+			case " ":
+				event.preventDefault();
+				if (isDisabled) return;
+				if (node.href) router.visit(node.href);
+				else {
+					const trigger = bodyRef.current?.querySelector("button");
+					if (trigger) {
+						trigger.click();
+						ref.current?.focus();
+					} else activate(node.id);
+				}
+				return;
+			default: if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) typeAhead(node.id, event.key);
+		}
+	}
+	return /* @__PURE__ */ jsxs("li", {
+		"aria-disabled": isDisabled,
+		"aria-expanded": expandable ? isExpanded : void 0,
+		"aria-label": node.label,
+		"aria-level": depth,
+		"aria-posinset": siblingIndex,
+		"aria-selected": isActive,
+		"aria-setsize": siblingCount,
+		"data-test": `tree-node-${node.id}`,
+		onKeyDown,
+		ref,
+		role: "treeitem",
+		tabIndex: isFocused ? 0 : -1,
+		children: [/* @__PURE__ */ jsxs("div", {
+			className: cn("flex items-center gap-2 rounded-lt-sm px-2 py-1.5 text-sm text-lt-fg", isActive && "bg-lt-muted font-medium", isDisabled && "pointer-events-none opacity-50"),
+			children: [expandable ? /* @__PURE__ */ jsx("button", {
+				"aria-label": isExpanded ? t("tree.collapse", "Collapse {{label}}", { label: node.label }) : t("tree.expand", "Expand {{label}}", { label: node.label }),
+				"data-test": `tree-node-${node.id}-toggle`,
+				onClick: () => toggle(node.id),
+				tabIndex: -1,
+				type: "button",
+				children: loading ? /* @__PURE__ */ jsx(Icon, {
+					className: "size-lt-icon-md shrink-0 animate-spin",
+					name: "loader-2"
+				}) : /* @__PURE__ */ jsx(Icon, {
+					className: cn("size-lt-icon-md shrink-0 transition-transform", isExpanded && "rotate-90"),
+					name: "chevron-right"
+				})
+			}) : null, /* @__PURE__ */ jsx("span", {
+				className: "flex min-w-0 flex-1 items-center gap-2",
+				ref: bodyRef,
+				children: /* @__PURE__ */ jsx(Renderer, { nodes: node.schema })
+			})]
+		}), expandable && isExpanded && children && children.length > 0 ? /* @__PURE__ */ jsx("ul", {
+			className: "pl-6",
+			role: "group",
+			children: children.map((child, index) => /* @__PURE__ */ jsx(TreeItem, {
+				depth: depth + 1,
+				node: child,
+				orderPath: `${orderPath}.${orderPathSegment(index)}`,
+				parentPath: path,
+				siblingCount: children.length,
+				siblingIndex: index + 1
+			}, child.id))
+		}) : null]
+	});
+}
+var ORDER_PATH_SEGMENT_WIDTH, TreeComponent;
+var init_tree = __esmMin((() => {
+	init_tree_context();
+	ORDER_PATH_SEGMENT_WIDTH = 6;
+	TreeComponent = ({ node }) => {
+		const identity = nodeIdentity(node);
+		const value = useTreeState({
+			activeId: node.props.activeId,
+			defaultExpanded: node.props.defaultExpanded,
+			endpoint: node.props.endpoint ?? null,
+			componentRef: node.props.ref ?? null,
+			lazy: node.props.lazy === true,
+			nodes: node.props.nodes,
+			rememberState: node.props.rememberState,
+			storageKey: `lattice:tree:${identity ?? "default"}`
+		});
+		const roots = node.props.nodes.length > 0 ? node.props.nodes : value.childrenFor("") ?? [];
+		return /* @__PURE__ */ jsx(TreeContext.Provider, {
+			value,
+			children: /* @__PURE__ */ jsx("ul", {
+				"data-lattice-component": identity,
+				role: "tree",
+				children: roots.map((child, index) => /* @__PURE__ */ jsx(TreeItem, {
+					depth: 1,
+					node: child,
+					orderPath: orderPathSegment(index),
+					parentPath: null,
+					siblingCount: roots.length,
+					siblingIndex: index + 1
+				}, child.id))
+			})
+		});
+	};
+}));
+//#endregion
+//#region resources/js/plugin.ts
+var plugin_default = {
+	name: "lattice/tree",
+	components: { tree: lazyComponent(() => Promise.resolve().then(() => (init_tree(), tree_exports))) },
+	i18n: { namespace: "tree" }
+};
+//#endregion
+export { plugin_default as default };

--- a/packages/tree/lang/de/tree.php
+++ b/packages/tree/lang/de/tree.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'expand' => ':label ausklappen',
+    'collapse' => ':label einklappen',
+];

--- a/packages/tree/lang/en/tree.php
+++ b/packages/tree/lang/en/tree.php
@@ -1,0 +1,7 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'expand' => 'Expand :label',
+    'collapse' => 'Collapse :label',
+];

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lattice-php/tree",
+  "version": "0.38.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "build:plugin": "vite build --mode plugin",
+    "dev": "vite",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@lattice-php/lattice": "^0.38.0",
+    "react": "^19.0.0"
+  }
+}

--- a/packages/tree/phpstan.neon
+++ b/packages/tree/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - vendor/mrpunyapal/peststan/extension.neon
+
+parameters:
+    paths:
+        - src
+        - tests
+        - workbench/app
+    level: 6

--- a/packages/tree/phpunit.xml
+++ b/packages/tree/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Browser">
+            <directory>tests/Browser</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/packages/tree/pint.json
+++ b/packages/tree/pint.json
@@ -1,0 +1,7 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "declare_strict_types": true,
+        "blank_line_after_opening_tag": false
+    }
+}

--- a/packages/tree/resources/js/plugin.ts
+++ b/packages/tree/resources/js/plugin.ts
@@ -1,0 +1,11 @@
+import { lazyComponent, type Plugin } from "@lattice-php/lattice/runtime";
+
+export default {
+  name: "lattice/tree",
+  components: {
+    tree: lazyComponent(() => import("./tree")),
+  },
+  i18n: {
+    namespace: "tree",
+  },
+} satisfies Plugin;

--- a/packages/tree/resources/js/test-setup.ts
+++ b/packages/tree/resources/js/test-setup.ts
@@ -1,0 +1,19 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, configure } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+configure({ testIdAttribute: "data-test" });
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class ResizeObserver {
+    disconnect() {}
+
+    observe() {}
+
+    unobserve() {}
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/tree/resources/js/test-support.tsx
+++ b/packages/tree/resources/js/test-support.tsx
@@ -1,0 +1,82 @@
+import { render, type RenderOptions, type RenderResult } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { vi } from "vitest";
+import {
+  RegistryContext,
+  type ComponentPropsOf,
+  type Node,
+  type Registry,
+  type RendererComponent,
+  type Schema,
+} from "@lattice-php/lattice/core";
+import type { TreeNodeData } from "./tree";
+
+/**
+ * The slice of `@inertiajs/react` the tree renderer touches — `router.visit`
+ * (Enter/Space on a linked node) and `Link` (an href label). Use inside a mock
+ * factory: `vi.mock("@inertiajs/react", async () => (await import("./test-support")).inertiaMock())`.
+ */
+export function inertiaMock(): Record<string, unknown> {
+  return {
+    Link: ({ children, ...rest }: { children?: ReactNode }) => <a {...rest}>{children}</a>,
+    router: {
+      visit: vi.fn<(url: string, options?: unknown) => void>(),
+    },
+  };
+}
+
+/**
+ * Renders `ui` with `registry` available to the core `<Renderer>` (used here to
+ * render a node's schema body), mirroring what the app Provider does.
+ */
+export function renderWithRegistry(
+  ui: ReactElement,
+  registry: Registry,
+  options?: RenderOptions,
+): RenderResult {
+  return render(
+    <RegistryContext.Provider value={registry}>{ui}</RegistryContext.Provider>,
+    options,
+  );
+}
+
+/**
+ * Build a node fixture with only the props a case cares about. The wire always
+ * carries the full prop object, but the component defaults what is omitted, so
+ * partial props are safe; prop names stay checked via `ComponentPropsOf`.
+ */
+export function fakeNode<TType extends string>(node: {
+  type: TType;
+  id?: string;
+  key?: string;
+  schema?: Schema;
+  props?: Partial<ComponentPropsOf<TType>>;
+}): Node<TType> {
+  return node as unknown as Node<TType>;
+}
+
+/**
+ * Stand-in body component registered under `"test.text"` alongside
+ * `"test.action"`, mirroring the compiled `text` envelope a real node's
+ * schema carries.
+ */
+export const TestText: RendererComponent = ({ node }) => (
+  <span>{String(node.props?.text ?? "")}</span>
+);
+
+/**
+ * Builds a schema-shaped `TreeNodeData` fixture so tests can stay terse
+ * without hand-writing the wrapping `test.text` envelope every time.
+ */
+export function treeNode(
+  id: string,
+  label: string,
+  extra: Partial<TreeNodeData> = {},
+): TreeNodeData {
+  return {
+    id,
+    label,
+    schema: [{ props: { text: label }, type: "test.text" }],
+    ...extra,
+  } as TreeNodeData;
+}

--- a/packages/tree/resources/js/tree-context.tsx
+++ b/packages/tree/resources/js/tree-context.tsx
@@ -1,0 +1,316 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { RefObject } from "react";
+import { apiJson, usePersistentState } from "@lattice-php/lattice/runtime";
+import type { TreeNodeData } from "./tree";
+
+export const ROOTS_KEY = "";
+
+export type TreeItemRegistration = {
+  id: string;
+  label: string;
+  orderPath: string;
+  parentPath: string | null;
+  path: string;
+  ref: RefObject<HTMLLIElement | null>;
+};
+
+export type TreeFocusDirection = "first" | "firstChild" | "last" | "next" | "parent" | "prev";
+
+export type TreeContextValue = {
+  activate: (id: string) => void;
+  activeId: string | null;
+  canLoad: boolean;
+  childrenFor: (id: string) => TreeNodeData[] | undefined;
+  expanded: Set<string>;
+  focus: (id: string) => void;
+  focusedId: string | null;
+  isLoading: (id: string) => boolean;
+  loadChildren: (id: string) => void;
+  moveFocus: (fromId: string, direction: TreeFocusDirection) => void;
+  register: (entry: TreeItemRegistration) => void;
+  toggle: (id: string) => void;
+  typeAhead: (fromId: string, character: string) => void;
+  unregister: (path: string) => void;
+};
+
+const defaultTreeContext: TreeContextValue = {
+  activate: () => {},
+  activeId: null,
+  canLoad: false,
+  childrenFor: () => undefined,
+  expanded: new Set(),
+  focus: () => {},
+  focusedId: null,
+  isLoading: () => false,
+  loadChildren: () => {},
+  moveFocus: () => {},
+  register: () => {},
+  toggle: () => {},
+  typeAhead: () => {},
+  unregister: () => {},
+};
+
+export const TreeContext = createContext<TreeContextValue>(defaultTreeContext);
+
+export function useTreeContext(): TreeContextValue {
+  return useContext(TreeContext);
+}
+
+function parseExpanded(raw: string): Set<string> {
+  const parsed: unknown = JSON.parse(raw);
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("expected an array of ids");
+  }
+
+  return new Set(parsed.filter((id): id is string => typeof id === "string"));
+}
+
+function visibleOrder(registry: Map<string, TreeItemRegistration>): TreeItemRegistration[] {
+  return [...registry.values()].sort((a, b) => a.orderPath.localeCompare(b.orderPath));
+}
+
+const TYPEAHEAD_IDLE_MS = 800;
+
+export function useTreeState({
+  activeId: initialActiveId,
+  defaultExpanded,
+  endpoint,
+  componentRef,
+  lazy,
+  nodes,
+  rememberState,
+  storageKey,
+}: {
+  activeId: string | null;
+  defaultExpanded: string[];
+  endpoint: string | null;
+  componentRef: string | null;
+  lazy: boolean;
+  nodes: Array<{ id: string }>;
+  rememberState: boolean;
+  storageKey: string;
+}): TreeContextValue {
+  const [expanded, setExpanded] = usePersistentState<Set<string>>(
+    storageKey,
+    () => new Set(defaultExpanded),
+    {
+      enabled: rememberState,
+      parse: parseExpanded,
+      serialize: (value) => JSON.stringify([...value]),
+    },
+  );
+  const [activeId, setActiveId] = useState<string | null>(initialActiveId);
+  const [focusedId, setFocusedId] = useState<string | null>(() => nodes[0]?.id ?? null);
+  const registryRef = useRef<Map<string, TreeItemRegistration>>(new Map());
+  const typeAheadRef = useRef<{ text: string; timestamp: number }>({ text: "", timestamp: 0 });
+  const [loaded, setLoaded] = useState<Map<string, TreeNodeData[]>>(new Map());
+  const [loading, setLoading] = useState<Set<string>>(new Set());
+  const inFlightRef = useRef<Set<string>>(new Set());
+  const loadedRef = useRef(loaded);
+  loadedRef.current = loaded;
+  const canLoad = endpoint !== null && endpoint !== "";
+
+  const toggle = useCallback(
+    (id: string) => {
+      setExpanded((current) => {
+        const next = new Set(current);
+
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+
+        return next;
+      });
+    },
+    [setExpanded],
+  );
+
+  const activate = useCallback((id: string) => setActiveId(id), []);
+
+  const focus = useCallback((id: string) => {
+    setFocusedId(id);
+    const entry = [...registryRef.current.values()].find((candidate) => candidate.id === id);
+    entry?.ref.current?.focus();
+  }, []);
+
+  const register = useCallback((entry: TreeItemRegistration) => {
+    registryRef.current.set(entry.path, entry);
+  }, []);
+
+  const unregister = useCallback((path: string) => {
+    registryRef.current.delete(path);
+  }, []);
+
+  const moveFocus = useCallback(
+    (fromId: string, direction: TreeFocusDirection) => {
+      const order = visibleOrder(registryRef.current);
+
+      if (order.length === 0) {
+        return;
+      }
+
+      const index = order.findIndex((entry) => entry.id === fromId);
+      const current = index === -1 ? undefined : order[index];
+
+      let target: TreeItemRegistration | undefined;
+
+      switch (direction) {
+        case "next":
+          target = index === -1 ? undefined : order[index + 1];
+          break;
+        case "prev":
+          target = index === -1 ? undefined : order[index - 1];
+          break;
+        case "first":
+          target = order[0];
+          break;
+        case "last":
+          target = order[order.length - 1];
+          break;
+        case "parent":
+          target = current ? order.find((entry) => entry.path === current.parentPath) : undefined;
+          break;
+        case "firstChild":
+          target = current ? order.find((entry) => entry.parentPath === current.path) : undefined;
+          break;
+      }
+
+      if (target) {
+        focus(target.id);
+      }
+    },
+    [focus],
+  );
+
+  const typeAhead = useCallback(
+    (fromId: string, character: string) => {
+      const order = visibleOrder(registryRef.current);
+
+      if (order.length === 0) {
+        return;
+      }
+
+      const now = Date.now();
+      const buffer = typeAheadRef.current;
+      const text = now - buffer.timestamp > TYPEAHEAD_IDLE_MS ? character : buffer.text + character;
+      typeAheadRef.current = { text, timestamp: now };
+
+      const needle = text.toLowerCase();
+      const startIndex = order.findIndex((entry) => entry.id === fromId);
+      const start = startIndex === -1 ? 0 : startIndex;
+
+      for (let offset = 1; offset <= order.length; offset++) {
+        const candidate = order[(start + offset) % order.length];
+
+        if (candidate.label.toLowerCase().startsWith(needle)) {
+          focus(candidate.id);
+          return;
+        }
+      }
+    },
+    [focus],
+  );
+
+  const loadChildren = useCallback(
+    (id: string) => {
+      if (!canLoad || inFlightRef.current.has(id) || loadedRef.current.has(id)) {
+        return;
+      }
+
+      inFlightRef.current.add(id);
+      setLoading((current) => new Set(current).add(id));
+
+      apiJson<{ nodes: TreeNodeData[] }>(`${endpoint}?parent=${encodeURIComponent(id)}`, {
+        ref: componentRef ?? "",
+      })
+        .then(({ nodes: fetched }) => {
+          setLoaded((current) => new Map(current).set(id, fetched));
+        })
+        .catch(() => {
+          // Collapse so the next expand retries; nothing is cached for the id.
+          setExpanded((current) => {
+            const next = new Set(current);
+            next.delete(id);
+
+            return next;
+          });
+        })
+        .finally(() => {
+          inFlightRef.current.delete(id);
+          setLoading((current) => {
+            const next = new Set(current);
+            next.delete(id);
+
+            return next;
+          });
+        });
+    },
+    [canLoad, componentRef, endpoint, setExpanded],
+  );
+
+  const childrenFor = useCallback((id: string) => loaded.get(id), [loaded]);
+
+  const isLoading = useCallback((id: string) => loading.has(id), [loading]);
+
+  const hasWireNodes = nodes.length > 0;
+
+  useEffect(() => {
+    if (lazy && !hasWireNodes) {
+      loadChildren(ROOTS_KEY);
+    }
+  }, [lazy, hasWireNodes, loadChildren]);
+
+  const firstFetchedRootId = loaded.get(ROOTS_KEY)?.[0]?.id;
+
+  useEffect(() => {
+    if (focusedId === null && firstFetchedRootId !== undefined) {
+      setFocusedId(firstFetchedRootId);
+    }
+  }, [focusedId, firstFetchedRootId]);
+
+  return useMemo(
+    () => ({
+      activate,
+      activeId,
+      canLoad,
+      childrenFor,
+      expanded,
+      focus,
+      focusedId,
+      isLoading,
+      loadChildren,
+      moveFocus,
+      register,
+      toggle,
+      typeAhead,
+      unregister,
+    }),
+    [
+      activate,
+      activeId,
+      canLoad,
+      childrenFor,
+      expanded,
+      focus,
+      focusedId,
+      isLoading,
+      loadChildren,
+      moveFocus,
+      register,
+      toggle,
+      typeAhead,
+      unregister,
+    ],
+  );
+}

--- a/packages/tree/resources/js/tree-keyboard.test.tsx
+++ b/packages/tree/resources/js/tree-keyboard.test.tsx
@@ -1,0 +1,329 @@
+import { act, fireEvent, screen } from "@testing-library/react";
+import { router } from "@inertiajs/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core";
+import type { RendererComponent } from "@lattice-php/lattice/core";
+import { fakeNode, renderWithRegistry, TestText, treeNode } from "./test-support";
+import TreeComponent, { type TreeNodeData } from "./tree";
+
+vi.mock("@inertiajs/react", async () => (await import("./test-support")).inertiaMock());
+
+const actionClicks: string[] = [];
+const TestAction: RendererComponent = ({ node }) => (
+  <button onClick={() => actionClicks.push(String(node.props?.label ?? ""))} type="button">
+    {String(node.props?.label ?? "")}
+  </button>
+);
+
+const registry = createRegistry({
+  components: {
+    "test.action": eagerComponent(TestAction),
+    "test.text": eagerComponent(TestText),
+    tree: eagerComponent(TreeComponent),
+  },
+  name: "test/tree-keyboard",
+});
+
+beforeEach(() => {
+  vi.mocked(router.visit).mockClear();
+  actionClicks.length = 0;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function renderTree(props: Record<string, unknown>, id = "t1") {
+  const node = fakeNode({
+    id,
+    props: { defaultExpanded: [], rememberState: false, ...props },
+    type: "tree",
+  });
+
+  return renderWithRegistry(<TreeComponent node={node}>{null}</TreeComponent>, registry);
+}
+
+const nodes: TreeNodeData[] = [
+  treeNode("1", "Electronics", {
+    children: [treeNode("2", "Laptops", { href: "/c/2" }), treeNode("3", "Phones")],
+  }),
+  treeNode("9", "Suppliers", { hasChildren: true }),
+];
+
+function item(id: string): HTMLElement {
+  return screen.getByTestId(`tree-node-${id}`);
+}
+
+const outOfOrderNodes: TreeNodeData[] = [
+  treeNode("9", "First Root", {
+    children: [treeNode("20", "Second Child"), treeNode("10", "First Child")],
+  }),
+  treeNode("1", "Second Root"),
+];
+
+describe("Tree keyboard navigation", () => {
+  it("focuses the first root by default with a single roving tabindex", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(item("1")).toHaveAttribute("tabindex", "0");
+    expect(item("2")).toHaveAttribute("tabindex", "-1");
+    expect(item("3")).toHaveAttribute("tabindex", "-1");
+    expect(item("9")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("moves focus down and up across visible nodes, skipping collapsed subtrees", () => {
+    renderTree({ defaultExpanded: [], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("9")).toHaveFocus();
+    expect(item("9")).toHaveAttribute("tabindex", "0");
+    expect(item("1")).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.keyDown(item("9"), { key: "ArrowUp" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("moves focus by authored position even when sibling ids are not in ascending order", () => {
+    renderTree({ defaultExpanded: [], nodes: outOfOrderNodes });
+    item("9").focus();
+
+    fireEvent.keyDown(item("9"), { key: "ArrowDown" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("descends to the first authored child even when child ids are not in ascending order", () => {
+    renderTree({ defaultExpanded: ["9"], nodes: outOfOrderNodes });
+    item("9").focus();
+
+    fireEvent.keyDown(item("9"), { key: "ArrowRight" });
+    expect(item("20")).toHaveFocus();
+  });
+
+  it("does not double-move focus when a keydown bubbles from a nested treeitem", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "ArrowDown" });
+    expect(item("3")).toHaveFocus();
+  });
+
+  it("expands a collapsed parent with ArrowRight, then descends into the first child", () => {
+    renderTree({ defaultExpanded: [], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowRight" });
+    expect(screen.getByText("Laptops")).toBeVisible();
+    expect(item("1")).toHaveFocus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowRight" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "ArrowRight" });
+    expect(item("2")).toHaveFocus();
+  });
+
+  it("collapses an expanded parent with ArrowLeft, then moves focus to the parent", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "ArrowLeft" });
+    expect(item("1")).toHaveFocus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowLeft" });
+    expect(screen.queryByText("Laptops")).not.toBeInTheDocument();
+    expect(item("1")).toHaveFocus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowLeft" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("jumps to the first and last visible node with Home and End", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "End" });
+    expect(item("9")).toHaveFocus();
+
+    fireEvent.keyDown(item("9"), { key: "Home" });
+    expect(item("1")).toHaveFocus();
+  });
+
+  it("type-ahead focuses the next visible node whose label starts with the typed text", () => {
+    vi.useFakeTimers();
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "p" });
+    expect(item("3")).toHaveFocus();
+
+    act(() => vi.advanceTimersByTime(2000));
+
+    fireEvent.keyDown(item("3"), { key: "s" });
+    expect(item("9")).toHaveFocus();
+  });
+
+  it("accumulates type-ahead characters within the idle window and resets after it elapses", () => {
+    vi.useFakeTimers();
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "l" });
+    fireEvent.keyDown(item("2"), { key: "a" });
+    expect(item("2")).toHaveFocus();
+
+    act(() => vi.advanceTimersByTime(2000));
+
+    fireEvent.keyDown(item("2"), { key: "s" });
+    expect(item("9")).toHaveFocus();
+  });
+
+  it("sets aria-level, aria-setsize and aria-posinset", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(item("1")).toHaveAttribute("aria-level", "1");
+    expect(item("1")).toHaveAttribute("aria-setsize", "2");
+    expect(item("1")).toHaveAttribute("aria-posinset", "1");
+
+    expect(item("9")).toHaveAttribute("aria-level", "1");
+    expect(item("9")).toHaveAttribute("aria-setsize", "2");
+    expect(item("9")).toHaveAttribute("aria-posinset", "2");
+
+    expect(item("2")).toHaveAttribute("aria-level", "2");
+    expect(item("2")).toHaveAttribute("aria-setsize", "2");
+    expect(item("2")).toHaveAttribute("aria-posinset", "1");
+
+    expect(item("3")).toHaveAttribute("aria-level", "2");
+    expect(item("3")).toHaveAttribute("aria-setsize", "2");
+    expect(item("3")).toHaveAttribute("aria-posinset", "2");
+  });
+
+  it("puts aria-expanded on the treeitem instead of the chevron, and leaves leaves without it", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(item("1")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("tree-node-1-toggle")).not.toHaveAttribute("aria-expanded");
+    expect(item("3")).not.toHaveAttribute("aria-expanded");
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+    expect(item("1")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("gives the chevron toggle an accessible name that reflects its state", () => {
+    renderTree({ defaultExpanded: [], nodes });
+
+    expect(screen.getByTestId("tree-node-1-toggle")).toHaveAttribute(
+      "aria-label",
+      "Expand Electronics",
+    );
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+
+    expect(screen.getByTestId("tree-node-1-toggle")).toHaveAttribute(
+      "aria-label",
+      "Collapse Electronics",
+    );
+  });
+
+  it("activates the focused node on Enter by following its href", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    expect(item("2")).toHaveFocus();
+
+    fireEvent.keyDown(item("2"), { key: "Enter" });
+    expect(router.visit).toHaveBeenCalledWith("/c/2");
+  });
+
+  it("activates the focused node on Space by marking it active when it has no href", () => {
+    renderTree({ defaultExpanded: ["1"], nodes });
+    item("1").focus();
+
+    fireEvent.keyDown(item("1"), { key: "ArrowDown" });
+    fireEvent.keyDown(item("2"), { key: "ArrowDown" });
+    expect(item("3")).toHaveFocus();
+
+    fireEvent.keyDown(item("3"), { key: " " });
+    expect(item("3")).toHaveAttribute("aria-selected", "true");
+    expect(router.visit).not.toHaveBeenCalled();
+  });
+
+  it("excludes a node's action control from the page tab order", () => {
+    const actionNodes: TreeNodeData[] = [
+      treeNode("5", "Accessories", {
+        schema: [
+          { props: { text: "Accessories" }, type: "test.text" },
+          { props: { label: "Delete" }, type: "test.action" },
+        ],
+      }),
+    ];
+
+    renderTree({ nodes: actionNodes });
+
+    expect(screen.getByRole("button", { name: "Delete" })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("triggers the focused node's action control on Enter when it has no href", () => {
+    const actionNodes: TreeNodeData[] = [
+      treeNode("5", "Accessories", {
+        schema: [
+          { props: { text: "Accessories" }, type: "test.text" },
+          { props: { label: "Delete" }, type: "test.action" },
+        ],
+      }),
+    ];
+
+    renderTree({ nodes: actionNodes });
+    item("5").focus();
+
+    fireEvent.keyDown(item("5"), { key: "Enter" });
+
+    expect(actionClicks).toEqual(["Delete"]);
+    expect(router.visit).not.toHaveBeenCalled();
+  });
+
+  it("triggers the focused node's action control on Space when it has no href", () => {
+    const actionNodes: TreeNodeData[] = [
+      treeNode("5", "Accessories", {
+        schema: [
+          { props: { text: "Accessories" }, type: "test.text" },
+          { props: { label: "Delete" }, type: "test.action" },
+        ],
+      }),
+    ];
+
+    renderTree({ nodes: actionNodes });
+    item("5").focus();
+
+    fireEvent.keyDown(item("5"), { key: " " });
+
+    expect(actionClicks).toEqual(["Delete"]);
+  });
+
+  it("prefers href over an action when both are present", () => {
+    const hrefAndActionNodes: TreeNodeData[] = [
+      treeNode("5", "Accessories", {
+        href: "/c/5",
+        schema: [
+          { props: { text: "Accessories" }, type: "test.text" },
+          { props: { label: "Delete" }, type: "test.action" },
+        ],
+      }),
+    ];
+
+    renderTree({ nodes: hrefAndActionNodes });
+    item("5").focus();
+
+    fireEvent.keyDown(item("5"), { key: "Enter" });
+
+    expect(router.visit).toHaveBeenCalledWith("/c/5");
+    expect(actionClicks).toEqual([]);
+  });
+});

--- a/packages/tree/resources/js/tree-lazy.test.tsx
+++ b/packages/tree/resources/js/tree-lazy.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core";
+import { fakeNode, renderWithRegistry, TestText, treeNode } from "./test-support";
+import TreeComponent, { type TreeNodeData } from "./tree";
+
+const registry = createRegistry({
+  components: { "test.text": eagerComponent(TestText), tree: eagerComponent(TreeComponent) },
+  name: "test/tree-lazy",
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    status: 200,
+  });
+}
+
+const fetchMock = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function renderLazyTree(props: Record<string, unknown>, id = "lazy-tree") {
+  const node = fakeNode({
+    id,
+    props: {
+      activeId: null,
+      defaultExpanded: [],
+      endpoint: "/lattice/trees/categories",
+      lazy: true,
+      ref: "sealed-ref",
+      rememberState: false,
+      ...props,
+    },
+    type: "tree",
+  });
+
+  return renderWithRegistry(<TreeComponent node={node}>{null}</TreeComponent>, registry);
+}
+
+const roots: TreeNodeData[] = [
+  treeNode("electronics", "Electronics", { hasChildren: true }),
+  treeNode("books", "Books"),
+];
+
+describe("lazy tree", () => {
+  it("fetches children once when a node expands via its chevron", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: [treeNode("laptops", "Laptops")] }));
+    renderLazyTree({ nodes: roots });
+
+    fireEvent.click(screen.getByTestId("tree-node-electronics-toggle"));
+
+    expect(await screen.findByText("Laptops")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/lattice/trees/categories?parent=electronics");
+    expect(new Headers(init.headers).get("X-Lattice-Ref")).toBe("sealed-ref");
+  });
+
+  it("fetches children when ArrowRight expands a collapsed node", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: [treeNode("laptops", "Laptops")] }));
+    renderLazyTree({ nodes: roots });
+
+    fireEvent.keyDown(screen.getByTestId("tree-node-electronics"), { key: "ArrowRight" });
+
+    expect(await screen.findByText("Laptops")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches on mount for nodes in defaultExpanded", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: [treeNode("laptops", "Laptops")] }));
+    renderLazyTree({ defaultExpanded: ["electronics"], nodes: roots });
+
+    expect(await screen.findByText("Laptops")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refetch cached children on collapse and re-expand", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: [treeNode("laptops", "Laptops")] }));
+    renderLazyTree({ nodes: roots });
+
+    const toggle = screen.getByTestId("tree-node-electronics-toggle");
+    fireEvent.click(toggle);
+    expect(await screen.findByText("Laptops")).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.queryByText("Laptops")).not.toBeInTheDocument());
+
+    fireEvent.click(toggle);
+    expect(await screen.findByText("Laptops")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses on a failed fetch and retries on the next expand", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValue(jsonResponse({ nodes: [treeNode("laptops", "Laptops")] }));
+    renderLazyTree({ nodes: roots });
+
+    const item = () => screen.getByTestId("tree-node-electronics");
+    fireEvent.click(screen.getByTestId("tree-node-electronics-toggle"));
+
+    await waitFor(() => expect(item()).toHaveAttribute("aria-expanded", "false"));
+
+    fireEvent.click(screen.getByTestId("tree-node-electronics-toggle"));
+
+    expect(await screen.findByText("Laptops")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetches the roots for a lazy skeleton without wire nodes", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ nodes: roots }));
+    renderLazyTree({ nodes: [] });
+
+    expect(await screen.findByText("Electronics")).toBeInTheDocument();
+    expect(await screen.findByText("Books")).toBeInTheDocument();
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("/lattice/trees/categories?parent=");
+    expect(screen.getByTestId("tree-node-electronics")).toHaveAttribute("tabindex", "0");
+  });
+
+  it("shows no chevron for hasChildren nodes without an endpoint", () => {
+    renderLazyTree({ endpoint: null, lazy: false, nodes: roots, ref: null });
+
+    expect(screen.queryByTestId("tree-node-electronics-toggle")).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tree/resources/js/tree.test.tsx
+++ b/packages/tree/resources/js/tree.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/lattice/core";
+import type { RendererComponent } from "@lattice-php/lattice/core";
+import { fakeNode, renderWithRegistry, TestText, treeNode } from "./test-support";
+import TreeComponent, { type TreeNodeData } from "./tree";
+
+const TestAction: RendererComponent = ({ node }) => (
+  <button type="button">{String(node.props?.label ?? "")}</button>
+);
+
+const registry = createRegistry({
+  components: {
+    "test.action": eagerComponent(TestAction),
+    "test.text": eagerComponent(TestText),
+    tree: eagerComponent(TreeComponent),
+  },
+  name: "test/tree",
+});
+
+function renderTree(props: Record<string, unknown>, id = "t1") {
+  const node = fakeNode({
+    id,
+    props: { defaultExpanded: [], rememberState: false, ...props },
+    type: "tree",
+  });
+
+  return renderWithRegistry(<TreeComponent node={node}>{null}</TreeComponent>, registry);
+}
+
+const nodes: TreeNodeData[] = [
+  treeNode("1", "Electronics", {
+    children: [treeNode("2", "Laptops", { href: "/c/2" }), treeNode("3", "Phones")],
+  }),
+  treeNode("9", "Suppliers", { hasChildren: true }),
+];
+
+describe("Tree component", () => {
+  it("renders roots and toggles a subtree via the chevron", () => {
+    renderTree({ defaultExpanded: [], nodes });
+
+    expect(screen.getByText("Electronics")).toBeVisible();
+    expect(screen.queryByText("Laptops")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+
+    expect(screen.getByText("Laptops")).toBeVisible();
+  });
+
+  it("shows a chevron for a loadable boundary and none for a leaf or a dead boundary", () => {
+    renderTree({ defaultExpanded: ["1"], endpoint: "/lattice/trees/demo", nodes, ref: "sealed" });
+
+    expect(screen.getByTestId("tree-node-9-toggle")).toBeInTheDocument();
+    expect(screen.queryByTestId("tree-node-3-toggle")).not.toBeInTheDocument();
+
+    cleanup();
+    renderTree({ defaultExpanded: ["1"], nodes });
+
+    expect(screen.queryByTestId("tree-node-9-toggle")).not.toBeInTheDocument();
+  });
+
+  it("marks the active node aria-selected", () => {
+    renderTree({ activeId: "3", defaultExpanded: ["1"], nodes });
+
+    expect(screen.getByTestId("tree-node-3")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("marks a disabled node aria-disabled", () => {
+    const disabledNodes: TreeNodeData[] = [
+      treeNode("4", "Tablets", { disabled: true, href: "/c/4" }),
+    ];
+
+    renderTree({ nodes: disabledNodes });
+
+    expect(screen.getByTestId("tree-node-4")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("renders a node's schema body", () => {
+    const actionNodes: TreeNodeData[] = [
+      treeNode("5", "Accessories", {
+        schema: [
+          { props: { text: "Accessories" }, type: "test.text" },
+          { props: { label: "Delete" }, type: "test.action" },
+        ],
+      }),
+    ];
+
+    renderTree({ nodes: actionNodes });
+
+    expect(screen.getByText("Accessories")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeVisible();
+  });
+
+  it("keeps the label as the treeitem's accessible name even when the schema omits it", () => {
+    const hiddenLabelNodes: TreeNodeData[] = [
+      {
+        id: "7",
+        label: "Hidden Label",
+        schema: [{ props: { text: "something else" }, type: "test.text" }],
+      },
+    ];
+
+    renderTree({ nodes: hiddenLabelNodes });
+
+    expect(screen.getByRole("treeitem", { name: "Hidden Label" })).toBeInTheDocument();
+  });
+
+  it("persists expanded ids when rememberState is set", () => {
+    window.localStorage.clear();
+
+    renderTree({ nodes, rememberState: true }, "remember-tree");
+
+    fireEvent.click(screen.getByTestId("tree-node-1-toggle"));
+
+    expect(window.localStorage.getItem("lattice:tree:remember-tree")).toBe('["1"]');
+    window.localStorage.clear();
+  });
+
+  it("restores the persisted expanded ids", () => {
+    window.localStorage.setItem("lattice:tree:remember-tree", JSON.stringify(["1"]));
+
+    renderTree({ nodes, rememberState: true }, "remember-tree");
+
+    expect(screen.getByText("Laptops")).toBeVisible();
+    window.localStorage.clear();
+  });
+});

--- a/packages/tree/resources/js/tree.tsx
+++ b/packages/tree/resources/js/tree.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useRef } from "react";
+import type { KeyboardEvent } from "react";
+import { cn, Icon, nodeIdentity, Renderer, router, useT } from "@lattice-php/lattice/runtime";
+import type { RendererComponent, Schema } from "@lattice-php/lattice/runtime";
+import { ROOTS_KEY, TreeContext, useTreeContext, useTreeState } from "./tree-context";
+
+/**
+ * The sparse wire shape a tree node serializes as (see `TreeNode::jsonSerialize()`):
+ * every optional/falsy field is omitted rather than sent as `null`/`false`. `schema`
+ * is the compiled body — icon/text-or-link/badge/actions — rendered by core's
+ * `<Renderer>`; `label` stays a plain string used for typeahead and registry
+ * registration, not for rendering.
+ */
+export type TreeNodeData = {
+  readonly id: string;
+  readonly label: string;
+  schema: Schema;
+  href?: string;
+  disabled?: boolean;
+  hasChildren?: boolean;
+  children?: TreeNodeData[];
+};
+
+export type TreeWireProps = {
+  activeId: string | null;
+  defaultExpanded: string[];
+  rememberState: boolean;
+  nodes: TreeNodeData[];
+  ref: string | null;
+  endpoint: string | null;
+  lazy: boolean;
+};
+
+declare module "@lattice-php/lattice" {
+  interface ComponentProps {
+    tree: TreeWireProps;
+  }
+}
+
+function isExpandable(
+  node: TreeNodeData,
+  children: TreeNodeData[] | undefined,
+  canLoad: boolean,
+): boolean {
+  return (
+    Boolean(children?.length) ||
+    (node.hasChildren === true && (canLoad || Boolean(node.children?.length)))
+  );
+}
+
+const ORDER_PATH_SEGMENT_WIDTH = 6;
+
+function orderPathSegment(index: number): string {
+  return String(index).padStart(ORDER_PATH_SEGMENT_WIDTH, "0");
+}
+
+function TreeItem({
+  depth,
+  node,
+  orderPath,
+  parentPath,
+  siblingCount,
+  siblingIndex,
+}: {
+  depth: number;
+  node: TreeNodeData;
+  orderPath: string;
+  parentPath: string | null;
+  siblingCount: number;
+  siblingIndex: number;
+}) {
+  const {
+    activate,
+    activeId,
+    canLoad,
+    childrenFor,
+    expanded,
+    focusedId,
+    isLoading,
+    loadChildren,
+    moveFocus,
+    register,
+    toggle,
+    typeAhead,
+    unregister,
+  } = useTreeContext();
+  const { t } = useT("tree");
+  const ref = useRef<HTMLLIElement>(null);
+  const path = parentPath ? `${parentPath}/${node.id}` : node.id;
+  const isExpanded = expanded.has(node.id);
+  const isActive = activeId === node.id;
+  const isFocused = focusedId === node.id;
+  const isDisabled = node.disabled === true;
+  const children = node.children ?? childrenFor(node.id);
+  const expandable = isExpandable(node, children, canLoad);
+  const loading = isLoading(node.id);
+  const bodyRef = useRef<HTMLSpanElement>(null);
+
+  // Fetching is an effect of "expanded but unloaded", so chevron clicks,
+  // ArrowRight, defaultExpanded, and a rememberState restore all share it.
+  useEffect(() => {
+    if (isExpanded && node.hasChildren === true && !node.children && !children) {
+      loadChildren(node.id);
+    }
+  }, [isExpanded, node, children, loadChildren]);
+
+  useEffect(() => {
+    register({ id: node.id, label: node.label, orderPath, parentPath, path, ref });
+
+    return () => unregister(path);
+  }, [node.id, node.label, orderPath, parentPath, path, register, unregister]);
+
+  useEffect(() => {
+    const container = bodyRef.current;
+
+    if (!container) {
+      return;
+    }
+
+    container.querySelectorAll<HTMLElement>("button, a[href], [tabindex]").forEach((control) => {
+      control.tabIndex = -1;
+    });
+  }, [node.schema]);
+
+  function onKeyDown(event: KeyboardEvent<HTMLLIElement>): void {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        moveFocus(node.id, "next");
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        moveFocus(node.id, "prev");
+        return;
+      case "ArrowRight":
+        event.preventDefault();
+        if (expandable && !isExpanded) {
+          toggle(node.id);
+        } else if (expandable) {
+          moveFocus(node.id, "firstChild");
+        }
+        return;
+      case "ArrowLeft":
+        event.preventDefault();
+        if (expandable && isExpanded) {
+          toggle(node.id);
+        } else {
+          moveFocus(node.id, "parent");
+        }
+        return;
+      case "Home":
+        event.preventDefault();
+        moveFocus(node.id, "first");
+        return;
+      case "End":
+        event.preventDefault();
+        moveFocus(node.id, "last");
+        return;
+      case "Enter":
+      case " ":
+        event.preventDefault();
+        if (isDisabled) {
+          return;
+        }
+        if (node.href) {
+          router.visit(node.href);
+        } else {
+          const trigger = bodyRef.current?.querySelector("button");
+
+          if (trigger) {
+            trigger.click();
+            ref.current?.focus();
+          } else {
+            activate(node.id);
+          }
+        }
+        return;
+      default:
+        if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+          typeAhead(node.id, event.key);
+        }
+    }
+  }
+
+  return (
+    <li
+      aria-disabled={isDisabled}
+      aria-expanded={expandable ? isExpanded : undefined}
+      aria-label={node.label}
+      aria-level={depth}
+      aria-posinset={siblingIndex}
+      aria-selected={isActive}
+      aria-setsize={siblingCount}
+      data-test={`tree-node-${node.id}`}
+      onKeyDown={onKeyDown}
+      ref={ref}
+      role="treeitem"
+      tabIndex={isFocused ? 0 : -1}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-lt-sm px-2 py-1.5 text-sm text-lt-fg",
+          isActive && "bg-lt-muted font-medium",
+          isDisabled && "pointer-events-none opacity-50",
+        )}
+      >
+        {expandable ? (
+          <button
+            aria-label={
+              isExpanded
+                ? t("tree.collapse", "Collapse {{label}}", { label: node.label })
+                : t("tree.expand", "Expand {{label}}", { label: node.label })
+            }
+            data-test={`tree-node-${node.id}-toggle`}
+            onClick={() => toggle(node.id)}
+            tabIndex={-1}
+            type="button"
+          >
+            {loading ? (
+              <Icon className="size-lt-icon-md shrink-0 animate-spin" name="loader-2" />
+            ) : (
+              <Icon
+                className={cn(
+                  "size-lt-icon-md shrink-0 transition-transform",
+                  isExpanded && "rotate-90",
+                )}
+                name="chevron-right"
+              />
+            )}
+          </button>
+        ) : null}
+        <span className="flex min-w-0 flex-1 items-center gap-2" ref={bodyRef}>
+          <Renderer nodes={node.schema} />
+        </span>
+      </div>
+      {expandable && isExpanded && children && children.length > 0 ? (
+        <ul className="pl-6" role="group">
+          {children.map((child, index) => (
+            <TreeItem
+              depth={depth + 1}
+              key={child.id}
+              node={child}
+              orderPath={`${orderPath}.${orderPathSegment(index)}`}
+              parentPath={path}
+              siblingCount={children.length}
+              siblingIndex={index + 1}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+const TreeComponent: RendererComponent<"tree"> = ({ node }) => {
+  const identity = nodeIdentity(node);
+  const value = useTreeState({
+    activeId: node.props.activeId,
+    defaultExpanded: node.props.defaultExpanded,
+    endpoint: node.props.endpoint ?? null,
+    componentRef: node.props.ref ?? null,
+    lazy: node.props.lazy === true,
+    nodes: node.props.nodes,
+    rememberState: node.props.rememberState,
+    storageKey: `lattice:tree:${identity ?? "default"}`,
+  });
+  const roots =
+    node.props.nodes.length > 0 ? node.props.nodes : (value.childrenFor(ROOTS_KEY) ?? []);
+
+  return (
+    <TreeContext.Provider value={value}>
+      <ul data-lattice-component={identity} role="tree">
+        {roots.map((child, index) => (
+          <TreeItem
+            depth={1}
+            key={child.id}
+            node={child}
+            orderPath={orderPathSegment(index)}
+            parentPath={null}
+            siblingCount={roots.length}
+            siblingIndex={index + 1}
+          />
+        ))}
+      </ul>
+    </TreeContext.Provider>
+  );
+};
+
+export default TreeComponent;

--- a/packages/tree/src/AsTree.php
+++ b/packages/tree/src/AsTree.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Attribute;
+use Lattice\Lattice\Attributes\DefinitionAttribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class AsTree extends DefinitionAttribute {}

--- a/packages/tree/src/CallbackTreeSource.php
+++ b/packages/tree/src/CallbackTreeSource.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Closure;
+
+final readonly class CallbackTreeSource implements TreeSource
+{
+    /**
+     * @param  Closure(): iterable<int, TreeNode>  $roots
+     * @param  (Closure(string): iterable<int, TreeNode>)|null  $children
+     */
+    public function __construct(
+        private Closure $roots,
+        private ?Closure $children = null,
+    ) {}
+
+    public function roots(): iterable
+    {
+        return ($this->roots)();
+    }
+
+    public function children(string $parentId): iterable
+    {
+        return $this->children instanceof Closure ? ($this->children)($parentId) : [];
+    }
+}

--- a/packages/tree/src/EloquentTreeSource.php
+++ b/packages/tree/src/EloquentTreeSource.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A {@see TreeSource} backed by an Eloquent adjacency-list hierarchy (a
+ * self-referencing parent column).
+ *
+ * The whole scoped table is loaded once and served from an in-memory
+ * adjacency map — for an adjacency list one scan beats a query per parent,
+ * and the eager Tree walk asks for every level anyway.
+ */
+final class EloquentTreeSource implements TreeSource
+{
+    private const string ROOTS = '';
+
+    /** @var Closure(Builder<Model>): mixed|null */
+    private ?Closure $scope = null;
+
+    private bool $lazy = false;
+
+    /** @var array<string, list<TreeNode>>|null */
+    private ?array $childrenByParent = null;
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    private function __construct(
+        private readonly string $model,
+        private string $labelKey = 'name',
+        private string $parentKey = 'parent_id',
+    ) {}
+
+    /**
+     * @param  class-string<Model>  $model
+     */
+    public static function make(string $model): self
+    {
+        return new self($model);
+    }
+
+    /**
+     * Constrain every query this source issues (e.g. only active rows).
+     *
+     * @param  Closure(Builder<Model>): mixed  $scope
+     */
+    public function scope(Closure $scope): self
+    {
+        $this->scope = $scope;
+        $this->childrenByParent = null;
+
+        return $this;
+    }
+
+    public function label(string $column): self
+    {
+        $this->labelKey = $column;
+        $this->childrenByParent = null;
+
+        return $this;
+    }
+
+    public function parent(string $column): self
+    {
+        $this->parentKey = $column;
+        $this->childrenByParent = null;
+
+        return $this;
+    }
+
+    /**
+     * Query one level per call instead of loading the whole scoped table.
+     * The right mode for the lazy endpoint, where each request asks for a
+     * single parent's children; the full scan stays optimal for the eager
+     * walk, which visits every level anyway.
+     */
+    public function lazy(bool $lazy = true): self
+    {
+        $this->lazy = $lazy;
+
+        return $this;
+    }
+
+    public function roots(): iterable
+    {
+        return $this->lazy
+            ? $this->level(null)
+            : $this->childrenByParent()[self::ROOTS] ?? [];
+    }
+
+    public function children(string $parentId): iterable
+    {
+        return $this->lazy
+            ? $this->level($parentId)
+            : $this->childrenByParent()[$parentId] ?? [];
+    }
+
+    /**
+     * One level plus a scoped EXISTS probe per row for hasChildren — no
+     * relation on the consumer's model is required.
+     *
+     * @return list<TreeNode>
+     */
+    private function level(?string $parentId): array
+    {
+        $query = $this->query();
+        $model = $query->getModel();
+        $table = $model->getTable();
+        $alias = "{$table}_lattice_children";
+
+        if ($parentId === null) {
+            $query->whereNull("{$table}.{$this->parentKey}");
+        } else {
+            $query->where("{$table}.{$this->parentKey}", $parentId);
+        }
+
+        $probe = $this->query()
+            ->from("{$table} as {$alias}")
+            ->selectRaw('1')
+            ->whereColumn("{$alias}.{$this->parentKey}", $model->getQualifiedKeyName())
+            ->limit(1);
+
+        $rows = $query
+            ->select("{$table}.*")
+            ->addSelect(['lattice_tree_has_children' => $probe])
+            ->orderBy($this->labelKey)
+            ->get();
+
+        return array_values($rows->map(
+            fn (Model $row): TreeNode => TreeNode::make(
+                (string) $row->getKey(),
+                (string) $row->getAttribute($this->labelKey),
+            )->hasChildren((bool) $row->getAttribute('lattice_tree_has_children')),
+        )->all());
+    }
+
+    /**
+     * @return Builder<Model>
+     */
+    private function query(): Builder
+    {
+        $builder = $this->model::query();
+
+        if ($this->scope instanceof Closure) {
+            $scoped = ($this->scope)($builder);
+
+            if ($scoped instanceof Builder) {
+                $builder = $scoped;
+            }
+        }
+
+        return $builder;
+    }
+
+    /**
+     * @return array<string, list<TreeNode>>
+     */
+    private function childrenByParent(): array
+    {
+        if ($this->childrenByParent !== null) {
+            return $this->childrenByParent;
+        }
+
+        /** @var array<string, list<Model>> $modelsByParent */
+        $modelsByParent = [];
+
+        foreach ($this->query()->orderBy($this->labelKey)->get() as $model) {
+            $parent = $model->getAttribute($this->parentKey);
+            $modelsByParent[$parent === null ? self::ROOTS : (string) $parent][] = $model;
+        }
+
+        $this->childrenByParent = [];
+
+        foreach ($modelsByParent as $parent => $models) {
+            $this->childrenByParent[$parent] = array_map(
+                fn (Model $model): TreeNode => TreeNode::make(
+                    (string) $model->getKey(),
+                    (string) $model->getAttribute($this->labelKey),
+                )->hasChildren(isset($modelsByParent[(string) $model->getKey()])),
+                $models,
+            );
+        }
+
+        return $this->childrenByParent;
+    }
+}

--- a/packages/tree/src/Tree.php
+++ b/packages/tree/src/Tree.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use InvalidArgumentException;
+use Lattice\Lattice\Attributes\AsComponent;
+use Lattice\Lattice\Attributes\SerializationHook;
+use Lattice\Lattice\Core\Contracts\InteractiveComponent;
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Components\IsInteractive;
+use LogicException;
+
+#[AsComponent('tree')]
+class Tree extends Component implements InteractiveComponent
+{
+    use IsInteractive;
+
+    private ?TreeSource $source = null;
+
+    public ?string $activeId = null;
+
+    /** @var list<string> */
+    public array $defaultExpanded = [];
+
+    public bool $rememberState = false;
+
+    public ?string $endpoint = null;
+
+    public bool $lazy = false;
+
+    private int $eagerDepth = self::MAX_DEPTH;
+
+    /**
+     * Serialization depth cap: the termination guarantee for source-backed
+     * trees whose adjacency data contains a cycle. Not a feature knob — lazy
+     * loading is the planned path for genuinely deep hierarchies.
+     */
+    private const int MAX_DEPTH = 50;
+
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+
+    /**
+     * Build a tree from a registered {@see TreeDefinition}: the definition's
+     * source provides the nodes, and the sealed reference lets the endpoint
+     * re-resolve it with the same context on a later request.
+     *
+     * @param  class-string<TreeDefinition>  $definition
+     * @param  array<string, mixed>  $context
+     */
+    public static function use(string $definition, array $context = []): static
+    {
+        /** @var static */
+        return app(TreeRegistry::class)->component($definition, $context);
+    }
+
+    public function endpoint(string $endpoint): static
+    {
+        $this->endpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * Serialize only the first $eagerDepth levels; deeper nodes are fetched
+     * from the endpoint when expanded. 0 serializes a bare skeleton whose
+     * roots the client fetches too.
+     */
+    public function lazy(int $eagerDepth = 1): static
+    {
+        if ($this->signatureKey === null) {
+            throw new LogicException('Tree::lazy() requires a definition-backed tree — build it with Tree::use(). Inline nodes()/source() trees cannot round-trip to the endpoint.');
+        }
+
+        if ($eagerDepth < 0) {
+            throw new InvalidArgumentException('Tree eager depth must be zero or greater.');
+        }
+
+        $this->lazy = true;
+        $this->eagerDepth = min($eagerDepth, self::MAX_DEPTH);
+
+        return $this;
+    }
+
+    /**
+     * @param  list<TreeNode|array<string, mixed>>  $nodes
+     */
+    public function nodes(array $nodes): static
+    {
+        $expanded = TreeNode::expand($nodes);
+        $this->source = new CallbackTreeSource(roots: static fn (): array => $expanded);
+
+        return $this;
+    }
+
+    public function source(TreeSource $source): static
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function activeId(?string $id): static
+    {
+        $this->activeId = $id;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<string>  $ids
+     */
+    public function defaultExpanded(array $ids): static
+    {
+        $this->defaultExpanded = $ids;
+
+        return $this;
+    }
+
+    public function rememberState(bool $remember = true): static
+    {
+        $this->rememberState = $remember;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 300)]
+    protected function serialiseNodes(array $data): array
+    {
+        // Eager trees serialize one level beyond MAX_DEPTH as a shallow
+        // boundary row; lazy trees serialize exactly $eagerDepth levels.
+        $maxLevels = $this->lazy ? $this->eagerDepth : self::MAX_DEPTH + 1;
+
+        $roots = $maxLevels > 0 && $this->source instanceof TreeSource
+            ? $this->nodeList($this->source->roots())
+            : [];
+
+        $data['props']['nodes'] = array_map(
+            fn (TreeNode $node): array => $this->serialiseNode($node, 1, $maxLevels),
+            $roots,
+        );
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialiseNode(TreeNode $node, int $level, int $maxLevels): array
+    {
+        $data = $node->serialiseShallow();
+
+        if ($level >= $maxLevels) {
+            if ($node->children !== []) {
+                $data['hasChildren'] = true;
+            }
+
+            return $data;
+        }
+
+        $children = $this->resolveChildren($node);
+
+        if ($children !== []) {
+            $data['children'] = array_map(fn (TreeNode $child): array => $this->serialiseNode($child, $level + 1, $maxLevels), $children);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return list<TreeNode>
+     */
+    private function resolveChildren(TreeNode $node): array
+    {
+        if ($node->children !== []) {
+            return $node->children;
+        }
+
+        if ($node->hasChildren && $this->source instanceof TreeSource) {
+            return $this->nodeList($this->source->children($node->id));
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  iterable<int, TreeNode>  $nodes
+     * @return list<TreeNode>
+     */
+    private function nodeList(iterable $nodes): array
+    {
+        return is_array($nodes) ? array_values($nodes) : iterator_to_array($nodes, false);
+    }
+}

--- a/packages/tree/src/TreeController.php
+++ b/packages/tree/src/TreeController.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Concerns\InteractsWithComponents;
+use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+
+final readonly class TreeController
+{
+    use InteractsWithComponents;
+
+    public function __construct(
+        private TreeRegistry $trees,
+        private SignsComponentReferences $references,
+    ) {}
+
+    public function __invoke(Request $request, string $tree): JsonResponse
+    {
+        [$request, $definition] = $this->authorizeComponent($request, $this->references, $this->trees, 'tree', $tree);
+
+        return response()->json($this->trees->response($tree, $request, $definition));
+    }
+}

--- a/packages/tree/src/TreeDefinition.php
+++ b/packages/tree/src/TreeDefinition.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Lattice\Lattice\Core\Definition;
+
+/**
+ * A registered, addressable tree: the server-side counterpart of
+ * `Tree::use()`. The registry key from {@see AsTree} lets the lazy endpoint
+ * re-resolve the definition on a later request, with the sealed context
+ * re-applied by the controller.
+ */
+abstract class TreeDefinition extends Definition
+{
+    abstract public function source(): TreeSource;
+}

--- a/packages/tree/src/TreeNode.php
+++ b/packages/tree/src/TreeNode.php
@@ -1,0 +1,244 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use JsonSerializable;
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Components\ActionGroup;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\Enums\ColorName;
+use Lattice\Lattice\Ui\Components\Badge;
+use Lattice\Lattice\Ui\Components\Component;
+use Lattice\Lattice\Ui\Components\Icon;
+use Lattice\Lattice\Ui\Components\Link;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Side;
+use Lattice\Lattice\Ui\Enums\StackDirection;
+use Lattice\Lattice\Ui\Enums\Width;
+
+final class TreeNode implements JsonSerializable
+{
+    /** @var list<Component>|null */
+    private ?array $schema = null;
+
+    public ?string $icon = null;
+
+    public ?string $badge = null;
+
+    public Color|ColorName|string|null $badgeColor = null;
+
+    public ?string $href = null;
+
+    public Action|ActionGroup|null $actions = null;
+
+    /** @var list<TreeNode> */
+    public array $children = [];
+
+    public bool $hasChildren = false;
+
+    public bool $disabled = false;
+
+    private function __construct(
+        public readonly string $id,
+        public readonly string $label,
+    ) {}
+
+    public static function make(string $id, string $label): self
+    {
+        return new self($id, $label);
+    }
+
+    public function icon(string $icon): self
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    public function badge(string $badge, Color|ColorName|string|null $color = null): self
+    {
+        $this->badge = $badge;
+        $this->badgeColor = $color;
+
+        return $this;
+    }
+
+    public function href(string $href): self
+    {
+        $this->href = $href;
+
+        return $this;
+    }
+
+    public function action(Action $action): self
+    {
+        $this->actions = $action;
+
+        return $this;
+    }
+
+    public function actions(ActionGroup $group): self
+    {
+        $this->actions = $group;
+
+        return $this;
+    }
+
+    /** @param  list<Component>  $components */
+    public function schema(array $components): self
+    {
+        $this->schema = $components;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<TreeNode|array<string, mixed>>  $children
+     */
+    public function children(array $children): self
+    {
+        $this->children = self::expand($children);
+
+        return $this;
+    }
+
+    public function hasChildren(bool $hasChildren = true): self
+    {
+        $this->hasChildren = $hasChildren;
+
+        return $this;
+    }
+
+    public function disabled(bool $disabled = true): self
+    {
+        $this->disabled = $disabled;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<TreeNode|array<string, mixed>>  $nodes
+     * @return list<TreeNode>
+     */
+    public static function expand(array $nodes): array
+    {
+        return array_map(
+            static fn (TreeNode|array $node): TreeNode => $node instanceof self ? $node : self::fromArray($node),
+            $nodes,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $node
+     */
+    private static function fromArray(array $node): self
+    {
+        $tree = self::make((string) $node['id'], (string) $node['label']);
+
+        foreach (['icon', 'badge', 'href'] as $key) {
+            if (isset($node[$key])) {
+                $tree->{$key} = (string) $node[$key];
+            }
+        }
+
+        if (! empty($node['children'])) {
+            $tree->children($node['children']);
+        }
+
+        if (! empty($node['hasChildren'])) {
+            $tree->hasChildren(true);
+        }
+
+        if (! empty($node['disabled'])) {
+            $tree->disabled(true);
+        }
+
+        return $tree;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = $this->serialiseShallow();
+
+        if ($this->children !== []) {
+            $data['children'] = array_map(static fn (TreeNode $child): array => $child->jsonSerialize(), $this->children);
+        }
+
+        return $data;
+    }
+
+    /**
+     * This node's own fields without its children, so a depth-aware walk (see
+     * Tree) can serialize each level exactly once.
+     *
+     * @return array<string, mixed>
+     */
+    public function serialiseShallow(): array
+    {
+        $data = [
+            'id' => $this->id,
+            'label' => $this->label,
+            'schema' => array_map(
+                static fn (Component $component): array => $component->jsonSerialize(),
+                $this->compiledSchema(),
+            ),
+        ];
+
+        if ($this->href !== null) {
+            $data['href'] = $this->href;
+        }
+
+        if ($this->disabled) {
+            $data['disabled'] = true;
+        }
+
+        if ($this->hasChildren) {
+            $data['hasChildren'] = true;
+        }
+
+        return $data;
+    }
+
+    /** @return list<Component> */
+    private function compiledSchema(): array
+    {
+        if ($this->schema !== null) {
+            return $this->schema;
+        }
+
+        $schema = [];
+
+        if ($this->icon !== null) {
+            $schema[] = Icon::make($this->icon)->class('size-lt-icon-md shrink-0');
+        }
+
+        $schema[] = $this->href !== null && ! $this->disabled
+            ? Link::make($this->label)->href($this->href)
+            : Text::make($this->label);
+
+        if ($this->badge !== null) {
+            $badge = Badge::make($this->badge);
+
+            if ($this->badgeColor !== null) {
+                $badge->color($this->badgeColor);
+            }
+
+            $schema[] = $badge;
+        }
+
+        if ($this->actions !== null) {
+            $schema[] = Stack::make()
+                ->direction(StackDirection::Row)
+                ->width(Width::Auto)
+                ->float(Side::End)
+                ->schema([$this->actions]);
+        }
+
+        return $schema;
+    }
+}

--- a/packages/tree/src/TreeRegistry.php
+++ b/packages/tree/src/TreeRegistry.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\DefinitionRegistry;
+
+/**
+ * @extends DefinitionRegistry<TreeDefinition>
+ */
+final class TreeRegistry extends DefinitionRegistry
+{
+    /**
+     * One level of the tree for the lazy endpoint: the roots when no parent
+     * is given, otherwise the immediate children of `?parent=`.
+     *
+     * @return array{nodes: list<array<string, mixed>>}
+     */
+    public function response(string $key, Request $request, ?TreeDefinition $definition = null): array
+    {
+        $definition ??= $this->resolve($key);
+        $source = $definition->source();
+
+        if ($source instanceof EloquentTreeSource) {
+            $source->lazy();
+        }
+
+        $parent = trim((string) $request->query('parent', ''));
+        $nodes = $parent === '' ? $source->roots() : $source->children($parent);
+        $nodes = is_array($nodes) ? array_values($nodes) : iterator_to_array($nodes, false);
+
+        return ['nodes' => array_map($this->serialiseLevelNode(...), $nodes)];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialiseLevelNode(TreeNode $node): array
+    {
+        $data = $node->serialiseShallow();
+
+        if ($node->children !== []) {
+            $data['hasChildren'] = true;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  class-string<TreeDefinition>  $tree
+     * @param  array<string, mixed>  $context
+     */
+    public function component(string $tree, array $context = []): Tree
+    {
+        return $this->gatedComponent(
+            $tree,
+            fn (string $key): Tree => Tree::make($key),
+            fn (TreeDefinition $definition, Tree $component, string $key): Tree => $component
+                ->id($key)
+                ->endpoint($this->endpointFor($key))
+                ->source($definition->source()),
+            $context,
+        );
+    }
+
+    protected function definitionClass(): string
+    {
+        return TreeDefinition::class;
+    }
+
+    public function attributeClass(): string
+    {
+        return AsTree::class;
+    }
+
+    protected function name(): string
+    {
+        return 'tree';
+    }
+
+    public function group(): string
+    {
+        return 'trees';
+    }
+}

--- a/packages/tree/src/TreeServiceProvider.php
+++ b/packages/tree/src/TreeServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
+use Lattice\Lattice\Ui\UiServiceProvider;
+
+final class TreeServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        $this->app->register(UiServiceProvider::class);
+
+        DiscoveryKinds::register('trees', AsTree::class);
+
+        $this->app->singleton(TreeRegistry::class);
+    }
+
+    public function boot(): void
+    {
+        // Registered directly on the loader rather than via loadTranslationsFrom():
+        // the i18next route resolves only the translation loader, never the
+        // translator, so the deferred loadTranslationsFrom() callback would never fire.
+        $this->app->make('translation.loader')->addNamespace('tree', __DIR__.'/../lang');
+
+        // Core's routes file has no contribution seam, so the package registers
+        // its endpoint itself, mirroring core's group conventions
+        // (config lattice.trees.{middleware,endpoint}).
+        Route::middleware(config('lattice.trees.middleware', ['web', 'auth']))
+            ->get((string) config('lattice.trees.endpoint', 'lattice/trees/{tree}'), TreeController::class)
+            ->where('tree', '.*')
+            ->name('lattice.trees.show');
+    }
+}

--- a/packages/tree/src/TreeSource.php
+++ b/packages/tree/src/TreeSource.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree;
+
+/**
+ * Where a tree's nodes come from. The package ships a callback and an Eloquent
+ * source; implement this for any other backing store. Keeps the Tree component
+ * free of persistence concerns.
+ */
+interface TreeSource
+{
+    /** @return iterable<int, TreeNode> */
+    public function roots(): iterable;
+
+    /** @return iterable<int, TreeNode> */
+    public function children(string $parentId): iterable;
+}

--- a/packages/tree/testbench.yaml
+++ b/packages/tree/testbench.yaml
@@ -1,0 +1,26 @@
+laravel: '@testbench'
+
+env:
+  - DB_CONNECTION=sqlite
+
+migrations:
+  - workbench/database/migrations
+
+workbench:
+  start: '/tree'
+  welcome: false
+  build:
+    - create-sqlite-db
+    - migrate:fresh:
+        --force: true
+    - db:seed:
+        --class: Workbench\App\Seeders\DatabaseSeeder
+        --force: true
+  discovers:
+    views: true
+
+providers:
+  - Inertia\ServiceProvider
+  - Lattice\Lattice\LatticeServiceProvider
+  - Lattice\Tree\TreeServiceProvider
+  - Workbench\App\Providers\WorkbenchServiceProvider

--- a/packages/tree/tests/Browser/LazyTreeTest.php
+++ b/packages/tree/tests/Browser/LazyTreeTest.php
@@ -1,0 +1,141 @@
+<?php
+declare(strict_types=1);
+
+use Workbench\App\Models\Category;
+
+function seedLazyCategories(): Category
+{
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+    $clothing = Category::factory()->create(['name' => 'Clothing']);
+    Category::factory()->childOf($clothing)->create(['name' => 'Men']);
+    Category::factory()->create(['name' => 'Books']);
+
+    return $electronics;
+}
+
+function categoryId(string $name): string
+{
+    return (string) Category::query()->where('name', $name)->value('id');
+}
+
+it('fetches and reveals children when an unloaded node expands', function (): void {
+    $electronics = seedLazyCategories();
+
+    $page = visit('/tree-lazy')
+        ->assertSee('Electronics')
+        ->assertNotPresent('[data-test="tree-node-'.categoryId('Laptops').'"]')
+        ->click('[data-test="tree-node-'.$electronics->getKey().'-toggle"]');
+
+    assertPresentEventually($page, '[data-test="tree-node-'.categoryId('Laptops').'"]');
+
+    $page
+        ->assertAriaAttribute('[data-test="tree-node-'.$electronics->getKey().'"]', 'expanded', 'true')
+        ->assertNoJavaScriptErrors();
+});
+
+it('fetches on ArrowRight and moves focus into the loaded child on the second press', function (): void {
+    $electronics = seedLazyCategories();
+    $electronicsNode = '[data-test="tree-node-'.$electronics->getKey().'"]';
+    $laptopsNode = '[data-test="tree-node-'.categoryId('Laptops').'"]';
+
+    $page = visit('/tree-lazy')
+        ->keys($electronicsNode, ['ArrowRight']);
+
+    assertPresentEventually($page, $laptopsNode);
+
+    $page->keys($electronicsNode, ['ArrowRight']);
+
+    retryUntil(function () use ($page, $laptopsNode): void {
+        $page->assertAttribute($laptopsNode, 'tabindex', '0');
+    });
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('loads defaultExpanded nodes beyond the eager depth on mount', function (): void {
+    seedLazyCategories();
+
+    $page = visit('/tree-lazy-expanded');
+
+    assertPresentEventually($page, '[data-test="tree-node-'.categoryId('Laptops').'"]');
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('restores remembered expansion after a reload by refetching', function (): void {
+    seedLazyCategories();
+    $clothingId = categoryId('Clothing');
+    $menNode = '[data-test="tree-node-'.categoryId('Men').'"]';
+
+    $page = visit('/tree-lazy-expanded')
+        ->click('[data-test="tree-node-'.$clothingId.'-toggle"]');
+
+    assertPresentEventually($page, $menNode);
+
+    $page->navigate('/tree-lazy-expanded');
+
+    assertPresentEventually($page, $menNode);
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('collapses the node when the sealed ref has expired', function (): void {
+    $electronics = seedLazyCategories();
+    $electronicsNode = '[data-test="tree-node-'.$electronics->getKey().'"]';
+
+    // visit() navigates lazily, on the first awaited interaction — the
+    // assertion forces the page (and its sealed ref) to exist before the
+    // clock moves, otherwise the ref would be minted with the traveled time.
+    $page = visit('/tree-lazy')->assertSee('Electronics');
+
+    $this->travel((int) config('lattice.security.ref_lifetime', 30) + 1)->minutes();
+
+    $page->click('[data-test="tree-node-'.$electronics->getKey().'-toggle"]');
+
+    retryUntil(function () use ($page, $electronicsNode): void {
+        $page->assertAriaAttribute($electronicsNode, 'expanded', 'false');
+    });
+
+    $page->assertNotPresent('[data-test="tree-node-'.categoryId('Laptops').'"]');
+});
+
+it('keeps the node collapsed when the fetch is rejected', function (): void {
+    $electronics = seedLazyCategories();
+    $electronicsNode = '[data-test="tree-node-'.$electronics->getKey().'"]';
+
+    $page = visit('/tree-lazy');
+
+    $page->script(<<<'JS'
+        () => {
+            const original = window.fetch;
+            window.fetch = (input, init) =>
+                String(input).includes('/lattice/trees/')
+                    ? Promise.reject(new TypeError('injected network failure'))
+                    : original(input, init);
+        }
+    JS);
+
+    $page->click('[data-test="tree-node-'.$electronics->getKey().'-toggle"]');
+
+    retryUntil(function () use ($page, $electronicsNode): void {
+        $page->assertAriaAttribute($electronicsNode, 'expanded', 'false');
+    });
+
+    $page->assertNotPresent('[data-test="tree-node-'.categoryId('Laptops').'"]');
+});
+
+it('fetches the roots for a lazy skeleton page', function (): void {
+    seedLazyCategories();
+
+    $page = visit('/tree-lazy-skeleton');
+
+    assertSeeEventually($page, 'Electronics');
+
+    $page
+        ->assertSee('Books')
+        ->assertSee('Clothing')
+        ->assertAttribute('[data-test="tree-node-'.categoryId('Books').'"]', 'tabindex', '0')
+        ->assertNoJavaScriptErrors();
+});

--- a/packages/tree/tests/Browser/TreeSmokeTest.php
+++ b/packages/tree/tests/Browser/TreeSmokeTest.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+it('renders the tree demo page without javascript errors', function (): void {
+    $page = visit('/tree');
+
+    $page->assertSee('Electronics')
+        ->assertSee('Documents')
+        ->assertPresent('[role="tree"]')
+        ->assertPresent('[data-test="tree-node-electronics"]')
+        ->assertNoJavaScriptErrors();
+});

--- a/packages/tree/tests/Browser/TreeTest.php
+++ b/packages/tree/tests/Browser/TreeTest.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+it('renders the tree demo with categories, active state, and row actions', function (): void {
+    visit('/tree')
+        ->assertSee('Electronics')
+        ->assertSee('Laptops')
+        ->assertSee('Phones')
+        ->assertSee('Clothing')
+        ->assertSee('Documents')
+        ->assertSee('Furniture')
+        ->assertSee('Help')
+        ->assertNotPresent('[data-test="tree-node-clothing-men"]')
+        ->assertAriaAttribute('[data-test="tree-node-electronics-phones"]', 'selected', 'true')
+        ->click('[data-test="tree-documents-actions"]')
+        ->assertPresent('[data-test="action-tree-documents-rename"]')
+        ->assertPresent('[data-test="action-tree-documents-archive"]')
+        ->assertSee('Rename')
+        ->assertSee('Archive')
+        ->assertNoJavaScriptErrors();
+});
+
+it('expands a collapsed subtree and reveals its children when the chevron is clicked', function (): void {
+    $page = visit('/tree')
+        ->assertNotPresent('[data-test="tree-node-clothing-men"]')
+        ->click('[data-test="tree-node-clothing-toggle"]');
+
+    assertPresentEventually($page, '[data-test="tree-node-clothing-men"]');
+
+    $page
+        ->assertSee('Men')
+        ->assertSee('Women')
+        ->assertAriaAttribute('[data-test="tree-node-clothing"]', 'expanded', 'true')
+        ->assertNoJavaScriptErrors();
+});
+
+it('moves focus with ArrowDown and expands a node with ArrowRight', function (): void {
+    $page = visit('/tree')
+        ->keys('[data-test="tree-node-electronics"]', ['ArrowDown']);
+
+    retryUntil(function () use ($page): void {
+        $page->assertAttribute('[data-test="tree-node-electronics-laptops"]', 'tabindex', '0');
+    });
+
+    $page
+        ->assertAttribute('[data-test="tree-node-electronics"]', 'tabindex', '-1')
+        ->assertNotPresent('[data-test="tree-node-clothing-men"]')
+        ->keys('[data-test="tree-node-clothing"]', ['ArrowRight']);
+
+    assertPresentEventually($page, '[data-test="tree-node-clothing-men"]');
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('navigates when an href node link is clicked', function (): void {
+    $page = visit('/tree')
+        ->click('[data-test="tree-node-clothing-toggle"]');
+
+    assertPresentEventually($page, '[data-test="tree-node-clothing-women"]');
+
+    $page
+        ->assertAttribute('[data-test="tree-node-clothing-women"] a', 'href', '/plain')
+        ->click('[data-test="tree-node-clothing-women"] a');
+
+    retryUntil(function () use ($page): void {
+        $page->assertPathIs('/plain');
+    });
+
+    $page
+        ->assertSee('Plain page')
+        ->assertNoJavaScriptErrors();
+});
+
+it('keeps row action controls out of the page tab order so Tab exits the tree cleanly', function (): void {
+    $page = visit('/tree')
+        ->assertAttribute('[data-test="tree-documents-actions"]', 'tabindex', '-1')
+        ->keys('[data-test="tree-node-electronics"]', ['Tab']);
+
+    $focusedInsideTree = $page->script(<<<'JS'
+        () => document.activeElement != null && document.activeElement.closest('[role="tree"]') != null
+    JS);
+
+    expect($focusedInsideTree)->toBeFalsy();
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('opens the info modal with Enter on the modal-action node and returns focus on close', function (): void {
+    $page = visit('/tree')
+        ->keys('[data-test="tree-node-electronics"]', ['End']);
+
+    retryUntil(function () use ($page): void {
+        $page->assertAttribute('[data-test="tree-node-help"]', 'tabindex', '0');
+    });
+
+    $page->keys('[data-test="tree-node-help"]', ['Enter']);
+
+    assertSeeEventually($page, 'Node info');
+
+    $page
+        ->assertSee('This modal was opened from a tree node action.')
+        ->click('[data-test="dialog-close"]');
+
+    assertDontSeeEventually($page, 'Node info');
+
+    retryUntil(function () use ($page): void {
+        $focusedTestId = $page->script(<<<'JS'
+            () => document.activeElement?.getAttribute('data-test') ?? null
+        JS);
+
+        expect($focusedTestId)->toBe('tree-node-help');
+    });
+
+    $page->assertNoJavaScriptErrors();
+});

--- a/packages/tree/tests/BrowserTestCase.php
+++ b/packages/tree/tests/BrowserTestCase.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree\Tests;
+
+use Pest\Browser\Playwright\Playwright;
+use RuntimeException;
+
+use function Orchestra\Testbench\package_path;
+
+abstract class BrowserTestCase extends TestCase
+{
+    private static bool $checkedWorkbenchManifest = false;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assertWorkbenchManifestExists();
+
+        // CI runners are slower than Playwright's tight 5s default, which
+        // intermittently trips browser actions/assertions under load.
+        Playwright::setTimeout(15_000);
+    }
+
+    /**
+     * The browser serves whatever the last `npm run build` produced; a missing
+     * manifest or a leftover dev-server marker would fail every test with
+     * blank pages, so fail fast with an actionable message instead.
+     */
+    private function assertWorkbenchManifestExists(): void
+    {
+        if (self::$checkedWorkbenchManifest) {
+            return;
+        }
+
+        $public = package_path('vendor/orchestra/testbench-core/laravel/public');
+        $manifest = $public.'/build/manifest.json';
+        $hot = $public.'/hot';
+
+        if (! is_file($manifest)) {
+            throw new RuntimeException("Missing workbench Vite manifest [{$manifest}]. Run `npm run build` before the browser suite (`composer test:browser` does this for you).");
+        }
+
+        if (is_file($hot)) {
+            throw new RuntimeException("Stale Vite hot file [{$hot}]. Delete it (a `composer serve` leftover), then rerun the browser suite.");
+        }
+
+        self::$checkedWorkbenchManifest = true;
+    }
+}

--- a/packages/tree/tests/Feature/EloquentTreeSourceTest.php
+++ b/packages/tree/tests/Feature/EloquentTreeSourceTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Lattice\Tree\EloquentTreeSource;
+use Lattice\Tree\Tree;
+use Lattice\Tree\TreeNode;
+use Workbench\App\Models\Category;
+
+it('resolves root categories ordered by label, flagging hasChildren for parents only', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->create(['name' => 'Books']);
+
+    $roots = EloquentTreeSource::make(Category::class)->roots();
+
+    expect(array_map(fn (TreeNode $node): array => [$node->label, $node->id, $node->hasChildren], $roots))->toBe([
+        ['Books', (string) Category::query()->where('name', 'Books')->value('id'), false],
+        ['Electronics', (string) $electronics->getKey(), true],
+    ]);
+});
+
+it('re-queries when the scope changes after a read', function (): void {
+    Category::factory()->create(['name' => 'Books']);
+    Category::factory()->create(['name' => 'Archive']);
+
+    $source = EloquentTreeSource::make(Category::class);
+    expect($source->roots())->toHaveCount(2);
+
+    $source->scope(fn ($query) => $query->where('name', 'Books'));
+
+    expect(array_map(fn (TreeNode $node): string => $node->label, $source->roots()))->toBe(['Books']);
+});
+
+it('resolves a category\'s immediate children ordered by label, flagging hasChildren for grandparents', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($electronics)->create(['name' => 'Cameras']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+
+    $children = EloquentTreeSource::make(Category::class)->children((string) $electronics->getKey());
+
+    expect(array_map(fn (TreeNode $node): array => [$node->label, $node->id, $node->hasChildren], $children))->toBe([
+        ['Cameras', (string) Category::query()->where('name', 'Cameras')->value('id'), false],
+        ['Laptops', (string) $laptops->getKey(), true],
+    ]);
+});
+
+it('serializes the whole hierarchy when wired through the Tree component', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+
+    $node = wire(Tree::make()->source(EloquentTreeSource::make(Category::class)));
+
+    $root = $node['props']['nodes'][0];
+    expect($root)->toMatchArray(['label' => 'Electronics', 'hasChildren' => true])
+        ->and($root['children'][0])->toMatchArray(['label' => 'Laptops', 'hasChildren' => true])
+        ->and($root['children'][0]['children'][0])->toMatchArray(['label' => 'Ultrabooks'])
+        ->and($root['children'][0]['children'][0])->not->toHaveKey('children');
+});
+
+it('applies a query scope to both roots and children', function (): void {
+    Category::factory()->create(['name' => 'Hidden Root']);
+    $visible = Category::factory()->create(['name' => 'Visible Root']);
+    Category::factory()->childOf($visible)->create(['name' => 'Hidden Child']);
+    Category::factory()->childOf($visible)->create(['name' => 'Visible Child']);
+
+    $source = EloquentTreeSource::make(Category::class)->scope(fn ($query) => $query->where('name', 'like', 'Visible%'));
+
+    expect(array_map(fn (TreeNode $node): string => $node->label, $source->roots()))->toBe(['Visible Root'])
+        ->and(array_map(fn (TreeNode $node): string => $node->label, $source->children((string) $visible->getKey())))->toBe(['Visible Child']);
+});
+
+it('queries one level per call in lazy mode instead of loading the table', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+    Category::factory()->create(['name' => 'Books']);
+
+    $source = EloquentTreeSource::make(Category::class)->lazy();
+
+    DB::enableQueryLog();
+    $roots = iterator_to_array($source->roots());
+
+    expect(DB::getQueryLog())->toHaveCount(1)
+        ->and(array_map(fn (TreeNode $node): array => [$node->label, $node->hasChildren], $roots))
+        ->toBe([['Books', false], ['Electronics', true]]);
+
+    DB::flushQueryLog();
+    $children = iterator_to_array($source->children((string) $electronics->getKey()));
+
+    expect(DB::getQueryLog())->toHaveCount(1)
+        ->and(array_map(fn (TreeNode $node): array => [$node->label, $node->hasChildren], $children))
+        ->toBe([['Laptops', true]]);
+});
+
+it('applies the scope to lazy level queries and the has-children probe', function (): void {
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    Category::factory()->childOf($electronics)->create(['name' => 'Hidden']);
+    $clothing = Category::factory()->create(['name' => 'Clothing']);
+    Category::factory()->childOf($clothing)->create(['name' => 'Men']);
+
+    $source = EloquentTreeSource::make(Category::class)
+        ->lazy()
+        ->scope(fn ($query) => $query->where('name', '!=', 'Hidden'));
+
+    $roots = iterator_to_array($source->roots());
+
+    expect(array_map(fn (TreeNode $node): array => [$node->label, $node->hasChildren], $roots))
+        ->toBe([['Clothing', true], ['Electronics', false]])
+        ->and(iterator_to_array($source->children((string) $electronics->getKey())))->toBe([]);
+});

--- a/packages/tree/tests/Feature/TreeEndpointTest.php
+++ b/packages/tree/tests/Feature/TreeEndpointTest.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Tree\Tree;
+use Workbench\App\Models\Category;
+use Workbench\App\Trees\CategoryTree;
+use Workbench\App\Trees\ScopedCategoryTree;
+
+use function Pest\Laravel\getJson;
+
+it('serves one level of children for a sealed tree', function (): void {
+    $electronics = seedCategoryTree();
+    $tree = $this->sealTree(Tree::use(CategoryTree::class)->lazy());
+
+    $response = getJson(
+        $tree['props']['endpoint'].'?parent='.$electronics->getKey(),
+        ['X-Lattice-Ref' => $tree['props']['ref']],
+    );
+
+    $response->assertOk();
+
+    $laptopsId = (string) Category::query()->where('name', 'Laptops')->value('id');
+
+    $response->assertExactJson([
+        'nodes' => [
+            [
+                'id' => $laptopsId,
+                'label' => 'Laptops',
+                'schema' => [
+                    [
+                        'type' => 'text',
+                        'props' => [
+                            'text' => 'Laptops',
+                            'align' => null,
+                            'color' => null,
+                            'copyable' => false,
+                            'size' => 'md',
+                        ],
+                    ],
+                ],
+                'hasChildren' => true,
+            ],
+        ],
+    ]);
+});
+
+it('serves the roots when no parent is given', function (): void {
+    seedCategoryTree();
+    $tree = $this->sealTree(Tree::use(CategoryTree::class)->lazy());
+
+    $response = getJson($tree['props']['endpoint'], ['X-Lattice-Ref' => $tree['props']['ref']]);
+
+    $response->assertOk();
+    expect(array_column($response->json('nodes'), 'label'))->toBe(['Books', 'Electronics']);
+});
+
+it('rejects a request without a ref', function (): void {
+    seedCategoryTree();
+    $tree = $this->sealTree(Tree::use(CategoryTree::class)->lazy());
+
+    getJson($tree['props']['endpoint'])->assertForbidden();
+});
+
+it('rejects a forged ref', function (): void {
+    seedCategoryTree();
+    $tree = $this->sealTree(Tree::use(CategoryTree::class)->lazy());
+
+    getJson($tree['props']['endpoint'], ['X-Lattice-Ref' => 'forged'])->assertForbidden();
+});
+
+it('rejects an expired ref', function (): void {
+    seedCategoryTree();
+    $tree = $this->sealTree(Tree::use(CategoryTree::class)->lazy());
+
+    $this->travel(config('lattice.security.ref_lifetime', 30) + 1)->minutes();
+
+    getJson($tree['props']['endpoint'], ['X-Lattice-Ref' => $tree['props']['ref']])->assertForbidden();
+});
+
+it('rejects a ref sealed for a different tree', function (): void {
+    seedCategoryTree();
+    $tree = $this->sealTree(Tree::use(CategoryTree::class)->lazy());
+
+    $foreign = app(SignsComponentReferences::class)->seal('tree', 'denied', []);
+
+    getJson($tree['props']['endpoint'], ['X-Lattice-Ref' => $foreign])->assertForbidden();
+});
+
+it('returns 404 for a sealed but unregistered tree key', function (): void {
+    $ref = app(SignsComponentReferences::class)->seal('tree', 'ghost', []);
+
+    getJson('/lattice/trees/ghost', ['X-Lattice-Ref' => $ref])->assertNotFound();
+});
+
+it('denies when the definition rejects authorization', function (): void {
+    $ref = app(SignsComponentReferences::class)->seal('tree', 'denied', []);
+
+    getJson('/lattice/trees/denied', ['X-Lattice-Ref' => $ref])->assertForbidden();
+});
+
+it('re-applies the sealed context on the endpoint', function (): void {
+    Category::factory()->create(['name' => 'Electronics']);
+    Category::factory()->create(['name' => 'Books']);
+
+    $tree = $this->sealTree(
+        Tree::use(ScopedCategoryTree::class, ['except' => 'Books'])->lazy(),
+    );
+
+    $response = getJson($tree['props']['endpoint'], ['X-Lattice-Ref' => $tree['props']['ref']]);
+
+    expect(array_column($response->json('nodes'), 'label'))->toBe(['Electronics']);
+});

--- a/packages/tree/tests/Feature/TreeRegistryTest.php
+++ b/packages/tree/tests/Feature/TreeRegistryTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Core\Discovery\DiscoveryKinds;
+use Lattice\Lattice\Core\Exceptions\UnknownComponent;
+use Lattice\Tree\AsTree;
+use Lattice\Tree\EloquentTreeSource;
+use Lattice\Tree\TreeRegistry;
+use Workbench\App\Trees\CategoryTree;
+
+it('registers the trees discovery kind', function (): void {
+    expect(DiscoveryKinds::components())->toHaveKey('trees', AsTree::class);
+});
+
+it('resolves a discovered tree definition by its attribute key', function (): void {
+    expect(app(TreeRegistry::class)->resolve('categories'))->toBeInstanceOf(CategoryTree::class);
+});
+
+it('resolves an explicitly registered definition', function (): void {
+    $registry = app(TreeRegistry::class);
+    $registry->register(CategoryTree::class);
+
+    expect($registry->resolve('categories'))->toBeInstanceOf(CategoryTree::class);
+});
+
+it('throws UnknownComponent for an unknown key', function (): void {
+    app(TreeRegistry::class)->resolve('nope');
+})->throws(UnknownComponent::class);
+
+it('builds the tree endpoint from the group convention', function (): void {
+    expect(app(TreeRegistry::class)->endpointFor('categories'))
+        ->toBe('/lattice/trees/categories');
+});
+
+it('exposes the definition source', function (): void {
+    $definition = app(TreeRegistry::class)->resolve('categories');
+
+    expect($definition->source())->toBeInstanceOf(EloquentTreeSource::class);
+});

--- a/packages/tree/tests/Feature/TreeTest.php
+++ b/packages/tree/tests/Feature/TreeTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Tree\CallbackTreeSource;
+use Lattice\Tree\Tree;
+use Lattice\Tree\TreeNode;
+
+it('serializes an eager node tree with defaults', function (): void {
+    $node = wire(
+        Tree::make()->nodes([
+            TreeNode::make('1', 'Electronics')->children([TreeNode::make('2', 'Laptops')]),
+        ]),
+    );
+
+    expect($node['type'])->toBe('tree')
+        ->and($node['props']['nodes'][0])->toMatchArray(['id' => '1', 'label' => 'Electronics'])
+        ->and($node['props']['nodes'][0]['children'][0])->toMatchArray(['id' => '2', 'label' => 'Laptops'])
+        ->and($node['props']['rememberState'])->toBeFalse()
+        ->and($node['props']['defaultExpanded'])->toBe([]);
+});
+
+it('serializes activeId, defaultExpanded, and rememberState', function (): void {
+    $node = wire(
+        Tree::make()->nodes([TreeNode::make('1', 'A')])->activeId('1')->defaultExpanded(['1'])->rememberState(),
+    );
+
+    expect($node['props'])->toMatchArray([
+        'activeId' => '1', 'defaultExpanded' => ['1'], 'rememberState' => true,
+    ]);
+});
+
+it('serializes source children recursively for hasChildren nodes', function (): void {
+    $childrenByParent = [
+        'root' => [TreeNode::make('child', 'Child')->hasChildren()],
+        'child' => [TreeNode::make('grandchild', 'Grandchild')],
+    ];
+
+    $node = wire(
+        Tree::make()->source(new CallbackTreeSource(
+            roots: fn (): array => [TreeNode::make('root', 'Root')->hasChildren()],
+            children: fn (string $parentId): array => $childrenByParent[$parentId] ?? [],
+        )),
+    );
+
+    $root = $node['props']['nodes'][0];
+    expect($root)->toMatchArray(['id' => 'root', 'hasChildren' => true])
+        ->and($root['children'][0])->toMatchArray(['id' => 'child'])
+        ->and($root['children'][0]['children'][0])->toMatchArray(['id' => 'grandchild', 'label' => 'Grandchild']);
+});
+
+it('stops fetching source children at the depth cap so cyclic data terminates', function (): void {
+    $fetches = 0;
+
+    $node = wire(
+        Tree::make()->source(new CallbackTreeSource(
+            roots: fn (): array => [TreeNode::make('n0', 'Root')->hasChildren()],
+            children: function (string $parentId) use (&$fetches): array {
+                $fetches++;
+
+                return [TreeNode::make("n{$fetches}", 'Child')->hasChildren()];
+            },
+        )),
+    );
+
+    $boundary = $node['props']['nodes'][0];
+    while (isset($boundary['children'])) {
+        $boundary = $boundary['children'][0];
+    }
+
+    expect($fetches)->toBe(50)
+        ->and($boundary)->toMatchArray(['id' => 'n50', 'hasChildren' => true]);
+});
+
+it('truncates eager children at the depth cap with a hasChildren marker', function (): void {
+    $subtree = TreeNode::make('leaf', 'Leaf');
+    foreach (range(51, 0) as $level) {
+        $subtree = TreeNode::make("n{$level}", "Level {$level}")->children([$subtree]);
+    }
+
+    $node = wire(Tree::make()->nodes([$subtree]));
+
+    $boundary = $node['props']['nodes'][0];
+    while (isset($boundary['children'])) {
+        $boundary = $boundary['children'][0];
+    }
+
+    expect($boundary)->toMatchArray(['id' => 'n50', 'hasChildren' => true]);
+});
+
+it('serves the package translations under the tree namespace', function (): void {
+    expect(__('tree::tree.expand', ['label' => 'Electronics']))->toBe('Expand Electronics');
+});

--- a/packages/tree/tests/Feature/TreeUseTest.php
+++ b/packages/tree/tests/Feature/TreeUseTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Tree\Tree;
+use Lattice\Tree\TreeNode;
+use Workbench\App\Trees\CategoryTree;
+use Workbench\App\Trees\DeniedTree;
+
+it('builds an interactive tree from a definition', function (): void {
+    seedCategoryTree();
+
+    $node = wire(Tree::use(CategoryTree::class, ['tenant' => 7]));
+
+    expect($node['type'])->toBe('tree')
+        ->and($node['props']['endpoint'])->toBe('/lattice/trees/categories')
+        ->and($node['props']['ref'])->toBeString()
+        ->and(array_column($node['props']['nodes'], 'label'))->toBe(['Books', 'Electronics'])
+        ->and($node['props']['nodes'][1]['children'][0]['children'][0]['label'])->toBe('Ultrabooks');
+});
+
+it('serializes only the roots for lazy eagerDepth 1', function (): void {
+    seedCategoryTree();
+
+    $node = wire(Tree::use(CategoryTree::class)->lazy());
+
+    expect($node['props']['lazy'])->toBeTrue()
+        ->and(array_column($node['props']['nodes'], 'label'))->toBe(['Books', 'Electronics'])
+        ->and($node['props']['nodes'][1])->toMatchArray(['hasChildren' => true])
+        ->and($node['props']['nodes'][1])->not->toHaveKey('children')
+        ->and($node['props']['nodes'][0])->not->toHaveKey('hasChildren');
+});
+
+it('serializes two levels for lazy eagerDepth 2, marking the boundary', function (): void {
+    seedCategoryTree();
+
+    $node = wire(Tree::use(CategoryTree::class)->lazy(2));
+
+    $laptops = $node['props']['nodes'][1]['children'][0];
+
+    expect($laptops)->toMatchArray(['label' => 'Laptops', 'hasChildren' => true])
+        ->and($laptops)->not->toHaveKey('children');
+});
+
+it('serializes a skeleton without nodes for lazy eagerDepth 0', function (): void {
+    seedCategoryTree();
+
+    $node = wire(Tree::use(CategoryTree::class)->lazy(0));
+
+    expect($node['props']['nodes'])->toBe([])
+        ->and($node['props']['lazy'])->toBeTrue()
+        ->and($node['props']['ref'])->toBeString();
+});
+
+it('throws when lazy is called on a tree without a definition', function (): void {
+    Tree::make('inline')->nodes([TreeNode::make('1', 'A')])->lazy();
+})->throws(LogicException::class);
+
+it('rejects a negative eager depth', function (): void {
+    Tree::use(CategoryTree::class)->lazy(-1);
+})->throws(InvalidArgumentException::class);
+
+it('hides the tree when the definition denies authorization', function (): void {
+    expect(Tree::use(DeniedTree::class)->shouldRender())->toBeFalse();
+});
+
+it('keeps interactive props inert on plain eager trees', function (): void {
+    $node = wire(Tree::make()->nodes([TreeNode::make('1', 'A')]));
+
+    expect($node['props']['ref'])->toBeNull()
+        ->and($node['props']['endpoint'])->toBeNull()
+        ->and($node['props']['lazy'])->toBeFalse();
+});

--- a/packages/tree/tests/Feature/WorkbenchTreePageTest.php
+++ b/packages/tree/tests/Feature/WorkbenchTreePageTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+it('serves the workbench tree demo page', function (): void {
+    withoutVite();
+
+    $response = get('/tree');
+
+    $response->assertSuccessful();
+    $response->assertInertia(
+        fn (Assert $page): Assert => $page
+            ->component('lattice/page', shouldExist: false)
+            ->where('lattice', fn (mixed $lattice): bool => str_contains(json_encode($lattice, JSON_THROW_ON_ERROR), '"type":"tree"')),
+    );
+});
+
+it('serves the plain page the demo tree links to', function (): void {
+    withoutVite();
+
+    get('/plain')->assertSuccessful();
+});
+
+it('serves the lazy tree demo page with interactive props', function (): void {
+    withoutVite();
+
+    $response = get('/tree-lazy');
+
+    $response->assertSuccessful();
+    $response->assertInertia(
+        fn (Assert $page): Assert => $page
+            ->component('lattice/page', shouldExist: false)
+            ->where('lattice', function (mixed $lattice): bool {
+                $wire = json_encode($lattice, JSON_THROW_ON_ERROR);
+
+                return str_contains($wire, '"lazy":true')
+                    && str_contains($wire, '\/lattice\/trees\/categories');
+            }),
+    );
+});

--- a/packages/tree/tests/Pest.php
+++ b/packages/tree/tests/Pest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Tree\Tests\BrowserTestCase;
+use Lattice\Tree\Tests\TestCase;
+
+require_once __DIR__.'/Support/Browser.php';
+require_once __DIR__.'/Support/Fixtures.php';
+
+uses(TestCase::class)->in('Feature');
+uses(BrowserTestCase::class)->in('Browser');
+
+/**
+ * @return array<array-key, mixed>
+ */
+function wire(mixed $value): array
+{
+    return json_decode(json_encode($value, JSON_THROW_ON_ERROR), true);
+}

--- a/packages/tree/tests/Support/Browser.php
+++ b/packages/tree/tests/Support/Browser.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+use Pest\Browser\Api\AwaitableWebpage;
+use Pest\Browser\Api\PendingAwaitablePage;
+use Pest\Browser\Api\Webpage;
+
+/**
+ * Retries browser assertions while asynchronous UI work settles.
+ *
+ * @param  Closure(): void  $assert
+ * @param  (Closure(): void)|null  $between
+ */
+function retryUntil(Closure $assert, int $attempts = 20, int $sleepMicroseconds = 500_000, ?Closure $between = null): void
+{
+    foreach (range(1, $attempts) as $attempt) {
+        try {
+            $assert();
+
+            return;
+        } catch (Throwable $exception) {
+            if ($attempt === $attempts) {
+                throw $exception;
+            }
+
+            $between?->__invoke();
+
+            usleep($sleepMicroseconds);
+        }
+    }
+}
+
+function assertSeeEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $page, string|int|float $text): void
+{
+    retryUntil(function () use ($page, $text): void {
+        $page->assertSee($text);
+    });
+}
+
+function assertDontSeeEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $page, string|int|float $text): void
+{
+    retryUntil(function () use ($page, $text): void {
+        $page->assertDontSee($text);
+    });
+}
+
+function assertPresentEventually(AwaitableWebpage|PendingAwaitablePage|Webpage $page, string $selector): void
+{
+    retryUntil(function () use ($page, $selector): void {
+        $page->assertPresent($selector);
+    });
+}

--- a/packages/tree/tests/Support/Fixtures.php
+++ b/packages/tree/tests/Support/Fixtures.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+use Workbench\App\Models\Category;
+
+/**
+ * Three levels under Electronics plus a root leaf — the shape the wire,
+ * endpoint, and lazy-depth tests all assert against.
+ */
+function seedCategoryTree(): Category
+{
+    $electronics = Category::factory()->create(['name' => 'Electronics']);
+    $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+    Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+    Category::factory()->create(['name' => 'Books']);
+
+    return $electronics;
+}

--- a/packages/tree/tests/TestCase.php
+++ b/packages/tree/tests/TestCase.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tree\Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\ServiceProvider as InertiaServiceProvider;
+use Lattice\Lattice\LatticeServiceProvider;
+use Lattice\Lattice\Support\Testing\InteractsWithLatticeComponents;
+use Lattice\Tree\TreeServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+use Workbench\App\WorkbenchConfig;
+
+abstract class TestCase extends BaseTestCase
+{
+    use InteractsWithLatticeComponents;
+    use RefreshDatabase;
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite.database', ':memory:');
+
+        foreach (WorkbenchConfig::lattice() as $key => $value) {
+            $app['config']->set($key, $value);
+        }
+        $app['config']->set('view.paths', [
+            ...$app['config']->get('view.paths', []),
+            dirname(__DIR__).'/workbench/resources/views',
+        ]);
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            InertiaServiceProvider::class,
+            LatticeServiceProvider::class,
+            TreeServiceProvider::class,
+        ];
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        $this->loadMigrationsFrom(dirname(__DIR__).'/workbench/database/migrations');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function sealTree(mixed $component): array
+    {
+        return $this->sealLatticeComponent($component);
+    }
+}

--- a/packages/tree/tests/Unit/CallbackTreeSourceTest.php
+++ b/packages/tree/tests/Unit/CallbackTreeSourceTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Tree\CallbackTreeSource;
+use Lattice\Tree\TreeNode;
+
+it('resolves roots and children from closures', function (): void {
+    $source = new CallbackTreeSource(
+        roots: fn (): array => [TreeNode::make('1', 'Root')->hasChildren()],
+        children: fn (string $parentId): array => [TreeNode::make("{$parentId}.1", "Child of {$parentId}")],
+    );
+
+    expect($source->roots()[0]->jsonSerialize())->toMatchArray(['id' => '1', 'hasChildren' => true])
+        ->and($source->children('1')[0]->jsonSerialize())->toMatchArray(['id' => '1.1', 'label' => 'Child of 1']);
+});
+
+it('returns no children when no children closure is given', function (): void {
+    $source = new CallbackTreeSource(roots: fn (): array => []);
+
+    expect($source->children('1'))->toBe([]);
+});

--- a/packages/tree/tests/Unit/TreeNodeTest.php
+++ b/packages/tree/tests/Unit/TreeNodeTest.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Core\Color;
+use Lattice\Lattice\Core\Enums\ColorKind;
+use Lattice\Lattice\Ui\Components\Badge;
+use Lattice\Tree\TreeNode;
+
+it('serializes id, label and a default text schema', function () {
+    $data = TreeNode::make('n1', 'Docs')->serialiseShallow();
+
+    expect($data['id'])->toBe('n1')
+        ->and($data['label'])->toBe('Docs')
+        ->and($data['schema'])->toHaveCount(1)
+        ->and($data['schema'][0]['type'])->toBe('text')
+        ->and($data['schema'][0]['props']['text'])->toBe('Docs')
+        ->and($data)->not->toHaveKeys(['icon', 'badge', 'actions', 'href', 'disabled', 'hasChildren', 'children']);
+});
+
+it('compiles icon and badge conveniences into the schema in order', function () {
+    $schema = TreeNode::make('n1', 'Docs')->icon('folder')->badge('12', 'blue')->serialiseShallow()['schema'];
+
+    expect(array_column($schema, 'type'))->toBe(['icon', 'text', 'badge'])
+        ->and($schema[0]['props']['name'])->toBe('folder')
+        ->and($schema[2]['props']['label'])->toBe('12')
+        ->and($schema[2]['props']['color'])->toBeInstanceOf(Color::class)
+        ->and($schema[2]['props']['color']->kind)->toBe(ColorKind::Named)
+        ->and($schema[2]['props']['color']->value)->toBe('blue');
+});
+
+it('compiles the label as a link when href is set and not disabled', function () {
+    $schema = TreeNode::make('n1', 'Docs')->href('/docs')->serialiseShallow();
+
+    expect($schema['href'])->toBe('/docs')
+        ->and($schema['schema'][0]['type'])->toBe('link')
+        ->and($schema['schema'][0]['props']['label'])->toBe('Docs')
+        ->and($schema['schema'][0]['props']['href'])->toBe('/docs');
+});
+
+it('compiles the label as plain text when disabled, even with href', function () {
+    $schema = TreeNode::make('n1', 'Docs')->href('/docs')->disabled()->serialiseShallow()['schema'];
+
+    expect($schema[0]['type'])->toBe('text');
+});
+
+it('wraps actions in an end-floated row stack at the end of the schema', function () {
+    $node = TreeNode::make('n1', 'Docs')->action(Action::make('delete')->label('Delete'));
+    $schema = $node->serialiseShallow()['schema'];
+    $stack = end($schema);
+
+    expect($stack['type'])->toBe('stack')
+        ->and($stack['props']['float'])->toBe('end')
+        ->and($stack['schema'][0])->toBeInstanceOf(Action::class)
+        ->and($stack['schema'][0]->jsonSerialize()['type'])->toBe('action');
+});
+
+it('a custom schema replaces the composed default entirely', function () {
+    $data = TreeNode::make('n1', 'Docs')->icon('folder')
+        ->schema([Badge::make('custom')])
+        ->serialiseShallow();
+
+    expect($data['schema'])->toHaveCount(1)
+        ->and($data['schema'][0]['type'])->toBe('badge');
+});
+
+it('keeps children serialization recursive and sparse', function () {
+    $data = TreeNode::make('p', 'Parent')->children([
+        TreeNode::make('c', 'Child'),
+        ['id' => 'c2', 'label' => 'From array', 'icon' => 'file'],
+    ])->jsonSerialize();
+
+    expect($data['children'])->toHaveCount(2)
+        ->and($data['children'][1]['schema'][0]['type'])->toBe('icon');
+});
+
+it('marks a lazy boundary without emitting children', function () {
+    $lazy = TreeNode::make('9', 'Suppliers')->hasChildren();
+
+    expect($lazy->jsonSerialize())->toMatchArray(['hasChildren' => true])
+        ->and($lazy->jsonSerialize())->not->toHaveKey('children');
+});
+
+it('marks a disabled node', function () {
+    expect(TreeNode::make('5', 'Plain')->disabled()->serialiseShallow())
+        ->toMatchArray(['disabled' => true]);
+});
+
+it('normalizes an array of nodes and arrays via expand', function () {
+    $nodes = TreeNode::expand([
+        TreeNode::make('1', 'A'),
+        ['id' => '2', 'label' => 'B'],
+    ]);
+
+    expect($nodes)->toHaveCount(2)
+        ->and($nodes[1]->jsonSerialize())->toMatchArray(['id' => '2', 'label' => 'B']);
+});

--- a/packages/tree/tsconfig.json
+++ b/packages/tree/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["resources/js"]
+}

--- a/packages/tree/vite.config.ts
+++ b/packages/tree/vite.config.ts
@@ -1,0 +1,42 @@
+import inertia from "@inertiajs/vite";
+import { lattice } from "../../resources/js/vite.ts";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import laravel from "laravel-vite-plugin";
+import { defineConfig } from "vite";
+
+export default defineConfig(({ mode }) => ({
+  plugins:
+    mode === "plugin"
+      ? [react()]
+      : [
+          lattice({ icons: { dts: false } }),
+          laravel({
+            input: ["workbench/resources/css/app.css", "workbench/resources/js/app.tsx"],
+            publicDirectory: "vendor/orchestra/testbench-core/laravel/public",
+            buildDirectory: "build",
+            refresh: ["workbench/app/**", "workbench/resources/views/**", "resources/js/**"],
+          }),
+          inertia(),
+          react(),
+          tailwindcss(),
+        ],
+  ...(mode === "plugin"
+    ? {
+        build: {
+          outDir: "dist",
+          emptyOutDir: true,
+          minify: false,
+          lib: {
+            entry: "resources/js/plugin.ts",
+            formats: ["es"] as const,
+            fileName: "plugin",
+          },
+          rollupOptions: {
+            external: [/^@lattice-php\/lattice\/runtime$/, /^react(?:\/.*)?$/],
+            output: { codeSplitting: false },
+          },
+        },
+      }
+    : {}),
+}));

--- a/packages/tree/vitest.config.ts
+++ b/packages/tree/vitest.config.ts
@@ -1,0 +1,11 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    include: ["resources/js/**/*.test.{ts,tsx}"],
+    setupFiles: ["resources/js/test-setup.ts"],
+  },
+});

--- a/packages/tree/workbench/app/Actions/ShowTreeNodeInfoAction.php
+++ b/packages/tree/workbench/app/Actions/ShowTreeNodeInfoAction.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Actions;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Actions\ActionDefinition;
+use Lattice\Lattice\Actions\ActionResult;
+use Lattice\Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Lattice\Attributes\AsAction;
+
+#[AsAction('workbench.tree.show-node-info')]
+final class ShowTreeNodeInfoAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Show info')->icon('info');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success()->openModal('tree-node-info');
+    }
+}

--- a/packages/tree/workbench/app/Factories/CategoryFactory.php
+++ b/packages/tree/workbench/app/Factories/CategoryFactory.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Workbench\App\Models\Category;
+
+/** @extends Factory<Category> */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    /** @return array<string, mixed> */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->words(2, true),
+            'parent_id' => null,
+        ];
+    }
+
+    public function childOf(Category $parent): static
+    {
+        return $this->state(['parent_id' => $parent->getKey()]);
+    }
+}

--- a/packages/tree/workbench/app/Layouts/AppLayout.php
+++ b/packages/tree/workbench/app/Layouts/AppLayout.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Layouts;
+
+use Illuminate\Http\Request;
+use Lattice\Lattice\Attributes\AsLayout;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Layouts\Components\Menu;
+use Lattice\Lattice\Layouts\Components\MenuItem;
+use Lattice\Lattice\Layouts\Components\Outlet;
+use Lattice\Lattice\Layouts\Components\Sidebar;
+use Lattice\Lattice\Layouts\LayoutDefinition;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Lattice\Ui\Enums\StackDirection;
+use Lattice\Lattice\Ui\Enums\Width;
+use Workbench\App\Pages\ExpandedLazyTreePage;
+use Workbench\App\Pages\LazyTreePage;
+use Workbench\App\Pages\PlainPage;
+use Workbench\App\Pages\SkeletonLazyTreePage;
+use Workbench\App\Pages\TreePage;
+
+#[AsLayout('app')]
+final class AppLayout extends LayoutDefinition
+{
+    public function schema(PageSchema $schema, Request $request): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('app-shell')
+                ->direction(StackDirection::Row)
+                ->gap(Gap::None)
+                ->schema([
+                    Sidebar::make('app-sidebar')->items([
+                        Menu::make('sidebar')->items([
+                            MenuItem::fromPage(TreePage::class)->key('tree')->label('Tree'),
+                            MenuItem::fromPage(LazyTreePage::class)->key('tree-lazy')->label('Lazy tree'),
+                            MenuItem::fromPage(ExpandedLazyTreePage::class)->key('tree-lazy-expanded')->label('Lazy, pre-expanded'),
+                            MenuItem::fromPage(SkeletonLazyTreePage::class)->key('tree-lazy-skeleton')->label('Lazy skeleton'),
+                            MenuItem::fromPage(PlainPage::class)->key('plain')->label('Plain'),
+                        ]),
+                    ]),
+                    Stack::make('app-main')
+                        ->width(Width::Fill)
+                        ->schema([Outlet::make()]),
+                ]),
+        ]);
+    }
+}

--- a/packages/tree/workbench/app/Models/Category.php
+++ b/packages/tree/workbench/app/Models/Category.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Workbench\App\Factories\CategoryFactory;
+
+/**
+ * @property string $name
+ * @property-read Category|null $parent
+ * @property-read Collection<int, Category> $children
+ */
+class Category extends Model
+{
+    /** @use HasFactory<CategoryFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = ['name', 'parent_id'];
+
+    /** @return BelongsTo<Category, $this> */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    /** @return HasMany<Category, $this> */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    protected static function newFactory(): CategoryFactory
+    {
+        return CategoryFactory::new();
+    }
+}

--- a/packages/tree/workbench/app/Pages/ExpandedLazyTreePage.php
+++ b/packages/tree/workbench/app/Pages/ExpandedLazyTreePage.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Tree\Tree;
+use Workbench\App\Models\Category;
+use Workbench\App\Trees\CategoryTree;
+
+#[AsPage(route: '/tree-lazy-expanded')]
+final class ExpandedLazyTreePage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Lazy tree, pre-expanded';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('lazy-expanded-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make($this->title()),
+                    Tree::use(CategoryTree::class)
+                        ->lazy()
+                        ->defaultExpanded([(string) Category::query()->where('name', 'Electronics')->value('id')])
+                        ->rememberState(),
+                ]),
+        ]);
+    }
+}

--- a/packages/tree/workbench/app/Pages/LazyTreePage.php
+++ b/packages/tree/workbench/app/Pages/LazyTreePage.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Tree\Tree;
+use Workbench\App\Trees\CategoryTree;
+
+#[AsPage(route: '/tree-lazy')]
+final class LazyTreePage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Lazy tree';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('lazy-tree-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make($this->title()),
+                    Text::make('Roots serialize eagerly; expanding fetches each level from the signed endpoint.'),
+                    Tree::use(CategoryTree::class)->lazy(),
+                ]),
+        ]);
+    }
+}

--- a/packages/tree/workbench/app/Pages/PlainPage.php
+++ b/packages/tree/workbench/app/Pages/PlainPage.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+
+#[AsPage(route: '/plain')]
+final class PlainPage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Plain';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([Heading::make('Plain page')]);
+    }
+}

--- a/packages/tree/workbench/app/Pages/SkeletonLazyTreePage.php
+++ b/packages/tree/workbench/app/Pages/SkeletonLazyTreePage.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Tree\Tree;
+use Workbench\App\Trees\CategoryTree;
+
+#[AsPage(route: '/tree-lazy-skeleton')]
+final class SkeletonLazyTreePage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Lazy tree skeleton';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('lazy-skeleton-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make($this->title()),
+                    Tree::use(CategoryTree::class)->lazy(0),
+                ]),
+        ]);
+    }
+}

--- a/packages/tree/workbench/app/Pages/TreePage.php
+++ b/packages/tree/workbench/app/Pages/TreePage.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Actions\Components\Action;
+use Lattice\Lattice\Actions\Components\ActionGroup;
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Core\PageSchema;
+use Lattice\Lattice\Ui\Components\Heading;
+use Lattice\Lattice\Ui\Components\Modal;
+use Lattice\Lattice\Ui\Components\Stack;
+use Lattice\Lattice\Ui\Components\Text;
+use Lattice\Lattice\Ui\Enums\Gap;
+use Lattice\Tree\Tree;
+use Lattice\Tree\TreeNode;
+use Workbench\App\Actions\ShowTreeNodeInfoAction;
+
+#[AsPage(route: '/tree')]
+final class TreePage extends WorkbenchPage
+{
+    public function title(): string
+    {
+        return 'Tree';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Stack::make('tree-page')
+                ->gap(Gap::ExtraLarge)
+                ->schema([
+                    Heading::make($this->title()),
+                    Text::make('A hierarchy rendered by the lattice-php/tree component package.'),
+                    Tree::make('demo-tree')
+                        ->nodes([
+                            TreeNode::make('electronics', 'Electronics')
+                                ->children([
+                                    TreeNode::make('electronics-laptops', 'Laptops'),
+                                    TreeNode::make('electronics-phones', 'Phones'),
+                                    TreeNode::make('electronics-accessories', 'Accessories')
+                                        ->children([
+                                            TreeNode::make('electronics-accessories-cases', 'Cases'),
+                                            TreeNode::make('electronics-accessories-chargers', 'Chargers'),
+                                        ]),
+                                ]),
+                            TreeNode::make('clothing', 'Clothing')
+                                ->children([
+                                    TreeNode::make('clothing-men', 'Men'),
+                                    TreeNode::make('clothing-women', 'Women')->href('/plain'),
+                                    TreeNode::make('clothing-kids', 'Kids')->badge('New', 'blue'),
+                                ]),
+                            TreeNode::make('documents', 'Documents')
+                                ->actions(
+                                    ActionGroup::make('tree-documents-actions')
+                                        ->actions([
+                                            Action::make('tree-documents-rename')->label('Rename'),
+                                            Action::make('tree-documents-archive')->label('Archive'),
+                                        ]),
+                                ),
+                            TreeNode::make('furniture', 'Furniture')
+                                ->children([
+                                    TreeNode::make('furniture-sofas', 'Sofas'),
+                                    TreeNode::make('furniture-beds', 'Beds'),
+                                ]),
+                            TreeNode::make('help', 'Help')
+                                ->action(Action::use(ShowTreeNodeInfoAction::class)),
+                        ])
+                        ->activeId('electronics-phones')
+                        ->defaultExpanded(['electronics', 'furniture'])
+                        ->rememberState(),
+                    Modal::make('tree-node-info')
+                        ->title('Node info')
+                        ->description('Details about the selected node.')
+                        ->schema([
+                            Text::make('This modal was opened from a tree node action.'),
+                        ]),
+                ]),
+        ]);
+    }
+}

--- a/packages/tree/workbench/app/Pages/WorkbenchPage.php
+++ b/packages/tree/workbench/app/Pages/WorkbenchPage.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages;
+
+use Lattice\Lattice\Attributes\AsPage;
+use Lattice\Lattice\Http\Page;
+use Lattice\Lattice\Ui\Enums\PageLayout;
+
+#[AsPage(layout: PageLayout::App, middleware: ['web'])]
+abstract class WorkbenchPage extends Page {}

--- a/packages/tree/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/packages/tree/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Laravel\Boost\Install\GuidelineComposer;
+use Laravel\Boost\Install\SkillComposer;
+use Laravel\Boost\Support\Config;
+use Laravel\Roster\Roster;
+use Workbench\App\Support\BoostConfig;
+use Workbench\App\Support\BoostGuidelineComposer;
+use Workbench\App\Support\BoostSkillComposer;
+use Workbench\App\WorkbenchConfig;
+
+use function Orchestra\Testbench\package_path;
+
+class WorkbenchServiceProvider extends ServiceProvider
+{
+    #[\Override]
+    public function register(): void
+    {
+        config(WorkbenchConfig::lattice());
+
+        $this->readBoostConfigFromPackageRoot();
+    }
+
+    public function boot(): void
+    {
+        $this->pointBoostAtPackageRoot();
+        $this->redirectBoostSkillsToPackageRoot();
+    }
+
+    private function readBoostConfigFromPackageRoot(): void
+    {
+        if (! class_exists(Config::class)) {
+            return;
+        }
+
+        $this->app->singleton(Config::class, fn (): Config => new BoostConfig);
+        $this->app->bind(GuidelineComposer::class, BoostGuidelineComposer::class);
+        $this->app->bind(SkillComposer::class, BoostSkillComposer::class);
+    }
+
+    private function pointBoostAtPackageRoot(): void
+    {
+        if (! class_exists(Roster::class)) {
+            return;
+        }
+
+        $this->app->singleton(Roster::class, fn (): Roster => Roster::scan(package_path()));
+    }
+
+    private function redirectBoostSkillsToPackageRoot(): void
+    {
+        if (! class_exists(Roster::class)) {
+            return;
+        }
+
+        $skeleton = ltrim(str_replace(package_path(), '', base_path()), '/');
+        $upToPackageRoot = str_repeat('../', substr_count($skeleton, '/') + 1);
+
+        config([
+            'boost.agents.claude_code.skills_path' => $upToPackageRoot.'.claude/skills',
+            'boost.agents.codex.skills_path' => $upToPackageRoot.'.agents/skills',
+        ]);
+    }
+}

--- a/packages/tree/workbench/app/Seeders/DatabaseSeeder.php
+++ b/packages/tree/workbench/app/Seeders/DatabaseSeeder.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Seeders;
+
+use Illuminate\Database\Seeder;
+use Workbench\App\Models\Category;
+
+final class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $electronics = Category::factory()->create(['name' => 'Electronics']);
+        $laptops = Category::factory()->childOf($electronics)->create(['name' => 'Laptops']);
+        Category::factory()->childOf($laptops)->create(['name' => 'Ultrabooks']);
+        Category::factory()->childOf($electronics)->create(['name' => 'Phones']);
+        $clothing = Category::factory()->create(['name' => 'Clothing']);
+        Category::factory()->childOf($clothing)->create(['name' => 'Men']);
+        Category::factory()->childOf($clothing)->create(['name' => 'Women']);
+        Category::factory()->create(['name' => 'Books']);
+    }
+}

--- a/packages/tree/workbench/app/Support/BoostConfig.php
+++ b/packages/tree/workbench/app/Support/BoostConfig.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Support;
+
+use Illuminate\Support\Str;
+use Laravel\Boost\Support\Config;
+
+use function Orchestra\Testbench\package_path;
+
+class BoostConfig extends Config
+{
+    protected function path(): string
+    {
+        return package_path(self::FILE);
+    }
+
+    #[\Override]
+    public function isValid(): bool
+    {
+        $path = $this->path();
+
+        if (! file_exists($path)) {
+            return false;
+        }
+
+        json_decode((string) file_get_contents($path), true);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    #[\Override]
+    public function flush(): void
+    {
+        $path = $this->path();
+
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    #[\Override]
+    protected function set(string $key, mixed $value): void
+    {
+        $config = array_filter($this->all(), fn ($value): bool => $value !== null && $value !== []);
+
+        data_set($config, $key, $value);
+
+        ksort($config);
+
+        file_put_contents(
+            $this->path(),
+            Str::of(json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))->append(PHP_EOL),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function all(): array
+    {
+        $path = $this->path();
+
+        if (! file_exists($path)) {
+            return [];
+        }
+
+        $config = json_decode((string) file_get_contents($path), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return [];
+        }
+
+        return $config ?? [];
+    }
+}

--- a/packages/tree/workbench/app/Support/BoostGuidelineComposer.php
+++ b/packages/tree/workbench/app/Support/BoostGuidelineComposer.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Support;
+
+use Laravel\Boost\Install\GuidelineComposer;
+
+use function Orchestra\Testbench\package_path;
+
+class BoostGuidelineComposer extends GuidelineComposer
+{
+    #[\Override]
+    public function customGuidelinePath(string $path = ''): string
+    {
+        return package_path($this->userGuidelineDir.'/'.ltrim($path, '/'));
+    }
+}

--- a/packages/tree/workbench/app/Support/BoostSkillComposer.php
+++ b/packages/tree/workbench/app/Support/BoostSkillComposer.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Support;
+
+use Illuminate\Support\Collection;
+use Laravel\Boost\Install\Skill;
+use Laravel\Boost\Install\SkillComposer;
+
+use function Orchestra\Testbench\package_path;
+
+class BoostSkillComposer extends SkillComposer
+{
+    #[\Override]
+    protected function discoverExplicitUserSkills(): Collection
+    {
+        $path = package_path('.ai/skills');
+
+        if (! is_dir($path)) {
+            return collect();
+        }
+
+        return collect(glob($path.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR))
+            ->map(fn (string $skillPath): ?Skill => $this->parseSkill($skillPath, 'user', custom: false))
+            ->filter()
+            ->keyBy(fn (Skill $skill): string => $skill->name);
+    }
+
+    #[\Override]
+    protected function discoverPackageSpecificUserSkills(): Collection
+    {
+        $userAiPath = package_path('.ai');
+
+        if (! is_dir($userAiPath)) {
+            return collect();
+        }
+
+        return $this->discoverPackagePaths($userAiPath)
+            ->flatMap(fn (array $package): Collection => $this->discoverSkillsFromPath(
+                $package['path'],
+                $package['name'],
+                $package['version'],
+            ));
+    }
+}

--- a/packages/tree/workbench/app/Trees/CategoryTree.php
+++ b/packages/tree/workbench/app/Trees/CategoryTree.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Trees;
+
+use Lattice\Tree\AsTree;
+use Lattice\Tree\EloquentTreeSource;
+use Lattice\Tree\TreeDefinition;
+use Lattice\Tree\TreeSource;
+use Workbench\App\Models\Category;
+
+#[AsTree('categories')]
+final class CategoryTree extends TreeDefinition
+{
+    public function source(): TreeSource
+    {
+        return EloquentTreeSource::make(Category::class);
+    }
+}

--- a/packages/tree/workbench/app/Trees/DeniedTree.php
+++ b/packages/tree/workbench/app/Trees/DeniedTree.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Trees;
+
+use Illuminate\Http\Request;
+use Lattice\Tree\AsTree;
+use Lattice\Tree\CallbackTreeSource;
+use Lattice\Tree\TreeDefinition;
+use Lattice\Tree\TreeSource;
+
+#[AsTree('denied')]
+final class DeniedTree extends TreeDefinition
+{
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+
+    public function source(): TreeSource
+    {
+        return new CallbackTreeSource(roots: static fn (): array => []);
+    }
+}

--- a/packages/tree/workbench/app/Trees/ScopedCategoryTree.php
+++ b/packages/tree/workbench/app/Trees/ScopedCategoryTree.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Trees;
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Tree\AsTree;
+use Lattice\Tree\EloquentTreeSource;
+use Lattice\Tree\TreeDefinition;
+use Lattice\Tree\TreeSource;
+use Workbench\App\Models\Category;
+
+#[AsTree('scoped-categories')]
+final class ScopedCategoryTree extends TreeDefinition
+{
+    public function source(): TreeSource
+    {
+        return EloquentTreeSource::make(Category::class)
+            ->scope(fn (Builder $query) => $query->where('name', '!=', (string) $this->context('except')));
+    }
+}

--- a/packages/tree/workbench/app/WorkbenchConfig.php
+++ b/packages/tree/workbench/app/WorkbenchConfig.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App;
+
+/**
+ * The Lattice config both consumers of the workbench share: the serve/CLI
+ * path (WorkbenchServiceProvider) and the test path (tests/TestCase), which
+ * boots without the workbench provider to keep the suite lean.
+ */
+final class WorkbenchConfig
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function lattice(): array
+    {
+        return [
+            'lattice.discover' => [__DIR__],
+            'lattice.trees.middleware' => ['web'],
+            'lattice.actions.middleware' => ['web'],
+        ];
+    }
+}

--- a/packages/tree/workbench/database/migrations/0001_01_01_000001_create_categories_table.php
+++ b/packages/tree/workbench/database/migrations/0001_01_01_000001_create_categories_table.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/packages/tree/workbench/resources/css/app.css
+++ b/packages/tree/workbench/resources/css/app.css
@@ -1,0 +1,3 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "@lattice-php/lattice/css";

--- a/packages/tree/workbench/resources/js/app.tsx
+++ b/packages/tree/workbench/resources/js/app.tsx
@@ -1,0 +1,11 @@
+/// <reference types="@lattice-php/lattice/svg-sprite-client" />
+/// <reference types="@lattice-php/lattice/vite-client" />
+import "../css/app.css";
+import { createLatticeApp } from "@lattice-php/lattice";
+import sprite from "virtual:svg-sprite";
+import plugins from "virtual:lattice/plugins";
+
+void createLatticeApp({
+  plugins,
+  sprite,
+});

--- a/packages/tree/workbench/resources/views/app.blade.php
+++ b/packages/tree/workbench/resources/views/app.blade.php
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title inertia>Lattice Tree</title>
+    @viteReactRefresh
+    @vite(['workbench/resources/css/app.css', 'workbench/resources/js/app.tsx'])
+    @inertiaHead
+</head>
+<body>
+    @inertia
+</body>
+</html>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ includes:
 parameters:
     paths:
         - src
+        - packages/tree/src
         - tests
         - workbench/app
     excludePaths:

--- a/rector.php
+++ b/rector.php
@@ -8,6 +8,7 @@ use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRec
 return RectorConfig::configure()
     ->withPaths([
         __DIR__.'/src',
+        __DIR__.'/packages/tree/src',
         __DIR__.'/tests',
         __DIR__.'/workbench/app',
         __DIR__.'/workbench/routes',

--- a/resources/js/runtime.test.ts
+++ b/resources/js/runtime.test.ts
@@ -1,11 +1,14 @@
 import { expect, it } from "vitest";
+import { router } from "@inertiajs/react";
 import { eagerComponent, loadPluginModules } from "./core/registry";
 import {
   eagerComponent as runtimeEagerComponent,
   loadPluginModules as runtimeLoadPluginModules,
+  router as runtimeRouter,
 } from "./runtime";
 
 it("exposes the public Lattice API to standalone plugins", () => {
   expect(runtimeEagerComponent).toBe(eagerComponent);
   expect(runtimeLoadPluginModules).toBe(loadPluginModules);
+  expect(runtimeRouter).toBe(router);
 });

--- a/resources/js/runtime.ts
+++ b/resources/js/runtime.ts
@@ -1,4 +1,6 @@
 export * from "./index";
+export { router } from "@inertiajs/react";
+export { apiJson, cn, nodeIdentity, usePersistentState } from "./core";
 export { setRefRefreshEndpoint } from "./core/api";
 export * from "./form/toolkit";
 export * from "./i18n";

--- a/tests/Feature/Console/PublishAssetsCommandTest.php
+++ b/tests/Feature/Console/PublishAssetsCommandTest.php
@@ -48,8 +48,13 @@ it('publishes standalone modules from discovered component packages', function (
     $manifest = json_decode(File::get(public_path('vendor/lattice/manifest.json')), true);
 
     expect(File::exists(public_path('vendor/lattice/plugins/lattice-php/signature-example.js')))->toBeTrue()
-        ->and($manifest['plugins'])->toBe(['plugins/lattice-php/signature-example.js'])
-        ->and($manifest['files']['plugins/lattice-php/signature-example.js'])->toBeString();
+        ->and(File::exists(public_path('vendor/lattice/plugins/lattice-php/tree.js')))->toBeTrue()
+        ->and($manifest['plugins'])->toBe([
+            'plugins/lattice-php/signature-example.js',
+            'plugins/lattice-php/tree.js',
+        ])
+        ->and($manifest['files']['plugins/lattice-php/signature-example.js'])->toBeString()
+        ->and($manifest['files']['plugins/lattice-php/tree.js'])->toBeString();
 });
 
 it('removes files left over from a previous version', function (): void {

--- a/tests/Feature/TreePackageContractTest.php
+++ b/tests/Feature/TreePackageContractTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Lattice\Lattice\Core\Discovery\ComponentPackages;
+use Lattice\Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Lattice\Forms\FormsServiceProvider;
+use Lattice\Lattice\Support\TypeScript\WireFamilies;
+use Lattice\Lattice\Support\TypeScript\WireFamily;
+use Lattice\Lattice\Support\TypeScript\WireTypeDiscovery;
+use Lattice\Lattice\Tables\TablesServiceProvider;
+use Lattice\Lattice\Ui\UiServiceProvider;
+use Lattice\Tree\AsTree;
+use Lattice\Tree\CallbackTreeSource;
+use Lattice\Tree\Tree;
+use Lattice\Tree\TreeDefinition;
+use Lattice\Tree\TreeRegistry;
+use Lattice\Tree\TreeServiceProvider;
+
+it('boots the tree package through the ui boundary', function (): void {
+    expect(class_exists(TreeServiceProvider::class))->toBeTrue();
+
+    $testApplication = Application::getInstance();
+
+    try {
+        $application = new Application;
+        $application->register(TreeServiceProvider::class);
+
+        $categories = array_map(
+            static fn (WireFamily $family): string => $family->category,
+            $application->make(WireFamilies::class)->all(),
+        );
+
+        expect($application->getProvider(UiServiceProvider::class))->not->toBeNull()
+            ->and($application->getProvider(FormsServiceProvider::class))->toBeNull()
+            ->and($application->getProvider(TablesServiceProvider::class))->toBeNull()
+            ->and($categories)->toBe(['component', 'effect']);
+    } finally {
+        Application::setInstance($testApplication);
+    }
+});
+
+it('contributes discovery and frontend entries', function (): void {
+    $package = collect(ComponentPackages::packages())->firstWhere('name', 'lattice-php/tree');
+    $packagePath = realpath(dirname(__DIR__, 2).'/packages/tree');
+
+    expect($packagePath)->not->toBeFalse()
+        ->and($package)->toMatchArray([
+            'roots' => [$packagePath.'/src'],
+            'plugin' => $packagePath.'/resources/js/plugin.ts',
+            'standalone' => $packagePath.'/dist/plugin.js',
+        ]);
+
+    $types = [];
+
+    foreach (DiscoveryManifest::configuredPaths() as $path) {
+        foreach (app(WireTypeDiscovery::class)->discover($path)->components as $component) {
+            $types[] = $component->type;
+        }
+    }
+
+    expect($types)->toContain('tree');
+});
+
+it('uses the core definition gate', function (): void {
+    app()->register(TreeServiceProvider::class);
+    app(TreeRegistry::class)->register(DeniedPackageTree::class);
+
+    expect(Tree::use(DeniedPackageTree::class)->shouldRender())->toBeFalse();
+});
+
+#[AsTree('denied-package-tree')]
+final class DeniedPackageTree extends TreeDefinition
+{
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+
+    public function source(): CallbackTreeSource
+    {
+        return new CallbackTreeSource(roots: static fn (): array => []);
+    }
+}


### PR DESCRIPTION
Adds `packages/tree` as the first real Composer/npm workspace package and keeps its release version synchronized with Lattice via Composer `self.version`.

Tree now registers only the UI boundary, contributes discovery plus source and prebuilt standalone plugins, and uses the shared Core authorization gate. The root gates build and verify workspace plugin artifacts, run Tree frontend tests, and statically analyze Tree production code.

Validation: `composer check`; `npm run check`.
