### PR TITLE
chore: automate synchronized package releases

### DIFF
--- a/.github/scripts/sync-package-versions.mjs
+++ b/.github/scripts/sync-package-versions.mjs
@@ -1,0 +1,60 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../..");
+const rootManifest = path.join(repositoryRoot, "package.json");
+const packageManifests = readdirSync(path.join(repositoryRoot, "packages"))
+  .map((directory) => path.join(repositoryRoot, "packages", directory, "package.json"))
+  .filter(existsSync);
+const manifestPaths = [rootManifest, ...packageManifests];
+const packages = manifestPaths.map((manifestPath) => ({
+  manifestPath,
+  package: JSON.parse(readFileSync(manifestPath, "utf8")),
+}));
+const version = packages[0].package.version;
+const workspaceNames = new Set(
+  packages.slice(1).map(({ package: packageJson }) => packageJson.name),
+);
+const check = process.argv.includes("--check");
+const changed = [];
+
+for (const entry of packages) {
+  const packageJson = entry.package;
+  let packageChanged = false;
+
+  if (entry.manifestPath !== rootManifest && packageJson.version !== version) {
+    packageJson.version = version;
+    packageChanged = true;
+  }
+
+  for (const section of [
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+  ]) {
+    for (const dependency of Object.keys(packageJson[section] ?? {})) {
+      if (workspaceNames.has(dependency)) {
+        if (packageJson[section][dependency] !== version) {
+          packageJson[section][dependency] = version;
+          packageChanged = true;
+        }
+      }
+    }
+  }
+
+  if (!packageChanged) {
+    continue;
+  }
+
+  changed.push(path.relative(repositoryRoot, entry.manifestPath));
+
+  if (!check) {
+    writeFileSync(entry.manifestPath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  }
+}
+
+if (check && changed.length > 0) {
+  console.error(`Package versions differ from ${version}: ${changed.join(", ")}`);
+  process.exitCode = 1;
+}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,12 +48,54 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run versions:check
+
       # `files` includes dist-standalone, but `npm pack` silently skips missing
       # entries — without this gate a tag whose asset commit never landed would
       # publish a package with no standalone assets.
       - run: npm run verify:standalone
 
-      # The prepack hook builds dist/ and runs the build guardrail before publish.
-      - run: npm publish --access public --provenance
+      # The root prepack hook rebuilds dist/; workspace dist files are committed
+      # and checked by the normal CI package gate.
+      - run: npm publish --workspaces --include-workspace-root --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  split-composer:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - local_path: action
+            split_repository: action
+          - local_path: core
+            split_repository: core
+          - local_path: form
+            split_repository: form
+          - local_path: media
+            split_repository: media
+          - local_path: table
+            split_repository: table
+          - local_path: tree
+            split_repository: tree
+          - local_path: ui
+            split_repository: ui
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: danharrin/monorepo-split-github-action@v2.4.0
+        with:
+          package_directory: packages/${{ matrix.package.local_path }}
+          repository_organization: lattice-php
+          repository_name: ${{ matrix.package.split_repository }}
+          tag: ${{ needs.release-please.outputs.tag_name }}
+          user_email: github-actions[bot]@users.noreply.github.com
+          user_name: github-actions[bot]
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/standalone-assets.yml
+++ b/.github/workflows/standalone-assets.yml
@@ -29,14 +29,18 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run versions:sync
+
+      - run: npm install --package-lock-only --ignore-scripts
+
       - run: npm run build:standalone
 
       - name: Commit refreshed standalone assets
         run: |
-          if [ -n "$(git status --porcelain dist-standalone)" ]; then
+          if [ -n "$(git status --porcelain package.json package-lock.json packages dist-standalone)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add dist-standalone
+            git add package.json package-lock.json packages/*/package.json dist-standalone
             git commit -m "chore: build standalone assets"
             git push
           fi

--- a/package.json
+++ b/package.json
@@ -2,27 +2,32 @@
   "name": "@lattice-php/lattice",
   "version": "0.38.0",
   "description": "Server-driven React components for Laravel and Inertia.",
-  "license": "MIT",
-  "author": "Manuel Christlieb <manuel@christlieb.eu>",
-  "type": "module",
-  "workspaces": [
-    "docs",
-    "packages/*"
+  "keywords": [
+    "inertia",
+    "laravel",
+    "react",
+    "server-driven-ui"
   ],
   "homepage": "https://latticephp.com",
+  "bugs": {
+    "url": "https://github.com/lattice-php/lattice/issues"
+  },
+  "license": "MIT",
+  "author": "Manuel Christlieb <manuel@christlieb.eu>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lattice-php/lattice.git"
   },
-  "bugs": {
-    "url": "https://github.com/lattice-php/lattice/issues"
-  },
-  "keywords": [
-    "laravel",
-    "inertia",
-    "react",
-    "server-driven-ui"
+  "workspaces": [
+    "docs",
+    "packages/*"
   ],
+  "files": [
+    "dist",
+    "dist-standalone",
+    "resources/icons"
+  ],
+  "type": "module",
   "sideEffects": [
     "**/*.css"
   ],
@@ -257,11 +262,6 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "dist",
-    "dist-standalone",
-    "resources/icons"
-  ],
   "publishConfig": {
     "access": "public"
   },
@@ -280,7 +280,7 @@
     "boost:refresh": "php vendor/bin/testbench boost:update --no-interaction",
     "typecheck": "tsc --noEmit",
     "type-coverage": "type-coverage --project tsconfig.json --at-least 99.5",
-    "check": "npm run lint && npm run format:check && npm run typecheck && npm run type-coverage && npm run test && npm run build:plugins && npm run build:lib && npm run check:package",
+    "check": "npm run versions:check && npm run lint && npm run format:check && npm run typecheck && npm run type-coverage && npm run test && npm run build:plugins && npm run build:lib && npm run check:package",
     "build:plugins": "npm run build:plugin --workspaces --if-present && git diff --exit-code -- packages/*/dist",
     "check:package": "publint --strict && attw --pack . --profile esm-only --exclude-entrypoints ./css --ignore-rules internal-resolution-error && publint packages/core --strict && attw --pack packages/core --profile esm-only && publint packages/ui --strict && attw --pack packages/ui --profile esm-only --exclude-entrypoints ./css && publint packages/form --strict && attw --pack packages/form --profile esm-only && publint packages/action --strict && attw --pack packages/action --profile esm-only && publint packages/table --strict && attw --pack packages/table --profile esm-only && publint packages/tree --strict && attw --pack packages/tree --profile esm-only && publint packages/media --strict && attw --pack packages/media --profile esm-only",
     "fix": "npm run lint:fix && npm run format",
@@ -289,6 +289,8 @@
     "lint": "oxlint resources/js workbench/resources/js packages/*/resources/js",
     "lint:fix": "oxlint resources/js workbench/resources/js packages/*/resources/js --fix",
     "lint:github": "oxlint resources/js workbench/resources/js packages/*/resources/js --format=github",
+    "versions:check": "node .github/scripts/sync-package-versions.mjs --check",
+    "versions:sync": "node .github/scripts/sync-package-versions.mjs",
     "format": "oxfmt --write \"resources/js/**/*.{ts,tsx}\" \"workbench/resources/js/**/*.{ts,tsx}\" \"packages/*/resources/js/**/*.{ts,tsx}\" \"docs/**/*.{ts,tsx,md,mdx}\"",
     "format:check": "oxfmt --check \"resources/js/**/*.{ts,tsx}\" \"workbench/resources/js/**/*.{ts,tsx}\" \"packages/*/resources/js/**/*.{ts,tsx}\" \"docs/**/*.{ts,tsx,md,mdx}\"",
     "analyze": "SONDA=1 vite build && mkdir -p docs/public && cp docs/generated/bundle-report.html docs/public/bundle-report.html",
@@ -297,11 +299,6 @@
     "docs:preview": "npm run preview -w docs"
   },
   "dependencies": {
-    "@lattice-php/action": "0.38.0",
-    "@lattice-php/core": "0.38.0",
-    "@lattice-php/form": "0.38.0",
-    "@lattice-php/table": "0.38.0",
-    "@lattice-php/ui": "0.38.0",
     "@atlaskit/pragmatic-drag-and-drop": "^2.0.1",
     "@atlaskit/pragmatic-drag-and-drop-auto-scroll": "^3.0.0",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^2.0.0",
@@ -314,6 +311,11 @@
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.7",
     "@internationalized/date": "^3.12.2",
+    "@lattice-php/action": "0.38.0",
+    "@lattice-php/core": "0.38.0",
+    "@lattice-php/form": "0.38.0",
+    "@lattice-php/table": "0.38.0",
+    "@lattice-php/ui": "0.38.0",
     "@lattice-php/vite-svg-sprite": "^0.3.0",
     "@lezer/highlight": "^1.2.3",
     "@radix-ui/react-toast": "^1.2.16",
@@ -329,21 +331,6 @@
     "@zag-js/date-picker": "^1.41.2",
     "@zag-js/react": "^1.41.2",
     "recharts": "^3.8.1"
-  },
-  "peerDependencies": {
-    "@inertiajs/react": "^3.0.0",
-    "@laravel/echo-react": "^2.0.0",
-    "pusher-js": "^8.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@laravel/echo-react": {
-      "optional": true
-    },
-    "pusher-js": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
@@ -381,5 +368,20 @@
     "vite-plugin-dts": "^5.0.3",
     "vitest": "^4.1.8",
     "vitest-browser-react": "^2.2.0"
+  },
+  "peerDependencies": {
+    "@inertiajs/react": "^3.0.0",
+    "@laravel/echo-react": "^2.0.0",
+    "pusher-js": "^8.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@laravel/echo-react": {
+      "optional": true
+    },
+    "pusher-js": {
+      "optional": true
+    }
   }
 }

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@lattice-php/action",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/action"
+  },
   "files": [
     "dist"
   ],
@@ -20,6 +24,9 @@
       "import": "./dist/*.js"
     },
     "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "vite build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@lattice-php/core",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/core"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -21,9 +28,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "dist"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "build:plugin": "npm run build",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@lattice-php/form",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/form"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -22,7 +29,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "build:plugin": "npm run build",

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@lattice-php/media",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/media"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -18,7 +25,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "build:plugin": "npm run build",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@lattice-php/table",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/table"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -18,7 +25,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "build:plugin": "npm run build",

--- a/packages/tree/package.json
+++ b/packages/tree/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@lattice-php/tree",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/tree"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -18,7 +25,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build --mode plugin",
     "build:plugin": "npm run build",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@lattice-php/ui",
   "version": "0.38.0",
-  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lattice-php/lattice.git",
+    "directory": "packages/ui"
+  },
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "sideEffects": [
     "**/*.css"
@@ -29,9 +36,9 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "dist"
-  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "vite build",
     "build:plugin": "npm run build",

--- a/tests/Feature/ReleaseAutomationContractTest.php
+++ b/tests/Feature/ReleaseAutomationContractTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+it('publishes synchronized npm and Composer packages from one release', function (): void {
+    $root = dirname(__DIR__, 2);
+    $workflow = file_get_contents($root.'/.github/workflows/release-please.yml');
+
+    expect($workflow)->toContain('npm publish --workspaces --include-workspace-root')
+        ->and($workflow)->toContain('danharrin/monorepo-split-github-action@v2.4.0');
+
+    foreach (['action', 'core', 'form', 'media', 'table', 'tree', 'ui'] as $name) {
+        $package = json_decode((string) file_get_contents($root.'/packages/'.$name.'/package.json'), true, flags: JSON_THROW_ON_ERROR);
+
+        expect($package)->not->toHaveKey('private')
+            ->and($package['publishConfig']['access'])->toBe('public')
+            ->and($package['repository']['directory'])->toBe('packages/'.$name)
+            ->and($workflow)->toContain("local_path: {$name}")
+            ->and($workflow)->toContain("split_repository: {$name}");
+    }
+});


### PR DESCRIPTION
Publishes the aggregate and package npm workspaces at one version and fans out Composer package directories to split repositories from the same release tag.

Release PR asset updates now synchronize workspace versions and dependency pins before tagging.

Checks: `composer check`, `npm run check`.

Setup before the first release: initialize `lattice-php/action`, `lattice-php/core`, `lattice-php/form`, `lattice-php/table`, and `lattice-php/ui`, then register their Composer packages with Packagist.