### PR TITLE
fix: ship per-package readmes in the split repos

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,7 @@
+# Lattice Core
+
+Core contracts, discovery, evaluation, and serialization for [Lattice](https://latticephp.com) — server-driven React components for Laravel and Inertia.
+
+You rarely install this directly; require [`lattice-php/lattice`](https://packagist.org/packages/lattice-php/lattice) instead.
+
+Development happens in the [lattice-php/lattice monorepo](https://github.com/lattice-php/lattice); this repository is a read-only split. Please open issues and pull requests there.

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,0 +1,7 @@
+# Lattice Form
+
+Form definitions, fields, validation, and rich content for [Lattice](https://latticephp.com) — server-driven React components for Laravel and Inertia.
+
+You rarely install this directly; require [`lattice-php/lattice`](https://packagist.org/packages/lattice-php/lattice) instead.
+
+Development happens in the [lattice-php/lattice monorepo](https://github.com/lattice-php/lattice); this repository is a read-only split. Please open issues and pull requests there.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -1,0 +1,14 @@
+# Lattice
+
+Server-driven React components for Laravel and Inertia.
+
+This is the full Lattice framework — the package you install as `lattice-php/lattice` and `@lattice-php/lattice`. It ties together [core](https://github.com/lattice-php/core), [ui](https://github.com/lattice-php/ui), [form](https://github.com/lattice-php/form), and [table](https://github.com/lattice-php/table) and adds actions, layouts, fragments, notifications, realtime, theming, and the Vite tooling.
+
+```bash
+composer require lattice-php/lattice
+npm install @lattice-php/lattice
+```
+
+Documentation: [latticephp.com](https://latticephp.com)
+
+Development happens in the [lattice-php/lattice monorepo](https://github.com/lattice-php/lattice); this repository is a read-only split. Please open issues and pull requests there.

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -1,0 +1,7 @@
+# Lattice Table
+
+Table definitions, columns, filters, and actions for [Lattice](https://latticephp.com) — server-driven React components for Laravel and Inertia.
+
+You rarely install this directly; require [`lattice-php/lattice`](https://packagist.org/packages/lattice-php/lattice) instead.
+
+Development happens in the [lattice-php/lattice monorepo](https://github.com/lattice-php/lattice); this repository is a read-only split. Please open issues and pull requests there.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,7 @@
+# Lattice UI
+
+UI components, theming primitives, icons, and translations for [Lattice](https://latticephp.com) — server-driven React components for Laravel and Inertia.
+
+You rarely install this directly; require [`lattice-php/lattice`](https://packagist.org/packages/lattice-php/lattice) instead.
+
+Development happens in the [lattice-php/lattice monorepo](https://github.com/lattice-php/lattice); this repository is a read-only split. Please open issues and pull requests there.


### PR DESCRIPTION
Adds a minimal README to each package so the split repos and their Packagist/npm pages aren't bare.

Carries `Release-As: 0.40.0` — 0.39.0 of `lattice-php/lattice` was indexed from the monorepo before the Packagist repoint, so consumers got the empty dev-harness package. 0.40.0 re-indexes cleanly from the framework split repo.