### PR TITLE
chore: run rector fix and cached phpstan check in pre-commit

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -15,10 +15,15 @@
 
 - Git hooks enforce the gate automatically. `composer install` points `core.hooksPath` at `.githooks/`; if the hooks are
   not active, run `composer install` (or `git config core.hooksPath .githooks`) once.
-  - **pre-commit** auto-formats staged PHP/JS (Pint, oxfmt, oxlint) and blocks on lint errors.
+  - **pre-commit** auto-fixes staged PHP with Pint and Rector, auto-formats staged JS (oxfmt, oxlint), re-stages the
+    fixes, then runs PHPStan (both configs) over the whole project and blocks on any error. PHPStan's result cache is
+    pinned to `.phpstan-cache/` (gitignored, `parameters.tmpDir` in `phpstan.neon.dist`/`phpstan-tests.neon.dist`) so
+    it persists across commits — after the first run, only files that actually changed get re-analysed, keeping the
+    hook fast despite running full-project.
   - **pre-push** runs the fast static gate: Pint and PHPStan on the PHP side, `npm run check` (lint, format, type check,
-    type coverage, Vitest, library build) on the JS side. Rector and the full Pest suite are too slow to run on every
-    push, so they run in CI and via explicit local runs (`composer check`, `composer test`) instead.
+    type coverage, Vitest, library build) on the JS side. The full Pest suite is too slow to run on every push, so it
+    runs in CI and via explicit local runs (`composer test`) instead. Its PHPStan run is a safety net for commits made
+    with `--no-verify`; a normal commit has already satisfied it.
 - Never push on red. Use `git commit`/`git push --no-verify` only in emergencies.
 - The library build is part of the gate on purpose: it is the artifact consumers receive, and it catches bundling
   regressions (e.g. dependencies that must stay external) that the type check and tests do not.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,10 @@
 #!/bin/sh
-# Fast pre-commit gate: auto-format staged PHP/JS and block on lint errors.
-# The full CI-equivalent gate runs on pre-push. Bypass with `git commit --no-verify`.
+# Fast pre-commit gate: auto-fix staged PHP/JS and block on remaining errors.
+# PHPStan runs full-project (not scoped to staged files) so its cross-file inference stays
+# accurate; parameters.tmpDir in phpstan.neon.dist/phpstan-tests.neon.dist points its result
+# cache at .phpstan-cache/ (gitignored, persists across commits) so repeat runs only
+# re-analyse what actually changed instead of the whole tree.
+# Bypass with `git commit --no-verify`.
 set -e
 
 root="$(git rev-parse --show-toplevel)"
@@ -9,7 +13,15 @@ cd "$root"
 if ! git diff --cached --quiet --diff-filter=ACMR -- '*.php'; then
     echo "▶ pint (staged PHP)"
     git diff -z --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -0 ./vendor/bin/pint
+
+    echo "▶ rector (staged PHP)"
+    git diff -z --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -0 ./vendor/bin/rector process --config=rector.php
+
     git diff -z --cached --name-only --diff-filter=ACMR -- '*.php' | xargs -0 git add
+
+    echo "▶ phpstan (cached)"
+    ./vendor/bin/phpstan analyse --no-progress
+    ./vendor/bin/phpstan analyse -c phpstan-tests.neon.dist --no-progress
 fi
 
 if ! git diff --cached --quiet --diff-filter=ACMR -- '*.ts' '*.tsx'; then

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 /.playwright-mcp
 /.phpunit.cache
 /.phpunit.result.cache
+/.phpstan-cache
 /vendor/orchestra/testbench-core/laravel
 /public/build
 /workbench/database/*.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 /.phpunit.cache
 /.phpunit.result.cache
 /.phpstan-cache
+/.rector-cache
 /vendor/orchestra/testbench-core/laravel
 /public/build
 /workbench/database/*.sqlite

--- a/phpstan-tests.neon.dist
+++ b/phpstan-tests.neon.dist
@@ -3,6 +3,7 @@ includes:
     - vendor/pestphp/pest-plugin-phpstan/extension.neon
 
 parameters:
+    tmpDir: %currentWorkingDirectory%/.phpstan-cache/tests
     paths:
         - tests
         - workbench/app

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,7 @@ includes:
     - vendor/pestphp/pest-plugin-phpstan/extension.neon
 
 parameters:
+    tmpDir: %currentWorkingDirectory%/.phpstan-cache/main
     paths:
         - packages
     excludePaths:

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,9 @@ return RectorConfig::configure()
         __DIR__.'/workbench/app',
         __DIR__.'/workbench/routes',
     ])
+    // Default is sys_get_temp_dir(), which is as volatile as PHPStan's — pin it locally
+    // (gitignored) so the cache survives between commits instead of resetting per OS cleanup.
+    ->withCache(cacheDirectory: __DIR__.'/.rector-cache')
     ->withPhpSets(php84: true)
     ->withPreparedSets(
         deadCode: true,


### PR DESCRIPTION
## Summary
- `pre-commit` now mirrors artisan-os's gate: after Pint fixes and restages staged PHP, it also runs Rector on those files, then runs PHPStan (both `phpstan.neon.dist` and `phpstan-tests.neon.dist`) full-project and blocks the commit on any error.
- PHPStan's `parameters.tmpDir` and Rector's `withCache()` are pinned to gitignored `.phpstan-cache/` and `.rector-cache/` instead of the volatile system temp dir, so their result caches survive between commits — PHPStan ~11-15s cold / ~1s warm, Rector ~18s cold / ~0.6s warm on a full-project run.
- `.ai/guidelines/development.md` updated to describe the new pre-commit behavior; `pre-push`'s PHPStan run is now mainly a safety net for `--no-verify` commits.

## Test plan
- [x] Ran the hook directly against a real staged PHP change: Pint fixed it, Rector ran clean, both PHPStan configs passed on the warm cache, exit 0
- [x] Timed cold vs warm runs for both PHPStan configs and Rector to confirm the cache pinning works
- [x] `git push` exercised the updated `pre-push` gate (Pint, both PHPStan configs, `npm run check`) — passed