### PR TITLE
fix(ci): deploy docs from main again

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -104,7 +104,9 @@ jobs:
   deploy:
     name: Deploy docs to GitHub Pages
     needs: docs
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    # The skipped `changes` job sits in the needs chain on push events, so the
+    # implicit success() would skip this job — check the docs result directly.
+    if: ${{ !cancelled() && needs.docs.result == 'success' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
Docs deploys have silently skipped on every main push since #—the July 11 required-check fix (5c5273cf) put the pull-request-only `changes` job into deploy's needs chain, where the implicit `success()` treats it as not-success. The build job passed, so nothing looked wrong; the live site just never updated.

Guard deploy the same way the docs job already guards itself: `!cancelled() && needs.docs.result == 'success'`.

Merging this touches `.github/workflows/docs.yml`, which is in the push paths filter, so the merge itself re-runs the workflow and publishes the current site (including the new api-reference page).