### PR TITLE
fix(form): decode PatternInput's JSON-string wire value before validating

### DIFF
--- a/packages/form/src/Components/Field.php
+++ b/packages/form/src/Components/Field.php
@@ -502,11 +502,8 @@ abstract class Field extends Component
 
     /**
      * Normalize this field's raw request value before {@see FieldValidator}
-     * builds the Validator — override when the client's wire format needs
-     * decoding before Laravel's dot-path rules can traverse it (e.g. a field
-     * whose value arrives as one JSON-encoded string but validates nested
-     * keys within it, like a token's own config). Defaults to a no-op; most
-     * fields' rules operate on the raw value directly.
+     * builds the Validator — override when the wire format needs decoding
+     * before dot-path rules can traverse it. No-op by default.
      */
     public function normalizeInput(mixed $value): mixed
     {

--- a/packages/form/src/Components/Field.php
+++ b/packages/form/src/Components/Field.php
@@ -501,6 +501,19 @@ abstract class Field extends Component
     }
 
     /**
+     * Normalize this field's raw request value before {@see FieldValidator}
+     * builds the Validator — override when the client's wire format needs
+     * decoding before Laravel's dot-path rules can traverse it (e.g. a field
+     * whose value arrives as one JSON-encoded string but validates nested
+     * keys within it, like a token's own config). Defaults to a no-op; most
+     * fields' rules operate on the raw value directly.
+     */
+    public function normalizeInput(mixed $value): mixed
+    {
+        return $value;
+    }
+
+    /**
      * React to the form's filled value for this field during serialization. Override
      * per field (e.g. a Select resolving labels for stored ids). Defaults to a no-op.
      */

--- a/packages/form/src/Components/PatternInput.php
+++ b/packages/form/src/Components/PatternInput.php
@@ -125,12 +125,9 @@ class PatternInput extends Field
     }
 
     /**
-     * Decodes the client's wire value (a JSON-encoded string, or already an
-     * array for programmatic construction) before validation, so nested rule
-     * paths built in {@see nestedRules()} — e.g. `pattern.0.config.padding` —
-     * can actually traverse it. An undecodable value passes through
-     * unchanged, so {@see PatternSegments} still fails it with its own
-     * "must be an array" message rather than this silently swallowing it.
+     * Decodes the wire value before validation so {@see nestedRules()}'s
+     * dot-path keys can traverse it. Passes an undecodable value through
+     * unchanged, so {@see PatternSegments} still reports its own failure.
      */
     #[\Override]
     public function normalizeInput(mixed $value): mixed

--- a/packages/form/src/Components/PatternInput.php
+++ b/packages/form/src/Components/PatternInput.php
@@ -79,7 +79,6 @@ class PatternInput extends Field
     {
         return [
             ...parent::defaultRules(),
-            'array',
             new PatternSegments($this->patternTokens, $this->requiredTokenNames),
         ];
     }
@@ -90,10 +89,10 @@ class PatternInput extends Field
     #[\Override]
     public function nestedRules(FormData $data, Request $request): array
     {
-        $segments = $data->get($this->name);
+        $segments = PatternSegments::decode($data->get($this->name));
         $rules = [];
 
-        if (! is_array($segments)) {
+        if ($segments === null) {
             return $rules;
         }
 
@@ -125,15 +124,31 @@ class PatternInput extends Field
         return $rules;
     }
 
+    /**
+     * Decodes the client's wire value (a JSON-encoded string, or already an
+     * array for programmatic construction) before validation, so nested rule
+     * paths built in {@see nestedRules()} — e.g. `pattern.0.config.padding` —
+     * can actually traverse it. An undecodable value passes through
+     * unchanged, so {@see PatternSegments} still fails it with its own
+     * "must be an array" message rather than this silently swallowing it.
+     */
+    #[\Override]
+    public function normalizeInput(mixed $value): mixed
+    {
+        return PatternSegments::decode($value) ?? $value;
+    }
+
     #[\Override]
     public function castValue(mixed $value): mixed
     {
-        if (! is_array($value)) {
+        $segments = PatternSegments::decode($value);
+
+        if ($segments === null) {
             return [];
         }
 
         return array_values(array_filter(
-            array_map($this->castSegment(...), $value),
+            array_map($this->castSegment(...), $segments),
             static fn (?array $segment): bool => $segment !== null,
         ));
     }

--- a/packages/form/src/FieldValidator.php
+++ b/packages/form/src/FieldValidator.php
@@ -57,11 +57,7 @@ final class FieldValidator
             if ($serverValue) {
                 Arr::set($input, $path, $field->resolvedValue());
             } elseif (Arr::has($input, $path)) {
-                // Normalize before the Validator sees $input, not after: a
-                // field's own nestedRules() below builds dot-path rule keys
-                // (e.g. a PatternInput token's `pattern.0.config.padding`)
-                // that only resolve if $input already holds the decoded
-                // shape those paths traverse.
+                // nestedRules() below builds dot-path rule keys that need $input already decoded.
                 Arr::set($input, $path, $field->normalizeInput(Arr::get($input, $path)));
             }
 

--- a/packages/form/src/FieldValidator.php
+++ b/packages/form/src/FieldValidator.php
@@ -56,6 +56,13 @@ final class FieldValidator
 
             if ($serverValue) {
                 Arr::set($input, $path, $field->resolvedValue());
+            } elseif (Arr::has($input, $path)) {
+                // Normalize before the Validator sees $input, not after: a
+                // field's own nestedRules() below builds dot-path rule keys
+                // (e.g. a PatternInput token's `pattern.0.config.padding`)
+                // that only resolve if $input already holds the decoded
+                // shape those paths traverse.
+                Arr::set($input, $path, $field->normalizeInput(Arr::get($input, $path)));
             }
 
             if (! $visible) {

--- a/packages/form/src/PatternInput/PatternSegments.php
+++ b/packages/form/src/PatternInput/PatternSegments.php
@@ -24,10 +24,8 @@ final readonly class PatternSegments implements ValidationRule
     ) {}
 
     /**
-     * Normalizes a submitted value into a segment array: an already-decoded
-     * array as-is, or the client's actual wire format — a JSON-encoded string
-     * carried in the field's single hidden `<input>` — decoded. Null when
-     * neither shape applies.
+     * Decodes a submitted value into a segment array — already an array, or
+     * the client's JSON-encoded wire string. Null if neither.
      *
      * @return array<int, mixed>|null
      */

--- a/packages/form/src/PatternInput/PatternSegments.php
+++ b/packages/form/src/PatternInput/PatternSegments.php
@@ -23,9 +23,36 @@ final readonly class PatternSegments implements ValidationRule
         private array $requiredTokens,
     ) {}
 
+    /**
+     * Normalizes a submitted value into a segment array: an already-decoded
+     * array as-is, or the client's actual wire format — a JSON-encoded string
+     * carried in the field's single hidden `<input>` — decoded. Null when
+     * neither shape applies.
+     *
+     * @return array<int, mixed>|null
+     */
+    public static function decode(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! is_array($value)) {
+        $value = self::decode($value);
+
+        if ($value === null) {
+            $fail("The {$attribute} field must be an array.");
+
             return;
         }
 

--- a/tests/Feature/Forms/PatternInputTest.php
+++ b/tests/Feature/Forms/PatternInputTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Lattice\Core\Support\Wire;
 use Lattice\Form\Components\Choice;
 use Lattice\Form\Components\PatternInput;
@@ -37,6 +38,34 @@ it('casts a submitted pattern into text and token segments', function (): void {
         ['type' => 'text', 'value' => '-'],
         ['type' => 'token', 'token' => 'YYYY', 'config' => []],
     ]);
+});
+
+it('casts a submitted pattern encoded as the client\'s JSON wire string', function (): void {
+    // The field submits one hidden <input> whose value is JSON.stringify(segments)
+    // (packages/form/resources/js/pattern-input/field.tsx) — a native array in a
+    // Request is a test convenience, never what a real browser sends.
+    $request = Request::create('/', 'POST', ['pattern' => json_encode([
+        ['type' => 'text', 'value' => 'RE-'],
+        ['type' => 'token', 'token' => 'NUMBER', 'config' => ['padding' => '5']],
+        ['type' => 'text', 'value' => '-'],
+        ['type' => 'token', 'token' => 'YYYY'],
+    ])]);
+
+    $validated = (new FieldValidator)->validate([documentNumberPattern()], $request);
+
+    expect($validated['pattern'])->toBe([
+        ['type' => 'text', 'value' => 'RE-'],
+        ['type' => 'token', 'token' => 'NUMBER', 'config' => ['padding' => '5']],
+        ['type' => 'text', 'value' => '-'],
+        ['type' => 'token', 'token' => 'YYYY', 'config' => []],
+    ]);
+});
+
+it('rejects a pattern value that is neither an array nor a JSON-encoded array string', function (): void {
+    $request = Request::create('/', 'POST', ['pattern' => 'not-json']);
+
+    expect(fn (): array => (new FieldValidator)->validate([documentNumberPattern()], $request))
+        ->toThrow(ValidationException::class);
 });
 
 it('drops a segment for a token no longer declared on the field', function (): void {

--- a/tests/Feature/Forms/PatternInputTest.php
+++ b/tests/Feature/Forms/PatternInputTest.php
@@ -41,9 +41,7 @@ it('casts a submitted pattern into text and token segments', function (): void {
 });
 
 it('casts a submitted pattern encoded as the client\'s JSON wire string', function (): void {
-    // The field submits one hidden <input> whose value is JSON.stringify(segments)
-    // (packages/form/resources/js/pattern-input/field.tsx) — a native array in a
-    // Request is a test convenience, never what a real browser sends.
+    // Real submissions arrive as JSON.stringify(segments) (pattern-input/field.tsx), not a native array.
     $request = Request::create('/', 'POST', ['pattern' => json_encode([
         ['type' => 'text', 'value' => 'RE-'],
         ['type' => 'token', 'token' => 'NUMBER', 'config' => ['padding' => '5']],

--- a/tests/Feature/Forms/Validation/PatternInputValidationTest.php
+++ b/tests/Feature/Forms/Validation/PatternInputValidationTest.php
@@ -31,6 +31,19 @@ it('accepts a well-formed pattern of text and token segments', function (): void
     expect($errors)->toBe([]);
 });
 
+it('accepts the same pattern encoded as the client\'s JSON wire string', function (): void {
+    $errors = validationErrors(testFormDefinition(fn (): array => [patternField()]), [
+        'pattern' => json_encode([
+            ['type' => 'text', 'value' => 'RE-'],
+            ['type' => 'token', 'token' => 'NUMBER', 'config' => ['padding' => '4']],
+            ['type' => 'text', 'value' => '-'],
+            ['type' => 'token', 'token' => 'YYYY'],
+        ]),
+    ]);
+
+    expect($errors)->toBe([]);
+});
+
 it('rejects an unknown token name', function (): void {
     $errors = validationErrors(testFormDefinition(fn (): array => [patternField()]), [
         'pattern' => [['type' => 'token', 'token' => 'MADE_UP']],


### PR DESCRIPTION
## Summary

`PatternInput` submits one hidden `<input>` whose value is `JSON.stringify(segments)` (`packages/form/resources/js/pattern-input/field.tsx`) — the same wire pattern `RichEditor` uses for its document. Unlike `RichEditor`, `PatternInput` never got the decode treatment:

- `defaultRules()` used Laravel's native `array` rule, which rejects a raw JSON string outright.
- `castValue()` and `nestedRules()` only handled an already-decoded array.
- Even past the native `array` rule, `nestedRules()`'s dot-path rule keys (e.g. `pattern.0.config.padding`) couldn't resolve, because `FieldValidator` builds `$input` straight from `$request->all()` before any field gets a chance to cast its value — so every token's `config` sub-fields failed as "required" even when present.

Net effect: **every real browser submission through a `PatternInput` field fails**, either with a validation error or (worse, when no custom rule catches it first) an uncaught `Error`.

No existing test caught this because every `PatternInputTest`/`PatternInputValidationTest` case posted a native PHP array — never `JSON.stringify()`'d like the client actually does.

## Fix

- `PatternSegments::decode()` (new, mirrors `RichContent::decodeDocument()`): accepts either an array or a JSON-encoded string.
- `PatternInput::defaultRules()` drops the native `array` rule — `PatternSegments`'s own rule now reports "must be an array" for anything it can't decode.
- `PatternInput::castValue()` / `nestedRules()` route through `PatternSegments::decode()`.
- New `Field::normalizeInput()` hook (no-op by default), overridden by `PatternInput` to decode before validation. Wired into `FieldValidator::validate()` so `$input` is normalized field-by-field *before* rules are built — this is what makes the nested dot-path rules resolve against a decoded value instead of a JSON string.

## Test plan

- [x] `vendor/bin/pest tests/Feature/Forms/PatternInputTest.php tests/Feature/Forms/Validation/PatternInputValidationTest.php` — added a JSON-string wire-format case to each, all passing
- [x] `vendor/bin/pest tests/Feature/Forms tests/Unit/Forms tests/Feature/Actions tests/Feature/Tables` — 658 passed (shared `Field`/`FieldValidator` change)
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/pint --test` — clean
- [x] Verified end-to-end against a real consumer app (artisan-os): a `PatternInput`-based form that 500s on every submit against the published 0.47.0 saves correctly with this patch applied