### PR TITLE
docs: test-quality guideline and test-audit skill

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -37,17 +37,6 @@
 - Keep comments that explain framework quirks, ordering requirements, browser/test timing, cache/build behavior, performance
   traps, or other constraints that are hard to infer from the code alone.
 
-## Testing
-
-- Prefer feature tests for backend behavior. Test the application through HTTP endpoints, actions, jobs, commands,
-  events, policies, and database effects rather than isolating internals by default.
-- Use unit tests only for complex algorithms implemented as pure functions or small deterministic value objects where
-  integration coverage would make the important cases hard to see.
-- For UI behavior that is not directly about an endpoint's returned payload, use Pest browser tests. This includes
-  interactions, client-side state, navigation, visual toggles, JavaScript behavior, and regressions that only appear in
-  the browser.
-- It is acceptable to add stable test attributes when they make browser assertions clearer or less brittle.
-
 ## Translation Conventions
 
 - **Lowercase keys only**: Translation key segments may use lowercase letters, numbers, dashes, or underscores. Never use camelCase. Both `billing.coming-soon` and `billing.coming_soon` are valid.

--- a/.ai/guidelines/testing.md
+++ b/.ai/guidelines/testing.md
@@ -1,0 +1,56 @@
+# Testing
+
+## Choosing the test type
+
+- Prefer feature tests for backend behavior. Test the application through HTTP endpoints, actions, jobs, commands,
+  events, policies, and database effects rather than isolating internals by default.
+- Use unit tests only for complex algorithms implemented as pure functions or small deterministic value objects where
+  integration coverage would make the important cases hard to see.
+- For UI behavior that is not directly about an endpoint's returned payload, use Pest browser tests. This includes
+  interactions, client-side state, navigation, visual toggles, JavaScript behavior, and regressions that only appear in
+  the browser.
+- It is acceptable to add stable test attributes when they make browser assertions clearer or less brittle.
+- Vitest runs from the root `vite.config.ts` only (a `jsdom` and a `browser` project). Never add per-package vitest
+  configs or setup files; the setup lives in `packages/framework/resources/js/test/`.
+- jsdom is for logic, wiring, and state. The browser project (`*.browser.test.tsx`, `npm run test:browser`) is for
+  anything that depends on layout or real input: portals and popovers, drag and resize, viewport breakpoints, focus
+  management, scrolling, file inputs, hydration.
+- Never stub layout APIs (`getBoundingClientRect`, `ResizeObserver`, `matchMedia` beyond core's `stubMatchMedia`,
+  `scrollIntoView`) or patch DOM prototypes to force jsdom through browser-only behavior — write a browser test.
+- Browser tests drive real input: locators plus `userEvent` from `vitest/browser`, asserted with
+  `await expect.element(...)` and `await expect.poll(...)`. Never `dispatchEvent` with synthetic events — synthetic
+  input skips the browser's own focus, capture, and default-action pipeline, which is the thing browser mode exists
+  to exercise.
+
+## What a test must earn
+
+Every test must assert an observable behavior change caused by an interaction, input, or state transition. The bar is
+the same for Pest and Vitest. Do not write — and delete on sight:
+
+- **Render-only / existence tests**: a component renders, an element or class is present, a page loads and shows static
+  text — with no interaction. This includes Pest assertions that a class or component merely exists.
+- **Styling pins**: `toHaveClass` on Tailwind utilities, class strings mirrored from the source, inline-style string
+  assertions. Assert semantic state instead (`aria-*`, `data-*` state attributes, disabled, focus). A purely
+  presentational component usually needs no unit test at all — its look is a browser or visual concern. "The sibling
+  test files do it" is not a reason; those files were deliberately cleaned.
+- **Absence-only assertions**: `not.toBeInTheDocument()` / `assertDontSee()` on initial render. Absence is only
+  meaningful after the same test establishes the positive case through an interaction (open shows content, close
+  removes it).
+- **Tautologies**: asserting a mock returns what it was configured to return, prop-to-attribute pass-through,
+  constants, re-export identity.
+- **Obsolete regression pins**: tests named after completed refactors, `not.toHaveClass` for classes that no longer
+  exist, guards for finished file moves.
+- **Duplicated coverage**: every behavior has exactly one owning test. Do not re-assert a lower layer's contract
+  (condition DSL, field scoping, cell renderers, formatting) in every consumer.
+- **Implementation-detail pins**: mock call wiring, React element internals, DOM nesting, render counts — except where
+  fine-grained subscription is the module's documented contract.
+
+## Test helpers (TypeScript)
+
+- Reuse the owned helpers before writing local ones: `@lattice-php/core/test-support` (`fakeNode`,
+  `renderWithRegistry`, `jsonResponse`, `stubMatchMedia`), `@lattice-php/form/test-support` (`fakeFormContext`,
+  `fakeConditions`, `renderField`, `createFieldRenderer`, `renderWithForm`), `@lattice-php/ui/test/inertia-mock` and
+  `@lattice-php/ui/test/effect-fixture`, and `packages/table/resources/js/test-support.ts` for table wire fixtures.
+- A helper needed by two or more test files moves to the `test-support` of the lowest package that owns its concepts —
+  never upward into framework, never copy-pasted sideways.
+- Helpers are source-only: excluded from library builds and never added to package exports.

--- a/.ai/skills/test-audit/SKILL.md
+++ b/.ai/skills/test-audit/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: test-audit
+description: Use when auditing or cleaning up the Lattice test suites (Pest or Vitest) — duplicated or misplaced test helpers, low-value or obsolete tests, jsdom tests fighting the environment, suite-wide config drift — or when asked to "get rid of useless tests", align testing across packages, or consolidate test infrastructure.
+---
+
+# Test Suite Audit & Cleanup
+
+## Overview
+
+A test suite audit removes tests that assert nothing real, moves helpers to the layer that owns them, and converts
+environment-fighting tests to the runner that can exercise them honestly. The quality bar for individual tests is
+defined in the Testing guideline (`.ai/guidelines/testing.md`) — this skill is the *process* for applying it at suite
+scale, for both PHP (Pest) and TypeScript (Vitest).
+
+The outcome of a full run in 2026-08 (PR #405): −145 low-value tests (−2,920 lines), all shared helpers relocated to
+their owning packages, and the Vitest browser suite grown 13 → 49 tests on real input — with zero behavioral coverage
+lost and every gate green.
+
+## When to use
+
+- The suites have accumulated render-only, class-pinning, `assertDontSee`, or copy-paste tests.
+- Test helpers are duplicated across packages, or leaf packages import helpers from a higher layer.
+- jsdom tests stub layout APIs, patch prototypes, or hand-invoke mocked callbacks to fake browser behavior.
+- Per-package test configs have drifted, or it is unclear which config CI actually runs.
+
+Not for writing individual new tests — the Testing guideline covers that bar directly.
+
+## Workflow
+
+1. **Isolate.** Create a worktree from latest `main` (use the `worktrees` skill). Never audit on a shared dirty
+   checkout.
+
+2. **Map the infrastructure before reading any test.**
+   - Which configs actually run in CI? (`.github/workflows/` is the truth — locally-runnable configs that CI never
+     executes are drift factories and delete candidates.)
+   - Inventory helper modules and setup files; diff near-duplicates.
+   - Trace helper imports across packages. An upward import (leaf package pulling framework test sources) or a
+     sideways copy-paste is a relocation finding.
+   - Grep for inline duplication clusters: fetch/XHR stubs, router and Inertia mocks, `matchMedia`/`ResizeObserver`
+     stubs, provider render wrappers, response builders, node/fixture factories. Count occurrences; 2+ definitions of
+     the same concept is a consolidation finding.
+   - PHP equivalents: TestCase hierarchy, `Pest.php` hooks, shared factories and datasets, leftover per-suite helpers.
+
+3. **Audit the tests.** Read every test file — grep alone misses most findings. At scale, fan out one read-only
+   subagent per package; require each finding as `file:line` + test name + one-line justification + a verdict:
+   - **DELETE** — fails the Testing guideline's bar (render-only, styling pin, absence-only, tautology, obsolete pin,
+     duplicate).
+   - **TRIM** — the test is sound but carries dead assertions (class pins, redundant absence checks) or duplicates a
+     sibling; also collapse N near-identical tests into one `it.each`/dataset.
+   - **MOVE** — the subject lives in another package/layer, or the behavior is already owned there.
+   - **CONVERT** — the test fights its environment: jsdom → Vitest browser project, or a Pest feature test asserting
+     UI → Pest browser test.
+   Also collect **exemplars** — the suite's best tests define the house style the survivors should match.
+
+4. **Verify before deleting — the iron rule.** A test dies only when its behavior is worthless *or* has exactly one
+   surviving owner, named in the verdict. A CONVERT deletes the original only after its replacement passes. Never
+   batch-delete on category alone; the audit lists are hypotheses until checked against the surviving suite.
+
+5. **Apply in ordered commits.** Order matters:
+   1. *Config consolidation first* — otherwise you centralize helpers into N drifting places again.
+   2. *Helper moves* — create the owned modules, update every import (no compat re-export shims), delete the copies.
+   3. *Deletions/trims* — disjoint packages parallelize safely across subagents.
+   4. *Conversions* — the slowest, most careful work.
+
+6. **Gate every stage.** `npm run check` and `composer check` after each commit-sized step; browser suites
+   (`npm run test:browser`, `composer test:browser`) whenever rendered behavior moved. Run the Vitest browser suite
+   once from a cold cache (`rm -rf node_modules/.vite`) before shipping — CI always runs cold. Rebuild
+   (`npm run build`) before Pest browser tests; they serve the last built bundle.
+
+## Verdict cheat-sheet
+
+| Smell | Verdict | Example from the 2026-08 run |
+|---|---|---|
+| `toHaveClass` mirrors the component's class string | DELETE | separator/skeleton/topbar test files |
+| `not.toHaveClass("x")` where `x` no longer exists in the repo | DELETE | `rounded-lt-md` pins |
+| Mock configured, then asserted | DELETE | `getActionEffects` mock-in-mock-out |
+| Same behavior asserted in N consumers | DELETE N−1, name the owner | visible-condition tests in 10 field files |
+| Sound test + dead class/absence assertions | TRIM | sidebar `md:*` mirrors next to `data-collapsed` |
+| N clones differing by one value | TRIM to `it.each`/dataset | invalid-date matrices, effect-bridge tests |
+| Framework test whose subject is a ui/form component | MOVE (often DELETE: already covered there) | menu-item-action vs button-action |
+| Stubbed `getBoundingClientRect`/`matchMedia`, prototype patches, hand-invoked drag callbacks | CONVERT to browser | tree-move, file-upload, table resize |
+| Fake timers around debounce feeding real UI | CONVERT (poll real timing) | precognitive typing test |
+
+## Traps
+
+- **Helper semantics differ subtly.** A render wrapper using RTL's `wrapper` option keeps its provider across
+  `rerender`; wrapping the element directly does not. When unifying duplicates, adopt the superset semantics and run
+  every consumer.
+- **Synthetic events hide harness bugs.** Converting `dispatchEvent` to real input regularly *fails first* — missing
+  `position: relative`, zero-height elements Playwright refuses to hit, focus that never arrived. That failure is
+  signal, not friction: fix the harness, don't fall back to synthetic events.
+- **Agents recreate deleted patterns from "sibling convention".** After a purge, an unguided agent asked to test a
+  presentational component will rebuild the exact class-pinning file you deleted. The Testing guideline is the
+  counterweight — point implementation subagents at it explicitly.
+- **Browser failure artifacts** (`__screenshots__/`, `.vitest-attachments/`) appear on red runs — keep them
+  gitignored and out of commits (`git add -A` after a red browser run is how they sneak in).
+- **A test that only passes because the environment is fake** (all-zero rects making any pixel number "correct",
+  scroll positions jsdom never changes) is not coverage — treat as CONVERT or DELETE even though it is green.
+- **PHP browser suite pollution**: the Pest browser suite writes translation stubs (e.g.
+  `lang/en/signature-example.php`) via `saveMissing`; remove them before full runs and never commit them.

--- a/boost.json
+++ b/boost.json
@@ -9,14 +9,16 @@
     "nightwatch": false,
     "sail": false,
     "skills": [
+        "infer-conventions",
         "laravel-best-practices",
         "pest-testing",
+        "tailwindcss-development",
         "inertia-react-development",
         "echo-react-development",
         "echo-development",
-        "tailwindcss-development",
         "documentation",
         "pr-review",
+        "test-audit",
         "worktrees"
     ]
 }

--- a/packages/framework/resources/js/chat/components/chat-box.test.tsx
+++ b/packages/framework/resources/js/chat/components/chat-box.test.tsx
@@ -133,6 +133,56 @@ describe("ChatBox component", () => {
     });
   });
 
+  it("surfaces a stream error frame to the user", async () => {
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (_url, init) => {
+        if ((init?.method ?? "GET") === "POST") {
+          return streamResponse(['{"type":"error","message":"Model unavailable"}\n']);
+        }
+
+        return historyResponse();
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatBox();
+    await screen.findByText("Hi");
+
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByTestId("chat-send"));
+
+    expect(await screen.findByText("Model unavailable")).toBeVisible();
+  });
+
+  it("disables the input while streaming and re-enables it when the stream completes", async () => {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (_url, init) =>
+        (init?.method ?? "GET") === "POST"
+          ? ({ ok: true, status: 200, body } as unknown as Response)
+          : historyResponse(),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderChatBox();
+    await screen.findByText("Hi");
+
+    fireEvent.change(screen.getByTestId("chat-input"), { target: { value: "Hello" } });
+    fireEvent.click(screen.getByTestId("chat-send"));
+
+    await waitFor(() => expect(screen.getByTestId("chat-input")).toBeDisabled());
+
+    controller.enqueue(new TextEncoder().encode('{"type":"done"}\n'));
+    controller.close();
+
+    await waitFor(() => expect(screen.getByTestId("chat-input")).not.toBeDisabled());
+  });
+
   it("loads history with a scoped browser token when remote access is configured", async () => {
     document.cookie = "XSRF-TOKEN=test-token";
     const fetchMock = vi.fn<typeof fetch>(async (url) => {


### PR DESCRIPTION
## What

Codifies what #405 established, so it survives the next contributor and the next agent:

- **`.ai/guidelines/testing.md`** — the Testing section moves out of `development.md` and gains the quality bar: the delete-on-sight categories (render-only, styling pins, absence-only without interaction, tautologies, obsolete pins, duplicated coverage, implementation-detail pins), the jsdom-vs-browser split with the real-input rules, and the test-helper ownership map. Applies to Pest and Vitest alike.
- **`.ai/skills/test-audit/`** — a project skill describing the suite-scale cleanup workflow for PHP and TS: infra map first, per-test verdicts (DELETE/TRIM/MOVE/CONVERT), the verify-before-delete rule, ordered commits, gates, and the traps we hit (helper wrapper semantics, synthetic events hiding harness bugs, failure artifacts). Registered in `boost.json`.
- **Two real chat-box tests** that fell out of verification: error-frame surfacing and the disabled-while-streaming cycle — wiring only chat-box owns.

## Verification

Tested the guideline against an unguided baseline: asked to cover `separator.tsx`, an agent without the guideline recreated the exact class-pinning test file #405 deleted ("follows the sibling convention"); with the guideline, the same task produced no separator test — citing the specific clauses — and behavioral chat-box tests with an explicit "deliberately not written" list. One rep per arm; the flip was categorical.