### PR TITLE
fix(table): stop page-level scroll leak, pin toolbar during scroll, translate status filter

### DIFF
--- a/packages/table/resources/js/components/table.browser.test.tsx
+++ b/packages/table/resources/js/components/table.browser.test.tsx
@@ -72,6 +72,41 @@ describe("Lattice table component in a browser", () => {
     expect(scroll.scrollWidth).toBeGreaterThan(scroll.clientWidth);
   });
 
+  it("keeps table-scroll as the containing block so the sr-only actions label scrolls with it instead of leaking page overflow", async () => {
+    const wideNode = node({
+      columns: Array.from({ length: 8 }, (_, index) =>
+        col({ key: `col${index}`, label: `Column ${index}`, width: "md" }),
+      ),
+      data: [
+        Object.fromEntries([
+          ["id", 1],
+          ...Array.from({ length: 8 }, (_, index) => [`col${index}`, `Value ${index}`]),
+          ["actions", [{ type: "unregistered-test-action", id: "a1", props: {} }]],
+        ]),
+      ],
+    });
+
+    const screen = await render(
+      <div style={{ display: "flex", width: "600px" }}>
+        <TableComponent node={wideNode} />
+      </div>,
+    );
+
+    const table = screen.getByRole("table").element();
+    const scroll = table.closest('[data-slot="table-scroll"]') as HTMLElement;
+    const wrapper = scroll.closest('[data-slot="table"]') as HTMLElement;
+    const ancestor = wrapper.parentElement as HTMLElement;
+
+    // The sr-only actions label has no explicit position, so it falls back to
+    // its static layout position within its containing block. If that
+    // containing block is an ancestor outside table-scroll (the actual
+    // scrolling element), the label renders at a fixed page coordinate that
+    // ignores scrollLeft entirely, leaking page-level horizontal overflow.
+    scroll.scrollLeft = scroll.scrollWidth;
+
+    expect(ancestor.scrollWidth).toBeLessThanOrEqual(ancestor.clientWidth + 1);
+  });
+
   it("keeps the header background painted behind every column even though the header row's own box is narrower than its grid tracks", async () => {
     const wideNode = node({
       columns: Array.from({ length: 8 }, (_, index) =>

--- a/packages/table/resources/js/components/table.browser.test.tsx
+++ b/packages/table/resources/js/components/table.browser.test.tsx
@@ -44,7 +44,7 @@ describe("Lattice table component in a browser", () => {
     expect(getComputedStyle(mobileLabel as HTMLElement).display).toBe("none");
   });
 
-  it("contains horizontal overflow inside table-scroll instead of a flex ancestor", async () => {
+  it("contains horizontal overflow inside table-grid-scroll instead of a flex ancestor", async () => {
     const wideNode = node({
       columns: Array.from({ length: 8 }, (_, index) =>
         col({ key: `col${index}`, label: `Column ${index}`, width: "md" }),
@@ -64,15 +64,46 @@ describe("Lattice table component in a browser", () => {
     );
 
     const table = screen.getByRole("table").element();
-    const scroll = table.closest('[data-slot="table-scroll"]') as HTMLElement;
-    const wrapper = scroll.closest('[data-slot="table"]') as HTMLElement;
+    const gridScroll = table.closest('[data-slot="table-grid-scroll"]') as HTMLElement;
+    const wrapper = table.closest('[data-slot="table"]') as HTMLElement;
     const ancestor = wrapper.parentElement as HTMLElement;
 
     expect(ancestor.scrollWidth).toBeLessThanOrEqual(ancestor.clientWidth + 1);
-    expect(scroll.scrollWidth).toBeGreaterThan(scroll.clientWidth);
+    expect(gridScroll.scrollWidth).toBeGreaterThan(gridScroll.clientWidth);
   });
 
-  it("keeps table-scroll as the containing block so the sr-only actions label scrolls with it instead of leaking page overflow", async () => {
+  it("keeps the toolbar, filter bar, and sort bar pinned instead of scrolling with the grid", async () => {
+    const wideNode = node({
+      columns: Array.from({ length: 8 }, (_, index) =>
+        col({ key: `col${index}`, label: `Column ${index}`, width: "md" }),
+      ),
+      data: [
+        Object.fromEntries([
+          ["id", 1],
+          ...Array.from({ length: 8 }, (_, index) => [`col${index}`, `Value ${index}`]),
+        ]),
+      ],
+      searchable: true,
+    });
+
+    const screen = await render(
+      <div style={{ display: "flex", width: "600px" }}>
+        <TableComponent node={wideNode} />
+      </div>,
+    );
+
+    const table = screen.getByRole("table").element();
+    const gridScroll = table.closest('[data-slot="table-grid-scroll"]') as HTMLElement;
+    const wrapper = gridScroll.closest('[data-slot="table"]') as HTMLElement;
+    const toolbar = wrapper.querySelector('[data-slot="table-toolbar"]') as HTMLElement;
+    const toolbarLeftBefore = toolbar.getBoundingClientRect().left;
+
+    gridScroll.scrollLeft = gridScroll.scrollWidth;
+
+    expect(toolbar.getBoundingClientRect().left).toBe(toolbarLeftBefore);
+  });
+
+  it("keeps table-grid-scroll as the containing block so the sr-only actions label scrolls with it instead of leaking page overflow", async () => {
     const wideNode = node({
       columns: Array.from({ length: 8 }, (_, index) =>
         col({ key: `col${index}`, label: `Column ${index}`, width: "md" }),
@@ -93,16 +124,16 @@ describe("Lattice table component in a browser", () => {
     );
 
     const table = screen.getByRole("table").element();
-    const scroll = table.closest('[data-slot="table-scroll"]') as HTMLElement;
-    const wrapper = scroll.closest('[data-slot="table"]') as HTMLElement;
+    const gridScroll = table.closest('[data-slot="table-grid-scroll"]') as HTMLElement;
+    const wrapper = table.closest('[data-slot="table"]') as HTMLElement;
     const ancestor = wrapper.parentElement as HTMLElement;
 
     // The sr-only actions label has no explicit position, so it falls back to
     // its static layout position within its containing block. If that
-    // containing block is an ancestor outside table-scroll (the actual
+    // containing block is an ancestor outside table-grid-scroll (the actual
     // scrolling element), the label renders at a fixed page coordinate that
     // ignores scrollLeft entirely, leaking page-level horizontal overflow.
-    scroll.scrollLeft = scroll.scrollWidth;
+    gridScroll.scrollLeft = gridScroll.scrollWidth;
 
     expect(ancestor.scrollWidth).toBeLessThanOrEqual(ancestor.clientWidth + 1);
   });

--- a/packages/table/resources/js/components/table.tsx
+++ b/packages/table/resources/js/components/table.tsx
@@ -154,7 +154,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
     <div data-slot="table" data-lattice-component={node.id} className="relative min-w-0">
       <div
         data-slot="table-scroll"
-        className="overflow-x-auto rounded-lt-sm border border-lt-border"
+        className="relative overflow-x-auto rounded-lt-sm border border-lt-border"
       >
         {hasToolbar && (
           <div

--- a/packages/table/resources/js/components/table.tsx
+++ b/packages/table/resources/js/components/table.tsx
@@ -152,10 +152,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
 
   return (
     <div data-slot="table" data-lattice-component={node.id} className="relative min-w-0">
-      <div
-        data-slot="table-scroll"
-        className="relative overflow-x-auto rounded-lt-sm border border-lt-border"
-      >
+      <div data-slot="table-scroll" className="rounded-lt-sm border border-lt-border">
         {hasToolbar && (
           <div
             data-slot="table-toolbar"
@@ -235,231 +232,239 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
             onClear={clearSort}
           />
         )}
-        <div
-          ref={resizeRootRef}
-          className="min-w-full text-base"
-          role="table"
-          style={{ "--lattice-table-columns": gridTemplateColumns } as never}
-        >
-          <div data-slot="table-header" role="rowgroup">
-            <div
-              className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
-              role="row"
-            >
-              {hasExpandable && (
-                <div
-                  className={cn(
-                    "bg-lt-muted/50 px-2 py-3",
-                    !hasFilters && "border-b border-lt-border",
-                  )}
-                  role="columnheader"
-                  aria-hidden="true"
-                />
-              )}
-              {hasBulkActions && (
-                <div
-                  className={cn(
-                    "flex items-center bg-lt-muted/50 px-4 py-3",
-                    !hasFilters && "border-b border-lt-border",
-                  )}
-                  role="columnheader"
-                >
-                  <Checkbox
-                    aria-label={t("table.select-all-rows", "Select all rows")}
-                    data-test="select-all"
-                    checked={selection.allSelected}
-                    onCheckedChange={() => selection.toggleAll()}
-                  />
-                </div>
-              )}
-              {visibleColumns.map((column, index) => (
-                <ColumnHeader
-                  column={column}
-                  key={column.key}
-                  processing={processing}
-                  resizeHandleProps={
-                    resizingEnabled ? getResizeHandleProps(sizingColumns[index]) : undefined
-                  }
-                  sort={sort}
-                  query={query}
-                  bottomBordered={!hasFilters}
-                />
-              ))}
-              {hasTrailingUtility && (
-                <div
-                  className={cn(
-                    "flex items-center justify-end gap-2 bg-lt-muted/50 px-4 py-2 align-middle font-semibold text-lt-fg",
-                    !hasFilters && "border-b border-lt-border",
-                  )}
-                  role="columnheader"
-                >
-                  <span className="sr-only">
-                    {node.props?.actionsLabel ?? t("table.actions", "Actions")}
-                  </span>
-                </div>
-              )}
-            </div>
-            {hasFilters && (
+        <div data-slot="table-grid-scroll" className="relative overflow-x-auto">
+          <div
+            ref={resizeRootRef}
+            className="min-w-full text-base"
+            role="table"
+            style={{ "--lattice-table-columns": gridTemplateColumns } as never}
+          >
+            <div data-slot="table-header" role="rowgroup">
               <div
                 className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
                 role="row"
               >
                 {hasExpandable && (
                   <div
-                    className="border-t border-b border-lt-border bg-lt-muted/50 px-2 py-2"
-                    role="cell"
+                    className={cn(
+                      "bg-lt-muted/50 px-2 py-3",
+                      !hasFilters && "border-b border-lt-border",
+                    )}
+                    role="columnheader"
+                    aria-hidden="true"
                   />
                 )}
                 {hasBulkActions && (
                   <div
-                    className="border-t border-b border-lt-border bg-lt-muted/50 px-4 py-2"
-                    role="cell"
-                  />
-                )}
-                {visibleColumns.map((column) => (
-                  <div
-                    key={column.key}
-                    className="min-w-0 border-t border-b border-lt-border bg-lt-muted/50 px-2 py-2"
-                    role="cell"
-                  >
-                    {column.props.filter != null && (
-                      <ColumnFilterControl
-                        column={column}
-                        clauses={filterEntries.filter((entry) => entry.clause.field === column.key)}
-                        processing={processing}
-                        onAdd={addFilter}
-                        onUpdate={updateFilter}
-                        onRemove={removeFilter}
-                        onReplace={replaceColumnFilters}
-                        onSearch={(query, signal) =>
-                          searchFilterOptions(`column:${column.key}`, query, signal)
-                        }
-                      />
+                    className={cn(
+                      "flex items-center bg-lt-muted/50 px-4 py-3",
+                      !hasFilters && "border-b border-lt-border",
                     )}
+                    role="columnheader"
+                  >
+                    <Checkbox
+                      aria-label={t("table.select-all-rows", "Select all rows")}
+                      data-test="select-all"
+                      checked={selection.allSelected}
+                      onCheckedChange={() => selection.toggleAll()}
+                    />
                   </div>
+                )}
+                {visibleColumns.map((column, index) => (
+                  <ColumnHeader
+                    column={column}
+                    key={column.key}
+                    processing={processing}
+                    resizeHandleProps={
+                      resizingEnabled ? getResizeHandleProps(sizingColumns[index]) : undefined
+                    }
+                    sort={sort}
+                    query={query}
+                    bottomBordered={!hasFilters}
+                  />
                 ))}
                 {hasTrailingUtility && (
                   <div
-                    className="border-t border-b border-lt-border bg-lt-muted/50 px-4 py-2"
-                    role="cell"
-                  />
+                    className={cn(
+                      "flex items-center justify-end gap-2 bg-lt-muted/50 px-4 py-2 align-middle font-semibold text-lt-fg",
+                      !hasFilters && "border-b border-lt-border",
+                    )}
+                    role="columnheader"
+                  >
+                    <span className="sr-only">
+                      {node.props?.actionsLabel ?? t("table.actions", "Actions")}
+                    </span>
+                  </div>
                 )}
               </div>
-            )}
-          </div>
-          <div role="rowgroup">
-            {!hasLoaded ? (
-              <div className="p-4 text-lt-muted-fg" role="row">
-                <div role="cell">{t("table.loading", "Loading rows...")}</div>
-              </div>
-            ) : rowEntries.length === 0 ? (
-              <div data-slot="table-empty" className="p-8 text-center text-lt-muted-fg" role="row">
-                <div role="cell">{node.props?.emptyLabel ?? t("table.empty", "No results")}</div>
-              </div>
-            ) : (
-              rowEntries.map(({ row, actions, detail, key }) => {
-                const expanded = detail != null && isExpanded(key);
-                const detailId = `${nodeIdentity(node) ?? "table"}-row-detail-${key}`;
-
-                return (
-                  <Fragment key={key}>
+              {hasFilters && (
+                <div
+                  className="hidden min-w-full md:grid md:grid-cols-[var(--lattice-table-columns)]"
+                  role="row"
+                >
+                  {hasExpandable && (
                     <div
-                      data-slot="table-row"
-                      className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
-                        striped ? "odd:bg-lt-muted/30" : ""
-                      }`}
-                      role="row"
+                      className="border-t border-b border-lt-border bg-lt-muted/50 px-2 py-2"
+                      role="cell"
+                    />
+                  )}
+                  {hasBulkActions && (
+                    <div
+                      className="border-t border-b border-lt-border bg-lt-muted/50 px-4 py-2"
+                      role="cell"
+                    />
+                  )}
+                  {visibleColumns.map((column) => (
+                    <div
+                      key={column.key}
+                      className="min-w-0 border-t border-b border-lt-border bg-lt-muted/50 px-2 py-2"
+                      role="cell"
                     >
-                      {hasExpandable && (
-                        <div className="flex items-center px-2 py-lt-cell-y" role="cell">
-                          {detail && (
-                            <button
-                              type="button"
-                              data-test={`row-expand-${key}`}
-                              aria-expanded={expanded}
-                              aria-controls={detailId}
-                              aria-label={t("table.row-detail.toggle", "Toggle detail")}
-                              className="inline-flex size-6 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg"
-                              onClick={() => toggleRow(key)}
-                            >
-                              <Icon
-                                name="chevron-down"
-                                aria-hidden="true"
-                                className={cn(
-                                  "size-lt-icon-md transition-transform",
-                                  !expanded && "-rotate-90",
-                                )}
-                              />
-                            </button>
+                      {column.props.filter != null && (
+                        <ColumnFilterControl
+                          column={column}
+                          clauses={filterEntries.filter(
+                            (entry) => entry.clause.field === column.key,
                           )}
-                        </div>
-                      )}
-                      {hasBulkActions && (
-                        <div className="flex items-center px-lt-cell-x py-lt-cell-y" role="cell">
-                          <Checkbox
-                            aria-label={t("table.select-row", "Select row {{key}}", { key })}
-                            data-test={`select-row-${key}`}
-                            checked={selection.isSelected(key)}
-                            onCheckedChange={() => selection.toggle(key)}
-                          />
-                        </div>
-                      )}
-                      {visibleColumns.map((column) => (
-                        <div
-                          key={column.key}
-                          data-slot="table-cell"
-                          className={cn(
-                            "grid min-w-0 content-center gap-1 overflow-hidden px-lt-cell-x py-lt-cell-y",
-                            alignText(column.props.align),
-                            alignJustifyItems(column.props.align),
-                          )}
-                          role="cell"
-                        >
-                          <span
-                            aria-hidden="true"
-                            className="text-xs font-medium text-lt-muted-fg md:hidden"
-                          >
-                            {column.props.label}
-                          </span>
-                          <div
-                            data-slot="table-cell-content"
-                            className="min-w-0 max-w-full overflow-hidden truncate"
-                          >
-                            <ColumnCell column={column} row={row} />
-                          </div>
-                        </div>
-                      ))}
-                      {hasTrailingUtility && (
-                        <div
-                          className={cn(
-                            "items-center justify-start gap-2 px-lt-cell-x py-lt-cell-y md:justify-end",
-                            actions.length > 0 ? "flex" : "hidden md:flex",
-                          )}
-                          role="cell"
-                        >
-                          {actions.map((action, actionIndex) => (
-                            <RenderNode
-                              key={action.key ?? action.id ?? actionIndex}
-                              node={action}
-                            />
-                          ))}
-                        </div>
+                          processing={processing}
+                          onAdd={addFilter}
+                          onUpdate={updateFilter}
+                          onRemove={removeFilter}
+                          onReplace={replaceColumnFilters}
+                          onSearch={(query, signal) =>
+                            searchFilterOptions(`column:${column.key}`, query, signal)
+                          }
+                        />
                       )}
                     </div>
-                    {expanded && detail && (
+                  ))}
+                  {hasTrailingUtility && (
+                    <div
+                      className="border-t border-b border-lt-border bg-lt-muted/50 px-4 py-2"
+                      role="cell"
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+            <div role="rowgroup">
+              {!hasLoaded ? (
+                <div className="p-4 text-lt-muted-fg" role="row">
+                  <div role="cell">{t("table.loading", "Loading rows...")}</div>
+                </div>
+              ) : rowEntries.length === 0 ? (
+                <div
+                  data-slot="table-empty"
+                  className="p-8 text-center text-lt-muted-fg"
+                  role="row"
+                >
+                  <div role="cell">{node.props?.emptyLabel ?? t("table.empty", "No results")}</div>
+                </div>
+              ) : (
+                rowEntries.map(({ row, actions, detail, key }) => {
+                  const expanded = detail != null && isExpanded(key);
+                  const detailId = `${nodeIdentity(node) ?? "table"}-row-detail-${key}`;
+
+                  return (
+                    <Fragment key={key}>
                       <div
-                        id={detailId}
-                        role="region"
-                        data-slot="table-row-detail"
-                        className="border-b border-lt-border bg-lt-muted/20 px-lt-cell-x py-lt-cell-y"
+                        data-slot="table-row"
+                        className={`grid grid-cols-1 border-b border-lt-border last:border-b-0 md:grid-cols-[var(--lattice-table-columns)] ${
+                          striped ? "odd:bg-lt-muted/30" : ""
+                        }`}
+                        role="row"
                       >
-                        <Renderer nodes={[detail]} />
+                        {hasExpandable && (
+                          <div className="flex items-center px-2 py-lt-cell-y" role="cell">
+                            {detail && (
+                              <button
+                                type="button"
+                                data-test={`row-expand-${key}`}
+                                aria-expanded={expanded}
+                                aria-controls={detailId}
+                                aria-label={t("table.row-detail.toggle", "Toggle detail")}
+                                className="inline-flex size-6 items-center justify-center rounded-lt-sm text-lt-muted-fg hover:bg-lt-muted hover:text-lt-fg"
+                                onClick={() => toggleRow(key)}
+                              >
+                                <Icon
+                                  name="chevron-down"
+                                  aria-hidden="true"
+                                  className={cn(
+                                    "size-lt-icon-md transition-transform",
+                                    !expanded && "-rotate-90",
+                                  )}
+                                />
+                              </button>
+                            )}
+                          </div>
+                        )}
+                        {hasBulkActions && (
+                          <div className="flex items-center px-lt-cell-x py-lt-cell-y" role="cell">
+                            <Checkbox
+                              aria-label={t("table.select-row", "Select row {{key}}", { key })}
+                              data-test={`select-row-${key}`}
+                              checked={selection.isSelected(key)}
+                              onCheckedChange={() => selection.toggle(key)}
+                            />
+                          </div>
+                        )}
+                        {visibleColumns.map((column) => (
+                          <div
+                            key={column.key}
+                            data-slot="table-cell"
+                            className={cn(
+                              "grid min-w-0 content-center gap-1 overflow-hidden px-lt-cell-x py-lt-cell-y",
+                              alignText(column.props.align),
+                              alignJustifyItems(column.props.align),
+                            )}
+                            role="cell"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="text-xs font-medium text-lt-muted-fg md:hidden"
+                            >
+                              {column.props.label}
+                            </span>
+                            <div
+                              data-slot="table-cell-content"
+                              className="min-w-0 max-w-full overflow-hidden truncate"
+                            >
+                              <ColumnCell column={column} row={row} />
+                            </div>
+                          </div>
+                        ))}
+                        {hasTrailingUtility && (
+                          <div
+                            className={cn(
+                              "items-center justify-start gap-2 px-lt-cell-x py-lt-cell-y md:justify-end",
+                              actions.length > 0 ? "flex" : "hidden md:flex",
+                            )}
+                            role="cell"
+                          >
+                            {actions.map((action, actionIndex) => (
+                              <RenderNode
+                                key={action.key ?? action.id ?? actionIndex}
+                                node={action}
+                              />
+                            ))}
+                          </div>
+                        )}
                       </div>
-                    )}
-                  </Fragment>
-                );
-              })
-            )}
+                      {expanded && detail && (
+                        <div
+                          id={detailId}
+                          role="region"
+                          data-slot="table-row-detail"
+                          className="border-b border-lt-border bg-lt-muted/20 px-lt-cell-x py-lt-cell-y"
+                        >
+                          <Renderer nodes={[detail]} />
+                        </div>
+                      )}
+                    </Fragment>
+                  );
+                })
+              )}
+            </div>
           </div>
         </div>
         {hasLoaded && (

--- a/workbench/app/Tables/CustomColumnTable.php
+++ b/workbench/app/Tables/CustomColumnTable.php
@@ -21,9 +21,9 @@ class CustomColumnTable extends BaseProductsDemoTable
         return [
             TextColumn::make('name')->label(__('workbench.tables.columns.name'))->sortable(),
             StatusBadgeColumn::make('status')->label(__('workbench.tables.columns.status'))->filterOptions([
-                'draft' => 'Draft',
-                'active' => 'Active',
-                'archived' => 'Archived',
+                'draft' => __('workbench.status.draft'),
+                'active' => __('workbench.status.active'),
+                'archived' => __('workbench.status.archived'),
             ])->colorMap(['draft' => 'gray', 'active' => 'green', 'archived' => 'red']),
         ];
     }

--- a/workbench/app/Tables/ProductsTable.php
+++ b/workbench/app/Tables/ProductsTable.php
@@ -60,9 +60,9 @@ class ProductsTable extends EloquentTableDefinition
             TextColumn::make('sku')->label(__('workbench.tables.columns.sku'))->sortable()->filterable()->toggleable(),
             MoneyColumn::make('default_price')->label(__('workbench.tables.columns.default-price'))->sortable()->currency('EUR'),
             StatusBadgeColumn::make('status')->label(__('workbench.tables.columns.status'))->filterOptions([
-                'draft' => 'Draft',
-                'active' => 'Active',
-                'archived' => 'Archived',
+                'draft' => __('workbench.status.draft'),
+                'active' => __('workbench.status.active'),
+                'archived' => __('workbench.status.archived'),
             ])->colorMap(['draft' => 'gray', 'active' => 'green', 'archived' => 'red']),
             BooleanColumn::make('featured')->label(__('workbench.tables.columns.featured'))->sortable()->filterable(),
             TextColumn::make('tags')->label(__('workbench.tables.columns.tags'))->multiple('name')->badge('color')->filterable()->toggleable(),


### PR DESCRIPTION
## Summary

**Table scroll leaking to the whole page (critical)**

`[data-slot="table-scroll"]` had no explicit `position`, so absolutely-positioned descendants without their own positioned wrapper (the sr-only "Actions" column label) resolved their containing block to the outer, non-scrolling `[data-slot="table"]` wrapper instead of the scrolling element. Their position was computed once against that wrapper and never re-evaluated against table-scroll's own scroll offset, so they rendered at a fixed page coordinate that ignored `scrollLeft` entirely — quietly pushing `document.body` wider than the viewport even though table-scroll's own box stayed correctly contained.

That leftover body-level horizontal scroll is what let scrolling anywhere on the page — not just over the table, but over the sidebar or topbar too — drag the whole layout sideways, since `position: sticky` only pins the axis it's given (`top`) and still moves with the rest of the page along the other axis. This is what caused table content to visually bleed behind the sidebar when scrolled.

Verified by reproducing the bug live (wheel-scrolling over the sidebar moved `document.body.scrollLeft` by 390px and `body.scrollWidth` exceeded the viewport by 390px) and confirming both symptoms disappear with the fix.

**Toolbar/filter/sort bars scrolling with the grid**

Everything above the column grid — the toolbar (search, filter menu, column visibility), dedicated filter chips, bulk-action bar, and sort chips — lived inside the same horizontally-scrolling container as the grid itself, so scrolling the table dragged them along with it: buttons anchored to the right edge would end up in the middle of the visible viewport once scrolled. None of that chrome is column-aligned, so it has no reason to move with the grid.

Split the horizontal scrolling into a new inner wrapper (`[data-slot="table-grid-scroll"]`) around just the column grid. The outer `[data-slot="table-scroll"]` keeps the rounded border and no longer scrolls itself, so the toolbar/filter/bulk/sort bars and pagination stay fixed while only the grid's own columns scroll beneath them.

**Products table status filter translation**

`StatusBadgeCell` already translates the cell value client-side via the `workbench.status.*` keys, but `ProductsTable`/`CustomColumnTable`'s `filterOptions()` hardcoded the English label literally, so the filter dropdown showed "Draft/Active/Archived" regardless of locale while the cells showed "Entwurf/Aktiv/Archiviert" in German — same status, two different label sources. Now both read from the same translation keys.

## Test plan
- [x] Browser test proves table-grid-scroll is the containing block for its absolutely-positioned descendants (fails without the fix)
- [x] Browser test proves the toolbar stays at a fixed position while the grid scrolls (fails without the fix)
- [x] Manually reproduced the reported page-scroll-leak bug end-to-end (wheel-scroll over sidebar/topbar dragging the whole page) and confirmed it's gone after the fix
- [x] Full gate green: `composer check` (Pint, PHPStan level 8, Rector, Pest — 1626 tests) and `npm run check` (lint, format, typecheck, type-coverage, Vitest — 1290 tests, lib build)