### PR TITLE
chore: tooling fixes across the monorepo

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,19 +3,38 @@
 # Bypass with `git push --no-verify` (emergencies only — never push on red).
 #
 # The generated-types and docs-fixtures diffs are intentionally left to CI: a local run
-# regenerates resources/js/types/generated.ts with a different property ordering than main,
+# regenerates the committed generated.ts with a different property ordering than main,
 # so a local diff check would fail spuriously. Pest Browser stays CI-only because it
 # needs the built workbench assets and Playwright browsers. docs:typecheck (docs/tsconfig.json)
 # and the icons-freshness diff also stay CI-only for the same local-drift reasons.
-set -e
+#
+# The PHP and JS gates are independent, so they run concurrently — JS logs to a
+# temp file that is replayed only on failure, PHP streams live.
 
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
-echo "▶ pre-push: composer check (pint, phpstan, rector, pest)"
-composer check
+js_log="$(mktemp)"
+trap 'rm -f "$js_log"' EXIT
 
-echo "▶ pre-push: npm run check (lint, format, typecheck, type-coverage, vitest, build:lib, check:package)"
-npm run check
+echo "▶ pre-push: composer check + npm run check (concurrent)"
+
+npm run check >"$js_log" 2>&1 &
+js_pid=$!
+
+composer check
+php_status=$?
+
+wait "$js_pid"
+js_status=$?
+
+if [ "$js_status" -ne 0 ]; then
+    echo "✗ npm run check failed:"
+    cat "$js_log"
+fi
+
+if [ "$php_status" -ne 0 ] || [ "$js_status" -ne 0 ]; then
+    exit 1
+fi
 
 echo "✓ pre-push gate passed"

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -14,8 +14,12 @@ concurrency:
 
 jobs:
   pest-browser:
-    name: Browser (Pest)
+    name: Browser (Pest, shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     permissions:
       contents: read
       id-token: write
@@ -101,7 +105,7 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: Pest (browser coverage)
-        run: composer test:browser:coverage
+        run: composer test:browser:coverage -- --shard=${{ matrix.shard }}/2
 
       - name: Upload Pest browser coverage to Codecov
         if: ${{ !cancelled() }}
@@ -110,7 +114,7 @@ jobs:
           use_oidc: true
           files: coverage_phpunit/browser-clover.xml
           flags: pest-browser
-          name: pest-browser
+          name: pest-browser-${{ matrix.shard }}
           disable_search: true
           fail_ci_if_error: true
 
@@ -121,7 +125,7 @@ jobs:
           use_oidc: true
           files: coverage_phpunit/pest-browser.junit.xml
           flags: pest-browser
-          name: pest-browser-tests
+          name: pest-browser-tests-${{ matrix.shard }}
           report_type: test_results
           disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,42 @@ jobs:
       - name: Icons are up to date
         run: git diff --exit-code -- packages/ui/resources/icons packages/ui/src/Enums/Icon.php workbench/resources/js/sprite-icons.ts
 
+  package-install:
+    name: Package installs standalone (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [action, core, form, framework, table, tree, ui]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: composer:v2
+
+      # Each package must be installable on its own — the monorepo's shared
+      # vendor dir masks missing dependency declarations, and an unresolvable
+      # manifest only surfaces after the split repos are tagged. Siblings come
+      # from path repositories with a stamped version so `self.version`
+      # constraints resolve against the PR's state, not yesterday's release.
+      - name: Install the package standalone
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          for manifest in ../*/composer.json; do
+            jq '.version = "0.99.0"' "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+          done
+          composer config repositories.siblings '{"type":"path","url":"../*","options":{"symlink":true}}'
+          composer update --no-interaction --no-progress --prefer-dist
+
+      - name: Provider class is autoloadable
+        working-directory: packages/${{ matrix.package }}
+        run: |
+          provider=$(jq -r '.extra.laravel.providers[0]' composer.json)
+          php -r "require 'vendor/autoload.php'; exit(class_exists('$provider') ? 0 : 1);"
+
   php-static:
     name: PHP Static (pint, phpstan, rector)
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
-      - "resources/**"
+      - "packages/*/resources/**"
       - "workbench/resources/**"
       - "vite.config.ts"
       - "tsconfig.json"
@@ -42,7 +42,7 @@ jobs:
           filters: |
             docs:
               - "docs/**"
-              - "resources/**"
+              - "packages/*/resources/**"
               - "workbench/resources/**"
               - "vite.config.ts"
               - "tsconfig.json"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 4
+    after_n_builds: 5
 
 coverage:
   status:
@@ -38,7 +38,7 @@ flags:
       - packages/
 
 comment:
-  after_n_builds: 4
+  after_n_builds: 5
   require_changes: false
   hide_project_coverage: false
 

--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,14 @@
         "test": "./vendor/bin/pest --testsuite Arch,Unit,Feature",
         "test:parallel": "./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel",
         "test:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel --coverage --coverage-clover coverage_phpunit/clover.xml --log-junit coverage_phpunit/pest.junit.xml",
-        "test:browser": "./vendor/bin/pest --testsuite Browser",
-        "test:browser:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Browser --coverage --coverage-clover coverage_phpunit/browser-clover.xml --log-junit coverage_phpunit/pest-browser.junit.xml",
+        "test:browser": [
+            "Composer\\Config::disableProcessTimeout",
+            "./vendor/bin/pest --testsuite Browser"
+        ],
+        "test:browser:coverage": [
+            "Composer\\Config::disableProcessTimeout",
+            "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Browser --coverage --coverage-clover coverage_phpunit/browser-clover.xml --log-junit coverage_phpunit/pest-browser.junit.xml"
+        ],
         "post-autoload-dump": [
             "@clear",
             "@prepare"

--- a/packages/action/tsconfig.json
+++ b/packages/action/tsconfig.json
@@ -1,28 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@lattice-php/core": ["../core/resources/js/index.ts"],
-      "@lattice-php/core/*": ["../core/resources/js/*"],
-      "@lattice-php/form": ["../form/resources/js/index.ts"],
-      "@lattice-php/form/*": ["../form/resources/js/*"],
-      "@lattice-php/lattice": ["../framework/resources/js/index.ts"],
-      "@lattice-php/lattice/*": ["../framework/resources/js/*"],
-      "@lattice-php/action": ["./resources/js/index.ts"],
-      "@lattice-php/action/*": ["./resources/js/*"],
-      "@lattice-php/ui": ["../ui/resources/js/index.ts"],
-      "@lattice-php/ui/*": ["../ui/resources/js/*"]
-    }
-  },
-  "include": ["resources/js"],
-  "exclude": ["resources/js/**/*.test.*", "resources/js/**/*.test-d.*"]
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ],
+  "exclude": [
+    "resources/js/**/*.test.*",
+    "resources/js/**/*.test-d.*"
+  ]
 }

--- a/packages/action/vitest.config.ts
+++ b/packages/action/vitest.config.ts
@@ -1,17 +1,11 @@
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@lattice-php/core": path.resolve(import.meta.dirname, "../core/resources/js"),
-      "@lattice-php/form": path.resolve(import.meta.dirname, "../form/resources/js"),
-      "@lattice-php/lattice": path.resolve(import.meta.dirname, "../framework/resources/js"),
-      "@lattice-php/action": path.resolve(import.meta.dirname, "resources/js"),
-      "@lattice-php/ui": path.resolve(import.meta.dirname, "../ui/resources/js"),
-    },
+    alias: workspaceAliases,
   },
   test: {
     environment: "jsdom",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,15 +1,6 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"]
-  },
-  "include": ["resources/js"]
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ]
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -25,6 +25,13 @@ export default defineConfig({
         "resources/js/test-setup.ts",
       ],
       rollupTypes: true,
+      compilerOptions: {
+        paths: {
+          "@lattice-php/core": [path.join(sourceRoot, "index.ts")],
+          "@lattice-php/core/*": [path.join(sourceRoot, "*")],
+        },
+        rootDir: sourceRoot,
+      },
       beforeWriteFile: (filePath, content) => ({
         filePath,
         content: withExplicitExtensions(content),

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,8 +1,12 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: workspaceAliases,
+  },
   test: {
     environment: "jsdom",
     include: ["resources/js/**/*.test.{ts,tsx}"],

--- a/packages/form/tsconfig.json
+++ b/packages/form/tsconfig.json
@@ -1,26 +1,9 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@lattice-php/core": ["../core/resources/js/index.ts"],
-      "@lattice-php/core/*": ["../core/resources/js/*"],
-      "@lattice-php/form": ["./resources/js/index.ts"],
-      "@lattice-php/form/*": ["./resources/js/*"],
-      "@lattice-php/lattice": ["../framework/resources/js/index.ts"],
-      "@lattice-php/lattice/*": ["../framework/resources/js/*"],
-      "@lattice-php/ui": ["../ui/resources/js/index.ts"],
-      "@lattice-php/ui/*": ["../ui/resources/js/*"]
-    }
-  },
-  "include": ["resources/js"],
-  "exclude": ["resources/js/**/*.test.*"]
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ],
+  "exclude": [
+    "resources/js/**/*.test.*"
+  ]
 }

--- a/packages/form/vitest.config.ts
+++ b/packages/form/vitest.config.ts
@@ -1,16 +1,11 @@
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@lattice-php/core": path.resolve(import.meta.dirname, "../core/resources/js"),
-      "@lattice-php/form": path.resolve(import.meta.dirname, "resources/js"),
-      "@lattice-php/lattice": path.resolve(import.meta.dirname, "../framework/resources/js"),
-      "@lattice-php/ui": path.resolve(import.meta.dirname, "../ui/resources/js"),
-    },
+    alias: workspaceAliases,
   },
   test: {
     environment: "jsdom",

--- a/packages/framework/tsconfig.json
+++ b/packages/framework/tsconfig.json
@@ -1,31 +1,8 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@lattice-php/action": ["../action/resources/js/index.ts"],
-      "@lattice-php/action/*": ["../action/resources/js/*"],
-      "@lattice-php/core": ["../core/resources/js/index.ts"],
-      "@lattice-php/core/*": ["../core/resources/js/*"],
-      "@lattice-php/form": ["../form/resources/js/index.ts"],
-      "@lattice-php/form/*": ["../form/resources/js/*"],
-      "@lattice-php/lattice": ["./resources/js/index.ts"],
-      "@lattice-php/lattice/*": ["./resources/js/*"],
-      "@lattice-php/table": ["../table/resources/js/index.ts"],
-      "@lattice-php/table/*": ["../table/resources/js/*"],
-      "@lattice-php/ui": ["../ui/resources/js/index.ts"],
-      "@lattice-php/ui/*": ["../ui/resources/js/*"]
-    }
-  },
-  "include": ["resources/js"],
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ],
   "exclude": [
     "resources/js/**/*.test.*",
     "resources/js/**/*.test-d.*",

--- a/packages/framework/vitest.config.ts
+++ b/packages/framework/vitest.config.ts
@@ -1,18 +1,11 @@
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@lattice-php/action": path.resolve(import.meta.dirname, "../action/resources/js"),
-      "@lattice-php/core": path.resolve(import.meta.dirname, "../core/resources/js"),
-      "@lattice-php/form": path.resolve(import.meta.dirname, "../form/resources/js"),
-      "@lattice-php/table": path.resolve(import.meta.dirname, "../table/resources/js"),
-      "@lattice-php/ui": path.resolve(import.meta.dirname, "../ui/resources/js"),
-      "@lattice-php/lattice": path.resolve(import.meta.dirname, "resources/js"),
-    },
+    alias: workspaceAliases,
   },
   test: {
     environment: "jsdom",

--- a/packages/table/src/TableDefinition.php
+++ b/packages/table/src/TableDefinition.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Table;
 
+use Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Core\Definition;
 use Lattice\Table\Columns\Column;
 use Lattice\Table\Contracts\TableSource;
@@ -103,7 +104,7 @@ abstract class TableDefinition extends Definition
     }
 
     /**
-     * @return array<int, Component>
+     * @return array<int, Component&InteractiveComponent>
      */
     public function bulkActions(): array
     {

--- a/packages/table/tsconfig.json
+++ b/packages/table/tsconfig.json
@@ -1,28 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@lattice-php/core": ["../core/resources/js/index.ts"],
-      "@lattice-php/core/*": ["../core/resources/js/*"],
-      "@lattice-php/form": ["../form/resources/js/index.ts"],
-      "@lattice-php/form/*": ["../form/resources/js/*"],
-      "@lattice-php/lattice": ["../framework/resources/js/index.ts"],
-      "@lattice-php/lattice/*": ["../framework/resources/js/*"],
-      "@lattice-php/table": ["./resources/js/index.ts"],
-      "@lattice-php/table/*": ["./resources/js/*"],
-      "@lattice-php/ui": ["../ui/resources/js/index.ts"],
-      "@lattice-php/ui/*": ["../ui/resources/js/*"]
-    }
-  },
-  "include": ["resources/js"],
-  "exclude": ["resources/js/**/*.test.*", "resources/js/**/*.test-d.*"]
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ],
+  "exclude": [
+    "resources/js/**/*.test.*",
+    "resources/js/**/*.test-d.*"
+  ]
 }

--- a/packages/table/vitest.config.ts
+++ b/packages/table/vitest.config.ts
@@ -1,17 +1,11 @@
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@lattice-php/core": path.resolve(import.meta.dirname, "../core/resources/js"),
-      "@lattice-php/form": path.resolve(import.meta.dirname, "../form/resources/js"),
-      "@lattice-php/lattice": path.resolve(import.meta.dirname, "../framework/resources/js"),
-      "@lattice-php/table": path.resolve(import.meta.dirname, "resources/js"),
-      "@lattice-php/ui": path.resolve(import.meta.dirname, "../ui/resources/js"),
-    },
+    alias: workspaceAliases,
   },
   test: {
     environment: "jsdom",

--- a/packages/tree/tsconfig.json
+++ b/packages/tree/tsconfig.json
@@ -1,30 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@lattice-php/core": ["../core/resources/js/index.ts"],
-      "@lattice-php/core/*": ["../core/resources/js/*"],
-      "@lattice-php/form": ["../form/resources/js/index.ts"],
-      "@lattice-php/form/*": ["../form/resources/js/*"],
-      "@lattice-php/lattice": ["../framework/resources/js/index.ts"],
-      "@lattice-php/lattice/*": ["../framework/resources/js/*"],
-      "@lattice-php/action": ["../action/resources/js/index.ts"],
-      "@lattice-php/action/*": ["../action/resources/js/*"],
-      "@lattice-php/tree": ["./resources/js/index.ts"],
-      "@lattice-php/tree/*": ["./resources/js/*"],
-      "@lattice-php/ui": ["../ui/resources/js/index.ts"],
-      "@lattice-php/ui/*": ["../ui/resources/js/*"]
-    }
-  },
-  "include": ["resources/js"],
-  "exclude": ["resources/js/**/*.test.*", "resources/js/**/*.test-d.*"]
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ],
+  "exclude": [
+    "resources/js/**/*.test.*",
+    "resources/js/**/*.test-d.*"
+  ]
 }

--- a/packages/tree/vitest.config.ts
+++ b/packages/tree/vitest.config.ts
@@ -1,18 +1,11 @@
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@lattice-php/core": path.resolve(import.meta.dirname, "../core/resources/js"),
-      "@lattice-php/form": path.resolve(import.meta.dirname, "../form/resources/js"),
-      "@lattice-php/lattice": path.resolve(import.meta.dirname, "../framework/resources/js"),
-      "@lattice-php/action": path.resolve(import.meta.dirname, "../action/resources/js"),
-      "@lattice-php/tree": path.resolve(import.meta.dirname, "resources/js"),
-      "@lattice-php/ui": path.resolve(import.meta.dirname, "../ui/resources/js"),
-    },
+    alias: workspaceAliases,
   },
   test: {
     environment: "jsdom",

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -22,6 +22,8 @@
       "@lattice-php/lattice/*": ["./framework/resources/js/*"],
       "@lattice-php/table": ["./table/resources/js/index.ts"],
       "@lattice-php/table/*": ["./table/resources/js/*"],
+      "@lattice-php/tree": ["./tree/resources/js/index.ts"],
+      "@lattice-php/tree/*": ["./tree/resources/js/*"],
       "@lattice-php/ui": ["./ui/resources/js/index.ts"],
       "@lattice-php/ui/*": ["./ui/resources/js/*"]
     }

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "allowImportingTsExtensions": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "types": ["node", "vite/client"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@lattice-php/action": ["./action/resources/js/index.ts"],
+      "@lattice-php/action/*": ["./action/resources/js/*"],
+      "@lattice-php/core": ["./core/resources/js/index.ts"],
+      "@lattice-php/core/*": ["./core/resources/js/*"],
+      "@lattice-php/form": ["./form/resources/js/index.ts"],
+      "@lattice-php/form/*": ["./form/resources/js/*"],
+      "@lattice-php/lattice": ["./framework/resources/js/index.ts"],
+      "@lattice-php/lattice/*": ["./framework/resources/js/*"],
+      "@lattice-php/table": ["./table/resources/js/index.ts"],
+      "@lattice-php/table/*": ["./table/resources/js/*"],
+      "@lattice-php/ui": ["./ui/resources/js/index.ts"],
+      "@lattice-php/ui/*": ["./ui/resources/js/*"]
+    }
+  }
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,22 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": true,
-    "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
-    "types": ["node", "vite/client"],
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "paths": {
-      "@lattice-php/action": ["../action/resources/js/index.ts"],
-      "@lattice-php/action/*": ["../action/resources/js/*"],
-      "@lattice-php/ui": ["./resources/js/index.ts"],
-      "@lattice-php/ui/*": ["./resources/js/*"]
-    }
-  },
-  "include": ["resources/js"],
-  "exclude": ["resources/js/**/*.test.*", "resources/js/**/*.test-d.*"]
+  "extends": "../tsconfig.base.json",
+  "include": [
+    "resources/js"
+  ],
+  "exclude": [
+    "resources/js/**/*.test.*",
+    "resources/js/**/*.test-d.*"
+  ]
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -51,6 +51,13 @@ export default defineConfig({
         "resources/js/**/*.test-d.*",
         "resources/js/test-setup.ts",
       ],
+      compilerOptions: {
+        paths: {
+          "@lattice-php/ui": [path.join(sourceRoot, "index.ts")],
+          "@lattice-php/ui/*": [path.join(sourceRoot, "*")],
+        },
+        rootDir: sourceRoot,
+      },
       beforeWriteFile: (filePath, content) => ({
         filePath,
         content: withExplicitExtensions(content),

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,17 +1,11 @@
 import react from "@vitejs/plugin-react";
-import path from "node:path";
 import { defineConfig } from "vitest/config";
+import { workspaceAliases } from "../vitest.shared";
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      "@lattice-php/action": path.resolve(import.meta.dirname, "../action/resources/js"),
-      "@lattice-php/core": path.resolve(import.meta.dirname, "../core/resources/js"),
-      "@lattice-php/form": path.resolve(import.meta.dirname, "../form/resources/js"),
-      "@lattice-php/lattice": path.resolve(import.meta.dirname, "../framework/resources/js"),
-      "@lattice-php/ui": path.resolve(import.meta.dirname, "resources/js"),
-    },
+    alias: workspaceAliases,
   },
   test: {
     environment: "jsdom",

--- a/packages/vitest.shared.ts
+++ b/packages/vitest.shared.ts
@@ -11,5 +11,6 @@ export const workspaceAliases: Record<string, string> = {
   "@lattice-php/form": path.resolve(import.meta.dirname, "form/resources/js"),
   "@lattice-php/lattice": path.resolve(import.meta.dirname, "framework/resources/js"),
   "@lattice-php/table": path.resolve(import.meta.dirname, "table/resources/js"),
+  "@lattice-php/tree": path.resolve(import.meta.dirname, "tree/resources/js"),
   "@lattice-php/ui": path.resolve(import.meta.dirname, "ui/resources/js"),
 };

--- a/packages/vitest.shared.ts
+++ b/packages/vitest.shared.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+
+/**
+ * Source aliases for every workspace package, so each package's vitest config
+ * (and any future tooling) resolves siblings identically without repeating the
+ * map. Unused aliases are inert.
+ */
+export const workspaceAliases: Record<string, string> = {
+  "@lattice-php/action": path.resolve(import.meta.dirname, "action/resources/js"),
+  "@lattice-php/core": path.resolve(import.meta.dirname, "core/resources/js"),
+  "@lattice-php/form": path.resolve(import.meta.dirname, "form/resources/js"),
+  "@lattice-php/lattice": path.resolve(import.meta.dirname, "framework/resources/js"),
+  "@lattice-php/table": path.resolve(import.meta.dirname, "table/resources/js"),
+  "@lattice-php/ui": path.resolve(import.meta.dirname, "ui/resources/js"),
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,14 +4,12 @@ includes:
 
 parameters:
     paths:
-        - packages/action/src
-        - packages/core/src
-        - packages/form/src
-        - packages/framework/src
-        - packages/tree/src
-        - packages/ui/src
+        - packages
         - tests
         - workbench/app
     excludePaths:
+        # The framework's publishable config file — larastan's env-outside-config
+        # rule keys on a root config/ dir, which packaged configs don't live in.
+        - packages/framework/config/lattice.php
         - tests/Fixtures/TypeScript/Unloadable/BrokenExtendsMissingClass.php
     level: 6

--- a/rector.php
+++ b/rector.php
@@ -7,12 +7,7 @@ use Rector\TypeDeclaration\Rector\FunctionLike\AddClosureParamTypeForArrayMapRec
 
 return RectorConfig::configure()
     ->withPaths([
-        __DIR__.'/packages/action/src',
-        __DIR__.'/packages/core/src',
-        __DIR__.'/packages/form/src',
-        __DIR__.'/packages/framework/src',
-        __DIR__.'/packages/tree/src',
-        __DIR__.'/packages/ui/src',
+        __DIR__.'/packages',
         __DIR__.'/tests',
         __DIR__.'/workbench/app',
         __DIR__.'/workbench/routes',


### PR DESCRIPTION
Applies the approved tooling proposals:

- **docs workflow filters follow the restructure** — both the push filter and the PR paths-filter still referenced the removed root `resources/**`, so the required docs check silently skipped on PRs touching only package JS. Now `packages/*/resources/**`.
- **`composer test:browser` no longer dies at composer's 300s process timeout** the suite has outgrown.
- **phpstan + rector scan `packages/` wholesale** — the hand-maintained path lists had silently dropped `packages/table/src`. Widening surfaced and fixed one real finding (`TableDefinition::bulkActions()` returns interactive components) and two larastan false positives on the packaged config file (excluded with a comment).
- **pre-push runs `composer check` and `npm run check` concurrently** — the gate now takes ~100s wall clock instead of the serial sum; JS output is replayed only on failure.
- **per-package vitest/tsconfig boilerplate collapses** into `packages/vitest.shared.ts` + `packages/tsconfig.base.json` — new packages get two-line configs, and the alias/paths maps can no longer drift per package. The core/ui dts builds get the same explicit self-only `paths` override form/table/action already had.

Tree's configs adopt the shared base in a follow-up once #399 merges.