### PR TITLE
test: make the default pest run TIA-compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /coverage_vitest
 /.playwright-mcp
 /.phpunit.cache
+/.phpunit.browser.cache
 /.phpunit.result.cache
 /.phpstan-cache
 /.rector-cache

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "lattice-php/tree": "@dev",
         "league/flysystem-aws-s3-v3": "^3.34",
         "orchestra/testbench": "^10.0 || ^11.0",
-        "pestphp/pest": "^5.0",
+        "pestphp/pest": "^5.1",
         "pestphp/pest-plugin-browser": "^5.0",
         "pestphp/pest-plugin-laravel": "^5.0",
         "pestphp/pest-plugin-phpstan": "^5.0",
@@ -67,16 +67,17 @@
             "npm run format",
             "@types"
         ],
-        "test": "./vendor/bin/pest --testsuite Arch,Unit,Feature",
-        "test:parallel": "./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel",
-        "test:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Arch,Unit,Feature --parallel --coverage --coverage-clover coverage_phpunit/clover.xml --log-junit coverage_phpunit/pest.junit.xml",
+        "test": "./vendor/bin/pest",
+        "test:parallel": "./vendor/bin/pest --parallel",
+        "test:tia": "./vendor/bin/pest --parallel --tia",
+        "test:coverage": "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --parallel --coverage --coverage-clover coverage_phpunit/clover.xml --log-junit coverage_phpunit/pest.junit.xml",
         "test:browser": [
             "Composer\\Config::disableProcessTimeout",
-            "./vendor/bin/pest --testsuite Browser"
+            "./vendor/bin/pest -c phpunit.browser.xml.dist"
         ],
         "test:browser:coverage": [
             "Composer\\Config::disableProcessTimeout",
-            "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest --testsuite Browser --coverage --coverage-clover coverage_phpunit/browser-clover.xml --log-junit coverage_phpunit/pest-browser.junit.xml"
+            "runner=; command -v herd >/dev/null 2>&1 && runner='herd coverage'; mkdir -p coverage_phpunit; $runner ./vendor/bin/pest -c phpunit.browser.xml.dist --coverage --coverage-clover coverage_phpunit/browser-clover.xml --log-junit coverage_phpunit/pest-browser.junit.xml"
         ],
         "post-autoload-dump": [
             "@clear",

--- a/phpunit.browser.xml.dist
+++ b/phpunit.browser.xml.dist
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Browser tests live in their own config so the default `pest` run is a full run:
+     Pest's Test Impact Analysis (tia) disables itself on testsuite-filtered runs. -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         cacheDirectory=".phpunit.cache"
+         cacheDirectory=".phpunit.browser.cache"
          failOnRisky="true"
          failOnWarning="true">
     <testsuites>
-        <testsuite name="Arch">
-            <file>tests/ArchTest.php</file>
-        </testsuite>
-        <testsuite name="Unit">
-            <directory>tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory>tests/Feature</directory>
-            <file>tests/StandalonePackagesTest.php</file>
+        <testsuite name="Browser">
+            <directory>tests/Browser</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
Makes the default `pest` run a full run so Test Impact Analysis works locally: TIA disables itself on `--testsuite`-filtered runs, and every composer script filtered.

- Browser tests move to their own `phpunit.browser.xml.dist` (own result cache); `phpunit.xml.dist` keeps Arch, Unit, Feature.
- Composer scripts drop the `--testsuite` filters; `test:browser`/`test:browser:coverage` switch to `-c phpunit.browser.xml.dist`. New: `composer test:tia`.
- Pest floor raised to `^5.1` (contains several `--tia` engine fixes).

With pcov, measured on 1668 tests (Arch+Unit+Feature, 10 workers): full parallel run 82s; TIA replay with no changes 4.2s; test-file change 6.1s; form-field change 8.5s (55 affected); leaf component 12s (151 affected). One-time cold record 85–113s. Worst case (core `Support/Wire.php`, 1447 affected) 107s. TIA needs pcov or Xdebug-coverage in the worker PHP; without a driver it errors on record rather than recording an empty graph.

Validated: `composer test:parallel` runs all 1668 tests (the pre-existing `ColumnPropsGenerationTest` failure on `main` remains); `composer test:browser` passes 128/128 through the new config (the green-suite exit-1 quirk pre-exists on `main`). CI is unaffected — it invokes the same composer scripts, and the browser workflow's `--shard` passthrough still applies.
