### PR TITLE
feat: enum abilities in can + page gates as route middleware

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade Guide
 
+## 0.42 → 0.43
+
+`#[AsPage(middleware: ...)]` now **merges after** the `lattice.pages.middleware` config default
+(`['web']`) instead of replacing it. A page declaring `middleware: 'auth'` registers with
+`['web', 'auth']` — drop any re-declared defaults from page attributes. The `middleware: []`
+opt-out is gone; to change the base stack for all pages, change the config value.
+
 ## 0.38 → 0.40 (the monorepo split)
 
 0.39 split the single `lattice-php/lattice` package into per-domain packages; 0.40 moved the

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -132,7 +132,7 @@ too.
 | `name`       | The route name. Defaults to the route segments joined by dots (`products.edit`), falling back to the class name without its `Page` suffix.                           |
 | `layout`     | The [layout](/core/layouts/) the page renders into — a [`PageLayout`](/advanced/enums/#pages) or a registered layout key. Defaults to `PageLayout::None` (no shell). |
 | `container`  | How the content is framed — a [`PageContainer`](/advanced/enums/#pages) (`Default` or `Centered`). Defaults to `PageContainer::Centered`.                            |
-| `middleware` | Middleware for the page's route — a string or an array. Defaults to the `lattice.pages.middleware` config (`['web']`); pass `[]` to register the route with none.    |
+| `middleware` | Extra middleware for the page's route — a string or an array, merged after the `lattice.pages.middleware` config default (`['web']`).                                |
 | `can`        | Abilities the current user must pass before the page renders — a string or an array. See [Authorization](/core/authorization/).                                      |
 
 ```php
@@ -144,7 +144,7 @@ use Lattice\Core\Enums\PageLayout;
     name: 'products.index',
     layout: PageLayout::App,
     container: PageContainer::Default,
-    middleware: ['web', 'auth'],
+    middleware: 'auth',
 )]
 ```
 
@@ -161,7 +161,7 @@ value set by a parent class. Put the shared framing on a base page once, and con
 only their own route:
 
 ```php
-#[AsPage(layout: PageLayout::App, container: PageContainer::Default, middleware: ['web'])]
+#[AsPage(layout: PageLayout::App, container: PageContainer::Default, middleware: 'auth')]
 abstract class AppPage extends Page {}
 
 #[AsPage(route: '/products', name: 'products.index')]

--- a/packages/core/src/Attributes/AsPage.php
+++ b/packages/core/src/Attributes/AsPage.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Lattice\Core\Attributes;
 
 use Attribute;
+use BackedEnum;
+use Lattice\Core\Authorization;
 use Lattice\Core\Contracts\DeclaresGate;
 use Lattice\Core\Enums\PageContainer;
 use Lattice\Core\Enums\PageLayout;
@@ -19,7 +21,7 @@ final readonly class AsPage implements DeclaresGate
 
     /**
      * @param  array<int, string>|string|null  $middleware
-     * @param  string|array<int, string>  $can
+     * @param  string|BackedEnum|array<int, string|BackedEnum>  $can
      */
     public function __construct(
         public ?string $route = null,
@@ -27,9 +29,9 @@ final readonly class AsPage implements DeclaresGate
         public PageLayout|string|null $layout = null,
         public PageContainer|string|null $container = null,
         public array|string|null $middleware = null,
-        string|array $can = [],
+        string|BackedEnum|array $can = [],
     ) {
-        $this->can = (array) $can;
+        $this->can = Authorization::abilities($can);
     }
 
     public function can(): array

--- a/packages/core/src/Attributes/DefinitionAttribute.php
+++ b/packages/core/src/Attributes/DefinitionAttribute.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Lattice\Core\Attributes;
 
+use BackedEnum;
+use Lattice\Core\Authorization;
 use Lattice\Core\Contracts\DeclaresGate;
 use Lattice\Core\Definition;
 
@@ -25,11 +27,11 @@ abstract class DefinitionAttribute implements DeclaresGate
     private readonly array $can;
 
     /**
-     * @param  string|array<int, string>  $can
+     * @param  string|BackedEnum|array<int, string|BackedEnum>  $can
      */
-    public function __construct(public readonly string $key, string|array $can = [])
+    public function __construct(public readonly string $key, string|BackedEnum|array $can = [])
     {
-        $this->can = (array) $can;
+        $this->can = Authorization::abilities($can);
     }
 
     public function can(): array

--- a/packages/core/src/Authorization.php
+++ b/packages/core/src/Authorization.php
@@ -3,10 +3,12 @@ declare(strict_types=1);
 
 namespace Lattice\Core;
 
+use BackedEnum;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Lattice\Core\Contracts\Authorizable;
 use Lattice\Core\Contracts\DeclaresGate;
+use Lattice\Core\Support\Wire;
 use Spatie\Attributes\Attributes;
 
 /**
@@ -29,6 +31,18 @@ final class Authorization
     public static function ensure(Authorizable $subject, Request $request): void
     {
         abort_unless(self::passes($subject, $request), 403);
+    }
+
+    /**
+     * The declared abilities as gate names: a `can` spelled as a single
+     * ability or a list, each either a string or a backed-enum case.
+     *
+     * @param  string|BackedEnum|array<int, string|BackedEnum>  $can
+     * @return array<int, string>
+     */
+    public static function abilities(string|BackedEnum|array $can): array
+    {
+        return array_map(Wire::scalar(...), is_array($can) ? array_values($can) : [$can]);
     }
 
     /**

--- a/packages/core/src/PageMetadata.php
+++ b/packages/core/src/PageMetadata.php
@@ -14,9 +14,9 @@ use Spatie\Attributes\Attributes;
 final readonly class PageMetadata
 {
     /**
-     * `$middleware` is null when no attribute in the class hierarchy declares
-     * one — the route falls back to `lattice.pages.middleware` at registration
-     * time. An explicit `middleware: []` opts the route out of any middleware.
+     * `$middleware` holds only what the class hierarchy declares (null when
+     * nothing does) — the route merges it after the `lattice.pages.middleware`
+     * default at registration time, so the default applies everywhere.
      *
      * @param  class-string  $class
      * @param  array<int, string>|null  $middleware

--- a/packages/core/src/PageMetadata.php
+++ b/packages/core/src/PageMetadata.php
@@ -20,6 +20,7 @@ final readonly class PageMetadata
      *
      * @param  class-string  $class
      * @param  array<int, string>|null  $middleware
+     * @param  array<int, string>  $can
      */
     private function __construct(
         public string $class,
@@ -28,6 +29,7 @@ final readonly class PageMetadata
         public PageLayout|string $layout,
         public PageContainer|string $container,
         public ?array $middleware,
+        public array $can,
     ) {}
 
     public static function for(PageContract|string $page): self
@@ -48,6 +50,7 @@ final readonly class PageMetadata
             layout: self::inherited($class, fn (AsPage $a): PageLayout|string|null => $a->layout) ?? PageLayout::None,
             container: self::inherited($class, fn (AsPage $a): PageContainer|string|null => $a->container) ?? PageContainer::Centered,
             middleware: self::inheritedMiddleware($class),
+            can: $own?->can() ?? [],
         );
     }
 
@@ -62,7 +65,7 @@ final readonly class PageMetadata
     }
 
     /**
-     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, container: string}
+     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, container: string, can: array<int, string>}
      */
     public function toArray(): array
     {
@@ -73,11 +76,15 @@ final readonly class PageMetadata
             'middleware' => $this->middleware,
             'layout' => $this->serialize($this->layout),
             'container' => $this->serialize($this->container),
+            'can' => $this->can,
         ];
     }
 
     /**
-     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, container: string}  $descriptor
+     * `can` defaults for descriptors cached by a manifest built before it
+     * existed, so an upgrade works without regenerating the discovery cache.
+     *
+     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, container: string, can?: array<int, string>}  $descriptor
      */
     public static function fromArray(array $descriptor): self
     {
@@ -88,6 +95,7 @@ final readonly class PageMetadata
             layout: $descriptor['layout'],
             container: $descriptor['container'],
             middleware: $descriptor['middleware'],
+            can: $descriptor['can'] ?? [],
         );
     }
 

--- a/packages/framework/config/lattice.php
+++ b/packages/framework/config/lattice.php
@@ -42,8 +42,8 @@ return [
     ],
 
     // Pages ship unauthenticated by default; authorization is opt-in via
-    // attribute middleware or Page::authorize(). `#[AsPage(middleware: [])]`
-    // opts a page out of this default entirely.
+    // attribute middleware, `can`, or Page::authorize(). Attribute middleware
+    // is merged after this default, never replacing it.
     'pages' => [
         'middleware' => ['web'],
     ],

--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -194,7 +194,10 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
             Route::get($page->route, [$page->class, 'render'])
                 ->name($page->name)
-                ->middleware($page->middleware ?? config('lattice.pages.middleware', ['web']));
+                ->middleware([
+                    ...$page->middleware ?? config('lattice.pages.middleware', ['web']),
+                    ...array_map(static fn (string $ability): string => 'can:'.$ability, $page->can),
+                ]);
         }
 
         Route::getRoutes()->refreshNameLookups();

--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -194,10 +194,11 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
             Route::get($page->route, [$page->class, 'render'])
                 ->name($page->name)
-                ->middleware([
-                    ...$page->middleware ?? config('lattice.pages.middleware', ['web']),
+                ->middleware(array_values(array_unique([
+                    ...config('lattice.pages.middleware', ['web']),
+                    ...$page->middleware ?? [],
                     ...array_map(static fn (string $ability): string => 'can:'.$ability, $page->can),
-                ]);
+                ])));
         }
 
         Route::getRoutes()->refreshNameLookups();

--- a/packages/ui/src/Concerns/GatesRendering.php
+++ b/packages/ui/src/Concerns/GatesRendering.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Ui\Concerns;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Http\Request;
 use Lattice\Core\Authorization;
@@ -36,11 +37,11 @@ trait GatesRendering
      * on a definition or page. Checked in addition to visible()/hidden() and
      * never widened by them, so the order of the calls does not matter.
      *
-     * @param  string|array<int, string>  $can
+     * @param  string|BackedEnum|array<int, string|BackedEnum>  $can
      */
-    public function can(string|array $can): static
+    public function can(string|BackedEnum|array $can): static
     {
-        $this->can = [...$this->can, ...(array) $can];
+        $this->can = [...$this->can, ...Authorization::abilities($can)];
         $this->resolvedVisibility = null;
 
         return $this;

--- a/tests/Feature/Authorization/DeclaredAbilityTest.php
+++ b/tests/Feature/Authorization/DeclaredAbilityTest.php
@@ -200,10 +200,10 @@ test('a declared ability on a component drops it from the payload', function ():
 test('visible() cannot widen a component\'s declared ability', function (): void {
     allowAbilities();
 
-    expect(Heading::make('x')->can('manage-widgets')->visible(true)->shouldRender())->toBeFalse();
+    expect(Heading::make('x')->can(DeclaredAbility::ManageWidgets)->visible(true)->shouldRender())->toBeFalse();
 });
 
-#[AsPage(can: 'manage-widgets')]
+#[AsPage(can: DeclaredAbility::ManageWidgets)]
 final class DeclaredAbilityAttributePage extends Page
 {
     public function title(): string
@@ -258,7 +258,13 @@ final class DeclaredAbilityAction extends ActionDefinition
     }
 }
 
-#[AsAction('declared.multi-action', can: ['manage-widgets', 'inspect-widgets'])]
+enum DeclaredAbility: string
+{
+    case ManageWidgets = 'manage-widgets';
+    case InspectWidgets = 'inspect-widgets';
+}
+
+#[AsAction('declared.multi-action', can: [DeclaredAbility::ManageWidgets, DeclaredAbility::InspectWidgets])]
 final class DeclaredAbilityMultiAction extends ActionDefinition
 {
     public function definition(ActionComponent $action): ActionComponent

--- a/tests/Feature/Core/PageMetadataTest.php
+++ b/tests/Feature/Core/PageMetadataTest.php
@@ -25,6 +25,9 @@ final class FixtureHomePage extends FixtureBasePage {}
 #[AsPage(route: '/standalone', container: PageContainer::Centered)]
 final class FixtureStandalonePage extends FixtureBasePage {}
 
+#[AsPage(route: '/guarded', can: 'manage-widgets')]
+final class FixtureGuardedPage extends FixtureBasePage {}
+
 test('metadata inherits layout and container from a base AsPage attribute', function (): void {
     $meta = PageMetadata::for(FixtureProductsPage::class);
 
@@ -76,6 +79,20 @@ test('page metadata round-trips through an array descriptor', function (): void 
         ->and($rebuilt->route)->toBe('/products/{product}/edit')
         ->and($rebuilt->layout)->toBe('app')
         ->and($rebuilt->container)->toBe('default');
+});
+
+test('a declared ability round-trips through the descriptor', function (): void {
+    $descriptor = PageMetadata::reflect(FixtureGuardedPage::class)->toArray();
+
+    expect($descriptor['can'])->toBe(['manage-widgets'])
+        ->and(PageMetadata::fromArray($descriptor)->can)->toBe(['manage-widgets']);
+});
+
+test('a descriptor cached before can existed defaults to no abilities', function (): void {
+    $descriptor = PageMetadata::reflect(FixtureEditPage::class)->toArray();
+    unset($descriptor['can']);
+
+    expect(PageMetadata::fromArray($descriptor)->can)->toBe([]);
 });
 
 test('for() prefers a manifest descriptor and falls back to reflection', function (): void {

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -52,6 +52,15 @@ final class RegBarePage extends RegBasePage
     }
 }
 
+#[AsPage(route: '/auth', name: 'auth.index', middleware: 'auth')]
+final class RegAuthPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Auth'));
+    }
+}
+
 #[AsPage(route: '/guarded', name: 'guarded.index', can: ['manage-widgets', 'inspect-widgets'])]
 final class RegGuardedPage extends RegBasePage
 {
@@ -120,12 +129,22 @@ test('the page middleware default is configurable', function (): void {
     expect(Route::getRoutes()->getByName('gadgets.index')->gatherMiddleware())->toBe(['web', 'auth']);
 });
 
-test('an explicit empty middleware attribute opts the page out of the default', function (): void {
+test('attribute middleware merges after the configured default without duplicates', function (): void {
+    config(['lattice.pages.middleware' => ['web']]);
+    Lattice::pages([RegWidgetsPage::class, RegAuthPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    expect(Route::getRoutes()->getByName('auth.index')->gatherMiddleware())->toBe(['web', 'auth'])
+        ->and(Route::getRoutes()->getByName('widgets.index')->gatherMiddleware())->toBe(['web']);
+});
+
+test('an empty middleware attribute keeps the configured default', function (): void {
     Lattice::pages([RegBarePage::class]);
 
     new LatticeServiceProvider(app())->bootPages();
 
-    expect(Route::getRoutes()->getByName('bare.index')->gatherMiddleware())->toBe([]);
+    expect(Route::getRoutes()->getByName('bare.index')->gatherMiddleware())->toBe(['web']);
 });
 
 test('a declared ability registers as can middleware after the page middleware', function (): void {
@@ -137,13 +156,13 @@ test('a declared ability registers as can middleware after the page middleware',
         ->toBe(['web', 'can:manage-widgets', 'can:inspect-widgets']);
 });
 
-test('a middleware opt-out still registers the declared ability as can middleware', function (): void {
+test('a page with empty attribute middleware still registers its declared ability after the default', function (): void {
     Lattice::pages([RegGuardedBarePage::class]);
 
     new LatticeServiceProvider(app())->bootPages();
 
     expect(Route::getRoutes()->getByName('guarded-bare.index')->gatherMiddleware())
-        ->toBe(['can:manage-widgets']);
+        ->toBe(['web', 'can:manage-widgets']);
 });
 
 test('an imperatively registered route-less page registers no route, while a routed sibling still gets its route', function (): void {

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -52,6 +52,24 @@ final class RegBarePage extends RegBasePage
     }
 }
 
+#[AsPage(route: '/guarded', name: 'guarded.index', can: ['manage-widgets', 'inspect-widgets'])]
+final class RegGuardedPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Guarded'));
+    }
+}
+
+#[AsPage(route: '/guarded-bare', name: 'guarded-bare.index', middleware: [], can: 'manage-widgets')]
+final class RegGuardedBarePage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Guarded bare'));
+    }
+}
+
 test('Lattice::pageRegistry()->all() resolves route metadata for registered pages', function (): void {
     Lattice::pages([RegWidgetsPage::class]);
 
@@ -108,6 +126,24 @@ test('an explicit empty middleware attribute opts the page out of the default', 
     new LatticeServiceProvider(app())->bootPages();
 
     expect(Route::getRoutes()->getByName('bare.index')->gatherMiddleware())->toBe([]);
+});
+
+test('a declared ability registers as can middleware after the page middleware', function (): void {
+    Lattice::pages([RegGuardedPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    expect(Route::getRoutes()->getByName('guarded.index')->gatherMiddleware())
+        ->toBe(['web', 'can:manage-widgets', 'can:inspect-widgets']);
+});
+
+test('a middleware opt-out still registers the declared ability as can middleware', function (): void {
+    Lattice::pages([RegGuardedBarePage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    expect(Route::getRoutes()->getByName('guarded-bare.index')->gatherMiddleware())
+        ->toBe(['can:manage-widgets']);
 });
 
 test('an imperatively registered route-less page registers no route, while a routed sibling still gets its route', function (): void {


### PR DESCRIPTION
## What

- `can:` on definition attributes (`AsAction`, `AsPage`, `AsTable`, …) and the `->can()` component modifier now accept backed-enum cases — single or in a list — alongside strings:

  ```php
  #[AsAction('admin.users.resend', can: [AdminPermission::Access, AdminPermission::ManageUsers])]
  #[AsPage(route: '/admin', can: AdminPermission::Access)]
  ```

  Normalized once at construct via `Authorization::abilities()` (`Wire::scalar` per entry), so everything downstream keeps seeing plain strings.

- A routed page's declared abilities now also register as standard `can:` route middleware: `PageMetadata` (and the discovery-manifest descriptor) carry `can`, and `bootPages()` appends one `can:{ability}` entry per ability. The gate becomes visible to `route:list` and fails inside the middleware stack.

- **Breaking**: attribute `middleware` now **merges after** the `lattice.pages.middleware` config default instead of replacing it — `middleware: 'auth'` yields `['web', 'auth']` without re-declaring `web` on every page. The `middleware: []` opt-out is gone; a page route always carries the configured default.

## Why

Enum-backed permission definitions couldn't be passed directly (`->value` everywhere); the page gate was only enforced at render time, invisible to route introspection; and replace-semantics forced every page that added middleware to repeat the default stack.

## Notes

- The render-time `Authorization::ensure()` stays authoritative — it covers embedded (route-less) pages, manually registered routes, and `authorize()` overrides; the middleware is fail-fast + introspection on top.
- `fromArray()` defaults a missing `can` key, so discovery caches written before this upgrade keep working without regeneration.
- Merged middleware is deduped, so a page re-declaring `web` registers it once.