### PR TITLE
fix(api-reference): ship a self-contained tsconfig for composer installs

### DIFF
--- a/packages/api-reference/tsconfig.json
+++ b/packages/api-reference/tsconfig.json
@@ -1,10 +1,15 @@
 {
-  "extends": "../tsconfig.base.json",
-  "include": [
-    "resources/js"
-  ],
-  "exclude": [
-    "resources/js/**/*.test.*",
-    "resources/js/**/*.test-d.*"
-  ]
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["resources/js"],
+  "exclude": ["resources/js/**/*.test.*", "resources/js/**/*.test-d.*"]
 }


### PR DESCRIPTION
#449 switched `packages/api-reference/tsconfig.json` to extend `packages/tsconfig.base.json`, which split-repo composer installs don't contain. Consumer Vite builds then fail transforming the composer plugin with `Tsconfig not found vendor/lattice-php/tsconfig.base.json` (hit in artisan-os on 0.50.0).

Restores the self-contained tsconfig that media, search, and tree ship for the same reason. Verified against artisan-os: patching the vendor file fixes `npm run build`.