### PR TITLE
fix(typescript): pipe generated files through oxfmt stdin

### DIFF
--- a/packages/framework/src/Support/TypeScript/OxfmtFormatter.php
+++ b/packages/framework/src/Support/TypeScript/OxfmtFormatter.php
@@ -11,6 +11,11 @@ use Symfony\Component\Process\Process;
  * falling back to the package checkout for local development. A missing binary
  * is a no-op: the byte-exact snapshot test catches any formatting divergence,
  * and the PHP CI test jobs deliberately run without node_modules.
+ *
+ * Files are piped through stdin instead of formatted with --write: since oxfmt
+ * 0.63 ignore rules (including the git root's .gitignore) apply to explicitly
+ * passed paths, and generated files regularly live in gitignored directories —
+ * the Testbench skeleton here, generated type folders in consumer apps.
  */
 final readonly class OxfmtFormatter
 {
@@ -29,11 +34,22 @@ final readonly class OxfmtFormatter
             return;
         }
 
-        $process = new Process([$binary, '--write', ...$files]);
-        $process->run();
+        foreach ($files as $file) {
+            $contents = file_get_contents($file);
 
-        if (! $process->isSuccessful()) {
-            throw new ProcessFailedException($process);
+            if ($contents === false) {
+                continue;
+            }
+
+            $process = new Process([$binary, '--stdin-filepath='.$file]);
+            $process->setInput($contents);
+            $process->run();
+
+            if (! $process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+
+            file_put_contents($file, $process->getOutput());
         }
     }
 

--- a/tests/Feature/Support/TypeScript/OxfmtFormatterTest.php
+++ b/tests/Feature/Support/TypeScript/OxfmtFormatterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\File;
 use Lattice\Support\TypeScript\OxfmtFormatter;
 
-it('uses the consumer oxfmt binary before the package fallback', function (): void {
+it('formats through the consumer oxfmt binary via stdin so ignore rules cannot exclude the target', function (): void {
     $nodeModules = base_path('node_modules');
     $binDirectory = $nodeModules.'/.bin';
     $binary = $binDirectory.'/oxfmt';
@@ -14,13 +14,14 @@ it('uses the consumer oxfmt binary before the package fallback', function (): vo
 
     try {
         File::ensureDirectoryExists($binDirectory);
-        File::put($binary, "#!/bin/sh\nprintf '%s\\n' \"\$@\" > ".escapeshellarg($log)."\n");
+        File::put($binary, "#!/bin/sh\nprintf '%s\\n' \"\$@\" > ".escapeshellarg($log)."\ntr -d ' '\n");
         chmod($binary, 0755);
-        File::put($target, 'export type Example={name:string};');
+        File::put($target, 'export type Example = {name: string};');
 
         (new OxfmtFormatter)->format([$target]);
 
-        expect(File::get($log))->toBe("--write\n{$target}\n");
+        expect(File::get($log))->toBe("--stdin-filepath={$target}\n")
+            ->and(File::get($target))->toBe('exporttypeExample={name:string};');
     } finally {
         File::delete([$binary, $log, $target]);
 


### PR DESCRIPTION
`ColumnPropsGenerationTest` has been red on `main` since the oxfmt 0.63 bump (#438): oxfmt now applies ignore rules — including the git root's `.gitignore` — to explicitly passed paths, and refuses generated files living in gitignored directories with "Expected at least one target file. All matched files may have been excluded by ignore rules." That hits the Testbench skeleton (`vendor/orchestra/testbench-core/laravel/...`) in this repo and any consumer app that gitignores its generated type folder. `--ignore-path=/dev/null` and a cwd change don't disable the git-root walk-up, so there is no flag-level escape.

`OxfmtFormatter` now pipes each file's content through `oxfmt --stdin-filepath=<path>` and writes the formatted output back. Stdin mode skips target-path ignore matching but keeps parser inference and config resolution.

Validated: full suite green via `composer test:tia` (1671 passed), including the previously failing test; the formatter test asserts the stdin contract end to end.
