### PR TITLE
feat(ui): add Modal::height() lever

### DIFF
--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -27,6 +27,7 @@ layout primitives.
     "Height",
     "ColumnWidth",
     "ModalWidth",
+    "ModalHeight",
     "Orientation",
     "StackDirection",
     "Placement",

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -787,6 +787,36 @@
         "name": "Justify",
         "namespace": "Lattice\\Ui\\Enums"
     },
+    "Lattice\\Ui\\Enums\\ModalHeight": {
+        "cases": [
+            {
+                "name": "Sm",
+                "value": "sm"
+            },
+            {
+                "name": "Md",
+                "value": "md"
+            },
+            {
+                "name": "Lg",
+                "value": "lg"
+            },
+            {
+                "name": "Xl",
+                "value": "xl"
+            },
+            {
+                "name": "Xl2",
+                "value": "2xl"
+            },
+            {
+                "name": "Xl3",
+                "value": "3xl"
+            }
+        ],
+        "name": "ModalHeight",
+        "namespace": "Lattice\\Ui\\Enums"
+    },
     "Lattice\\Ui\\Enums\\ModalWidth": {
         "cases": [
             {

--- a/packages/ui/resources/js/components/modal.tsx
+++ b/packages/ui/resources/js/components/modal.tsx
@@ -78,6 +78,7 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
         {...(description ? {} : { "aria-describedby": undefined })}
         placement={node.props.side ?? "center"}
         width={node.props.width}
+        height={node.props.height}
       >
         <DialogHeader closeLabel={closeLabel} description={description} title={title} />
         <div className="mt-6 space-y-6">{children}</div>

--- a/packages/ui/resources/js/dialog.tsx
+++ b/packages/ui/resources/js/dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cva } from "class-variance-authority";
 import { Button } from "./button";
 import { cn } from "./lib/utils";
-import type { ModalWidth, Side } from "./types";
+import type { ModalHeight, ModalWidth, Side } from "./types";
 
 export type DialogPlacement = "center" | Side;
 
@@ -14,7 +14,7 @@ const dialogContentVariants = cva(
     variants: {
       placement: {
         center:
-          "left-1/2 top-1/2 max-h-[min(680px,calc(100vh-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border data-[state=open]:animate-lt-dialog-in data-[state=closed]:animate-lt-dialog-out",
+          "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border data-[state=open]:animate-lt-dialog-in data-[state=closed]:animate-lt-dialog-out",
         start:
           "inset-y-0 start-0 border-e border-lt-border data-[state=open]:animate-lt-sheet-in-start data-[state=closed]:animate-lt-sheet-out-start",
         end: "inset-y-0 end-0 border-s border-lt-border data-[state=open]:animate-lt-sheet-in-end data-[state=closed]:animate-lt-sheet-out-end",
@@ -27,8 +27,24 @@ const dialogContentVariants = cva(
         "2xl": "max-w-2xl",
         "3xl": "max-w-3xl",
       },
+      height: {
+        sm: "",
+        md: "",
+        lg: "",
+        xl: "",
+        "2xl": "",
+        "3xl": "",
+      },
     },
-    defaultVariants: { placement: "center", width: "lg" },
+    compoundVariants: [
+      { placement: "center", height: "sm", class: "max-h-[min(480px,calc(100vh-2rem))]" },
+      { placement: "center", height: "md", class: "max-h-[min(600px,calc(100vh-2rem))]" },
+      { placement: "center", height: "lg", class: "max-h-[min(680px,calc(100vh-2rem))]" },
+      { placement: "center", height: "xl", class: "max-h-[min(820px,calc(100vh-2rem))]" },
+      { placement: "center", height: "2xl", class: "max-h-[min(920px,calc(100vh-2rem))]" },
+      { placement: "center", height: "3xl", class: "max-h-[min(1040px,calc(100vh-2rem))]" },
+    ],
+    defaultVariants: { placement: "center", width: "lg", height: "lg" },
   },
 );
 
@@ -68,10 +84,12 @@ function DialogContent({
   className,
   placement = "center",
   width = "lg",
+  height = "lg",
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   placement?: DialogPlacement;
   width?: ModalWidth;
+  height?: ModalHeight;
 }) {
   return (
     <DialogPrimitive.Portal>
@@ -80,7 +98,7 @@ function DialogContent({
         data-slot="dialog-overlay"
       />
       <DialogPrimitive.Content
-        className={cn(dialogContentVariants({ placement, width }), className)}
+        className={cn(dialogContentVariants({ placement, width, height }), className)}
         data-slot="dialog-content"
         {...props}
       >

--- a/packages/ui/resources/js/generated.ts
+++ b/packages/ui/resources/js/generated.ts
@@ -185,12 +185,14 @@ export type LocaleChange = {
 export type Modal = {
   closeLabel: string;
   description: string | null;
+  height: ModalHeight;
   open: boolean;
   ref: string | null;
   side: Side | null;
   title: string | null;
   width: ModalWidth;
 };
+export type ModalHeight = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl";
 export type ModalWidth = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl";
 export type NodeType =
   | "avatar"

--- a/packages/ui/resources/js/types.ts
+++ b/packages/ui/resources/js/types.ts
@@ -15,6 +15,7 @@ export type {
   DateTimeStyle,
   HttpMethod,
   Justify,
+  ModalHeight,
   ModalWidth,
   NumberFormat,
   NumberFormatUnit,

--- a/packages/ui/src/Components/Modal.php
+++ b/packages/ui/src/Components/Modal.php
@@ -5,6 +5,7 @@ namespace Lattice\Ui\Components;
 
 use Lattice\Core\Attributes\AsComponent;
 use Lattice\Core\Contracts\InteractiveComponent;
+use Lattice\Ui\Enums\ModalHeight;
 use Lattice\Ui\Enums\ModalWidth;
 use Lattice\Ui\Enums\Side;
 
@@ -24,6 +25,8 @@ class Modal extends ContainerComponent implements InteractiveComponent
     public ?Side $side = null;
 
     public ModalWidth $width = ModalWidth::Lg;
+
+    public ModalHeight $height = ModalHeight::Lg;
 
     public function __construct(?string $key = null)
     {
@@ -78,6 +81,13 @@ class Modal extends ContainerComponent implements InteractiveComponent
     public function width(ModalWidth $width): static
     {
         $this->width = $width;
+
+        return $this;
+    }
+
+    public function height(ModalHeight $height): static
+    {
+        $this->height = $height;
 
         return $this;
     }

--- a/packages/ui/src/Enums/ModalHeight.php
+++ b/packages/ui/src/Enums/ModalHeight.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Ui\Enums;
+
+use Lattice\Core\Attributes\TypeScript;
+
+#[TypeScript]
+enum ModalHeight: string
+{
+    case Sm = 'sm';
+    case Md = 'md';
+    case Lg = 'lg';
+    case Xl = 'xl';
+    case Xl2 = '2xl';
+    case Xl3 = '3xl';
+}

--- a/tests/Feature/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Feature/Core/Components/CoreTypedPropsTest.php
@@ -13,6 +13,7 @@ use Lattice\Ui\Enums\Align;
 use Lattice\Ui\Enums\Gap;
 use Lattice\Ui\Enums\Icon as IconName;
 use Lattice\Ui\Enums\Justify;
+use Lattice\Ui\Enums\ModalHeight;
 use Lattice\Ui\Enums\ModalWidth;
 use Lattice\Ui\Enums\Orientation;
 use Lattice\Ui\Enums\Side;
@@ -86,6 +87,7 @@ it('modal serializes id title description and children', function (): void {
                 'open' => true,
                 'side' => null,
                 'width' => 'lg',
+                'height' => 'lg',
                 'ref' => null,
             ],
             'schema' => [
@@ -106,6 +108,7 @@ it('modal without optional props includes them as null', function (): void {
                 'open' => false,
                 'side' => null,
                 'width' => 'lg',
+                'height' => 'lg',
                 'ref' => null,
             ],
         ]);
@@ -120,6 +123,12 @@ it('modal serializes slide-out side and width', function (): void {
         'side' => 'start',
         'width' => '2xl',
     ]);
+});
+
+it('modal serializes a custom height', function (): void {
+    $payload = wire(Modal::make('order.preview')->height(ModalHeight::Xl2));
+
+    expect($payload['props'])->toMatchArray(['height' => '2xl']);
 });
 
 it('modal slide-out defaults to the end side', function (): void {


### PR DESCRIPTION
## Summary
- Add `Lattice\Ui\Enums\ModalHeight` (Sm/Md/Lg/Xl/Xl2/Xl3), mirroring `ModalWidth`.
- Add `Modal::height()` and a `ModalHeight::Lg` default that preserves the current 680px max-height exactly, so no existing modal changes without opting in.
- Extract the hardcoded `placement.center` max-height into a `height` cva variant, gated to `placement: "center"` via `compoundVariants` so slideOut sheets (already full-height via `inset-y-0`) stay untouched.
- Wire `height` through `DialogContent` and `modal.tsx`, and regenerate the TS wire types.

## Test plan
- [x] `composer test` (full Pest suite, 1638 tests)
- [x] `./vendor/bin/pint --dirty` / PHPStan (both configs)
- [x] `npx vitest run` for the `ui` package (dialog + modal suites)
- [x] `npm run build` + scoped `tsc --noEmit` for the `ui` package
- [x] Regenerated `docs/fixtures/enums.json` and `enums.mdx` reference list