### PR TITLE
ci: sync composer split repos on every push to main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,9 +59,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  # Runs on every push to main: the split action no-ops for packages whose
+  # contents are unchanged, and only pushes the tag when a release was created.
   split-composer:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -91,7 +92,7 @@ jobs:
           package_directory: ${{ matrix.package.directory }}
           repository_organization: lattice-php
           repository_name: ${{ matrix.package.repository }}
-          tag: ${{ needs.release-please.outputs.tag_name }}
+          tag: ${{ needs.release-please.outputs.release_created == 'true' && needs.release-please.outputs.tag_name || '' }}
           user_email: github-actions[bot]@users.noreply.github.com
           user_name: github-actions[bot]
         env:


### PR DESCRIPTION
The split-composer job was gated on a release being created, so the lattice-php/action repo stays empty (and lattice-php/tree stays on pre-monorepo content) until 0.41.0 lands.

The split action already no-ops for packages whose contents are unchanged (`git status --porcelain` check in its entrypoint) and skips tagging when the tag input is empty, so the job now runs on every push to main and only attaches the tag on actual releases. This seeds the split repos immediately on merge, making them submittable to Packagist ahead of the release.