### PR TITLE
fix: package discovery fatals in consumer apps without testbench (0.45 regression)

### DIFF
--- a/packages/core/src/Discovery/DiscoveryManifest.php
+++ b/packages/core/src/Discovery/DiscoveryManifest.php
@@ -10,6 +10,7 @@ use Lattice\Core\PageMetadata;
 use Lattice\Core\Support\Discovery\ClassWalker;
 use ReflectionClass;
 use Spatie\Attributes\Attributes;
+use Throwable;
 
 final class DiscoveryManifest
 {
@@ -109,7 +110,18 @@ final class DiscoveryManifest
 
         foreach (self::configuredPaths() as $path) {
             foreach (ClassWalker::classes($path) as $class) {
-                if (new ReflectionClass($class)->isAbstract()) {
+                try {
+                    $abstract = new ReflectionClass($class)->isAbstract();
+                } catch (Throwable) {
+                    // A discovered class can fail to autoload when it depends on an
+                    // optional (e.g. require-dev) package that isn't installed in the
+                    // consuming app — e.g. Lattice's own Testbench-based test
+                    // scaffolding. It can't carry a discoverable attribute either
+                    // way, so skip it rather than fatal.
+                    continue;
+                }
+
+                if ($abstract) {
                     continue;
                 }
 

--- a/tests/Feature/Discovery/DiscoveryManifestTest.php
+++ b/tests/Feature/Discovery/DiscoveryManifestTest.php
@@ -119,3 +119,15 @@ test('the class walker returns classes under a path and an empty list for a miss
 test('the class walker includes enums via all()', function (): void {
     expect(ClassWalker::all(dirname(__DIR__, 3).'/packages/table/src/Enums'))->toContain(ColumnType::class);
 });
+
+test('the manifest skips a class that fails to autoload instead of throwing', function (): void {
+    config(['lattice.discover' => [
+        dirname(__DIR__, 2).'/Fixtures/Discovery',
+        dirname(__DIR__, 2).'/Fixtures/TypeScript/Unloadable',
+    ]]);
+    app(DiscoveryManifest::class)->clear();
+
+    $manifest = app(DiscoveryManifest::class);
+
+    expect($manifest->forGroup('forms'))->toMatchArray(['fixtures.profile' => DiscoveredProfileForm::class]);
+});


### PR DESCRIPTION
## Summary

Consumer apps requiring `lattice-php/lattice` `^0.45` **without** `orchestra/testbench` (not a runtime dependency) fatal during `php artisan package:discover`:

```
Class "Orchestra\Testbench\TestCase" not found
```

at `src/Support/Testing/PackageTestCase.php:21` (also `PackageBrowserTestCase`). This blocks any consumer from upgrading to 0.45.

## Root cause

`DiscoveryManifest::build()` reflects over every class discovered under each configured/component-package root — which for the framework package includes its own `src/`, and therefore `src/Support/Testing/PackageTestCase.php` and `PackageBrowserTestCase.php`. Those classes extend `Orchestra\Testbench\TestCase`, a require-dev-only dependency the framework itself pulls in for its own test suite but never ships to consumers. Reflecting on them autoloads the file, which fatals when the parent class can't be resolved — and this call was not guarded.

`bootPages()` runs `DiscoveryManifest::build()` on every application boot (via `$this->app->booted(...)`), including console commands like `package:discover`, so any fresh consumer install hits this immediately.

`WireTypeDiscovery` already handles this exact scenario (a discovered class whose parent lives in an uninstalled optional dependency) by catching the reflection failure and skipping the class. `DiscoveryManifest::build()` had the same reflection call unguarded.

## Fix

Wrap the reflection in `DiscoveryManifest::build()` in a try/catch, matching the existing `WireTypeDiscovery` pattern: skip a class that fails to autoload instead of letting the `Error` propagate. This is a general fix — any discovered class with an unloadable parent (not just Testbench-based fixtures) is now skipped safely rather than fataling the whole discovery pass.

## Test plan

- [x] New regression test (`the manifest skips a class that fails to autoload instead of throwing`) reproduces the fatal against the existing `Unloadable` fixtures before the fix, and passes after
- [x] `composer check` (pint, phpstan, rector, full pest suite) green
- [x] `npm run check` green