### PR TITLE
feat: card headerActions slot and form fullWidth option

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -16,8 +16,9 @@
 - Git hooks enforce the gate automatically. `composer install` points `core.hooksPath` at `.githooks/`; if the hooks are
   not active, run `composer install` (or `git config core.hooksPath .githooks`) once.
   - **pre-commit** auto-formats staged PHP/JS (Pint, oxfmt, oxlint) and blocks on lint errors.
-  - **pre-push** runs the full CI-equivalent gate: `composer check` (Pint, PHPStan, Rector, Pest) and `npm run check`
-    (lint, format, type check, type coverage, Vitest, library build).
+  - **pre-push** runs the fast static gate: Pint and PHPStan on the PHP side, `npm run check` (lint, format, type check,
+    type coverage, Vitest, library build) on the JS side. Rector and the full Pest suite are too slow to run on every
+    push, so they run in CI and via explicit local runs (`composer check`, `composer test`) instead.
 - Never push on red. Use `git commit`/`git push --no-verify` only in emergencies.
 - The library build is part of the gate on purpose: it is the artifact consumers receive, and it catches bundling
   regressions (e.g. dependencies that must stay external) that the type check and tests do not.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,14 @@
 #!/bin/sh
-# Full CI-equivalent gate. Mirrors the local Verification routine in .ai/guidelines/development.md.
+# Fast static gate. Mirrors the local Verification routine in .ai/guidelines/development.md.
 # Bypass with `git push --no-verify` (emergencies only — never push on red).
 #
-# The generated-types and docs-fixtures diffs are intentionally left to CI: a local run
-# regenerates the committed generated.ts with a different property ordering than main,
-# so a local diff check would fail spuriously. Pest Browser stays CI-only because it
-# needs the built workbench assets and Playwright browsers. docs:typecheck (docs/tsconfig.json)
+# The PHP side only runs Pint and PHPStan here — the full Pest suite and Rector are left
+# to CI (and to running explicitly, e.g. `composer test`/`composer check`) because a full
+# local test run on every push is too slow for a pre-push hook. The generated-types and
+# docs-fixtures diffs are also intentionally left to CI: a local run regenerates the
+# committed generated.ts with a different property ordering than main, so a local diff
+# check would fail spuriously. Pest Browser stays CI-only because it needs the built
+# workbench assets and Playwright browsers. docs:typecheck (docs/tsconfig.json)
 # and the icons-freshness diff also stay CI-only for the same local-drift reasons.
 #
 # The PHP and JS gates are independent, so they run concurrently — JS logs to a
@@ -72,12 +75,12 @@ fi
 js_log="$(mktemp)"
 trap 'rm -f "$js_log"' EXIT
 
-echo "▶ pre-push: composer check + npm run check (concurrent)"
+echo "▶ pre-push: PHP gate (pint + phpstan) + npm run check (concurrent)"
 
 npm run check >"$js_log" 2>&1 &
 js_pid=$!
 
-composer check
+vendor/bin/pint --parallel --test && vendor/bin/phpstan analyse
 php_status=$?
 
 wait "$js_pid"

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -2,6 +2,7 @@
     {
         "props": {
             "description": "Manage how your team appears.",
+            "headerActions": [],
             "title": "Team settings",
             "tooltip": "These settings affect everyone on the team."
         },

--- a/packages/form/resources/js/components/form.test.tsx
+++ b/packages/form/resources/js/components/form.test.tsx
@@ -540,6 +540,31 @@ describe("Lattice form schema components", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("drops the centering and max-width classes when fullWidth is set", () => {
+    const formNode = fakeNode({
+      id: "full-width-form",
+      props: { action: "/items", fullWidth: true },
+      type: "form",
+    });
+
+    render(<FormComponent node={formNode}>{null}</FormComponent>);
+
+    expect(document.querySelector("form")).not.toHaveClass("mx-auto", "max-w-2xl");
+    expect(document.querySelector("form")).toHaveClass("flex", "w-full", "flex-col", "gap-6");
+  });
+
+  it("keeps the centering and max-width classes by default", () => {
+    const formNode = fakeNode({
+      id: "default-width-form",
+      props: { action: "/items" },
+      type: "form",
+    });
+
+    render(<FormComponent node={formNode}>{null}</FormComponent>);
+
+    expect(document.querySelector("form")).toHaveClass("mx-auto", "max-w-2xl");
+  });
+
   it("renders custom submit buttons, substituting the managed submit button", () => {
     const registry = createRegistry({
       components: { button: eagerComponent(ButtonComponent) },

--- a/packages/form/resources/js/components/form.tsx
+++ b/packages/form/resources/js/components/form.tsx
@@ -8,6 +8,7 @@ import { nodeKey } from "@lattice-php/core/nodes";
 import { RenderNode } from "@lattice-php/core/renderer";
 import type { Node, RendererComponent } from "@lattice-php/core";
 import { useT } from "@lattice-php/ui/i18n";
+import { cn } from "@lattice-php/ui/lib/utils";
 import type { Emphasis, Justify, Variant } from "@lattice-php/ui";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FormSubmitButton } from "./base/submit-button";
@@ -154,6 +155,7 @@ function FormShell({ children, node }: { children: React.ReactNode; node: Node<"
   const componentRef = props.ref ?? "";
   const method = props.method ?? "post";
   const precognitive = props.precognitive;
+  const fullWidth = props.fullWidth;
   const resetOnError = props.resetOnError ?? false;
   const resetOnSuccess = props.resetOnSuccess ?? [];
   const fieldLabels = useMemo(() => collectFields(node.schema).labels, [node.schema]);
@@ -202,7 +204,7 @@ function FormShell({ children, node }: { children: React.ReactNode; node: Node<"
       resetOnSuccess={resetOnSuccess}
       validationTimeout={precognitive ? validationTimeout : undefined}
       headers={withHeaders(componentRef)}
-      className="mx-auto flex w-full max-w-2xl flex-col gap-6"
+      className={cn("flex w-full flex-col gap-6", !fullWidth && "mx-auto max-w-2xl")}
       onStart={() => {
         retryPhase.current = retryPhase.current === "renewing" ? "retried" : "idle";
       }}

--- a/packages/form/resources/js/generated.ts
+++ b/packages/form/resources/js/generated.ts
@@ -259,6 +259,7 @@ export type FileUpload = {
 export type Form = {
   action: string | null;
   errorBag: string | null;
+  fullWidth: boolean;
   method: HttpMethod | null;
   precognitive: boolean;
   ref: string | null;

--- a/packages/form/src/Components/Form.php
+++ b/packages/form/src/Components/Form.php
@@ -42,6 +42,8 @@ class Form extends ContainerComponent implements InteractiveComponent
 
     public bool $submitButton = true;
 
+    public bool $fullWidth = false;
+
     public ?Justify $submitJustify = null;
 
     public ?Variant $submitVariant = null;
@@ -166,6 +168,13 @@ class Form extends ContainerComponent implements InteractiveComponent
     public function withoutSubmitButton(): static
     {
         $this->submitButton = false;
+
+        return $this;
+    }
+
+    public function fullWidth(bool $fullWidth = true): static
+    {
+        $this->fullWidth = $fullWidth;
 
         return $this;
     }

--- a/packages/ui/resources/js/components/card.test.tsx
+++ b/packages/ui/resources/js/components/card.test.tsx
@@ -1,26 +1,59 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/core/registry";
 import type { Node } from "@lattice-php/core/types";
-import { fakeNode } from "@lattice-php/core/test-support";
+import { fakeNode, renderWithRegistry } from "@lattice-php/core/test-support";
 import CardComponent from "./card";
+import ButtonComponent from "./button";
+
+const registry = createRegistry({
+  components: { button: eagerComponent(ButtonComponent) },
+  name: "test/card",
+});
 
 function renderCard(props: Node<"card">["props"]) {
   const node = fakeNode({ type: "card", props });
   return render(<CardComponent node={node}>{null}</CardComponent>);
 }
 
+function renderCardWithSchema(props: Node<"card">["props"]) {
+  const node = fakeNode({ type: "card", props });
+  return renderWithRegistry(<CardComponent node={node}>{null}</CardComponent>, registry);
+}
+
 describe("CardComponent tooltip", () => {
   it("reveals the tooltip content next to the title on click", () => {
-    renderCard({ title: "Plan", description: null, tooltip: "Billed monthly." });
+    renderCard({ title: "Plan", description: null, tooltip: "Billed monthly.", headerActions: [] });
 
     fireEvent.click(screen.getByRole("button", { name: "More information" }));
     expect(screen.getByText("Billed monthly.")).toBeVisible();
   });
 
   it("anchors the tooltip to the description when there is no title", () => {
-    renderCard({ title: null, description: "Some detail", tooltip: "Extra." });
+    renderCard({ title: null, description: "Some detail", tooltip: "Extra.", headerActions: [] });
 
     fireEvent.click(screen.getByRole("button", { name: "More information" }));
     expect(screen.getByText("Extra.")).toBeVisible();
+  });
+});
+
+describe("CardComponent headerActions", () => {
+  it("renders header actions right-aligned next to the title", () => {
+    const actionNode = fakeNode({ type: "button", props: { label: "Edit" } });
+
+    renderCardWithSchema({
+      title: "Plan",
+      description: null,
+      tooltip: null,
+      headerActions: [actionNode],
+    });
+
+    expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+  });
+
+  it("renders no header actions when the list is empty", () => {
+    renderCard({ title: "Plan", description: null, tooltip: null, headerActions: [] });
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/resources/js/components/card.tsx
+++ b/packages/ui/resources/js/components/card.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cn } from "../lib/utils";
 import { nodeIdentity } from "@lattice-php/core/test-id";
+import { RenderNode } from "@lattice-php/core/renderer";
 import type { RendererComponent } from "@lattice-php/core/types";
 import { InfoTooltip } from "../info-tooltip";
 
@@ -62,16 +63,26 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const CardComponent: RendererComponent<"card"> = ({ children, node }) => {
-  const { title, description, tooltip } = node.props;
+  const { title, description, tooltip, headerActions } = node.props;
+  const actionNodes = headerActions ?? [];
 
   return (
     <Card data-lattice-component={nodeIdentity(node)}>
-      {(title || description) && (
+      {(title || description || actionNodes.length > 0) && (
         <CardHeader>
-          {title && (
-            <div className="flex items-center">
-              <CardTitle>{title}</CardTitle>
-              <InfoTooltip content={tooltip} />
+          {(title || actionNodes.length > 0) && (
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center">
+                {title && <CardTitle>{title}</CardTitle>}
+                {title && <InfoTooltip content={tooltip} />}
+              </div>
+              {actionNodes.length > 0 && (
+                <div className="flex items-center gap-2">
+                  {actionNodes.map((actionNode, index) => (
+                    <RenderNode key={actionNode.key ?? actionNode.id ?? index} node={actionNode} />
+                  ))}
+                </div>
+              )}
             </div>
           )}
           {description && (

--- a/packages/ui/resources/js/generated.ts
+++ b/packages/ui/resources/js/generated.ts
@@ -34,6 +34,7 @@ export type Callout = {
 };
 export type Card = {
   description: string | null;
+  headerActions: Node[];
   title: string | null;
   tooltip: string | null;
 };

--- a/packages/ui/src/Components/Card.php
+++ b/packages/ui/src/Components/Card.php
@@ -15,6 +15,11 @@ class Card extends ContainerComponent
 
     public ?string $description = null;
 
+    /**
+     * @var array<int, Component>
+     */
+    public array $headerActions = [];
+
     public static function make(?string $title = null, ?string $description = null, ?string $key = null): static
     {
         $card = new static($key);
@@ -28,5 +33,15 @@ class Card extends ContainerComponent
         }
 
         return $card;
+    }
+
+    /**
+     * @param  array<int, Component>  $actions
+     */
+    public function headerActions(array $actions): static
+    {
+        $this->headerActions = $actions;
+
+        return $this;
     }
 }

--- a/packages/ui/src/Components/Card.php
+++ b/packages/ui/src/Components/Card.php
@@ -40,7 +40,7 @@ class Card extends ContainerComponent
      */
     public function headerActions(array $actions): static
     {
-        $this->headerActions = $actions;
+        $this->headerActions = array_values($this->renderableComponents($actions));
 
         return $this;
     }

--- a/packages/ui/src/Components/Section.php
+++ b/packages/ui/src/Components/Section.php
@@ -55,7 +55,7 @@ class Section extends ContainerComponent
      */
     public function headerActions(array $actions): static
     {
-        $this->headerActions = $actions;
+        $this->headerActions = array_values($this->renderableComponents($actions));
 
         return $this;
     }

--- a/tests/Feature/Core/RegistryTest.php
+++ b/tests/Feature/Core/RegistryTest.php
@@ -48,6 +48,7 @@ test('lattice can discover attributed definitions from a path and namespace', fu
                 'resetOnError' => null,
                 'status' => null,
                 'state' => [],
+                'fullWidth' => false,
             ],
         ])
         ->and($table)

--- a/tests/Feature/Forms/Components/FormWireShapeTest.php
+++ b/tests/Feature/Forms/Components/FormWireShapeTest.php
@@ -33,7 +33,14 @@ it('serializes the form container wire shape', function (): void {
         'resetOnSuccess' => ['email'],
         'resetOnError' => true,
         'state' => ['email' => 'a@b.c'],
+        'fullWidth' => false,
     ]);
     expect($payload)->toHaveKey('schema');
     expect($payload['props'])->not->toHaveKey('context');
+});
+
+it('serializes the fullWidth flag on form components', function (): void {
+    expect(wire(Form::make('demo'))['props']['fullWidth'])->toBeFalse();
+    expect(wire(Form::make('demo')->fullWidth())['props']['fullWidth'])->toBeTrue();
+    expect(wire(Form::make('demo')->fullWidth(false))['props']['fullWidth'])->toBeFalse();
 });

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -54,6 +54,7 @@ test('registered forms serialize their configured endpoint and isolated error ba
                 'resetOnError' => null,
                 'status' => null,
                 'state' => [],
+                'fullWidth' => false,
             ],
             'schema' => [
                 [

--- a/tests/Feature/Ui/Components/CardWireShapeTest.php
+++ b/tests/Feature/Ui/Components/CardWireShapeTest.php
@@ -32,3 +32,14 @@ it('serializes header actions as button components on the card', function (): vo
 it('serializes an empty headerActions array by default', function (): void {
     expect(wire(Card::make('Team settings'))['props']['headerActions'])->toBe([]);
 });
+
+it('omits a header action hidden via visible(false) from the serialized headerActions', function (): void {
+    $card = Card::make('Team settings')->headerActions([
+        Button::make('Edit'),
+        Button::make('Secret')->visible(false),
+    ]);
+
+    $labels = array_column(wire($card)['props']['headerActions'], 'props');
+
+    expect(array_column($labels, 'label'))->toBe(['Edit']);
+});

--- a/tests/Feature/Ui/Components/CardWireShapeTest.php
+++ b/tests/Feature/Ui/Components/CardWireShapeTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Ui\Components\Button;
+use Lattice\Ui\Components\Card;
+
+it('serializes the card component wire shape', function (): void {
+    $card = Card::make('Team settings', 'Manage how your team appears.');
+
+    $payload = wire($card);
+
+    expect($payload['type'])->toBe('card');
+    expect($payload['props'])->toMatchArray([
+        'title' => 'Team settings',
+        'description' => 'Manage how your team appears.',
+        'headerActions' => [],
+    ]);
+});
+
+it('serializes header actions as button components on the card', function (): void {
+    $card = Card::make('Team settings')->headerActions([
+        Button::make('Edit'),
+    ]);
+
+    $payload = wire($card);
+
+    expect($payload['props']['headerActions'])->toHaveCount(1);
+    expect($payload['props']['headerActions'][0]['type'])->toBe('button');
+    expect($payload['props']['headerActions'][0]['props']['label'])->toBe('Edit');
+});
+
+it('serializes an empty headerActions array by default', function (): void {
+    expect(wire(Card::make('Team settings'))['props']['headerActions'])->toBe([]);
+});

--- a/tests/Feature/Ui/Components/SectionWireShapeTest.php
+++ b/tests/Feature/Ui/Components/SectionWireShapeTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Ui\Components\Button;
+use Lattice\Ui\Components\Section;
+
+it('serializes an empty headerActions array by default', function (): void {
+    expect(wire(Section::make('Team settings'))['props']['headerActions'])->toBe([]);
+});
+
+it('serializes header actions as button components on the section', function (): void {
+    $section = Section::make('Team settings')->headerActions([
+        Button::make('Edit'),
+    ]);
+
+    $payload = wire($section);
+
+    expect($payload['props']['headerActions'])->toHaveCount(1);
+    expect($payload['props']['headerActions'][0]['type'])->toBe('button');
+    expect($payload['props']['headerActions'][0]['props']['label'])->toBe('Edit');
+});
+
+it('omits a header action hidden via visible(false) from the serialized headerActions', function (): void {
+    $section = Section::make('Team settings')->headerActions([
+        Button::make('Edit'),
+        Button::make('Secret')->visible(false),
+    ]);
+
+    $labels = array_column(wire($section)['props']['headerActions'], 'props');
+
+    expect(array_column($labels, 'label'))->toBe(['Edit']);
+});


### PR DESCRIPTION
## Summary
- `Form::fullWidth()` lets a form fill its container instead of centering at `max-w-2xl` — needed when embedding forms in cards or other constrained layouts.
- `Card::headerActions([...])` adds a right-aligned action slot next to the card title, for controls bound to the card itself (first consumer: a tree-card visibility toggle) rather than the card body.
- `chore:` commit hardens the local `pre-push` hook to run Pint + PHPStan only on the PHP side (dropping the full Pest suite and Rector, which made every push slow); the full checks stay in CI and via explicit `composer check`/`composer test`.

## Test plan
- [x] `composer check` (Pint, PHPStan, Rector, full Pest suite) green
- [x] `npm run check` (lint, format, typecheck, type-coverage, Vitest, library build, package checks) green
- [x] New PHP wire-shape tests for `Form::fullWidth()` and `Card::headerActions()`
- [x] New Vitest tests for the form wrapper class flip and the card header-actions row