### PR TITLE
feat!: commit flat wire-protocol schema documents and lattice:schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,17 +308,43 @@ jobs:
 
       - run: composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Generated TypeScript types are up to date
+      - name: Generated wire-protocol schema documents and TypeScript types are up to date
         run: |
           composer types
           git add --intent-to-add \
+            packages/action/resources/schema/action.schema.json \
+            packages/api-reference/resources/schema/api-reference.schema.json \
+            packages/calendar/resources/schema/calendar.schema.json \
+            packages/core/resources/schema/core.schema.json \
+            packages/form/resources/schema/form.schema.json \
+            packages/framework/resources/schema/lattice.schema.json \
+            packages/media/resources/schema/media.schema.json \
+            packages/search/resources/schema/search.schema.json \
+            packages/signature-example/resources/schema/signature-example.schema.json \
+            packages/table/resources/schema/table.schema.json \
+            packages/tree/resources/schema/tree.schema.json \
+            packages/ui/resources/schema/ui.schema.json \
             packages/framework/resources/js/types/generated.ts \
+            packages/core/resources/js/generated.ts \
             packages/form/resources/js/generated.ts \
             packages/table/resources/js/generated.ts \
             packages/action/resources/js/generated.ts \
             packages/ui/resources/js/generated.ts
           git diff --exit-code -- \
+            packages/action/resources/schema/action.schema.json \
+            packages/api-reference/resources/schema/api-reference.schema.json \
+            packages/calendar/resources/schema/calendar.schema.json \
+            packages/core/resources/schema/core.schema.json \
+            packages/form/resources/schema/form.schema.json \
+            packages/framework/resources/schema/lattice.schema.json \
+            packages/media/resources/schema/media.schema.json \
+            packages/search/resources/schema/search.schema.json \
+            packages/signature-example/resources/schema/signature-example.schema.json \
+            packages/table/resources/schema/table.schema.json \
+            packages/tree/resources/schema/tree.schema.json \
+            packages/ui/resources/schema/ui.schema.json \
             packages/framework/resources/js/types/generated.ts \
+            packages/core/resources/js/generated.ts \
             packages/form/resources/js/generated.ts \
             packages/table/resources/js/generated.ts \
             packages/action/resources/js/generated.ts \

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "lattice-php/signature-example": "@dev",
         "lattice-php/tree": "@dev",
         "league/flysystem-aws-s3-v3": "^3.34",
+        "opis/json-schema": "^2.6",
         "orchestra/testbench": "^10.0 || ^11.0",
         "pestphp/pest": "^5.1",
         "pestphp/pest-plugin-browser": "^5.0",
@@ -60,7 +61,10 @@
         "test:lint": "./vendor/bin/pint --test",
         "rector": "./vendor/bin/rector process",
         "rector:test": "./vendor/bin/rector process --dry-run",
-        "types": "@php vendor/bin/testbench lattice:typescript",
+        "types": [
+            "@php vendor/bin/testbench lattice:schema",
+            "@php vendor/bin/testbench lattice:typescript"
+        ],
         "fix": [
             "@rector",
             "@lint:fix",

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -214,6 +214,7 @@ export default defineConfig({
           items: [
             { label: "Security", link: "/advanced/security/" },
             { label: "Server-side rendering", link: "/advanced/ssr/" },
+            { label: "Wire protocol schema", link: "/advanced/wire-protocol/" },
             { label: "Remote components", link: "/advanced/remote/" },
             { label: "Bundle size", link: "/advanced/bundle-size/" },
             { label: "Enums reference", link: "/advanced/enums/" },

--- a/docs/content/docs/advanced/remote.mdx
+++ b/docs/content/docs/advanced/remote.mdx
@@ -185,8 +185,10 @@ public function render(PageSchema $schema, Request $request, RemoteSourceRegistr
 }
 ```
 
-The manifest is a tree of `{ "type", "id", "props", "schema" }` nodes. A remote-capable node only
-needs to declare its `audience` and `scopes` — the consumer stamps the trusted `remote` access:
+The manifest is a tree of `{ "type", "id", "props", "schema" }` nodes; its published contract is
+`#/$defs/RemoteManifest` in the [wire protocol schema](/advanced/wire-protocol/), so a provider can
+validate a manifest before serving it. A remote-capable node only needs to declare its `audience`
+and `scopes` — the consumer stamps the trusted `remote` access:
 
 ```json
 {

--- a/docs/content/docs/advanced/wire-protocol.mdx
+++ b/docs/content/docs/advanced/wire-protocol.mdx
@@ -1,0 +1,95 @@
+---
+title: Wire protocol schema
+description: The JSON Schema documents that formally specify every wire shape Lattice serializes.
+---
+
+import Info from "@components/Info.astro";
+
+Everything Lattice sends to the client — component nodes, columns, filters, effects, the page
+payload, remote manifests — is specified by JSON Schema (draft 2020-12) documents generated from
+the PHP classes. PHP reflection over the wire-contributing classes is the canonical, internal wire
+model; it is never committed or versioned itself. Two projections come out of it:
+
+```
+PHP reflection (wire model, internal)
+        ├─→ TypeScript emitter → generated.ts modules (idiomatic, hand-shaped per package)
+        └─→ Schema writer      → flat, self-contained committed .schema.json files
+```
+
+"No drift" holds because both projections are produced from the same model — a shape that isn't in
+the schema doesn't exist on the wire, and a shape the TypeScript module exports is always backed by
+a schema def.
+
+## Committed documents
+
+Every wire-contributing package — including the framework itself — ships its own schema document at
+`vendor/lattice-php/{package}/resources/schema/{package}.schema.json`. Each one is **flat and
+self-contained**: every component/column/filter def carries its complete props inlined — nested
+value objects, enums, and shared props from another package are dereferenced directly into place, so
+nothing in the file ever points outside it.
+
+The one structural exception is the recursive envelope core (`Node`, `Schema`, and the other loose
+node/column/filter envelopes): a `Node` cannot be inlined into itself, since its `schema` property
+recursively contains more `Node`s. Every file that references node-shaped props therefore carries its
+own copy of those few envelope defs, addressed with an intra-document `$ref` — the only `$ref`s a
+committed file ever contains.
+
+The framework's own document, `vendor/lattice-php/lattice/resources/schema/lattice.schema.json`
+(also npm-exported as `@lattice-php/lattice/schema/lattice.schema.json`), is the **merged spec**: a
+single flat document combining every package's defs, the envelopes once, and the `x-lattice`
+protocol catalog. It is what `lattice:schema` builds by merging every package's already-flat
+committed file — never by re-deriving anything from PHP.
+
+Its identifier is `https://lattice-php.dev/schema/lattice/v1.json`, and the document carries an
+`x-lattice.protocolVersion` (currently `1`) that only changes on breaking wire-shape changes — it is
+independent of the package version.
+
+## Entry points
+
+Every def is a direct, local `$defs` pointer — validate against whichever one matches your payload:
+
+| Pointer                                                 | Validates                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| `#/$defs/PagePayload`                                   | The `lattice` prop of a rendered page                        |
+| `#/$defs/Node`                                          | Any component node (loose — unknown types allowed)           |
+| `#/$defs/ComponentNode`                                 | Any component node (strict — closed over the built-in types) |
+| `#/$defs/node:button`, `#/$defs/column:column.badge`, … | One concrete node type                                       |
+| `#/$defs/RemoteManifest`                                | A [remote schema manifest](/advanced/remote/)                |
+
+Every component also has a props def under its TypeScript name (`#/$defs/Button`), and enums and
+value objects it doesn't share with another def appear under theirs (`#/$defs/ButtonType`).
+
+## The `x-lattice` vocabulary
+
+Standard validators ignore the `x-lattice` extension key; it carries Lattice's own metadata. In the
+merged spec's root, `families` catalogs every wire family (components, columns, filters, effects,
+editor extensions) with a `types` map from wire `type` string to node and props refs, and `domains`
+lists the per-domain type-string catalogs (`UiNodeType`, `FormFieldNodeType`, …) — only the merged
+document carries these; a per-package file's own defs each carry `kind`, `family`, `wireType`, and
+`php` recording what the def is and which class produced it. The TypeScript generator consumes
+exactly this metadata — nothing outside the document.
+
+## Structured output for AI
+
+Because every node type is a closed schema with a `const` discriminator, the merged document works
+directly as a structured-output contract. Handing an LLM `#/$defs/ComponentNode` (or a single
+`#/$defs/node:…` def for a narrower task) constrains it to emit valid Lattice nodes, which a
+[remote source](/advanced/remote/) can then serve as a manifest.
+
+## Exporting your app's schema
+
+```bash
+php artisan lattice:schema
+```
+
+writes the merged document — every installed package's committed, flat schema file merged with your
+app's own wire types, reflected fresh — to `lattice.schema.json` in your project root (configurable
+via `lattice.schema.output`). Vendor PHP is never reflected for this: installed packages contribute
+their already-committed documents; only your app's own discover paths are reflected. App-defined defs
+are marked `x-lattice.origin: "app"`, so third parties consuming your export can tell your types from
+the built-ins.
+
+<Info>
+  `php artisan lattice:typescript` derives its module augmentation from the same PHP reflection
+  pass, so the exported schema and your generated TypeScript can never disagree.
+</Info>

--- a/packages/action/resources/schema/action.schema.json
+++ b/packages/action/resources/schema/action.schema.json
@@ -1,0 +1,1164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/action/v1.json",
+  "title": "Lattice action wire types",
+  "$defs": {
+    "Action": {
+      "type": "object",
+      "properties": {
+        "confirmation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Confirmation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:form"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazyForm": {
+          "type": "boolean"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalSide": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "end"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Side"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl",
+                "3xl"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\ModalWidth"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmation",
+        "emphasis",
+        "endpoint",
+        "form",
+        "icon",
+        "label",
+        "lazyForm",
+        "method",
+        "modalSide",
+        "modalWidth",
+        "ref",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\Action"
+      }
+    },
+    "ActionGroup": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orientation": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "horizontal",
+                "vertical"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Orientation"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "label",
+        "orientation",
+        "ref"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action.group",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\ActionGroup"
+      }
+    },
+    "ActionResult": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "effects"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Actions\\ActionResult"
+      }
+    },
+    "BulkAction": {
+      "type": "object",
+      "properties": {
+        "confirmation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Confirmation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:form"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazyForm": {
+          "type": "boolean"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalSide": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "end"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Side"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl",
+                "3xl"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\ModalWidth"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmation",
+        "emphasis",
+        "endpoint",
+        "form",
+        "icon",
+        "label",
+        "lazyForm",
+        "method",
+        "modalSide",
+        "modalWidth",
+        "ref",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action.bulk",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\BulkAction"
+      }
+    },
+    "Button": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buttonType": {
+          "$ref": "#/$defs/ButtonType"
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Emphasis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Variant"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "buttonType",
+        "effects",
+        "emphasis",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "button",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "ButtonType": {
+      "type": "string",
+      "enum": [
+        "button",
+        "submit",
+        "reset"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ButtonType"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Confirmation": {
+      "type": "object",
+      "properties": {
+        "cancelLabel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "confirmLabel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "cancelLabel",
+        "confirmLabel",
+        "description",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Actions\\Confirmation"
+      }
+    },
+    "Effect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "effect"
+      }
+    },
+    "Emphasis": {
+      "type": "string",
+      "enum": [
+        "solid",
+        "outline",
+        "ghost",
+        "link"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Emphasis"
+      }
+    },
+    "Form": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errorBag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "precognitive": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resetOnError": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resetOnSuccess": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "state": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitButton": {
+          "type": "boolean"
+        },
+        "submitButtons": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/node:button"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitEmphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitJustify": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "between",
+                "around",
+                "evenly"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Justify"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitVariant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "validationSummaryLabel": {
+          "type": "string"
+        },
+        "validationTimeout": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "errorBag",
+        "method",
+        "precognitive",
+        "ref",
+        "resetOnError",
+        "resetOnSuccess",
+        "state",
+        "status",
+        "submitButton",
+        "submitButtons",
+        "submitEmphasis",
+        "submitJustify",
+        "submitLabel",
+        "submitVariant",
+        "validationSummaryLabel",
+        "validationTimeout"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "form",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\HttpMethod"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "Variant": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "danger"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Variant"
+      }
+    },
+    "node:action": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Action"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action",
+        "php": "Lattice\\Actions\\Components\\Action"
+      }
+    },
+    "node:action.bulk": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action.bulk"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BulkAction"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action.bulk",
+        "php": "Lattice\\Actions\\Components\\BulkAction"
+      }
+    },
+    "node:action.group": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action.group"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ActionGroup"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action.group",
+        "php": "Lattice\\Actions\\Components\\ActionGroup"
+      }
+    },
+    "node:button": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "button"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Button"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "button",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "node:form": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "form"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Form"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "ActionNodeType": [
+        "action",
+        "action.bulk",
+        "action.group"
+      ],
+      "NodeType": [
+        "action",
+        "action.bulk",
+        "action.group"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "action": {
+            "node": "#/$defs/node:action",
+            "props": "#/$defs/Action",
+            "domain": "Actions",
+            "interactive": true
+          },
+          "action.bulk": {
+            "node": "#/$defs/node:action.bulk",
+            "props": "#/$defs/BulkAction",
+            "domain": "Actions",
+            "interactive": true
+          },
+          "action.group": {
+            "node": "#/$defs/node:action.group",
+            "props": "#/$defs/ActionGroup",
+            "domain": "Actions",
+            "container": true,
+            "interactive": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/api-reference/resources/schema/api-reference.schema.json
+++ b/packages/api-reference/resources/schema/api-reference.schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/api-reference/v1.json",
+  "title": "Lattice api-reference wire types",
+  "$defs": {
+    "ApiReference": {
+      "type": "object",
+      "properties": {
+        "defaultOperation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expandDepth": {
+          "type": "integer"
+        },
+        "hideBaseUrl": {
+          "type": "boolean"
+        },
+        "hideHeader": {
+          "type": "boolean"
+        },
+        "operation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "token": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "twoColumnBreakpoint": {
+          "type": "string",
+          "enum": [
+            "default",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\Breakpoint"
+          }
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "defaultOperation",
+        "expandDepth",
+        "hideBaseUrl",
+        "hideHeader",
+        "operation",
+        "spec",
+        "tags",
+        "title",
+        "token",
+        "twoColumnBreakpoint",
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "api-reference",
+        "php": "Lattice\\ApiReference\\ApiReference"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "node:api-reference": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "api-reference"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ApiReference"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "api-reference",
+        "php": "Lattice\\ApiReference\\ApiReference"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "NodeType": [
+        "api-reference"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "api-reference": {
+            "node": "#/$defs/node:api-reference",
+            "props": "#/$defs/ApiReference"
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/calendar/resources/schema/calendar.schema.json
+++ b/packages/calendar/resources/schema/calendar.schema.json
@@ -1,0 +1,335 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/calendar/v1.json",
+  "title": "Lattice calendar wire types",
+  "$defs": {
+    "ColorKind": {
+      "type": "string",
+      "enum": [
+        "named",
+        "css"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorKind"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "EntryData": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "end": {
+          "type": "string",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "start": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "color",
+        "end",
+        "id",
+        "label",
+        "resourceId",
+        "start"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Calendar\\EntryData"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "ResourceGroupData": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "label"
+            ]
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "key",
+        "label",
+        "resources"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Calendar\\ResourceGroupData"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "Timeline": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "integer"
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EntryData"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResourceGroupData"
+          }
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "days",
+        "endpoint",
+        "events",
+        "from",
+        "groups",
+        "ref"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "timeline",
+        "domain": "Calendar",
+        "php": "Lattice\\Calendar\\Components\\Timeline"
+      }
+    },
+    "node:timeline": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "timeline"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Timeline"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "timeline",
+        "php": "Lattice\\Calendar\\Components\\Timeline"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "CalendarNodeType": [
+        "timeline"
+      ],
+      "NodeType": [
+        "timeline"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "timeline": {
+            "node": "#/$defs/node:timeline",
+            "props": "#/$defs/Timeline",
+            "domain": "Calendar",
+            "interactive": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/core/resources/schema/core.schema.json
+++ b/packages/core/resources/schema/core.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/core/v1.json",
+  "title": "Lattice core wire types",
+  "$defs": {
+    "Affix": {
+      "type": "object",
+      "properties": {
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "text": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "icon",
+        "text"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Support\\Affix"
+      }
+    },
+    "Breadcrumb": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string",
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "href",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Breadcrumb"
+      }
+    },
+    "Color": {
+      "type": "object",
+      "properties": {
+        "dark": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "kind": {
+          "$ref": "#/$defs/ColorKind",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "dark",
+        "kind",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Color"
+      }
+    },
+    "ColorKind": {
+      "type": "string",
+      "enum": [
+        "named",
+        "css"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorKind"
+      }
+    },
+    "ColorName": {
+      "type": "string",
+      "enum": [
+        "default",
+        "muted",
+        "primary",
+        "success",
+        "info",
+        "warning",
+        "danger",
+        "gray",
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorName"
+      }
+    },
+    "Op": {
+      "type": "string",
+      "enum": [
+        "contains",
+        "starts_with",
+        "ends_with",
+        "eq",
+        "neq",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "in",
+        "not_in",
+        "before",
+        "after",
+        "empty",
+        "filled"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\Op"
+      }
+    },
+    "Option": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Option"
+      }
+    },
+    "PageLayout": {
+      "type": "string",
+      "enum": [
+        "app",
+        "auth",
+        "none"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\PageLayout"
+      }
+    },
+    "PageWidth": {
+      "type": "string",
+      "enum": [
+        "full",
+        "lg",
+        "md",
+        "sm"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\PageWidth"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {},
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {}
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/core/src/JsonSchema/FlatProjection.php
+++ b/packages/core/src/JsonSchema/FlatProjection.php
@@ -1,0 +1,216 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\JsonSchema;
+
+use LogicException;
+
+/**
+ * Dereferences a `WireModelBuilder::buildAll()`/`buildRootDocument()` origin
+ * document into a flat, self-contained projection: every `$ref` — local or
+ * cross-document — is resolved against the full def universe and inlined in
+ * place, so the committed artifact never points outside itself.
+ *
+ * The recursive envelope core (`Node`, `Schema`, and the other loose node/
+ * column/filter envelopes) cannot be inlined into itself, so those defs are
+ * copied into the projection's own `$defs` once and referenced with an
+ * intra-document `$ref`. Every `props`/`common-props`/`strict` def (a
+ * component/column/filter/effect/editor-extension's own props def, or its
+ * `node:button`-style strict wire-type envelope) gets the same copy-once
+ * treatment rather than full inlining: it is a reusable, independently
+ * addressable identity referenced from a strict union or a nullable
+ * node-typed prop, and inlining it in place would duplicate its entire
+ * (possibly large) props tree at every use site.
+ *
+ * Once a copy-once def is pulled in from a foreign origin, any OTHER def it
+ * references that is native to that SAME foreign origin (`$defOrigins`, e.g.
+ * a component's props def and a value object it embeds, both owned by the
+ * same wire package) gets the same copy-once treatment too, even though its
+ * own kind (`value-object`/`enum`) would normally get it inlined — because
+ * the very same def is independently pulled in by every document that
+ * references it, and those copies are later merged back together
+ * (`SchemaBundler`); a same-origin sibling must render byte-identically
+ * everywhere it is reached, which only a stable, origin-aware rule
+ * guarantees. Anything reached that is NOT native to the currently active
+ * origin (e.g. a plain enum from a third package) still inlines normally.
+ *
+ * The same copy-once treatment dynamically applies to any def that turns out
+ * to be part of a reference cycle, so a foreign cross-cycle never recurses
+ * forever — it resolves as an intra-document `$ref` too.
+ *
+ * The document's own top-level `$defs` entries (its family props/common-props/
+ * strict/value-object/enum defs — everything `buildAll()` already scoped to
+ * this origin) always stay addressable under their own name, fully
+ * dereferenced; nothing pulled in from elsewhere earns a standalone entry
+ * unless its kind or origin keeps it universally addressable, or a cycle
+ * forces it.
+ */
+final class FlatProjection
+{
+    private const array ENVELOPE_CORE = [
+        'Node', 'ColumnNode', 'FilterNode', 'Effect', 'EditorExtension', 'Schema', 'CommonNodeProps',
+    ];
+
+    private const array COPY_ONCE_KINDS = ['props', 'common-props', 'strict'];
+
+    /** @var array<string, mixed> */
+    private array $roots;
+
+    /** @var array<string, mixed> */
+    private array $universe;
+
+    /** @var array<string, string> */
+    private array $defOrigins;
+
+    /** @var array<string, mixed> */
+    private array $out;
+
+    /** @var array<string, true> */
+    private array $inProgress;
+
+    /** @var array<string, true> */
+    private array $cyclic;
+
+    private ?string $currentOrigin = null;
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @param  array<string, mixed>  $universe  every def, from every origin, keyed by def name
+     * @param  array<string, string>  $defOrigins  def name => owning origin's shortName, covering the full universe
+     * @param  string|null  $documentOrigin  this document's own origin shortName, for same-origin sibling tracking
+     * @return array<string, mixed>
+     */
+    public function project(array $document, array $universe, array $defOrigins = [], ?string $documentOrigin = null): array
+    {
+        $this->roots = $document['$defs'] ?? [];
+        $this->universe = $universe;
+        $this->defOrigins = $defOrigins;
+        $this->out = [];
+        $this->inProgress = [];
+        $this->cyclic = [];
+        $this->currentOrigin = $documentOrigin;
+
+        $defs = [];
+
+        foreach ($this->roots as $name => $def) {
+            $defs[$name] = $this->walk($def);
+        }
+
+        $document['$defs'] = [...$this->out, ...$defs];
+        ksort($document['$defs']);
+
+        return $document;
+    }
+
+    private function walk(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value['$ref'] ?? null)) {
+            $resolved = $this->resolve($this->nameFromRef($value['$ref']));
+
+            foreach ($value as $key => $sibling) {
+                if ($key !== '$ref') {
+                    $resolved[$key] = $this->walk($sibling);
+                }
+            }
+
+            return $resolved;
+        }
+
+        return array_map($this->walk(...), $value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolve(string $name): array
+    {
+        if (isset($this->roots[$name])) {
+            return ['$ref' => '#/$defs/'.$name];
+        }
+
+        if (isset($this->inProgress[$name])) {
+            $this->cyclic[$name] = true;
+
+            return ['$ref' => '#/$defs/'.$name];
+        }
+
+        // Whether a def "stays addressable" is either universal (envelope
+        // core, or a props/common-props/strict kind — always true, safe to
+        // memoize in $out regardless of who is asking) or context-dependent
+        // (a same-origin sibling of whatever is CURRENTLY being walked). The
+        // $out memo only applies once we know which one this is: reusing it
+        // unconditionally would let an earlier, differently-origined walk
+        // that promoted this name to copy-once silently leak into a walk
+        // that would otherwise correctly inline it here.
+        $addressable = $this->staysAddressable($name);
+
+        if ($addressable && isset($this->out[$name])) {
+            return ['$ref' => '#/$defs/'.$name];
+        }
+
+        $walked = $this->walkDef($name);
+
+        // `cyclic` only communicates a dynamically detected reentry up to the
+        // walkDef() frame that is still in progress for it; once consumed it
+        // must not linger; the previous "addressable" flag on the SAME name
+        // may legitimately differ (false) the next time an unrelated,
+        // differently-origined caller resolves it.
+        $reentered = isset($this->cyclic[$name]);
+        unset($this->cyclic[$name]);
+
+        if ($addressable || $reentered) {
+            $this->out[$name] = $walked;
+
+            return ['$ref' => '#/$defs/'.$name];
+        }
+
+        return $walked;
+    }
+
+    private function staysAddressable(string $name): bool
+    {
+        if (in_array($name, self::ENVELOPE_CORE, true) || $this->isCopyOnceKind($name)) {
+            return true;
+        }
+
+        return $this->currentOrigin !== null && ($this->defOrigins[$name] ?? null) === $this->currentOrigin;
+    }
+
+    private function walkDef(string $name): mixed
+    {
+        $def = $this->universe[$name] ?? throw new LogicException(sprintf(
+            'Schema def [%s] is referenced but missing from the def universe.',
+            $name,
+        ));
+
+        $previousOrigin = $this->currentOrigin;
+        $this->currentOrigin = $this->defOrigins[$name] ?? $previousOrigin;
+
+        $this->inProgress[$name] = true;
+        $walked = $this->walk($def);
+        unset($this->inProgress[$name]);
+
+        $this->currentOrigin = $previousOrigin;
+
+        return $walked;
+    }
+
+    private function isCopyOnceKind(string $name): bool
+    {
+        $def = $this->universe[$name] ?? null;
+        $kind = is_array($def) ? $def['x-lattice']['kind'] ?? null : null;
+
+        return in_array($kind, self::COPY_ONCE_KINDS, true);
+    }
+
+    private function nameFromRef(string $ref): string
+    {
+        $position = strrpos($ref, '/$defs/');
+
+        return $position === false ? $ref : substr($ref, $position + strlen('/$defs/'));
+    }
+}

--- a/packages/core/src/JsonSchema/SchemaBundler.php
+++ b/packages/core/src/JsonSchema/SchemaBundler.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\JsonSchema;
+
+use LogicException;
+
+/**
+ * Merges a set of already-flat, self-contained schema documents (each
+ * `FlatProjection`-processed, so none of them point outside themselves) into
+ * one: every def name lands directly in the merged `$defs`, keeping `$base`'s
+ * `$schema`/`$id`/`title`/`x-lattice`. Every flat document carries its own
+ * copy of the envelope core, so the same name recurs across documents with
+ * byte-identical content — those collapse silently.
+ *
+ * Two different classes may declare the SAME wire type (`#[AsFilter]`/
+ * `#[AsComponent]` reusing an existing control's type string, e.g. a
+ * component package's filter opting into the built-in `filter.select`
+ * control) — their `strict` node-envelope defs then collide on the same
+ * `prefix:type` name with genuinely different content. That is a pre-existing
+ * property of the wire model (present before this fan-out), not something
+ * this merge can adjudicate, so it keeps whichever document is processed
+ * first — deterministic given a stable source order — instead of failing the
+ * build. Any OTHER kind of name collision is a real bug (e.g. two unrelated
+ * classes accidentally sharing a `class_basename()`) and still throws.
+ */
+final readonly class SchemaBundler
+{
+    /**
+     * @param  array<string, mixed>  $base
+     * @param  list<array<string, mixed>>  $documents
+     * @return array<string, mixed>
+     */
+    public function bundle(array $base, array $documents): array
+    {
+        $defs = $base['$defs'] ?? [];
+
+        foreach ($documents as $document) {
+            foreach ($document['$defs'] ?? [] as $name => $def) {
+                if (isset($defs[$name]) && $defs[$name] !== $def) {
+                    if (($defs[$name]['x-lattice']['kind'] ?? null) === 'strict' && ($def['x-lattice']['kind'] ?? null) === 'strict') {
+                        continue;
+                    }
+
+                    throw new LogicException(sprintf(
+                        'Schema definition name [%s] is claimed by two different defs while merging the wire-protocol bundle.',
+                        $name,
+                    ));
+                }
+
+                $defs[$name] = $def;
+            }
+        }
+
+        ksort($defs);
+        $base['$defs'] = $defs;
+
+        return $base;
+    }
+}

--- a/packages/core/src/JsonSchema/SchemaDocumentWriter.php
+++ b/packages/core/src/JsonSchema/SchemaDocumentWriter.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\JsonSchema;
+
+use stdClass;
+
+/**
+ * Deterministic serialization of the schema document: two-space pretty JSON,
+ * unescaped slashes, trailing newline. Empty PHP arrays are JSON objects here —
+ * the document never contains a legitimately empty JSON array, while the empty
+ * schema `{}` (PHP `mixed`) and propless `properties` maps are common.
+ */
+final readonly class SchemaDocumentWriter
+{
+    /**
+     * @param  array<string, mixed>  $document
+     */
+    public function write(array $document): string
+    {
+        $json = json_encode(
+            $this->objectified($document),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
+
+        $json = preg_replace_callback(
+            '/^ +/m',
+            static fn (array $matches): string => str_repeat(' ', intdiv(strlen($matches[0]), 2)),
+            $json,
+        );
+
+        return $json."\n";
+    }
+
+    private function objectified(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if ($value === []) {
+            return new stdClass;
+        }
+
+        return array_map($this->objectified(...), $value);
+    }
+}

--- a/packages/core/src/Wire/WireModelBuilder.php
+++ b/packages/core/src/Wire/WireModelBuilder.php
@@ -160,9 +160,18 @@ final class WireModelBuilder
      * compile-time totality check needs, since only the full manifest knows
      * about every origin's node types.
      *
+     * `$includeFrameworkEnvelope` opts the framework document into the
+     * recursive envelope core, strict unions, and the remote-manifest
+     * contract — the JSON Schema fan-out needs those as real, resolvable
+     * `$defs` since the format has no hand-written counterpart to fall back
+     * on. The TypeScript emitter's own `buildAll()` callers leave this off:
+     * `Node`/`Schema`/`ColumnNode`/`FilterNode`/`Effect`/`EditorExtension`
+     * are hand-written in `@lattice-php/core`/`@lattice-php/ui`, and emitting
+     * generated counterparts here would shadow those imports.
+     *
      * @return array{documents: array<string, array<string, mixed>>, defOrigins: array<string, string>}
      */
-    public function buildAll(): array
+    public function buildAll(bool $includeFrameworkEnvelope = false): array
     {
         $this->appClasses = [];
 
@@ -185,7 +194,7 @@ final class WireModelBuilder
         $documents = [];
 
         foreach ($sources as $source) {
-            $documents[$source->shortName] = $this->document($source, $manifest, $names, $markers, $nodeDefs, $classOrigins);
+            $documents[$source->shortName] = $this->document($source, $manifest, $names, $markers, $nodeDefs, $classOrigins, $includeFrameworkEnvelope);
         }
 
         $defOrigins = [];
@@ -288,6 +297,7 @@ final class WireModelBuilder
         array $markers,
         array $nodeDefs,
         array $classOrigins,
+        bool $includeFrameworkEnvelope = false,
     ): array {
         $context = new WireModelContext($names, $nodeDefs, $markers);
         $mapper = new PropertyTypeMapper($context);
@@ -344,14 +354,30 @@ final class WireModelBuilder
             }
         }
 
+        if ($isFramework && $includeFrameworkEnvelope) {
+            foreach ($this->envelopeDefs() as $name => $def) {
+                $defs[$name] = $def;
+            }
+
+            foreach ($this->strictUnionDefs($manifest, $context) as $name => $def) {
+                $defs[$name] = $def;
+            }
+
+            $defs['RemoteManifest'] = $this->remoteManifestDef();
+            $defs['RemoteManifestNode'] = $this->remoteManifestNodeDef();
+        }
+
         ksort($defs);
 
         $catalogManifest = $isFramework ? $manifest : $originManifest;
 
         return [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
             '$id' => $source->schemaId(),
+            'title' => $isFramework ? 'Lattice wire protocol' : sprintf('Lattice %s wire types', $source->shortName),
             '$defs' => $defs,
             'x-lattice' => [
+                ...($isFramework && $includeFrameworkEnvelope ? ['protocolVersion' => self::PROTOCOL_VERSION] : []),
                 'domains' => $this->domainsCatalog($catalogManifest),
                 'families' => $this->familiesCatalog($originManifest, $names, $context),
             ],

--- a/packages/form/resources/schema/form.schema.json
+++ b/packages/form/resources/schema/form.schema.json
@@ -1,0 +1,6086 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/form/v1.json",
+  "title": "Lattice form wire types",
+  "$defs": {
+    "Builder": {
+      "type": "object",
+      "properties": {
+        "addLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultItems": {
+          "type": "integer"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout": {
+          "$ref": "#/$defs/RowLayout"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "reorderable": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "resizableColumns": {
+          "type": "boolean"
+        },
+        "resizeIndicator": {
+          "type": "boolean"
+        },
+        "rowActions": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RowAction"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "templates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RowTemplateData"
+          }
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "addLabel",
+        "columnWidth",
+        "conditions",
+        "defaultItems",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "layout",
+        "maxItems",
+        "minItems",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "reorderable",
+        "required",
+        "resizableColumns",
+        "resizeIndicator",
+        "rowActions",
+        "templates",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.builder",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Builder"
+      }
+    },
+    "Button": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buttonType": {
+          "$ref": "#/$defs/ButtonType"
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Emphasis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Variant"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "buttonType",
+        "effects",
+        "emphasis",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "button",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "ButtonType": {
+      "type": "string",
+      "enum": [
+        "button",
+        "submit",
+        "reset"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ButtonType"
+      }
+    },
+    "Checkbox": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.checkbox",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Checkbox"
+      }
+    },
+    "Choice": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "options",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.choice",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Choice"
+      }
+    },
+    "ColorPicker": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "palette": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "palette",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.color-picker",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\ColorPicker"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Condition": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "readOnly": true
+        },
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "readOnly": true
+        }
+      },
+      "required": [
+        "field",
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Conditions\\Condition"
+      }
+    },
+    "DateInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.date-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\DateInput"
+      }
+    },
+    "DateTimeInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "convertTimezone": {
+          "type": "boolean"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "step": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "timezone": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "convertTimezone",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "step",
+        "tabIndex",
+        "timezone",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.date-time-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\DateTimeInput"
+      }
+    },
+    "EditorBlockquote": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "blockquote",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Blockquote"
+      }
+    },
+    "EditorBold": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "bold",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Bold"
+      }
+    },
+    "EditorBulletList": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "bullet-list",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\BulletList"
+      }
+    },
+    "EditorCode": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "code",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Code"
+      }
+    },
+    "EditorCodeBlock": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "code-block",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\CodeBlock"
+      }
+    },
+    "EditorDetails": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "details",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Details"
+      }
+    },
+    "EditorEmoji": {
+      "type": "object",
+      "properties": {
+        "emojis": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "emojis"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "emoji",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Emoji"
+      }
+    },
+    "EditorExtension": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "editor-extension"
+      }
+    },
+    "EditorHeading": {
+      "type": "object",
+      "properties": {
+        "levels": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "required": [
+        "levels"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "heading",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Heading"
+      }
+    },
+    "EditorHighlight": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "highlight",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Highlight"
+      }
+    },
+    "EditorHorizontalRule": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "horizontal-rule",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\HorizontalRule"
+      }
+    },
+    "EditorItalic": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "italic",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Italic"
+      }
+    },
+    "EditorLink": {
+      "type": "object",
+      "properties": {
+        "openOnClick": {
+          "type": "boolean"
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "openOnClick",
+        "protocols"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "link",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Link"
+      }
+    },
+    "EditorOrderedList": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "ordered-list",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\OrderedList"
+      }
+    },
+    "EditorStrike": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "strike",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Strike"
+      }
+    },
+    "EditorTable": {
+      "type": "object",
+      "properties": {
+        "cols": {
+          "type": "integer"
+        },
+        "rows": {
+          "type": "integer"
+        },
+        "withHeaderRow": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "cols",
+        "rows",
+        "withHeaderRow"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "table",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Table"
+      }
+    },
+    "EditorTextAlign": {
+      "type": "object",
+      "properties": {
+        "alignments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "alignments"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "text-align",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\TextAlign"
+      }
+    },
+    "EditorUnderline": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "underline",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Underline"
+      }
+    },
+    "Effect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "effect"
+      }
+    },
+    "Emphasis": {
+      "type": "string",
+      "enum": [
+        "solid",
+        "outline",
+        "ghost",
+        "link"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Emphasis"
+      }
+    },
+    "FieldConditions": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        },
+        "readOnly": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        },
+        "visible": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "disabled",
+        "readOnly",
+        "required",
+        "visible"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Conditions\\FieldConditions"
+      }
+    },
+    "FileUpload": {
+      "type": "object",
+      "properties": {
+        "accept": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "files": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "token": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "key",
+                  "name",
+                  "size",
+                  "token",
+                  "url"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maxFiles": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "maxSize": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "signed": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "accept",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "files",
+        "helperText",
+        "image",
+        "label",
+        "labelAction",
+        "maxFiles",
+        "maxSize",
+        "multiple",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "signed",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.file-upload",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\FileUpload"
+      }
+    },
+    "Form": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errorBag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "precognitive": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resetOnError": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resetOnSuccess": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "state": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitButton": {
+          "type": "boolean"
+        },
+        "submitButtons": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/node:button"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitEmphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitJustify": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "between",
+                "around",
+                "evenly"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Justify"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitVariant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "validationSummaryLabel": {
+          "type": "string"
+        },
+        "validationTimeout": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "errorBag",
+        "method",
+        "precognitive",
+        "ref",
+        "resetOnError",
+        "resetOnSuccess",
+        "state",
+        "status",
+        "submitButton",
+        "submitButtons",
+        "submitEmphasis",
+        "submitJustify",
+        "submitLabel",
+        "submitVariant",
+        "validationSummaryLabel",
+        "validationTimeout"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "form",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "HiddenInput": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.hidden-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\HiddenInput"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\HttpMethod"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "NumberInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "slider": {
+          "type": "boolean"
+        },
+        "step": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "prefix",
+        "readOnly",
+        "required",
+        "slider",
+        "step",
+        "suffix",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.number-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\NumberInput"
+      }
+    },
+    "OtpInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "length": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "length",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.otp",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\OtpInput"
+      }
+    },
+    "PasswordInput": {
+      "type": "object",
+      "properties": {
+        "autoComplete": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "confirmation": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "placeholder": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "name",
+                "placeholder"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "passwordRules": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoComplete",
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "confirmation",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "passwordRules",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "prefix",
+        "readOnly",
+        "required",
+        "suffix",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.password-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\PasswordInput"
+      }
+    },
+    "PatternInput": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "separator": {
+          "type": "string"
+        },
+        "tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PatternTokenData"
+          }
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "separator",
+        "tokens",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.pattern-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\PatternInput"
+      }
+    },
+    "PatternTokenData": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "label",
+        "name",
+        "schema"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\PatternInput\\PatternTokenData"
+      }
+    },
+    "Repeater": {
+      "type": "object",
+      "properties": {
+        "addLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultItems": {
+          "type": "integer"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemLabels": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout": {
+          "$ref": "#/$defs/RowLayout"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "reorderable": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "resizableColumns": {
+          "type": "boolean"
+        },
+        "resizeIndicator": {
+          "type": "boolean"
+        },
+        "rowActions": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RowAction"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "addLabel",
+        "columnWidth",
+        "conditions",
+        "defaultItems",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "itemLabel",
+        "itemLabels",
+        "label",
+        "labelAction",
+        "layout",
+        "maxItems",
+        "minItems",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "reorderable",
+        "required",
+        "resizableColumns",
+        "resizeIndicator",
+        "rowActions",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.repeater",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Repeater"
+      }
+    },
+    "ResolveResponse": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "prefill": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        },
+        "values": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        }
+      },
+      "required": [
+        "fields",
+        "prefill",
+        "values"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\ResolveResponse"
+      }
+    },
+    "RichEditor": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EditorExtension"
+          }
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "extensions",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.rich-editor",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\RichEditor"
+      }
+    },
+    "RowAction": {
+      "type": "object",
+      "properties": {
+        "danger": {
+          "type": "boolean"
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/$defs/RowActionType"
+        }
+      },
+      "required": [
+        "danger",
+        "icon",
+        "key",
+        "label",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Components\\RowAction"
+      }
+    },
+    "RowActionType": {
+      "type": "string",
+      "enum": [
+        "duplicate",
+        "remove"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Form\\Enums\\RowActionType"
+      }
+    },
+    "RowLayout": {
+      "type": "string",
+      "enum": [
+        "stack",
+        "table"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Form\\Enums\\RowLayout"
+      }
+    },
+    "RowTemplateData": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "label",
+        "schema",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Components\\RowTemplateData"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "Select": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "creatable": {
+          "type": "boolean"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "emptyLabel": {
+          "type": "string"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "optionSchema": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Node"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "searchPlaceholder": {
+          "type": "string"
+        },
+        "searchable": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "creatable",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "emptyLabel",
+        "helperText",
+        "label",
+        "labelAction",
+        "multiple",
+        "name",
+        "optionSchema",
+        "options",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "searchPlaceholder",
+        "searchable",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.select",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Select"
+      }
+    },
+    "SignedUpload": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        },
+        "key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "get",
+            "post",
+            "put",
+            "patch",
+            "delete"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\HttpMethod"
+          },
+          "readOnly": true
+        },
+        "url": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "headers",
+        "key",
+        "method",
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Components\\SignedUpload"
+      }
+    },
+    "TextInput": {
+      "type": "object",
+      "properties": {
+        "autoComplete": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoComplete",
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "copyable",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "prefix",
+        "readOnly",
+        "required",
+        "suffix",
+        "tabIndex",
+        "tooltip",
+        "type",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.text-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\TextInput"
+      }
+    },
+    "Textarea": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "rows": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "rows",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.textarea",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Textarea"
+      }
+    },
+    "TimeInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "step": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "step",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.time-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\TimeInput"
+      }
+    },
+    "Toggle": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.toggle",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Toggle"
+      }
+    },
+    "Variant": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "danger"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Variant"
+      }
+    },
+    "Wizard": {
+      "type": "object",
+      "properties": {
+        "orientation": {
+          "type": "string",
+          "enum": [
+            "horizontal",
+            "vertical"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\Orientation"
+          }
+        }
+      },
+      "required": [
+        "orientation"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "wizard",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Wizard"
+      }
+    },
+    "WizardStep": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "label",
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "wizard-step",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\WizardStep"
+      }
+    },
+    "editor-extension:blockquote": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "blockquote"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorBlockquote"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "blockquote"
+      }
+    },
+    "editor-extension:bold": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "bold"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorBold"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "bold"
+      }
+    },
+    "editor-extension:bullet-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "bullet-list"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorBulletList"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "bullet-list"
+      }
+    },
+    "editor-extension:code": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "code"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorCode"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "code"
+      }
+    },
+    "editor-extension:code-block": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "code-block"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorCodeBlock"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "code-block"
+      }
+    },
+    "editor-extension:details": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "details"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorDetails"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "details"
+      }
+    },
+    "editor-extension:emoji": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "emoji"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorEmoji"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "emoji"
+      }
+    },
+    "editor-extension:heading": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "heading"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorHeading"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "heading"
+      }
+    },
+    "editor-extension:highlight": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "highlight"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorHighlight"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "highlight"
+      }
+    },
+    "editor-extension:horizontal-rule": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "horizontal-rule"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorHorizontalRule"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "horizontal-rule"
+      }
+    },
+    "editor-extension:italic": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "italic"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorItalic"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "italic"
+      }
+    },
+    "editor-extension:link": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "link"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorLink"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "link"
+      }
+    },
+    "editor-extension:ordered-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "ordered-list"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorOrderedList"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "ordered-list"
+      }
+    },
+    "editor-extension:strike": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "strike"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorStrike"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "strike"
+      }
+    },
+    "editor-extension:table": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "table"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorTable"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "table"
+      }
+    },
+    "editor-extension:text-align": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "text-align"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorTextAlign"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "text-align"
+      }
+    },
+    "editor-extension:underline": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "underline"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorUnderline"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "underline"
+      }
+    },
+    "node:button": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "button"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Button"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "button",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "node:field.builder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.builder"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Builder"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.builder",
+        "php": "Lattice\\Form\\Components\\Builder"
+      }
+    },
+    "node:field.checkbox": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.checkbox"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Checkbox"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.checkbox",
+        "php": "Lattice\\Form\\Components\\Checkbox"
+      }
+    },
+    "node:field.choice": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.choice"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Choice"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.choice",
+        "php": "Lattice\\Form\\Components\\Choice"
+      }
+    },
+    "node:field.color-picker": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.color-picker"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ColorPicker"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.color-picker",
+        "php": "Lattice\\Form\\Components\\ColorPicker"
+      }
+    },
+    "node:field.date-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.date-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.date-input",
+        "php": "Lattice\\Form\\Components\\DateInput"
+      }
+    },
+    "node:field.date-time-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.date-time-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateTimeInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.date-time-input",
+        "php": "Lattice\\Form\\Components\\DateTimeInput"
+      }
+    },
+    "node:field.file-upload": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.file-upload"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FileUpload"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.file-upload",
+        "php": "Lattice\\Form\\Components\\FileUpload"
+      }
+    },
+    "node:field.hidden-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.hidden-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/HiddenInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.hidden-input",
+        "php": "Lattice\\Form\\Components\\HiddenInput"
+      }
+    },
+    "node:field.number-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.number-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/NumberInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.number-input",
+        "php": "Lattice\\Form\\Components\\NumberInput"
+      }
+    },
+    "node:field.otp": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.otp"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OtpInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.otp",
+        "php": "Lattice\\Form\\Components\\OtpInput"
+      }
+    },
+    "node:field.password-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.password-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/PasswordInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.password-input",
+        "php": "Lattice\\Form\\Components\\PasswordInput"
+      }
+    },
+    "node:field.pattern-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.pattern-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/PatternInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.pattern-input",
+        "php": "Lattice\\Form\\Components\\PatternInput"
+      }
+    },
+    "node:field.repeater": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.repeater"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Repeater"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.repeater",
+        "php": "Lattice\\Form\\Components\\Repeater"
+      }
+    },
+    "node:field.rich-editor": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.rich-editor"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RichEditor"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.rich-editor",
+        "php": "Lattice\\Form\\Components\\RichEditor"
+      }
+    },
+    "node:field.select": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.select"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Select"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.select",
+        "php": "Lattice\\Form\\Components\\Select"
+      }
+    },
+    "node:field.text-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.text-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.text-input",
+        "php": "Lattice\\Form\\Components\\TextInput"
+      }
+    },
+    "node:field.textarea": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.textarea"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Textarea"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.textarea",
+        "php": "Lattice\\Form\\Components\\Textarea"
+      }
+    },
+    "node:field.time-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.time-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TimeInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.time-input",
+        "php": "Lattice\\Form\\Components\\TimeInput"
+      }
+    },
+    "node:field.toggle": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.toggle"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Toggle"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.toggle",
+        "php": "Lattice\\Form\\Components\\Toggle"
+      }
+    },
+    "node:form": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "form"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Form"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "node:wizard": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "wizard"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Wizard"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "wizard",
+        "php": "Lattice\\Form\\Components\\Wizard"
+      }
+    },
+    "node:wizard-step": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "wizard-step"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/WizardStep"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "wizard-step",
+        "php": "Lattice\\Form\\Components\\WizardStep"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "FormFieldNodeType": [
+        "field.builder",
+        "field.checkbox",
+        "field.choice",
+        "field.color-picker",
+        "field.date-input",
+        "field.date-time-input",
+        "field.file-upload",
+        "field.hidden-input",
+        "field.number-input",
+        "field.otp",
+        "field.password-input",
+        "field.pattern-input",
+        "field.repeater",
+        "field.rich-editor",
+        "field.select",
+        "field.text-input",
+        "field.textarea",
+        "field.time-input",
+        "field.toggle",
+        "wizard",
+        "wizard-step"
+      ],
+      "FormNodeType": [
+        "field.builder",
+        "field.checkbox",
+        "field.choice",
+        "field.color-picker",
+        "field.date-input",
+        "field.date-time-input",
+        "field.file-upload",
+        "field.hidden-input",
+        "field.number-input",
+        "field.otp",
+        "field.password-input",
+        "field.pattern-input",
+        "field.repeater",
+        "field.rich-editor",
+        "field.select",
+        "field.text-input",
+        "field.textarea",
+        "field.time-input",
+        "field.toggle",
+        "form",
+        "wizard",
+        "wizard-step"
+      ],
+      "NodeType": [
+        "field.builder",
+        "field.checkbox",
+        "field.choice",
+        "field.color-picker",
+        "field.date-input",
+        "field.date-time-input",
+        "field.file-upload",
+        "field.hidden-input",
+        "field.number-input",
+        "field.otp",
+        "field.password-input",
+        "field.pattern-input",
+        "field.repeater",
+        "field.rich-editor",
+        "field.select",
+        "field.text-input",
+        "field.textarea",
+        "field.time-input",
+        "field.toggle",
+        "form",
+        "wizard",
+        "wizard-step"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "field.builder": {
+            "node": "#/$defs/node:field.builder",
+            "props": "#/$defs/Builder",
+            "domain": "Form"
+          },
+          "field.checkbox": {
+            "node": "#/$defs/node:field.checkbox",
+            "props": "#/$defs/Checkbox",
+            "domain": "Form"
+          },
+          "field.choice": {
+            "node": "#/$defs/node:field.choice",
+            "props": "#/$defs/Choice",
+            "domain": "Form"
+          },
+          "field.color-picker": {
+            "node": "#/$defs/node:field.color-picker",
+            "props": "#/$defs/ColorPicker",
+            "domain": "Form"
+          },
+          "field.date-input": {
+            "node": "#/$defs/node:field.date-input",
+            "props": "#/$defs/DateInput",
+            "domain": "Form"
+          },
+          "field.date-time-input": {
+            "node": "#/$defs/node:field.date-time-input",
+            "props": "#/$defs/DateTimeInput",
+            "domain": "Form"
+          },
+          "field.file-upload": {
+            "node": "#/$defs/node:field.file-upload",
+            "props": "#/$defs/FileUpload",
+            "domain": "Form"
+          },
+          "field.hidden-input": {
+            "node": "#/$defs/node:field.hidden-input",
+            "props": "#/$defs/HiddenInput",
+            "domain": "Form"
+          },
+          "field.number-input": {
+            "node": "#/$defs/node:field.number-input",
+            "props": "#/$defs/NumberInput",
+            "domain": "Form"
+          },
+          "field.otp": {
+            "node": "#/$defs/node:field.otp",
+            "props": "#/$defs/OtpInput",
+            "domain": "Form"
+          },
+          "field.password-input": {
+            "node": "#/$defs/node:field.password-input",
+            "props": "#/$defs/PasswordInput",
+            "domain": "Form"
+          },
+          "field.pattern-input": {
+            "node": "#/$defs/node:field.pattern-input",
+            "props": "#/$defs/PatternInput",
+            "domain": "Form"
+          },
+          "field.repeater": {
+            "node": "#/$defs/node:field.repeater",
+            "props": "#/$defs/Repeater",
+            "domain": "Form",
+            "container": true
+          },
+          "field.rich-editor": {
+            "node": "#/$defs/node:field.rich-editor",
+            "props": "#/$defs/RichEditor",
+            "domain": "Form"
+          },
+          "field.select": {
+            "node": "#/$defs/node:field.select",
+            "props": "#/$defs/Select",
+            "domain": "Form"
+          },
+          "field.text-input": {
+            "node": "#/$defs/node:field.text-input",
+            "props": "#/$defs/TextInput",
+            "domain": "Form"
+          },
+          "field.textarea": {
+            "node": "#/$defs/node:field.textarea",
+            "props": "#/$defs/Textarea",
+            "domain": "Form"
+          },
+          "field.time-input": {
+            "node": "#/$defs/node:field.time-input",
+            "props": "#/$defs/TimeInput",
+            "domain": "Form"
+          },
+          "field.toggle": {
+            "node": "#/$defs/node:field.toggle",
+            "props": "#/$defs/Toggle",
+            "domain": "Form"
+          },
+          "form": {
+            "node": "#/$defs/node:form",
+            "props": "#/$defs/Form",
+            "domain": "Form",
+            "container": true,
+            "interactive": true
+          },
+          "wizard": {
+            "node": "#/$defs/node:wizard",
+            "props": "#/$defs/Wizard",
+            "domain": "Form",
+            "container": true
+          },
+          "wizard-step": {
+            "node": "#/$defs/node:wizard-step",
+            "props": "#/$defs/WizardStep",
+            "domain": "Form",
+            "container": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {
+          "blockquote": {
+            "node": "#/$defs/editor-extension:blockquote",
+            "props": "#/$defs/EditorBlockquote"
+          },
+          "bold": {
+            "node": "#/$defs/editor-extension:bold",
+            "props": "#/$defs/EditorBold"
+          },
+          "bullet-list": {
+            "node": "#/$defs/editor-extension:bullet-list",
+            "props": "#/$defs/EditorBulletList"
+          },
+          "code": {
+            "node": "#/$defs/editor-extension:code",
+            "props": "#/$defs/EditorCode"
+          },
+          "code-block": {
+            "node": "#/$defs/editor-extension:code-block",
+            "props": "#/$defs/EditorCodeBlock"
+          },
+          "details": {
+            "node": "#/$defs/editor-extension:details",
+            "props": "#/$defs/EditorDetails"
+          },
+          "emoji": {
+            "node": "#/$defs/editor-extension:emoji",
+            "props": "#/$defs/EditorEmoji"
+          },
+          "heading": {
+            "node": "#/$defs/editor-extension:heading",
+            "props": "#/$defs/EditorHeading"
+          },
+          "highlight": {
+            "node": "#/$defs/editor-extension:highlight",
+            "props": "#/$defs/EditorHighlight"
+          },
+          "horizontal-rule": {
+            "node": "#/$defs/editor-extension:horizontal-rule",
+            "props": "#/$defs/EditorHorizontalRule"
+          },
+          "italic": {
+            "node": "#/$defs/editor-extension:italic",
+            "props": "#/$defs/EditorItalic"
+          },
+          "link": {
+            "node": "#/$defs/editor-extension:link",
+            "props": "#/$defs/EditorLink"
+          },
+          "ordered-list": {
+            "node": "#/$defs/editor-extension:ordered-list",
+            "props": "#/$defs/EditorOrderedList"
+          },
+          "strike": {
+            "node": "#/$defs/editor-extension:strike",
+            "props": "#/$defs/EditorStrike"
+          },
+          "table": {
+            "node": "#/$defs/editor-extension:table",
+            "props": "#/$defs/EditorTable"
+          },
+          "text-align": {
+            "node": "#/$defs/editor-extension:text-align",
+            "props": "#/$defs/EditorTextAlign"
+          },
+          "underline": {
+            "node": "#/$defs/editor-extension:underline",
+            "props": "#/$defs/EditorUnderline"
+          }
+        }
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/framework/config/lattice.php
+++ b/packages/framework/config/lattice.php
@@ -84,4 +84,8 @@ return [
         'output' => resource_path('js/lattice/generated.d.ts'),
         'module' => '@lattice-php/core',
     ],
+
+    'schema' => [
+        'output' => base_path('lattice.schema.json'),
+    ],
 ];

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -93,6 +93,7 @@
     "./svg-sprite-client": {
       "types": "./dist/svg-sprite-client.d.ts"
     },
+    "./schema/lattice.schema.json": "./resources/schema/lattice.schema.json",
     "./vite": {
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
@@ -104,7 +105,8 @@
   },
   "files": [
     "dist",
-    "dist-standalone"
+    "dist-standalone",
+    "resources/schema"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/framework/resources/schema/lattice.schema.json
+++ b/packages/framework/resources/schema/lattice.schema.json
@@ -1,0 +1,16877 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/lattice/v1.json",
+  "title": "Lattice wire protocol",
+  "$defs": {
+    "Action": {
+      "type": "object",
+      "properties": {
+        "confirmation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Confirmation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:form"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazyForm": {
+          "type": "boolean"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalSide": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "end"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Side"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl",
+                "3xl"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\ModalWidth"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmation",
+        "emphasis",
+        "endpoint",
+        "form",
+        "icon",
+        "label",
+        "lazyForm",
+        "method",
+        "modalSide",
+        "modalWidth",
+        "ref",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\Action"
+      }
+    },
+    "ActionGroup": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orientation": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "horizontal",
+                "vertical"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Orientation"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "label",
+        "orientation",
+        "ref"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action.group",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\ActionGroup"
+      }
+    },
+    "ActionResult": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "effects"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Actions\\ActionResult"
+      }
+    },
+    "Affix": {
+      "type": "object",
+      "properties": {
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "text": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "icon",
+        "text"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Support\\Affix"
+      }
+    },
+    "Align": {
+      "type": "string",
+      "enum": [
+        "center",
+        "left",
+        "start",
+        "stretch"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Align"
+      }
+    },
+    "ApiReference": {
+      "type": "object",
+      "properties": {
+        "defaultOperation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expandDepth": {
+          "type": "integer"
+        },
+        "hideBaseUrl": {
+          "type": "boolean"
+        },
+        "hideHeader": {
+          "type": "boolean"
+        },
+        "operation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "spec": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "tags": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "token": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "twoColumnBreakpoint": {
+          "type": "string",
+          "enum": [
+            "default",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\Breakpoint"
+          }
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "defaultOperation",
+        "expandDepth",
+        "hideBaseUrl",
+        "hideHeader",
+        "operation",
+        "spec",
+        "tags",
+        "title",
+        "token",
+        "twoColumnBreakpoint",
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "api-reference",
+        "php": "Lattice\\ApiReference\\ApiReference"
+      }
+    },
+    "Avatar": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shape": {
+          "$ref": "#/$defs/AvatarShape"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "src": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "shape",
+        "size",
+        "src"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "avatar",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Avatar"
+      }
+    },
+    "AvatarShape": {
+      "type": "string",
+      "enum": [
+        "circle",
+        "rounded"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\AvatarShape"
+      }
+    },
+    "Badge": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "badge",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Badge"
+      }
+    },
+    "BadgeColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "colors": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "dark": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "readOnly": true
+                  },
+                  "kind": {
+                    "$ref": "#/$defs/ColorKind",
+                    "readOnly": true
+                  },
+                  "value": {
+                    "type": "string",
+                    "readOnly": true
+                  }
+                },
+                "required": [
+                  "dark",
+                  "kind",
+                  "value"
+                ],
+                "x-lattice": {
+                  "kind": "value-object",
+                  "php": "Lattice\\Core\\Color"
+                }
+              },
+              "x-lattice": {
+                "keys": "integer|string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "colors",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.badge",
+        "php": "Lattice\\Table\\Columns\\BadgeColumn"
+      }
+    },
+    "BadgeEntry": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "color",
+        "description",
+        "label",
+        "name",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.badge",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\BadgeEntry"
+      }
+    },
+    "BooleanColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.boolean",
+        "php": "Lattice\\Table\\Columns\\BooleanColumn"
+      }
+    },
+    "BooleanEntry": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "falseIcon": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "trueIcon": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "description",
+        "falseIcon",
+        "label",
+        "name",
+        "trueIcon",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.boolean",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\BooleanEntry"
+      }
+    },
+    "Breadcrumb": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string",
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "href",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Breadcrumb"
+      }
+    },
+    "Breadcrumbs": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "breadcrumbs",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Breadcrumbs"
+      }
+    },
+    "Breakpoint": {
+      "type": "string",
+      "enum": [
+        "default",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Breakpoint"
+      }
+    },
+    "BrowserToken": {
+      "type": "object",
+      "properties": {
+        "accessToken": {
+          "type": "string",
+          "readOnly": true
+        },
+        "audience": {
+          "type": "string",
+          "readOnly": true
+        },
+        "expiresIn": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "tokenType": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "accessToken",
+        "audience",
+        "expiresIn",
+        "scopes",
+        "tokenType"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Remote\\BrowserToken"
+      }
+    },
+    "Builder": {
+      "type": "object",
+      "properties": {
+        "addLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultItems": {
+          "type": "integer"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout": {
+          "$ref": "#/$defs/RowLayout"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "reorderable": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "resizableColumns": {
+          "type": "boolean"
+        },
+        "resizeIndicator": {
+          "type": "boolean"
+        },
+        "rowActions": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RowAction"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "templates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RowTemplateData"
+          }
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "addLabel",
+        "columnWidth",
+        "conditions",
+        "defaultItems",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "layout",
+        "maxItems",
+        "minItems",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "reorderable",
+        "required",
+        "resizableColumns",
+        "resizeIndicator",
+        "rowActions",
+        "templates",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.builder",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Builder"
+      }
+    },
+    "BulkAction": {
+      "type": "object",
+      "properties": {
+        "confirmation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Confirmation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:form"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazyForm": {
+          "type": "boolean"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalSide": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "end"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Side"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl",
+                "3xl"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\ModalWidth"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmation",
+        "emphasis",
+        "endpoint",
+        "form",
+        "icon",
+        "label",
+        "lazyForm",
+        "method",
+        "modalSide",
+        "modalWidth",
+        "ref",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action.bulk",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\BulkAction"
+      }
+    },
+    "Button": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buttonType": {
+          "$ref": "#/$defs/ButtonType"
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Emphasis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Variant"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "buttonType",
+        "effects",
+        "emphasis",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "button",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "ButtonType": {
+      "type": "string",
+      "enum": [
+        "button",
+        "submit",
+        "reset"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ButtonType"
+      }
+    },
+    "Callout": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dismissible": {
+          "type": "boolean"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Translatable"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "title": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Translatable"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unique": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "$ref": "#/$defs/Variant"
+        }
+      },
+      "required": [
+        "action",
+        "dismissible",
+        "message",
+        "title",
+        "unique",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "callout",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Callout"
+      }
+    },
+    "Callouts": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "callouts",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Callouts"
+      }
+    },
+    "Card": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headerActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "description",
+        "headerActions",
+        "title",
+        "tooltip"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "card",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Card"
+      }
+    },
+    "ChannelVisibility": {
+      "type": "string",
+      "enum": [
+        "public",
+        "private",
+        "presence"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Realtime\\Enums\\ChannelVisibility"
+      }
+    },
+    "Chart": {
+      "type": "object",
+      "properties": {
+        "categoryFormat": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateFormat"
+            },
+            {
+              "$ref": "#/$defs/NumberFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "categoryKey": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "grid": {
+          "type": "boolean"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "legend": {
+          "type": "boolean"
+        },
+        "series": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChartSeries"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": "boolean"
+        },
+        "valueFormat": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "xAxis": {
+          "type": "boolean"
+        },
+        "yAxis": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "categoryFormat",
+        "categoryKey",
+        "data",
+        "description",
+        "grid",
+        "height",
+        "legend",
+        "series",
+        "title",
+        "tooltip",
+        "valueFormat",
+        "xAxis",
+        "yAxis"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "chart",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Chart"
+      }
+    },
+    "ChartSeries": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "dataKey": {
+          "type": "string",
+          "readOnly": true
+        },
+        "innerRadius": {
+          "type": "string",
+          "readOnly": true
+        },
+        "maxValue": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "nameKey": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "stackId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/$defs/ChartSeriesType",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "color",
+        "dataKey",
+        "innerRadius",
+        "maxValue",
+        "name",
+        "nameKey",
+        "stackId",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\Values\\ChartSeries"
+      }
+    },
+    "ChartSeriesType": {
+      "type": "string",
+      "enum": [
+        "area",
+        "bar",
+        "distribution",
+        "gauge",
+        "line",
+        "pie"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ChartSeriesType"
+      }
+    },
+    "ChatBox": {
+      "type": "object",
+      "properties": {
+        "fill": {
+          "type": "boolean"
+        },
+        "historyEndpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "remote": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RemoteAccess"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "streamEndpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "fill",
+        "historyEndpoint",
+        "placeholder",
+        "remote",
+        "streamEndpoint",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "chat.box",
+        "domain": "Chat",
+        "php": "Lattice\\Chat\\Components\\ChatBox"
+      }
+    },
+    "ChatMessage": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "parts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "role": {
+          "$ref": "#/$defs/ChatRole",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "parts",
+        "role"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Chat\\ChatMessage"
+      }
+    },
+    "ChatRole": {
+      "type": "string",
+      "enum": [
+        "user",
+        "assistant",
+        "system"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Chat\\Enums\\ChatRole"
+      }
+    },
+    "Checkbox": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.checkbox",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Checkbox"
+      }
+    },
+    "Choice": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "options",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.choice",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Choice"
+      }
+    },
+    "CloseModal": {
+      "type": "object",
+      "properties": {
+        "modal": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "modal"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "close-modal",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\CloseModal"
+      }
+    },
+    "CodeBlock": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "language": {
+          "$ref": "#/$defs/CodeBlockLanguage"
+        },
+        "lineNumbers": {
+          "type": "boolean"
+        },
+        "maxHeight": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "wrap": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "code",
+        "copyable",
+        "language",
+        "lineNumbers",
+        "maxHeight",
+        "wrap"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "code-block",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\CodeBlock"
+      }
+    },
+    "CodeBlockLanguage": {
+      "type": "string",
+      "enum": [
+        "text",
+        "json",
+        "javascript",
+        "shell",
+        "php"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\CodeBlockLanguage"
+      }
+    },
+    "Collapsible": {
+      "type": "object",
+      "properties": {
+        "collapsed": {
+          "type": "boolean"
+        },
+        "rememberState": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "collapsed",
+        "rememberState",
+        "tooltip",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "collapsible",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Collapsible"
+      }
+    },
+    "Color": {
+      "type": "object",
+      "properties": {
+        "dark": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "kind": {
+          "$ref": "#/$defs/ColorKind",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "dark",
+        "kind",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Color"
+      }
+    },
+    "ColorKind": {
+      "type": "string",
+      "enum": [
+        "named",
+        "css"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorKind"
+      }
+    },
+    "ColorName": {
+      "type": "string",
+      "enum": [
+        "default",
+        "muted",
+        "primary",
+        "success",
+        "info",
+        "warning",
+        "danger",
+        "gray",
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorName"
+      }
+    },
+    "ColorPicker": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "palette": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "palette",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.color-picker",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\ColorPicker"
+      }
+    },
+    "Column": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "common-props",
+        "family": "column",
+        "php": "Lattice\\Table\\Columns\\Column"
+      }
+    },
+    "ColumnAlign": {
+      "type": "string",
+      "enum": [
+        "start",
+        "center",
+        "end"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\ColumnAlign"
+      }
+    },
+    "ColumnFilter": {
+      "type": "object",
+      "properties": {
+        "clauseOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ColumnFilterOption"
+          },
+          "readOnly": true
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FilterControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "defaultOperator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "multiple": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "operators": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "contains",
+              "starts_with",
+              "ends_with",
+              "eq",
+              "neq",
+              "gt",
+              "gte",
+              "lt",
+              "lte",
+              "in",
+              "not_in",
+              "before",
+              "after",
+              "empty",
+              "filled"
+            ],
+            "x-lattice": {
+              "kind": "enum",
+              "php": "Lattice\\Core\\Enums\\Op"
+            }
+          },
+          "readOnly": true
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          },
+          "readOnly": true
+        },
+        "searchable": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/$defs/FilterType",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "clauseOptions",
+        "control",
+        "defaultOperator",
+        "multiple",
+        "operators",
+        "options",
+        "searchable",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Columns\\ColumnFilter"
+      }
+    },
+    "ColumnFilterOption": {
+      "type": "object",
+      "properties": {
+        "clauses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ColumnFilterOptionClause"
+          },
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "clauses",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Columns\\ColumnFilterOption"
+      }
+    },
+    "ColumnFilterOptionClause": {
+      "type": "object",
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Columns\\ColumnFilterOptionClause"
+      }
+    },
+    "ColumnNode": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "column"
+      }
+    },
+    "ColumnNodeStrict": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/column:column.badge"
+        },
+        {
+          "$ref": "#/$defs/column:column.boolean"
+        },
+        {
+          "$ref": "#/$defs/column:column.icon"
+        },
+        {
+          "$ref": "#/$defs/column:column.image"
+        },
+        {
+          "$ref": "#/$defs/column:column.money"
+        },
+        {
+          "$ref": "#/$defs/column:column.number"
+        },
+        {
+          "$ref": "#/$defs/column:column.stack"
+        },
+        {
+          "$ref": "#/$defs/column:column.text"
+        }
+      ],
+      "x-lattice": {
+        "kind": "union",
+        "family": "column"
+      }
+    },
+    "ColumnWidth": {
+      "type": "string",
+      "enum": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "ComponentEntry": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "description",
+        "label",
+        "name",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.component",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\ComponentEntry"
+      }
+    },
+    "ComponentNode": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/node:action"
+        },
+        {
+          "$ref": "#/$defs/node:action.bulk"
+        },
+        {
+          "$ref": "#/$defs/node:action.group"
+        },
+        {
+          "$ref": "#/$defs/node:api-reference"
+        },
+        {
+          "$ref": "#/$defs/node:avatar"
+        },
+        {
+          "$ref": "#/$defs/node:badge"
+        },
+        {
+          "$ref": "#/$defs/node:breadcrumbs"
+        },
+        {
+          "$ref": "#/$defs/node:button"
+        },
+        {
+          "$ref": "#/$defs/node:callouts"
+        },
+        {
+          "$ref": "#/$defs/node:card"
+        },
+        {
+          "$ref": "#/$defs/node:chart"
+        },
+        {
+          "$ref": "#/$defs/node:chat.box"
+        },
+        {
+          "$ref": "#/$defs/node:chat.part.text"
+        },
+        {
+          "$ref": "#/$defs/node:chat.part.tool-call"
+        },
+        {
+          "$ref": "#/$defs/node:code-block"
+        },
+        {
+          "$ref": "#/$defs/node:collapsible"
+        },
+        {
+          "$ref": "#/$defs/node:description-list"
+        },
+        {
+          "$ref": "#/$defs/node:dropdown"
+        },
+        {
+          "$ref": "#/$defs/node:entry.badge"
+        },
+        {
+          "$ref": "#/$defs/node:entry.boolean"
+        },
+        {
+          "$ref": "#/$defs/node:entry.component"
+        },
+        {
+          "$ref": "#/$defs/node:entry.date"
+        },
+        {
+          "$ref": "#/$defs/node:entry.text"
+        },
+        {
+          "$ref": "#/$defs/node:field.builder"
+        },
+        {
+          "$ref": "#/$defs/node:field.checkbox"
+        },
+        {
+          "$ref": "#/$defs/node:field.choice"
+        },
+        {
+          "$ref": "#/$defs/node:field.color-picker"
+        },
+        {
+          "$ref": "#/$defs/node:field.date-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.date-time-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.file-upload"
+        },
+        {
+          "$ref": "#/$defs/node:field.hidden-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.media-picker"
+        },
+        {
+          "$ref": "#/$defs/node:field.number-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.otp"
+        },
+        {
+          "$ref": "#/$defs/node:field.password-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.pattern-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.repeater"
+        },
+        {
+          "$ref": "#/$defs/node:field.rich-editor"
+        },
+        {
+          "$ref": "#/$defs/node:field.select"
+        },
+        {
+          "$ref": "#/$defs/node:field.text-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.textarea"
+        },
+        {
+          "$ref": "#/$defs/node:field.time-input"
+        },
+        {
+          "$ref": "#/$defs/node:field.toggle"
+        },
+        {
+          "$ref": "#/$defs/node:floating-panel"
+        },
+        {
+          "$ref": "#/$defs/node:form"
+        },
+        {
+          "$ref": "#/$defs/node:fragment"
+        },
+        {
+          "$ref": "#/$defs/node:grid"
+        },
+        {
+          "$ref": "#/$defs/node:heading"
+        },
+        {
+          "$ref": "#/$defs/node:icon"
+        },
+        {
+          "$ref": "#/$defs/node:image"
+        },
+        {
+          "$ref": "#/$defs/node:link"
+        },
+        {
+          "$ref": "#/$defs/node:media.library"
+        },
+        {
+          "$ref": "#/$defs/node:menu"
+        },
+        {
+          "$ref": "#/$defs/node:menu-item"
+        },
+        {
+          "$ref": "#/$defs/node:modal"
+        },
+        {
+          "$ref": "#/$defs/node:notifications"
+        },
+        {
+          "$ref": "#/$defs/node:outlet"
+        },
+        {
+          "$ref": "#/$defs/node:progress"
+        },
+        {
+          "$ref": "#/$defs/node:raw-block"
+        },
+        {
+          "$ref": "#/$defs/node:remote.data-list"
+        },
+        {
+          "$ref": "#/$defs/node:search.box"
+        },
+        {
+          "$ref": "#/$defs/node:search.categories"
+        },
+        {
+          "$ref": "#/$defs/node:search.input"
+        },
+        {
+          "$ref": "#/$defs/node:search.preview"
+        },
+        {
+          "$ref": "#/$defs/node:search.recent"
+        },
+        {
+          "$ref": "#/$defs/node:search.results"
+        },
+        {
+          "$ref": "#/$defs/node:section"
+        },
+        {
+          "$ref": "#/$defs/node:segmented-control"
+        },
+        {
+          "$ref": "#/$defs/node:separator"
+        },
+        {
+          "$ref": "#/$defs/node:sidebar"
+        },
+        {
+          "$ref": "#/$defs/node:signature"
+        },
+        {
+          "$ref": "#/$defs/node:stack"
+        },
+        {
+          "$ref": "#/$defs/node:tab"
+        },
+        {
+          "$ref": "#/$defs/node:table"
+        },
+        {
+          "$ref": "#/$defs/node:tabs"
+        },
+        {
+          "$ref": "#/$defs/node:text"
+        },
+        {
+          "$ref": "#/$defs/node:timeline"
+        },
+        {
+          "$ref": "#/$defs/node:tooltip"
+        },
+        {
+          "$ref": "#/$defs/node:topbar"
+        },
+        {
+          "$ref": "#/$defs/node:tree"
+        },
+        {
+          "$ref": "#/$defs/node:wizard"
+        },
+        {
+          "$ref": "#/$defs/node:wizard-step"
+        }
+      ],
+      "x-lattice": {
+        "kind": "union",
+        "family": "component"
+      }
+    },
+    "Condition": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "readOnly": true
+        },
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "readOnly": true
+        }
+      },
+      "required": [
+        "field",
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Conditions\\Condition"
+      }
+    },
+    "Confirmation": {
+      "type": "object",
+      "properties": {
+        "cancelLabel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "confirmLabel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "cancelLabel",
+        "confirmLabel",
+        "description",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Actions\\Confirmation"
+      }
+    },
+    "DataList": {
+      "type": "object",
+      "properties": {
+        "dataEndpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "emptyLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "remote": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RemoteAccess"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "dataEndpoint",
+        "emptyLabel",
+        "remote"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "remote.data-list",
+        "domain": "Remote",
+        "php": "Lattice\\Remote\\Components\\DataList"
+      }
+    },
+    "DateEntry": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/DateFormat"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "description",
+        "format",
+        "label",
+        "name",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.date",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\DateEntry"
+      }
+    },
+    "DateFormat": {
+      "type": "object",
+      "properties": {
+        "dateStyle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateTimeStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "kind": {
+          "type": "string"
+        },
+        "month": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeStyle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateTimeStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "year": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "dateStyle",
+        "kind",
+        "month",
+        "timeStyle",
+        "year"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\Values\\DateFormat"
+      }
+    },
+    "DateInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.date-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\DateInput"
+      }
+    },
+    "DateRangeFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.date-range",
+        "php": "Lattice\\Table\\Filters\\DateRangeFilter"
+      }
+    },
+    "DateTimeInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "convertTimezone": {
+          "type": "boolean"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "step": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "timezone": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "convertTimezone",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "step",
+        "tabIndex",
+        "timezone",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.date-time-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\DateTimeInput"
+      }
+    },
+    "DateTimeStyle": {
+      "type": "string",
+      "enum": [
+        "full",
+        "long",
+        "medium",
+        "short"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\DateTimeStyle"
+      }
+    },
+    "DescriptionList": {
+      "type": "object",
+      "properties": {
+        "bleed": {
+          "type": "boolean"
+        },
+        "divided": {
+          "type": "boolean"
+        },
+        "emptyLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bleed",
+        "divided",
+        "emptyLabel",
+        "semantic"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "description-list",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\DescriptionList"
+      }
+    },
+    "Download": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "download",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Download"
+      }
+    },
+    "Dropdown": {
+      "type": "object",
+      "properties": {
+        "placement": {
+          "type": "string",
+          "enum": [
+            "top",
+            "bottom",
+            "right"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\Placement"
+          }
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "placement",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "dropdown",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Dropdown"
+      }
+    },
+    "EditorBlockquote": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "blockquote",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Blockquote"
+      }
+    },
+    "EditorBold": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "bold",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Bold"
+      }
+    },
+    "EditorBulletList": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "bullet-list",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\BulletList"
+      }
+    },
+    "EditorCode": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "code",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Code"
+      }
+    },
+    "EditorCodeBlock": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "code-block",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\CodeBlock"
+      }
+    },
+    "EditorDetails": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "details",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Details"
+      }
+    },
+    "EditorEmoji": {
+      "type": "object",
+      "properties": {
+        "emojis": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "emojis"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "emoji",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Emoji"
+      }
+    },
+    "EditorExtension": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "editor-extension"
+      }
+    },
+    "EditorExtensionStrict": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/editor-extension:blockquote"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:bold"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:bullet-list"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:code"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:code-block"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:details"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:emoji"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:heading"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:highlight"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:horizontal-rule"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:italic"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:link"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:media-image"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:ordered-list"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:strike"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:table"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:text-align"
+        },
+        {
+          "$ref": "#/$defs/editor-extension:underline"
+        }
+      ],
+      "x-lattice": {
+        "kind": "union",
+        "family": "editor-extension"
+      }
+    },
+    "EditorHeading": {
+      "type": "object",
+      "properties": {
+        "levels": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "required": [
+        "levels"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "heading",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Heading"
+      }
+    },
+    "EditorHighlight": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "highlight",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Highlight"
+      }
+    },
+    "EditorHorizontalRule": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "horizontal-rule",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\HorizontalRule"
+      }
+    },
+    "EditorItalic": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "italic",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Italic"
+      }
+    },
+    "EditorLink": {
+      "type": "object",
+      "properties": {
+        "openOnClick": {
+          "type": "boolean"
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "openOnClick",
+        "protocols"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "link",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Link"
+      }
+    },
+    "EditorMediaImage": {
+      "type": "object",
+      "properties": {
+        "conversions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "library": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:media.library"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "conversions",
+        "library"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "media-image",
+        "php": "Lattice\\Media\\Forms\\RichEditor\\MediaImage"
+      }
+    },
+    "EditorOrderedList": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "ordered-list",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\OrderedList"
+      }
+    },
+    "EditorStrike": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "strike",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Strike"
+      }
+    },
+    "EditorTable": {
+      "type": "object",
+      "properties": {
+        "cols": {
+          "type": "integer"
+        },
+        "rows": {
+          "type": "integer"
+        },
+        "withHeaderRow": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "cols",
+        "rows",
+        "withHeaderRow"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "table",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Table"
+      }
+    },
+    "EditorTextAlign": {
+      "type": "object",
+      "properties": {
+        "alignments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "alignments"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "text-align",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\TextAlign"
+      }
+    },
+    "EditorUnderline": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "underline",
+        "php": "Lattice\\Form\\RichEditor\\Extensions\\Underline"
+      }
+    },
+    "Effect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "effect"
+      }
+    },
+    "EffectStrict": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/effect:callout"
+        },
+        {
+          "$ref": "#/$defs/effect:close-modal"
+        },
+        {
+          "$ref": "#/$defs/effect:download"
+        },
+        {
+          "$ref": "#/$defs/effect:locale-change"
+        },
+        {
+          "$ref": "#/$defs/effect:open-modal"
+        },
+        {
+          "$ref": "#/$defs/effect:redirect"
+        },
+        {
+          "$ref": "#/$defs/effect:reload-component"
+        },
+        {
+          "$ref": "#/$defs/effect:reload-page"
+        },
+        {
+          "$ref": "#/$defs/effect:reset-form"
+        },
+        {
+          "$ref": "#/$defs/effect:retract-callout"
+        },
+        {
+          "$ref": "#/$defs/effect:toast"
+        },
+        {
+          "$ref": "#/$defs/effect:toggle-sidebar"
+        }
+      ],
+      "x-lattice": {
+        "kind": "union",
+        "family": "effect"
+      }
+    },
+    "Emphasis": {
+      "type": "string",
+      "enum": [
+        "solid",
+        "outline",
+        "ghost",
+        "link"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Emphasis"
+      }
+    },
+    "EntryData": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "end": {
+          "type": "string",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "resourceId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "start": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "color",
+        "end",
+        "id",
+        "label",
+        "resourceId",
+        "start"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Calendar\\EntryData"
+      }
+    },
+    "FieldConditions": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        },
+        "readOnly": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        },
+        "required": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        },
+        "visible": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Condition"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "disabled",
+        "readOnly",
+        "required",
+        "visible"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Conditions\\FieldConditions"
+      }
+    },
+    "FileUpload": {
+      "type": "object",
+      "properties": {
+        "accept": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "files": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "token": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                },
+                "required": [
+                  "key",
+                  "name",
+                  "size",
+                  "token",
+                  "url"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maxFiles": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "maxSize": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "signed": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "accept",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "files",
+        "helperText",
+        "image",
+        "label",
+        "labelAction",
+        "maxFiles",
+        "maxSize",
+        "multiple",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "signed",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.file-upload",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\FileUpload"
+      }
+    },
+    "Filter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "common-props",
+        "family": "filter",
+        "php": "Lattice\\Table\\Filters\\Filter"
+      }
+    },
+    "FilterClause": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "readOnly": true
+        },
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "field",
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\FilterClause"
+      }
+    },
+    "FilterControl": {
+      "type": "string",
+      "enum": [
+        "filter.select",
+        "filter.ternary",
+        "filter.date-range",
+        "filter.toggle"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\FilterControl"
+      }
+    },
+    "FilterIndicator": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "filter",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Filters\\FilterIndicator"
+      }
+    },
+    "FilterNode": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "filter"
+      }
+    },
+    "FilterNodeStrict": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/filter:filter.date-range"
+        },
+        {
+          "$ref": "#/$defs/filter:filter.media-type"
+        },
+        {
+          "$ref": "#/$defs/filter:filter.select"
+        },
+        {
+          "$ref": "#/$defs/filter:filter.ternary"
+        },
+        {
+          "$ref": "#/$defs/filter:filter.toggle"
+        }
+      ],
+      "x-lattice": {
+        "kind": "union",
+        "family": "filter"
+      }
+    },
+    "FilterType": {
+      "type": "string",
+      "enum": [
+        "text",
+        "number",
+        "date",
+        "boolean"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\FilterType"
+      }
+    },
+    "FloatingPanel": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "offset": {
+          "type": "integer"
+        },
+        "placement": {
+          "$ref": "#/$defs/FloatingPlacement"
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "label",
+        "offset",
+        "placement",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "floating-panel",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\FloatingPanel"
+      }
+    },
+    "FloatingPlacement": {
+      "type": "string",
+      "enum": [
+        "bottom-end",
+        "bottom-start",
+        "top-end",
+        "top-start"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\FloatingPlacement"
+      }
+    },
+    "Form": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errorBag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "precognitive": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resetOnError": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resetOnSuccess": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "state": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitButton": {
+          "type": "boolean"
+        },
+        "submitButtons": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/node:button"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitEmphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitJustify": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "between",
+                "around",
+                "evenly"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Justify"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitVariant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "validationSummaryLabel": {
+          "type": "string"
+        },
+        "validationTimeout": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "errorBag",
+        "method",
+        "precognitive",
+        "ref",
+        "resetOnError",
+        "resetOnSuccess",
+        "state",
+        "status",
+        "submitButton",
+        "submitButtons",
+        "submitEmphasis",
+        "submitJustify",
+        "submitLabel",
+        "submitVariant",
+        "validationSummaryLabel",
+        "validationTimeout"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "form",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "Fragment": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazy": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "size": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl",
+            "2xl",
+            "3xl",
+            "4xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\Size"
+          }
+        }
+      },
+      "required": [
+        "endpoint",
+        "lazy",
+        "ref",
+        "size"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "fragment",
+        "domain": "Fragments",
+        "php": "Lattice\\Fragments\\Components\\Fragment"
+      }
+    },
+    "FragmentResponse": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "schema"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Fragments\\FragmentResponse"
+      }
+    },
+    "Gap": {
+      "type": "string",
+      "enum": [
+        "none",
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Gap"
+      }
+    },
+    "Grid": {
+      "type": "object",
+      "properties": {
+        "columns": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": [
+                  "integer",
+                  "string"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "columns"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "grid",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Grid"
+      }
+    },
+    "Heading": {
+      "type": "object",
+      "properties": {
+        "copyable": {
+          "type": "boolean"
+        },
+        "level": {
+          "type": "integer"
+        },
+        "text": {
+          "type": "string"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "copyable",
+        "level",
+        "text",
+        "tooltip"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "heading",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Heading"
+      }
+    },
+    "Height": {
+      "type": "string",
+      "enum": [
+        "full",
+        "screen"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Height"
+      }
+    },
+    "HiddenInput": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.hidden-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\HiddenInput"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\HttpMethod"
+      }
+    },
+    "I18nConfig": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "locales": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "preloadLocales": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "saveMissing": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "timezone": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "enabled",
+        "locales",
+        "preloadLocales",
+        "saveMissing",
+        "timezone"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Http\\I18nConfig"
+      }
+    },
+    "Icon": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        }
+      },
+      "required": [
+        "class",
+        "color",
+        "name",
+        "size"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "icon",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Icon"
+      }
+    },
+    "IconColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "colors": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "dark": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "readOnly": true
+                  },
+                  "kind": {
+                    "$ref": "#/$defs/ColorKind",
+                    "readOnly": true
+                  },
+                  "value": {
+                    "type": "string",
+                    "readOnly": true
+                  }
+                },
+                "required": [
+                  "dark",
+                  "kind",
+                  "value"
+                ],
+                "x-lattice": {
+                  "kind": "value-object",
+                  "php": "Lattice\\Core\\Color"
+                }
+              },
+              "x-lattice": {
+                "keys": "integer|string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icons": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "x-lattice": {
+                "keys": "integer|string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "colors",
+        "filter",
+        "hiddenByDefault",
+        "icon",
+        "icons",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.icon",
+        "php": "Lattice\\Table\\Columns\\IconColumn"
+      }
+    },
+    "Image": {
+      "type": "object",
+      "properties": {
+        "alt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "circular": {
+          "type": "boolean"
+        },
+        "previewable": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "src": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "alt",
+        "circular",
+        "previewable",
+        "size",
+        "src"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "image",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Image"
+      }
+    },
+    "ImageColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "circular": {
+          "type": "boolean"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "previewable": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "circular",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "previewable",
+        "size",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.image",
+        "php": "Lattice\\Table\\Columns\\ImageColumn"
+      }
+    },
+    "Justify": {
+      "type": "string",
+      "enum": [
+        "start",
+        "center",
+        "end",
+        "between",
+        "around",
+        "evenly"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Justify"
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "effects",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "prefix",
+        "suffix",
+        "tabIndex"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "link",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Link"
+      }
+    },
+    "Listen": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string",
+          "readOnly": true
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "visibility": {
+          "$ref": "#/$defs/ChannelVisibility",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "channel",
+        "effects",
+        "events",
+        "visibility"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Realtime\\Listen"
+      }
+    },
+    "LocaleChange": {
+      "type": "object",
+      "properties": {
+        "locale": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "locale"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "locale-change",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\LocaleChange"
+      }
+    },
+    "MediaLibrary": {
+      "type": "object",
+      "properties": {
+        "accept": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "picker": {
+          "type": "boolean"
+        },
+        "signed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "accept",
+        "picker",
+        "signed"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "media.library",
+        "domain": "Media",
+        "php": "Lattice\\Media\\Components\\MediaLibrary"
+      }
+    },
+    "MediaPicker": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "disabled": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                },
+                "readOnly": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                },
+                "required": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                },
+                "visible": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "disabled",
+                "readOnly",
+                "required",
+                "visible"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Form\\Conditions\\FieldConditions"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maxFiles": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "selected": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "mime_type": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "preview_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "id",
+                  "mime_type",
+                  "name",
+                  "preview_url",
+                  "url",
+                  "values"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "maxFiles",
+        "multiple",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "selected",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.media-picker",
+        "domain": "Forms",
+        "php": "Lattice\\Media\\Forms\\Components\\MediaPicker"
+      }
+    },
+    "MediaTypeFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.media-type",
+        "php": "Lattice\\Media\\Tables\\Filters\\MediaTypeFilter"
+      }
+    },
+    "Menu": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "menu",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Menu"
+      }
+    },
+    "MenuItem": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "effects",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "prefix",
+        "suffix"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "menu-item",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\MenuItem"
+      }
+    },
+    "Modal": {
+      "type": "object",
+      "properties": {
+        "closeLabel": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "height": {
+          "$ref": "#/$defs/ModalHeight"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "side": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Side"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "$ref": "#/$defs/ModalWidth"
+        }
+      },
+      "required": [
+        "closeLabel",
+        "description",
+        "height",
+        "open",
+        "ref",
+        "side",
+        "title",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "modal",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Modal"
+      }
+    },
+    "ModalHeight": {
+      "type": "string",
+      "enum": [
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl",
+        "3xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ModalHeight"
+      }
+    },
+    "ModalWidth": {
+      "type": "string",
+      "enum": [
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl",
+        "3xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ModalWidth"
+      }
+    },
+    "MoneyColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "currency": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "currencyField": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maximumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "copyable",
+        "currency",
+        "currencyField",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "maximumFractionDigits",
+        "minimumFractionDigits",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.money",
+        "php": "Lattice\\Table\\Columns\\MoneyColumn"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "NotificationItem": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "body": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "payload": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "replacements": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "boolean",
+                      "number",
+                      "integer",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "key",
+                "payload",
+                "replacements"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Ui\\I18n\\Values\\Translatable"
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "isRead": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "payload": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "replacements": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": [
+                      "boolean",
+                      "number",
+                      "integer",
+                      "string"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "key",
+                "payload",
+                "replacements"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Ui\\I18n\\Values\\Translatable"
+              }
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "actions",
+        "body",
+        "createdAt",
+        "href",
+        "icon",
+        "id",
+        "isRead",
+        "title",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Notifications\\NotificationItem"
+      }
+    },
+    "NotificationList": {
+      "type": "object",
+      "properties": {
+        "hasMore": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "notifications": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/NotificationItem"
+          },
+          "readOnly": true
+        },
+        "unreadCount": {
+          "type": "integer",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "hasMore",
+        "notifications",
+        "unreadCount"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Notifications\\NotificationList"
+      }
+    },
+    "Notifications": {
+      "type": "object",
+      "properties": {
+        "channel": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "pollingInterval": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "slideOut": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "channel",
+        "endpoint",
+        "pollingInterval",
+        "slideOut"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "notifications",
+        "domain": "Notifications",
+        "php": "Lattice\\Notifications\\Components\\Notifications"
+      }
+    },
+    "NumberColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "compact": {
+          "type": "boolean"
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maximumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "percent",
+                "kilogram",
+                "gram",
+                "kilometer",
+                "meter",
+                "byte",
+                "kilobyte",
+                "megabyte",
+                "gigabyte",
+                "millisecond",
+                "second",
+                "minute",
+                "hour",
+                "celsius",
+                "fahrenheit"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\NumberFormatUnit"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "compact",
+        "copyable",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "maximumFractionDigits",
+        "minimumFractionDigits",
+        "options",
+        "sortable",
+        "toggleable",
+        "unit",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.number",
+        "php": "Lattice\\Table\\Columns\\NumberColumn"
+      }
+    },
+    "NumberFormat": {
+      "type": "object",
+      "properties": {
+        "currency": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "type": "string"
+        },
+        "maximumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "notation": {
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberFormatUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "currency",
+        "kind",
+        "maximumFractionDigits",
+        "minimumFractionDigits",
+        "notation",
+        "unit"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\Values\\NumberFormat"
+      }
+    },
+    "NumberFormatUnit": {
+      "type": "string",
+      "enum": [
+        "percent",
+        "kilogram",
+        "gram",
+        "kilometer",
+        "meter",
+        "byte",
+        "kilobyte",
+        "megabyte",
+        "gigabyte",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "celsius",
+        "fahrenheit"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\NumberFormatUnit"
+      }
+    },
+    "NumberInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "slider": {
+          "type": "boolean"
+        },
+        "step": {
+          "type": [
+            "number",
+            "integer",
+            "null"
+          ]
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "prefix",
+        "readOnly",
+        "required",
+        "slider",
+        "step",
+        "suffix",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.number-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\NumberInput"
+      }
+    },
+    "Op": {
+      "type": "string",
+      "enum": [
+        "contains",
+        "starts_with",
+        "ends_with",
+        "eq",
+        "neq",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "in",
+        "not_in",
+        "before",
+        "after",
+        "empty",
+        "filled"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\Op"
+      }
+    },
+    "OpenModal": {
+      "type": "object",
+      "properties": {
+        "modal": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "modal"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "open-modal",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\OpenModal"
+      }
+    },
+    "Option": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Core\\Option"
+      }
+    },
+    "Orientation": {
+      "type": "string",
+      "enum": [
+        "horizontal",
+        "vertical"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Orientation"
+      }
+    },
+    "OtpInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "length": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "length",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.otp",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\OtpInput"
+      }
+    },
+    "Outlet": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "outlet",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Outlet"
+      }
+    },
+    "PageLayout": {
+      "type": "string",
+      "enum": [
+        "app",
+        "auth",
+        "none"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\PageLayout"
+      }
+    },
+    "PageLayoutPayload": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "key",
+        "schema"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Http\\PageLayoutPayload"
+      }
+    },
+    "PagePayload": {
+      "type": "object",
+      "properties": {
+        "breadcrumbs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "href": {
+                "type": "string",
+                "readOnly": true
+              },
+              "title": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "href",
+              "title"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Breadcrumb"
+            }
+          },
+          "readOnly": true
+        },
+        "layout": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageLayoutPayload"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "listeners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Listen"
+          },
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "width": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "breadcrumbs",
+        "layout",
+        "listeners",
+        "schema",
+        "title",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Http\\PagePayload"
+      }
+    },
+    "PageWidth": {
+      "type": "string",
+      "enum": [
+        "full",
+        "lg",
+        "md",
+        "sm"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\PageWidth"
+      }
+    },
+    "PaginationType": {
+      "type": "string",
+      "enum": [
+        "none",
+        "simple",
+        "table",
+        "infinite"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\PaginationType"
+      }
+    },
+    "PasswordInput": {
+      "type": "object",
+      "properties": {
+        "autoComplete": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "confirmation": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "placeholder": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "name",
+                "placeholder"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "passwordRules": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoComplete",
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "confirmation",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "passwordRules",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "prefix",
+        "readOnly",
+        "required",
+        "suffix",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.password-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\PasswordInput"
+      }
+    },
+    "PatternInput": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "separator": {
+          "type": "string"
+        },
+        "tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PatternTokenData"
+          }
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "separator",
+        "tokens",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.pattern-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\PatternInput"
+      }
+    },
+    "PatternTokenData": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "label",
+        "name",
+        "schema"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\PatternInput\\PatternTokenData"
+      }
+    },
+    "Placement": {
+      "type": "string",
+      "enum": [
+        "top",
+        "bottom",
+        "right"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Placement"
+      }
+    },
+    "Progress": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": "number"
+        },
+        "shape": {
+          "$ref": "#/$defs/ProgressShape"
+        },
+        "showValue": {
+          "type": "boolean"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "color",
+        "max",
+        "shape",
+        "showValue",
+        "size",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "progress",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Progress"
+      }
+    },
+    "ProgressShape": {
+      "type": "string",
+      "enum": [
+        "bar",
+        "circle"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ProgressShape"
+      }
+    },
+    "RawBlock": {
+      "type": "object",
+      "properties": {
+        "html": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "html"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "raw-block",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\RawBlock"
+      }
+    },
+    "RecordSelectionResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/$defs/SearchResult",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/$defs/RecordSelectionState",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "state"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\RecordSelectionResponse"
+      }
+    },
+    "RecordSelectionState": {
+      "type": "object",
+      "properties": {
+        "recorded": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "recorded"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\RecordSelectionState"
+      }
+    },
+    "Redirect": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "redirect",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Redirect"
+      }
+    },
+    "ReloadComponent": {
+      "type": "object",
+      "properties": {
+        "component": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "component"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "reload-component",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ReloadComponent"
+      }
+    },
+    "ReloadPage": {
+      "type": "object",
+      "properties": {
+        "full": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "full"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "reload-page",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ReloadPage"
+      }
+    },
+    "RemoteAccess": {
+      "type": "object",
+      "properties": {
+        "audience": {
+          "type": "string",
+          "readOnly": true
+        },
+        "nodeId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "nodeType": {
+          "type": "string",
+          "readOnly": true
+        },
+        "ref": {
+          "type": "string",
+          "readOnly": true
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "source": {
+          "type": "string",
+          "readOnly": true
+        },
+        "tokenEndpoint": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "audience",
+        "nodeId",
+        "nodeType",
+        "ref",
+        "scopes",
+        "source",
+        "tokenEndpoint"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Remote\\RemoteAccess"
+      }
+    },
+    "RemoteManifest": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RemoteManifestNode"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "version": {
+              "type": "integer"
+            },
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RemoteManifestNode"
+              }
+            }
+          },
+          "required": [
+            "schema"
+          ]
+        }
+      ],
+      "x-lattice": {
+        "kind": "remote"
+      }
+    },
+    "RemoteManifestNode": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "enum": [
+                "action",
+                "endpoint",
+                "ref",
+                "remote",
+                "tokenEndpoint"
+              ]
+            }
+          }
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/RemoteManifestNode"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "chat.box",
+                  "remote.data-list"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "required": [
+                  "id"
+                ]
+              },
+              {
+                "required": [
+                  "key"
+                ]
+              }
+            ],
+            "properties": {
+              "props": {
+                "required": [
+                  "audience"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "x-lattice": {
+        "kind": "remote"
+      }
+    },
+    "Repeater": {
+      "type": "object",
+      "properties": {
+        "addLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultItems": {
+          "type": "integer"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "itemLabels": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "layout": {
+          "$ref": "#/$defs/RowLayout"
+        },
+        "maxItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minItems": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "reorderable": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "resizableColumns": {
+          "type": "boolean"
+        },
+        "resizeIndicator": {
+          "type": "boolean"
+        },
+        "rowActions": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RowAction"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "addLabel",
+        "columnWidth",
+        "conditions",
+        "defaultItems",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "itemLabel",
+        "itemLabels",
+        "label",
+        "labelAction",
+        "layout",
+        "maxItems",
+        "minItems",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "reorderable",
+        "required",
+        "resizableColumns",
+        "resizeIndicator",
+        "rowActions",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.repeater",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Repeater"
+      }
+    },
+    "ResetForm": {
+      "type": "object",
+      "properties": {
+        "form": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "form"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "reset-form",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ResetForm"
+      }
+    },
+    "ResolveResponse": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "prefill": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        },
+        "values": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        }
+      },
+      "required": [
+        "fields",
+        "prefill",
+        "values"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\ResolveResponse"
+      }
+    },
+    "ResourceGroupData": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "label"
+            ]
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "key",
+        "label",
+        "resources"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Calendar\\ResourceGroupData"
+      }
+    },
+    "RetractCallout": {
+      "type": "object",
+      "properties": {
+        "unique": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "unique"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "retract-callout",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\RetractCallout"
+      }
+    },
+    "RichEditor": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EditorExtension"
+          }
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "extensions",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.rich-editor",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\RichEditor"
+      }
+    },
+    "RowAction": {
+      "type": "object",
+      "properties": {
+        "danger": {
+          "type": "boolean"
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "key": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/$defs/RowActionType"
+        }
+      },
+      "required": [
+        "danger",
+        "icon",
+        "key",
+        "label",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Components\\RowAction"
+      }
+    },
+    "RowActionType": {
+      "type": "string",
+      "enum": [
+        "duplicate",
+        "remove"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Form\\Enums\\RowActionType"
+      }
+    },
+    "RowLayout": {
+      "type": "string",
+      "enum": [
+        "stack",
+        "table"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Form\\Enums\\RowLayout"
+      }
+    },
+    "RowTemplateData": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "label",
+        "schema",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Components\\RowTemplateData"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "SearchBox": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "perPage": {
+          "type": "integer"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shortcut": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "endpoint",
+        "perPage",
+        "placeholder",
+        "shortcut",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.box",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchBox"
+      }
+    },
+    "SearchCategories": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.categories",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchCategories"
+      }
+    },
+    "SearchCategory": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "count",
+        "icon",
+        "label",
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchCategory"
+      }
+    },
+    "SearchInput": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.input",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchInput"
+      }
+    },
+    "SearchMode": {
+      "type": "string",
+      "enum": [
+        "results",
+        "recent"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Search\\Enums\\SearchMode"
+      }
+    },
+    "SearchPagination": {
+      "type": "object",
+      "properties": {
+        "hasMore": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "nextPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "page": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "perPage": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "total": {
+          "type": "integer",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "hasMore",
+        "nextPage",
+        "page",
+        "perPage",
+        "total"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchPagination"
+      }
+    },
+    "SearchPreview": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.preview",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchPreview"
+      }
+    },
+    "SearchRecent": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.recent",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchRecent"
+      }
+    },
+    "SearchResponse": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SearchCategory"
+          },
+          "readOnly": true
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SearchResult"
+          },
+          "readOnly": true
+        },
+        "pagination": {
+          "$ref": "#/$defs/SearchPagination",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/$defs/SearchState",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "categories",
+        "data",
+        "pagination",
+        "state"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResponse"
+      }
+    },
+    "SearchResult": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "$ref": "#/$defs/SearchResultCategory",
+          "readOnly": true
+        },
+        "item": {
+          "$ref": "#/$defs/SearchResultItem",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "category",
+        "item"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResult"
+      }
+    },
+    "SearchResultCategory": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResultCategory"
+      }
+    },
+    "SearchResultItem": {
+      "type": "object",
+      "properties": {
+        "additionalInfo": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "badge": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "link": {
+          "type": "string",
+          "readOnly": true
+        },
+        "subtitle": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "additionalInfo",
+        "badge",
+        "id",
+        "link",
+        "subtitle",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResultItem"
+      }
+    },
+    "SearchResults": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.results",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchResults"
+      }
+    },
+    "SearchState": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "countsIncluded": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/$defs/SearchMode",
+          "readOnly": true
+        },
+        "perPage": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "query": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "category",
+        "countsIncluded",
+        "mode",
+        "perPage",
+        "query"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchState"
+      }
+    },
+    "Section": {
+      "type": "object",
+      "properties": {
+        "collapsed": {
+          "type": "boolean"
+        },
+        "collapsible": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headerActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "rememberState": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "collapsed",
+        "collapsible",
+        "description",
+        "headerActions",
+        "rememberState",
+        "title",
+        "tooltip"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "section",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Section"
+      }
+    },
+    "SegmentedControl": {
+      "type": "object",
+      "properties": {
+        "emits": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "emits",
+        "label",
+        "name",
+        "options",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "segmented-control",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\SegmentedControl"
+      }
+    },
+    "Select": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "creatable": {
+          "type": "boolean"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "emptyLabel": {
+          "type": "string"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "optionSchema": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Node"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "searchPlaceholder": {
+          "type": "string"
+        },
+        "searchable": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "creatable",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "emptyLabel",
+        "helperText",
+        "label",
+        "labelAction",
+        "multiple",
+        "name",
+        "optionSchema",
+        "options",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "searchPlaceholder",
+        "searchable",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.select",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Select"
+      }
+    },
+    "SelectFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "searchable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "label",
+        "multiple",
+        "options",
+        "placeholder",
+        "searchable"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.select",
+        "php": "Lattice\\Table\\Filters\\SelectFilter"
+      }
+    },
+    "Separator": {
+      "type": "object",
+      "properties": {
+        "bleed": {
+          "type": "boolean"
+        },
+        "orientation": {
+          "$ref": "#/$defs/Orientation"
+        }
+      },
+      "required": [
+        "bleed",
+        "orientation"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "separator",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Separator"
+      }
+    },
+    "Side": {
+      "type": "string",
+      "enum": [
+        "start",
+        "end"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Side"
+      }
+    },
+    "Sidebar": {
+      "type": "object",
+      "properties": {
+        "collapsible": {
+          "type": "boolean"
+        },
+        "rememberState": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "collapsible",
+        "rememberState"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "sidebar",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Sidebar"
+      }
+    },
+    "Signature": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "signature",
+        "domain": "SignatureExample",
+        "php": "Lattice\\SignatureExample\\Components\\Signature"
+      }
+    },
+    "SignedUpload": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": true,
+          "readOnly": true
+        },
+        "key": {
+          "type": "string",
+          "readOnly": true
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "get",
+            "post",
+            "put",
+            "patch",
+            "delete"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\HttpMethod"
+          },
+          "readOnly": true
+        },
+        "url": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "headers",
+        "key",
+        "method",
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Components\\SignedUpload"
+      }
+    },
+    "Size": {
+      "type": "string",
+      "enum": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl",
+        "3xl",
+        "4xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Size"
+      }
+    },
+    "SortDirection": {
+      "type": "string",
+      "enum": [
+        "asc",
+        "desc"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\SortDirection"
+      }
+    },
+    "Stack": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Align"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "direction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StackDirection"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "float": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Side"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Gap"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "height": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Height"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "justify": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Justify"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "width": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Width"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "align",
+        "direction",
+        "float",
+        "gap",
+        "height",
+        "justify",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "stack",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Stack"
+      }
+    },
+    "StackColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.stack",
+        "php": "Lattice\\Table\\Columns\\StackColumn"
+      }
+    },
+    "StackDirection": {
+      "type": "string",
+      "enum": [
+        "row",
+        "column"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\StackDirection"
+      }
+    },
+    "Tab": {
+      "type": "object",
+      "properties": {
+        "confirm": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "redirectUrl": {
+                  "type": "string"
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "timeout": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "redirectUrl",
+                "required",
+                "timeout"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "confirm",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tab",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Tab"
+      }
+    },
+    "Table": {
+      "type": "object",
+      "properties": {
+        "actionsLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bulkActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ColumnNode"
+          }
+        },
+        "data": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emptyLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FilterNode"
+          }
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazy": {
+          "type": "boolean"
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TablePagination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "perPageOptions": {
+          "type": "array",
+          "items": {
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "query": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TableQuery"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resizableColumns": {
+          "type": "boolean"
+        },
+        "resizeIndicator": {
+          "type": "boolean"
+        },
+        "searchable": {
+          "type": "boolean"
+        },
+        "striped": {
+          "type": "boolean"
+        },
+        "toolbar": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "actionsLabel",
+        "bulkActions",
+        "columns",
+        "data",
+        "emptyLabel",
+        "endpoint",
+        "filters",
+        "layout",
+        "lazy",
+        "pagination",
+        "perPageOptions",
+        "query",
+        "ref",
+        "resizableColumns",
+        "resizeIndicator",
+        "searchable",
+        "striped",
+        "toolbar"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "table",
+        "domain": "Table",
+        "php": "Lattice\\Table\\Components\\Table"
+      }
+    },
+    "TablePagination": {
+      "type": "object",
+      "properties": {
+        "currentPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "from": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "hasMore": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "lastPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/$defs/PaginationType",
+          "readOnly": true
+        },
+        "nextPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "perPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "to": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "total": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "currentPage",
+        "from",
+        "hasMore",
+        "lastPage",
+        "mode",
+        "nextPage",
+        "perPage",
+        "to",
+        "total"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TablePagination"
+      }
+    },
+    "TableQuery": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FilterClause"
+          },
+          "readOnly": true
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PaginationType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "page": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "perPage": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "search": {
+          "type": "string",
+          "readOnly": true
+        },
+        "sorts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableSort"
+          },
+          "readOnly": true
+        },
+        "tableFilterIndicators": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FilterIndicator"
+          },
+          "readOnly": true
+        },
+        "tableFilters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "filters",
+        "mode",
+        "page",
+        "perPage",
+        "search",
+        "sorts",
+        "tableFilterIndicators",
+        "tableFilters"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TableQuery"
+      }
+    },
+    "TableResult": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "readOnly": true
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TablePagination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "query": {
+          "$ref": "#/$defs/TableQuery",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "pagination",
+        "query"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TableResult"
+      }
+    },
+    "TableSort": {
+      "type": "object",
+      "properties": {
+        "direction": {
+          "$ref": "#/$defs/SortDirection",
+          "readOnly": true
+        },
+        "key": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "direction",
+        "key"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TableSort"
+      }
+    },
+    "Tabs": {
+      "type": "object",
+      "properties": {
+        "activeValue": {
+          "type": "string"
+        },
+        "alignment": {
+          "$ref": "#/$defs/TabsAlignment"
+        },
+        "defaultValue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orientation": {
+          "$ref": "#/$defs/Orientation"
+        },
+        "queryKey": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "activeValue",
+        "alignment",
+        "defaultValue",
+        "orientation",
+        "queryKey"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tabs",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Tabs"
+      }
+    },
+    "TabsAlignment": {
+      "type": "string",
+      "enum": [
+        "start",
+        "center",
+        "end",
+        "stretch"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\TabsAlignment"
+      }
+    },
+    "TernaryFilter": {
+      "type": "object",
+      "properties": {
+        "falseLabel": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "trueLabel": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "falseLabel",
+        "label",
+        "placeholder",
+        "trueLabel"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.ternary",
+        "php": "Lattice\\Table\\Filters\\TernaryFilter"
+      }
+    },
+    "Text": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Align"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "align",
+        "color",
+        "copyable",
+        "size",
+        "text"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "text",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Text"
+      }
+    },
+    "TextColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "badge": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "colorKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "colorKey"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "date": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dateStyle": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "full",
+                        "long",
+                        "medium",
+                        "short"
+                      ],
+                      "x-lattice": {
+                        "kind": "enum",
+                        "php": "Lattice\\Ui\\Enums\\DateTimeStyle"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "timeStyle": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "full",
+                        "long",
+                        "medium",
+                        "short"
+                      ],
+                      "x-lattice": {
+                        "kind": "enum",
+                        "php": "Lattice\\Ui\\Enums\\DateTimeStyle"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "dateStyle",
+                "timeStyle"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "link": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "external": {
+                  "type": "boolean"
+                },
+                "href": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "external",
+                "href"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multiple": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "badge",
+        "copyable",
+        "date",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "link",
+        "multiple",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.text",
+        "php": "Lattice\\Table\\Columns\\TextColumn"
+      }
+    },
+    "TextEntry": {
+      "type": "object",
+      "properties": {
+        "copyable": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "copyable",
+        "description",
+        "label",
+        "name",
+        "placeholder",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.text",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\TextEntry"
+      }
+    },
+    "TextInput": {
+      "type": "object",
+      "properties": {
+        "autoComplete": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoComplete",
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "copyable",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "prefix",
+        "readOnly",
+        "required",
+        "suffix",
+        "tabIndex",
+        "tooltip",
+        "type",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.text-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\TextInput"
+      }
+    },
+    "TextPart": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "chat.part.text",
+        "domain": "Chat",
+        "php": "Lattice\\Chat\\Components\\TextPart"
+      }
+    },
+    "Textarea": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "rows": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "placeholder",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "rows",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.textarea",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Textarea"
+      }
+    },
+    "TimeInput": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "min": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "step": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "max",
+        "min",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "step",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.time-input",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\TimeInput"
+      }
+    },
+    "Timeline": {
+      "type": "object",
+      "properties": {
+        "days": {
+          "type": "integer"
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EntryData"
+          }
+        },
+        "from": {
+          "type": "string"
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ResourceGroupData"
+          }
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "days",
+        "endpoint",
+        "events",
+        "from",
+        "groups",
+        "ref"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "timeline",
+        "domain": "Calendar",
+        "php": "Lattice\\Calendar\\Components\\Timeline"
+      }
+    },
+    "Toast": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dismissible": {
+          "type": "boolean"
+        },
+        "duration": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Translatable"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "persistent": {
+          "type": "boolean"
+        },
+        "variant": {
+          "$ref": "#/$defs/Variant"
+        }
+      },
+      "required": [
+        "action",
+        "dismissible",
+        "duration",
+        "message",
+        "persistent",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "toast",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Toast"
+      }
+    },
+    "Toggle": {
+      "type": "object",
+      "properties": {
+        "autoFocus": {
+          "type": "boolean"
+        },
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FieldConditions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "autoFocus",
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "tabIndex",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.toggle",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Toggle"
+      }
+    },
+    "ToggleFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.toggle",
+        "php": "Lattice\\Table\\Filters\\ToggleFilter"
+      }
+    },
+    "ToggleSidebar": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "toggle-sidebar",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ToggleSidebar"
+      }
+    },
+    "ToolCallPart": {
+      "type": "object",
+      "properties": {
+        "args": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "args",
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "chat.part.tool-call",
+        "domain": "Chat",
+        "php": "Lattice\\Chat\\Components\\ToolCallPart"
+      }
+    },
+    "Tooltip": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tooltip",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Tooltip"
+      }
+    },
+    "Topbar": {
+      "type": "object",
+      "properties": {
+        "sticky": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "sticky"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "topbar",
+        "domain": "Layouts",
+        "php": "Lattice\\Layouts\\Components\\Topbar"
+      }
+    },
+    "Translatable": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "payload": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "replacements": {
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "boolean",
+              "number",
+              "integer",
+              "string"
+            ]
+          }
+        }
+      },
+      "required": [
+        "key",
+        "payload",
+        "replacements"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\I18n\\Values\\Translatable"
+      }
+    },
+    "Tree": {
+      "type": "object",
+      "properties": {
+        "activeId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "activePath": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultExpanded": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazy": {
+          "type": "boolean"
+        },
+        "moveAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:action"
+            },
+            {
+              "$ref": "#/$defs/node:action.bulk"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TreeNodeData"
+          }
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rememberState": {
+          "type": "boolean"
+        },
+        "revision": {
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ]
+        },
+        "selectAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:action"
+            },
+            {
+              "$ref": "#/$defs/node:action.bulk"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "activeId",
+        "activePath",
+        "defaultExpanded",
+        "endpoint",
+        "lazy",
+        "moveAction",
+        "nodes",
+        "ref",
+        "rememberState",
+        "revision",
+        "selectAction"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tree",
+        "php": "Lattice\\Tree\\Tree"
+      }
+    },
+    "TreeNodeData": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TreeNodeData"
+          },
+          "readOnly": true
+        },
+        "disabled": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "hasChildren": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "children",
+        "disabled",
+        "hasChildren",
+        "href",
+        "id",
+        "label",
+        "schema"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Tree\\TreeNodeData"
+      }
+    },
+    "UnreadCount": {
+      "type": "object",
+      "properties": {
+        "unreadCount": {
+          "type": "integer",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "unreadCount"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Notifications\\UnreadCount"
+      }
+    },
+    "Variant": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "danger"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Variant"
+      }
+    },
+    "Width": {
+      "type": "string",
+      "enum": [
+        "full",
+        "auto",
+        "sm",
+        "md",
+        "lg",
+        "fill"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Width"
+      }
+    },
+    "Wizard": {
+      "type": "object",
+      "properties": {
+        "orientation": {
+          "type": "string",
+          "enum": [
+            "horizontal",
+            "vertical"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\Orientation"
+          }
+        }
+      },
+      "required": [
+        "orientation"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "wizard",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Wizard"
+      }
+    },
+    "WizardStep": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "description",
+        "label",
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "wizard-step",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\WizardStep"
+      }
+    },
+    "column:column.badge": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.badge"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BadgeColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.badge",
+        "php": "Lattice\\Table\\Columns\\BadgeColumn"
+      }
+    },
+    "column:column.boolean": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BooleanColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.boolean",
+        "php": "Lattice\\Table\\Columns\\BooleanColumn"
+      }
+    },
+    "column:column.icon": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.icon"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/IconColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.icon",
+        "php": "Lattice\\Table\\Columns\\IconColumn"
+      }
+    },
+    "column:column.image": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.image"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ImageColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.image",
+        "php": "Lattice\\Table\\Columns\\ImageColumn"
+      }
+    },
+    "column:column.money": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.money"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MoneyColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.money",
+        "php": "Lattice\\Table\\Columns\\MoneyColumn"
+      }
+    },
+    "column:column.number": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.number"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/NumberColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.number",
+        "php": "Lattice\\Table\\Columns\\NumberColumn"
+      }
+    },
+    "column:column.stack": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.stack"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/StackColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.stack",
+        "php": "Lattice\\Table\\Columns\\StackColumn"
+      }
+    },
+    "column:column.text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.text"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.text",
+        "php": "Lattice\\Table\\Columns\\TextColumn"
+      }
+    },
+    "editor-extension:blockquote": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "blockquote"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorBlockquote"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "blockquote"
+      }
+    },
+    "editor-extension:bold": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "bold"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorBold"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "bold"
+      }
+    },
+    "editor-extension:bullet-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "bullet-list"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorBulletList"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "bullet-list"
+      }
+    },
+    "editor-extension:code": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "code"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorCode"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "code"
+      }
+    },
+    "editor-extension:code-block": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "code-block"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorCodeBlock"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "code-block"
+      }
+    },
+    "editor-extension:details": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "details"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorDetails"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "details"
+      }
+    },
+    "editor-extension:emoji": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "emoji"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorEmoji"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "emoji"
+      }
+    },
+    "editor-extension:heading": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "heading"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorHeading"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "heading"
+      }
+    },
+    "editor-extension:highlight": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "highlight"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorHighlight"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "highlight"
+      }
+    },
+    "editor-extension:horizontal-rule": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "horizontal-rule"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorHorizontalRule"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "horizontal-rule"
+      }
+    },
+    "editor-extension:italic": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "italic"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorItalic"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "italic"
+      }
+    },
+    "editor-extension:link": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "link"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorLink"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "link"
+      }
+    },
+    "editor-extension:media-image": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "media-image"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorMediaImage"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "media-image"
+      }
+    },
+    "editor-extension:ordered-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "ordered-list"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorOrderedList"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "ordered-list"
+      }
+    },
+    "editor-extension:strike": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "strike"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorStrike"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "strike"
+      }
+    },
+    "editor-extension:table": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "table"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorTable"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "table"
+      }
+    },
+    "editor-extension:text-align": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "text-align"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorTextAlign"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "text-align"
+      }
+    },
+    "editor-extension:underline": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "underline"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorUnderline"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "underline"
+      }
+    },
+    "effect:callout": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "callout"
+        },
+        "props": {
+          "$ref": "#/$defs/Callout"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "callout"
+      }
+    },
+    "effect:close-modal": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "close-modal"
+        },
+        "props": {
+          "$ref": "#/$defs/CloseModal"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "close-modal"
+      }
+    },
+    "effect:download": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "download"
+        },
+        "props": {
+          "$ref": "#/$defs/Download"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "download"
+      }
+    },
+    "effect:locale-change": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "locale-change"
+        },
+        "props": {
+          "$ref": "#/$defs/LocaleChange"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "locale-change"
+      }
+    },
+    "effect:open-modal": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "open-modal"
+        },
+        "props": {
+          "$ref": "#/$defs/OpenModal"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "open-modal"
+      }
+    },
+    "effect:redirect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "redirect"
+        },
+        "props": {
+          "$ref": "#/$defs/Redirect"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "redirect"
+      }
+    },
+    "effect:reload-component": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "reload-component"
+        },
+        "props": {
+          "$ref": "#/$defs/ReloadComponent"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "reload-component"
+      }
+    },
+    "effect:reload-page": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "reload-page"
+        },
+        "props": {
+          "$ref": "#/$defs/ReloadPage"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "reload-page"
+      }
+    },
+    "effect:reset-form": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "reset-form"
+        },
+        "props": {
+          "$ref": "#/$defs/ResetForm"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "reset-form"
+      }
+    },
+    "effect:retract-callout": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "retract-callout"
+        },
+        "props": {
+          "$ref": "#/$defs/RetractCallout"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "retract-callout"
+      }
+    },
+    "effect:toast": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "toast"
+        },
+        "props": {
+          "$ref": "#/$defs/Toast"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "toast"
+      }
+    },
+    "effect:toggle-sidebar": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "toggle-sidebar"
+        },
+        "props": {
+          "$ref": "#/$defs/ToggleSidebar"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "toggle-sidebar"
+      }
+    },
+    "filter:filter.date-range": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.date-range"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateRangeFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.date-range",
+        "php": "Lattice\\Table\\Filters\\DateRangeFilter"
+      }
+    },
+    "filter:filter.media-type": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.media-type"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaTypeFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.media-type",
+        "php": "Lattice\\Media\\Tables\\Filters\\MediaTypeFilter"
+      }
+    },
+    "filter:filter.select": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.select"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SelectFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.select",
+        "php": "Lattice\\Table\\Filters\\SelectFilter"
+      }
+    },
+    "filter:filter.ternary": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.ternary"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TernaryFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.ternary",
+        "php": "Lattice\\Table\\Filters\\TernaryFilter"
+      }
+    },
+    "filter:filter.toggle": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.toggle"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToggleFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.toggle",
+        "php": "Lattice\\Table\\Filters\\ToggleFilter"
+      }
+    },
+    "node:action": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Action"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action",
+        "php": "Lattice\\Actions\\Components\\Action"
+      }
+    },
+    "node:action.bulk": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action.bulk"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BulkAction"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action.bulk",
+        "php": "Lattice\\Actions\\Components\\BulkAction"
+      }
+    },
+    "node:action.group": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action.group"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ActionGroup"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action.group",
+        "php": "Lattice\\Actions\\Components\\ActionGroup"
+      }
+    },
+    "node:api-reference": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "api-reference"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ApiReference"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "api-reference",
+        "php": "Lattice\\ApiReference\\ApiReference"
+      }
+    },
+    "node:avatar": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "avatar"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Avatar"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "avatar",
+        "php": "Lattice\\Ui\\Components\\Avatar"
+      }
+    },
+    "node:badge": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "badge"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Badge"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "badge",
+        "php": "Lattice\\Ui\\Components\\Badge"
+      }
+    },
+    "node:breadcrumbs": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "breadcrumbs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Breadcrumbs"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "breadcrumbs",
+        "php": "Lattice\\Layouts\\Components\\Breadcrumbs"
+      }
+    },
+    "node:button": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "button"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Button"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "button",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "node:callouts": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "callouts"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Callouts"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "callouts",
+        "php": "Lattice\\Layouts\\Components\\Callouts"
+      }
+    },
+    "node:card": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "card"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Card"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "card",
+        "php": "Lattice\\Ui\\Components\\Card"
+      }
+    },
+    "node:chart": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "chart"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Chart"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "chart",
+        "php": "Lattice\\Ui\\Components\\Chart"
+      }
+    },
+    "node:chat.box": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "chat.box"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ChatBox"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "chat.box",
+        "php": "Lattice\\Chat\\Components\\ChatBox"
+      }
+    },
+    "node:chat.part.text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "chat.part.text"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextPart"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "chat.part.text",
+        "php": "Lattice\\Chat\\Components\\TextPart"
+      }
+    },
+    "node:chat.part.tool-call": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "chat.part.tool-call"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToolCallPart"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "chat.part.tool-call",
+        "php": "Lattice\\Chat\\Components\\ToolCallPart"
+      }
+    },
+    "node:code-block": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "code-block"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/CodeBlock"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "code-block",
+        "php": "Lattice\\Ui\\Components\\CodeBlock"
+      }
+    },
+    "node:collapsible": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "collapsible"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Collapsible"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "collapsible",
+        "php": "Lattice\\Ui\\Components\\Collapsible"
+      }
+    },
+    "node:description-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "description-list"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DescriptionList"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "description-list",
+        "php": "Lattice\\Ui\\Components\\DescriptionList"
+      }
+    },
+    "node:dropdown": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "dropdown"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Dropdown"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "dropdown",
+        "php": "Lattice\\Layouts\\Components\\Dropdown"
+      }
+    },
+    "node:entry.badge": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.badge"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BadgeEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.badge",
+        "php": "Lattice\\Ui\\Components\\Entries\\BadgeEntry"
+      }
+    },
+    "node:entry.boolean": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BooleanEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.boolean",
+        "php": "Lattice\\Ui\\Components\\Entries\\BooleanEntry"
+      }
+    },
+    "node:entry.component": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.component"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ComponentEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.component",
+        "php": "Lattice\\Ui\\Components\\Entries\\ComponentEntry"
+      }
+    },
+    "node:entry.date": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.date"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.date",
+        "php": "Lattice\\Ui\\Components\\Entries\\DateEntry"
+      }
+    },
+    "node:entry.text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.text"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.text",
+        "php": "Lattice\\Ui\\Components\\Entries\\TextEntry"
+      }
+    },
+    "node:field.builder": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.builder"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Builder"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.builder",
+        "php": "Lattice\\Form\\Components\\Builder"
+      }
+    },
+    "node:field.checkbox": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.checkbox"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Checkbox"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.checkbox",
+        "php": "Lattice\\Form\\Components\\Checkbox"
+      }
+    },
+    "node:field.choice": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.choice"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Choice"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.choice",
+        "php": "Lattice\\Form\\Components\\Choice"
+      }
+    },
+    "node:field.color-picker": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.color-picker"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ColorPicker"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.color-picker",
+        "php": "Lattice\\Form\\Components\\ColorPicker"
+      }
+    },
+    "node:field.date-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.date-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.date-input",
+        "php": "Lattice\\Form\\Components\\DateInput"
+      }
+    },
+    "node:field.date-time-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.date-time-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateTimeInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.date-time-input",
+        "php": "Lattice\\Form\\Components\\DateTimeInput"
+      }
+    },
+    "node:field.file-upload": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.file-upload"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FileUpload"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.file-upload",
+        "php": "Lattice\\Form\\Components\\FileUpload"
+      }
+    },
+    "node:field.hidden-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.hidden-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/HiddenInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.hidden-input",
+        "php": "Lattice\\Form\\Components\\HiddenInput"
+      }
+    },
+    "node:field.media-picker": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.media-picker"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaPicker"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.media-picker",
+        "php": "Lattice\\Media\\Forms\\Components\\MediaPicker"
+      }
+    },
+    "node:field.number-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.number-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/NumberInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.number-input",
+        "php": "Lattice\\Form\\Components\\NumberInput"
+      }
+    },
+    "node:field.otp": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.otp"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/OtpInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.otp",
+        "php": "Lattice\\Form\\Components\\OtpInput"
+      }
+    },
+    "node:field.password-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.password-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/PasswordInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.password-input",
+        "php": "Lattice\\Form\\Components\\PasswordInput"
+      }
+    },
+    "node:field.pattern-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.pattern-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/PatternInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.pattern-input",
+        "php": "Lattice\\Form\\Components\\PatternInput"
+      }
+    },
+    "node:field.repeater": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.repeater"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Repeater"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.repeater",
+        "php": "Lattice\\Form\\Components\\Repeater"
+      }
+    },
+    "node:field.rich-editor": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.rich-editor"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RichEditor"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.rich-editor",
+        "php": "Lattice\\Form\\Components\\RichEditor"
+      }
+    },
+    "node:field.select": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.select"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Select"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.select",
+        "php": "Lattice\\Form\\Components\\Select"
+      }
+    },
+    "node:field.text-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.text-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.text-input",
+        "php": "Lattice\\Form\\Components\\TextInput"
+      }
+    },
+    "node:field.textarea": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.textarea"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Textarea"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.textarea",
+        "php": "Lattice\\Form\\Components\\Textarea"
+      }
+    },
+    "node:field.time-input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.time-input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TimeInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.time-input",
+        "php": "Lattice\\Form\\Components\\TimeInput"
+      }
+    },
+    "node:field.toggle": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.toggle"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Toggle"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.toggle",
+        "php": "Lattice\\Form\\Components\\Toggle"
+      }
+    },
+    "node:floating-panel": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "floating-panel"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FloatingPanel"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "floating-panel",
+        "php": "Lattice\\Ui\\Components\\FloatingPanel"
+      }
+    },
+    "node:form": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "form"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Form"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "node:fragment": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "fragment"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Fragment"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "fragment",
+        "php": "Lattice\\Fragments\\Components\\Fragment"
+      }
+    },
+    "node:grid": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "grid"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Grid"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "grid",
+        "php": "Lattice\\Ui\\Components\\Grid"
+      }
+    },
+    "node:heading": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "heading"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Heading"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "heading",
+        "php": "Lattice\\Ui\\Components\\Heading"
+      }
+    },
+    "node:icon": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "icon"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Icon"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "icon",
+        "php": "Lattice\\Ui\\Components\\Icon"
+      }
+    },
+    "node:image": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "image"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Image"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "image",
+        "php": "Lattice\\Ui\\Components\\Image"
+      }
+    },
+    "node:link": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "link"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Link"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "link",
+        "php": "Lattice\\Ui\\Components\\Link"
+      }
+    },
+    "node:media.library": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "media.library"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaLibrary"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "media.library",
+        "php": "Lattice\\Media\\Components\\MediaLibrary"
+      }
+    },
+    "node:menu": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "menu"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Menu"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "menu",
+        "php": "Lattice\\Layouts\\Components\\Menu"
+      }
+    },
+    "node:menu-item": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "menu-item"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MenuItem"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "menu-item",
+        "php": "Lattice\\Layouts\\Components\\MenuItem"
+      }
+    },
+    "node:modal": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "modal"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Modal"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "modal",
+        "php": "Lattice\\Ui\\Components\\Modal"
+      }
+    },
+    "node:notifications": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "notifications"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Notifications"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "notifications",
+        "php": "Lattice\\Notifications\\Components\\Notifications"
+      }
+    },
+    "node:outlet": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "outlet"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Outlet"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "outlet",
+        "php": "Lattice\\Layouts\\Components\\Outlet"
+      }
+    },
+    "node:progress": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "progress"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Progress"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "progress",
+        "php": "Lattice\\Ui\\Components\\Progress"
+      }
+    },
+    "node:raw-block": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "raw-block"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RawBlock"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "raw-block",
+        "php": "Lattice\\Ui\\Components\\RawBlock"
+      }
+    },
+    "node:remote.data-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "remote.data-list"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DataList"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "remote.data-list",
+        "php": "Lattice\\Remote\\Components\\DataList"
+      }
+    },
+    "node:search.box": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.box"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchBox"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.box",
+        "php": "Lattice\\Search\\Components\\SearchBox"
+      }
+    },
+    "node:search.categories": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.categories"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchCategories"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.categories",
+        "php": "Lattice\\Search\\Components\\SearchCategories"
+      }
+    },
+    "node:search.input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.input",
+        "php": "Lattice\\Search\\Components\\SearchInput"
+      }
+    },
+    "node:search.preview": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.preview"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchPreview"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.preview",
+        "php": "Lattice\\Search\\Components\\SearchPreview"
+      }
+    },
+    "node:search.recent": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.recent"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchRecent"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.recent",
+        "php": "Lattice\\Search\\Components\\SearchRecent"
+      }
+    },
+    "node:search.results": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.results"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchResults"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.results",
+        "php": "Lattice\\Search\\Components\\SearchResults"
+      }
+    },
+    "node:section": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "section"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Section"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "section",
+        "php": "Lattice\\Ui\\Components\\Section"
+      }
+    },
+    "node:segmented-control": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "segmented-control"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SegmentedControl"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "segmented-control",
+        "php": "Lattice\\Ui\\Components\\SegmentedControl"
+      }
+    },
+    "node:separator": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "separator"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Separator"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "separator",
+        "php": "Lattice\\Ui\\Components\\Separator"
+      }
+    },
+    "node:sidebar": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "sidebar"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Sidebar"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "sidebar",
+        "php": "Lattice\\Layouts\\Components\\Sidebar"
+      }
+    },
+    "node:signature": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "signature"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Signature"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "signature",
+        "php": "Lattice\\SignatureExample\\Components\\Signature"
+      }
+    },
+    "node:stack": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "stack"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Stack"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "stack",
+        "php": "Lattice\\Ui\\Components\\Stack"
+      }
+    },
+    "node:tab": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tab"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tab"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tab",
+        "php": "Lattice\\Ui\\Components\\Tab"
+      }
+    },
+    "node:table": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "table"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Table"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "table",
+        "php": "Lattice\\Table\\Components\\Table"
+      }
+    },
+    "node:tabs": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tabs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tabs"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tabs",
+        "php": "Lattice\\Ui\\Components\\Tabs"
+      }
+    },
+    "node:text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "text"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Text"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "text",
+        "php": "Lattice\\Ui\\Components\\Text"
+      }
+    },
+    "node:timeline": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "timeline"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Timeline"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "timeline",
+        "php": "Lattice\\Calendar\\Components\\Timeline"
+      }
+    },
+    "node:tooltip": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tooltip"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tooltip"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tooltip",
+        "php": "Lattice\\Ui\\Components\\Tooltip"
+      }
+    },
+    "node:topbar": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "topbar"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Topbar"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "topbar",
+        "php": "Lattice\\Layouts\\Components\\Topbar"
+      }
+    },
+    "node:tree": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tree"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tree"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tree",
+        "php": "Lattice\\Tree\\Tree"
+      }
+    },
+    "node:wizard": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "wizard"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Wizard"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "wizard",
+        "php": "Lattice\\Form\\Components\\Wizard"
+      }
+    },
+    "node:wizard-step": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "wizard-step"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/WizardStep"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "wizard-step",
+        "php": "Lattice\\Form\\Components\\WizardStep"
+      }
+    }
+  },
+  "x-lattice": {
+    "protocolVersion": 1,
+    "domains": {
+      "FormFieldNodeType": [
+        "field.builder",
+        "field.checkbox",
+        "field.choice",
+        "field.color-picker",
+        "field.date-input",
+        "field.date-time-input",
+        "field.file-upload",
+        "field.hidden-input",
+        "field.media-picker",
+        "field.number-input",
+        "field.otp",
+        "field.password-input",
+        "field.pattern-input",
+        "field.repeater",
+        "field.rich-editor",
+        "field.select",
+        "field.text-input",
+        "field.textarea",
+        "field.time-input",
+        "field.toggle",
+        "wizard",
+        "wizard-step"
+      ],
+      "FormNodeType": [
+        "field.builder",
+        "field.checkbox",
+        "field.choice",
+        "field.color-picker",
+        "field.date-input",
+        "field.date-time-input",
+        "field.file-upload",
+        "field.hidden-input",
+        "field.media-picker",
+        "field.number-input",
+        "field.otp",
+        "field.password-input",
+        "field.pattern-input",
+        "field.repeater",
+        "field.rich-editor",
+        "field.select",
+        "field.text-input",
+        "field.textarea",
+        "field.time-input",
+        "field.toggle",
+        "form",
+        "wizard",
+        "wizard-step"
+      ],
+      "ActionNodeType": [
+        "action",
+        "action.bulk",
+        "action.group"
+      ],
+      "CalendarNodeType": [
+        "timeline"
+      ],
+      "ChatNodeType": [
+        "chat.box",
+        "chat.part.text",
+        "chat.part.tool-call"
+      ],
+      "FragmentNodeType": [
+        "fragment"
+      ],
+      "LayoutNodeType": [
+        "breadcrumbs",
+        "callouts",
+        "dropdown",
+        "menu",
+        "menu-item",
+        "outlet",
+        "sidebar",
+        "topbar"
+      ],
+      "MediumNodeType": [
+        "media.library"
+      ],
+      "NotificationNodeType": [
+        "notifications"
+      ],
+      "RemoteNodeType": [
+        "remote.data-list"
+      ],
+      "SearchNodeType": [
+        "search.box",
+        "search.categories",
+        "search.input",
+        "search.preview",
+        "search.recent",
+        "search.results"
+      ],
+      "SignatureExampleNodeType": [
+        "signature"
+      ],
+      "TableNodeType": [
+        "table"
+      ],
+      "UiNodeType": [
+        "avatar",
+        "badge",
+        "button",
+        "card",
+        "chart",
+        "code-block",
+        "collapsible",
+        "description-list",
+        "entry.badge",
+        "entry.boolean",
+        "entry.component",
+        "entry.date",
+        "entry.text",
+        "floating-panel",
+        "grid",
+        "heading",
+        "icon",
+        "image",
+        "link",
+        "modal",
+        "progress",
+        "raw-block",
+        "section",
+        "segmented-control",
+        "separator",
+        "stack",
+        "tab",
+        "tabs",
+        "text",
+        "tooltip"
+      ],
+      "NodeType": [
+        "action",
+        "action.bulk",
+        "action.group",
+        "api-reference",
+        "avatar",
+        "badge",
+        "breadcrumbs",
+        "button",
+        "callouts",
+        "card",
+        "chart",
+        "chat.box",
+        "chat.part.text",
+        "chat.part.tool-call",
+        "code-block",
+        "collapsible",
+        "description-list",
+        "dropdown",
+        "entry.badge",
+        "entry.boolean",
+        "entry.component",
+        "entry.date",
+        "entry.text",
+        "field.builder",
+        "field.checkbox",
+        "field.choice",
+        "field.color-picker",
+        "field.date-input",
+        "field.date-time-input",
+        "field.file-upload",
+        "field.hidden-input",
+        "field.media-picker",
+        "field.number-input",
+        "field.otp",
+        "field.password-input",
+        "field.pattern-input",
+        "field.repeater",
+        "field.rich-editor",
+        "field.select",
+        "field.text-input",
+        "field.textarea",
+        "field.time-input",
+        "field.toggle",
+        "floating-panel",
+        "form",
+        "fragment",
+        "grid",
+        "heading",
+        "icon",
+        "image",
+        "link",
+        "media.library",
+        "menu",
+        "menu-item",
+        "modal",
+        "notifications",
+        "outlet",
+        "progress",
+        "raw-block",
+        "remote.data-list",
+        "search.box",
+        "search.categories",
+        "search.input",
+        "search.preview",
+        "search.recent",
+        "search.results",
+        "section",
+        "segmented-control",
+        "separator",
+        "sidebar",
+        "signature",
+        "stack",
+        "tab",
+        "table",
+        "tabs",
+        "text",
+        "timeline",
+        "tooltip",
+        "topbar",
+        "tree",
+        "wizard",
+        "wizard-step"
+      ],
+      "ColumnNodeType": [
+        "column.badge",
+        "column.boolean",
+        "column.icon",
+        "column.image",
+        "column.money",
+        "column.number",
+        "column.stack",
+        "column.text"
+      ],
+      "FilterNodeType": [
+        "filter.date-range",
+        "filter.media-type",
+        "filter.select",
+        "filter.ternary",
+        "filter.toggle"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "breadcrumbs": {
+            "node": "#/$defs/node:breadcrumbs",
+            "props": "#/$defs/Breadcrumbs",
+            "domain": "Layouts"
+          },
+          "callouts": {
+            "node": "#/$defs/node:callouts",
+            "props": "#/$defs/Callouts",
+            "domain": "Layouts"
+          },
+          "chat.box": {
+            "node": "#/$defs/node:chat.box",
+            "props": "#/$defs/ChatBox",
+            "domain": "Chat"
+          },
+          "chat.part.text": {
+            "node": "#/$defs/node:chat.part.text",
+            "props": "#/$defs/TextPart",
+            "domain": "Chat"
+          },
+          "chat.part.tool-call": {
+            "node": "#/$defs/node:chat.part.tool-call",
+            "props": "#/$defs/ToolCallPart",
+            "domain": "Chat"
+          },
+          "dropdown": {
+            "node": "#/$defs/node:dropdown",
+            "props": "#/$defs/Dropdown",
+            "domain": "Layouts",
+            "container": true
+          },
+          "fragment": {
+            "node": "#/$defs/node:fragment",
+            "props": "#/$defs/Fragment",
+            "domain": "Fragments",
+            "container": true,
+            "interactive": true
+          },
+          "menu": {
+            "node": "#/$defs/node:menu",
+            "props": "#/$defs/Menu",
+            "domain": "Layouts",
+            "container": true
+          },
+          "menu-item": {
+            "node": "#/$defs/node:menu-item",
+            "props": "#/$defs/MenuItem",
+            "domain": "Layouts",
+            "container": true
+          },
+          "notifications": {
+            "node": "#/$defs/node:notifications",
+            "props": "#/$defs/Notifications",
+            "domain": "Notifications"
+          },
+          "outlet": {
+            "node": "#/$defs/node:outlet",
+            "props": "#/$defs/Outlet",
+            "domain": "Layouts"
+          },
+          "remote.data-list": {
+            "node": "#/$defs/node:remote.data-list",
+            "props": "#/$defs/DataList",
+            "domain": "Remote",
+            "container": true
+          },
+          "sidebar": {
+            "node": "#/$defs/node:sidebar",
+            "props": "#/$defs/Sidebar",
+            "domain": "Layouts",
+            "container": true
+          },
+          "topbar": {
+            "node": "#/$defs/node:topbar",
+            "props": "#/$defs/Topbar",
+            "domain": "Layouts",
+            "container": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/framework/src/Console/Commands/SchemaCommand.php
+++ b/packages/framework/src/Console/Commands/SchemaCommand.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Console\Commands;
+
+use Illuminate\Console\Command;
+use Lattice\Core\JsonSchema\SchemaDocumentWriter;
+use Lattice\Core\Wire\WireModelBuilder;
+use Lattice\Support\Schema\SchemaProfile;
+
+final class SchemaCommand extends Command
+{
+    protected $signature = 'lattice:schema';
+
+    protected $description = 'Export the Lattice wire-protocol JSON Schema for the current project';
+
+    public function handle(SchemaProfile $profile, WireModelBuilder $builder, SchemaDocumentWriter $writer): int
+    {
+        $this->components->info($profile->run($builder, $writer));
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -22,6 +22,7 @@ use Lattice\Console\Commands\MakeDefinitionCommand;
 use Lattice\Console\Commands\MakeFieldCommand;
 use Lattice\Console\Commands\PruneNotificationsCommand;
 use Lattice\Console\Commands\PublishAssetsCommand;
+use Lattice\Console\Commands\SchemaCommand;
 use Lattice\Console\Commands\TypeScriptCommand;
 use Lattice\Core\Attributes\AsFragment;
 use Lattice\Core\Attributes\AsLayout;
@@ -42,6 +43,8 @@ use Lattice\Layouts\LayoutRegistry;
 use Lattice\Remote\RemoteSourceDefinition;
 use Lattice\Remote\RemoteSourceRegistry;
 use Lattice\Support\Frontend\StandaloneAssets;
+use Lattice\Support\Schema\ExportSchemaProfile;
+use Lattice\Support\Schema\SchemaProfile;
 use Lattice\Support\TypeScript\AugmentProfile;
 use Lattice\Support\TypeScript\TypeScriptProfile;
 use Lattice\Table\TableServiceProvider;
@@ -63,6 +66,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
             ->hasRoute('web')
             ->hasConsoleCommands([
                 TypeScriptCommand::class,
+                SchemaCommand::class,
                 MakeComponentCommand::class,
                 MakeFieldCommand::class,
                 MakeColumnCommand::class,
@@ -83,6 +87,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
         $this->app->singleton(WireSourceCatalog::class, static fn (): WireSourceCatalog => WireSourceCatalog::fromApplication());
         $this->app->bind(TypeScriptProfile::class, AugmentProfile::class);
+        $this->app->bind(SchemaProfile::class, ExportSchemaProfile::class);
 
         if ($this->app->runningInConsole()) {
             $this->commands(MakeDefinitionCommand::all());

--- a/packages/framework/src/Support/Schema/ExportSchemaProfile.php
+++ b/packages/framework/src/Support/Schema/ExportSchemaProfile.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support\Schema;
+
+use Illuminate\Support\Facades\File;
+use Lattice\Core\JsonSchema\FlatProjection;
+use Lattice\Core\JsonSchema\SchemaBundler;
+use Lattice\Core\JsonSchema\SchemaDocumentWriter;
+use Lattice\Core\Wire\WireModelBuilder;
+use Lattice\Core\Wire\WireSource;
+use Lattice\Core\Wire\WireSourceCatalog;
+
+/**
+ * Default profile: assembles the app's effective wire-protocol schema by
+ * merging every installed wire package's COMMITTED schema document (already
+ * flat and self-contained, never reflected here) with the root package's own
+ * document — reflected fresh, then projected flat against the installed
+ * packages' committed `$defs` as its def universe, so a root prop typed with
+ * an installed package's class resolves to a local pointer instead of
+ * reflecting vendor PHP.
+ */
+final readonly class ExportSchemaProfile implements SchemaProfile
+{
+    public function __construct(
+        private WireSourceCatalog $catalog,
+        private SchemaBundler $bundler,
+    ) {}
+
+    public function run(WireModelBuilder $builder, SchemaDocumentWriter $writer): string
+    {
+        $sources = $this->catalog->discover();
+        $root = null;
+        $installed = [];
+
+        foreach ($sources as $source) {
+            if ($source->isRoot) {
+                $root = $source;
+            } else {
+                $installed[] = $source;
+            }
+        }
+
+        $installedDocuments = $this->committedDocuments($installed);
+
+        $others = [];
+        $universe = [];
+        $defOrigins = [];
+
+        foreach ($installedDocuments as $shortName => $document) {
+            if ($shortName !== 'lattice') {
+                $others[] = $document;
+            }
+
+            foreach ($document['$defs'] as $name => $def) {
+                $universe[$name] = $def;
+                $defOrigins[$name] ??= $shortName;
+            }
+        }
+
+        if ($root !== null) {
+            $rootDocument = $builder->buildRootDocument($root, $installed);
+            $others[] = new FlatProjection()->project($rootDocument, $universe, $defOrigins, $root->shortName);
+        }
+
+        $framework = $installedDocuments['lattice'] ?? ['$schema' => 'https://json-schema.org/draft/2020-12/schema', '$defs' => []];
+        $bundle = $this->bundler->bundle($framework, $others);
+
+        $output = (string) config('lattice.schema.output');
+
+        File::ensureDirectoryExists(dirname($output));
+        File::put($output, $writer->write($bundle));
+
+        return sprintf('Wrote the wire-protocol schema → %s', $output);
+    }
+
+    /**
+     * @param  list<WireSource>  $sources
+     * @return array<string, array<string, mixed>>
+     */
+    private function committedDocuments(array $sources): array
+    {
+        $documents = [];
+
+        foreach ($sources as $source) {
+            $path = $source->schemaPath();
+
+            if (! is_file($path)) {
+                continue;
+            }
+
+            $decoded = json_decode((string) file_get_contents($path), true);
+
+            if (is_array($decoded)) {
+                $documents[$source->shortName] = $decoded;
+            }
+        }
+
+        return $documents;
+    }
+}

--- a/packages/framework/src/Support/Schema/SchemaProfile.php
+++ b/packages/framework/src/Support/Schema/SchemaProfile.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support\Schema;
+
+use Lattice\Core\JsonSchema\SchemaDocumentWriter;
+use Lattice\Core\Wire\WireModelBuilder;
+
+/**
+ * The role lattice:schema plays in the current project. Consumer apps export
+ * the merged document (built-ins + app types); the workbench rebinds this to
+ * regenerate the committed built-ins-only artifacts.
+ */
+interface SchemaProfile
+{
+    public function run(WireModelBuilder $builder, SchemaDocumentWriter $writer): string;
+}

--- a/packages/media/resources/schema/media.schema.json
+++ b/packages/media/resources/schema/media.schema.json
@@ -1,0 +1,639 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/media/v1.json",
+  "title": "Lattice media wire types",
+  "$defs": {
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Condition": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "readOnly": true
+        },
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "readOnly": true
+        }
+      },
+      "required": [
+        "field",
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Form\\Conditions\\Condition"
+      }
+    },
+    "EditorMediaImage": {
+      "type": "object",
+      "properties": {
+        "conversions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "library": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:media.library"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "conversions",
+        "library"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "editor-extension",
+        "wireType": "media-image",
+        "php": "Lattice\\Media\\Forms\\RichEditor\\MediaImage"
+      }
+    },
+    "MediaLibrary": {
+      "type": "object",
+      "properties": {
+        "accept": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "picker": {
+          "type": "boolean"
+        },
+        "signed": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "accept",
+        "picker",
+        "signed"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "media.library",
+        "domain": "Media",
+        "php": "Lattice\\Media\\Components\\MediaLibrary"
+      }
+    },
+    "MediaPicker": {
+      "type": "object",
+      "properties": {
+        "columnWidth": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        },
+        "conditions": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "disabled": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                },
+                "readOnly": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                },
+                "required": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                },
+                "visible": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/Condition"
+                  },
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "disabled",
+                "readOnly",
+                "required",
+                "visible"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Form\\Conditions\\FieldConditions"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dependsOnAny": {
+          "type": "boolean"
+        },
+        "dependsOnKeys": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "editablePrefill": {
+          "type": "boolean"
+        },
+        "helperText": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "labelAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "maxFiles": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "prefillRefreshOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefillResetOn": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "selected": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "mime_type": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "preview_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "id",
+                  "mime_type",
+                  "name",
+                  "preview_url",
+                  "url",
+                  "values"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "columnWidth",
+        "conditions",
+        "dependsOnAny",
+        "dependsOnKeys",
+        "disabled",
+        "editablePrefill",
+        "helperText",
+        "label",
+        "labelAction",
+        "maxFiles",
+        "multiple",
+        "name",
+        "prefillRefreshOn",
+        "prefillResetOn",
+        "readOnly",
+        "required",
+        "selected",
+        "tooltip",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "field.media-picker",
+        "domain": "Forms",
+        "php": "Lattice\\Media\\Forms\\Components\\MediaPicker"
+      }
+    },
+    "MediaTypeFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.media-type",
+        "php": "Lattice\\Media\\Tables\\Filters\\MediaTypeFilter"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "editor-extension:media-image": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "media-image"
+        },
+        "props": {
+          "$ref": "#/$defs/EditorMediaImage"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "editor-extension",
+        "wireType": "media-image"
+      }
+    },
+    "filter:filter.media-type": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.media-type"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaTypeFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.media-type",
+        "php": "Lattice\\Media\\Tables\\Filters\\MediaTypeFilter"
+      }
+    },
+    "node:field.media-picker": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "field.media-picker"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaPicker"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "field.media-picker",
+        "php": "Lattice\\Media\\Forms\\Components\\MediaPicker"
+      }
+    },
+    "node:media.library": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "media.library"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MediaLibrary"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "media.library",
+        "php": "Lattice\\Media\\Components\\MediaLibrary"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "FormFieldNodeType": [
+        "field.media-picker"
+      ],
+      "FormNodeType": [
+        "field.media-picker"
+      ],
+      "MediumNodeType": [
+        "media.library"
+      ],
+      "NodeType": [
+        "field.media-picker",
+        "media.library"
+      ],
+      "FilterNodeType": [
+        "filter.media-type"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "field.media-picker": {
+            "node": "#/$defs/node:field.media-picker",
+            "props": "#/$defs/MediaPicker",
+            "domain": "Forms"
+          },
+          "media.library": {
+            "node": "#/$defs/node:media.library",
+            "props": "#/$defs/MediaLibrary",
+            "domain": "Media",
+            "container": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {
+          "media-image": {
+            "node": "#/$defs/editor-extension:media-image",
+            "props": "#/$defs/EditorMediaImage"
+          }
+        }
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {
+          "filter.media-type": {
+            "node": "#/$defs/filter:filter.media-type",
+            "props": "#/$defs/MediaTypeFilter"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/search/resources/schema/search.schema.json
+++ b/packages/search/resources/schema/search.schema.json
@@ -1,0 +1,766 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/search/v1.json",
+  "title": "Lattice search wire types",
+  "$defs": {
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "RecordSelectionResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/$defs/SearchResult",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/$defs/RecordSelectionState",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "state"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\RecordSelectionResponse"
+      }
+    },
+    "RecordSelectionState": {
+      "type": "object",
+      "properties": {
+        "recorded": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "recorded"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\RecordSelectionState"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "SearchBox": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "perPage": {
+          "type": "integer"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shortcut": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "endpoint",
+        "perPage",
+        "placeholder",
+        "shortcut",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.box",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchBox"
+      }
+    },
+    "SearchCategories": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.categories",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchCategories"
+      }
+    },
+    "SearchCategory": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "count",
+        "icon",
+        "label",
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchCategory"
+      }
+    },
+    "SearchInput": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.input",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchInput"
+      }
+    },
+    "SearchMode": {
+      "type": "string",
+      "enum": [
+        "results",
+        "recent"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Search\\Enums\\SearchMode"
+      }
+    },
+    "SearchPagination": {
+      "type": "object",
+      "properties": {
+        "hasMore": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "nextPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "page": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "perPage": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "total": {
+          "type": "integer",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "hasMore",
+        "nextPage",
+        "page",
+        "perPage",
+        "total"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchPagination"
+      }
+    },
+    "SearchPreview": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.preview",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchPreview"
+      }
+    },
+    "SearchRecent": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.recent",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchRecent"
+      }
+    },
+    "SearchResponse": {
+      "type": "object",
+      "properties": {
+        "categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SearchCategory"
+          },
+          "readOnly": true
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SearchResult"
+          },
+          "readOnly": true
+        },
+        "pagination": {
+          "$ref": "#/$defs/SearchPagination",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/$defs/SearchState",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "categories",
+        "data",
+        "pagination",
+        "state"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResponse"
+      }
+    },
+    "SearchResult": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "$ref": "#/$defs/SearchResultCategory",
+          "readOnly": true
+        },
+        "item": {
+          "$ref": "#/$defs/SearchResultItem",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "category",
+        "item"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResult"
+      }
+    },
+    "SearchResultCategory": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResultCategory"
+      }
+    },
+    "SearchResultItem": {
+      "type": "object",
+      "properties": {
+        "additionalInfo": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "badge": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "link": {
+          "type": "string",
+          "readOnly": true
+        },
+        "subtitle": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "additionalInfo",
+        "badge",
+        "id",
+        "link",
+        "subtitle",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchResultItem"
+      }
+    },
+    "SearchResults": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "search.results",
+        "domain": "Search",
+        "php": "Lattice\\Search\\Components\\SearchResults"
+      }
+    },
+    "SearchState": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "countsIncluded": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/$defs/SearchMode",
+          "readOnly": true
+        },
+        "perPage": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "query": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "category",
+        "countsIncluded",
+        "mode",
+        "perPage",
+        "query"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Search\\SearchState"
+      }
+    },
+    "node:search.box": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.box"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchBox"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.box",
+        "php": "Lattice\\Search\\Components\\SearchBox"
+      }
+    },
+    "node:search.categories": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.categories"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchCategories"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.categories",
+        "php": "Lattice\\Search\\Components\\SearchCategories"
+      }
+    },
+    "node:search.input": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.input"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchInput"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.input",
+        "php": "Lattice\\Search\\Components\\SearchInput"
+      }
+    },
+    "node:search.preview": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.preview"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchPreview"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.preview",
+        "php": "Lattice\\Search\\Components\\SearchPreview"
+      }
+    },
+    "node:search.recent": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.recent"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchRecent"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.recent",
+        "php": "Lattice\\Search\\Components\\SearchRecent"
+      }
+    },
+    "node:search.results": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "search.results"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SearchResults"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "search.results",
+        "php": "Lattice\\Search\\Components\\SearchResults"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "SearchNodeType": [
+        "search.box",
+        "search.categories",
+        "search.input",
+        "search.preview",
+        "search.recent",
+        "search.results"
+      ],
+      "NodeType": [
+        "search.box",
+        "search.categories",
+        "search.input",
+        "search.preview",
+        "search.recent",
+        "search.results"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "search.box": {
+            "node": "#/$defs/node:search.box",
+            "props": "#/$defs/SearchBox",
+            "domain": "Search",
+            "container": true
+          },
+          "search.categories": {
+            "node": "#/$defs/node:search.categories",
+            "props": "#/$defs/SearchCategories",
+            "domain": "Search"
+          },
+          "search.input": {
+            "node": "#/$defs/node:search.input",
+            "props": "#/$defs/SearchInput",
+            "domain": "Search"
+          },
+          "search.preview": {
+            "node": "#/$defs/node:search.preview",
+            "props": "#/$defs/SearchPreview",
+            "domain": "Search"
+          },
+          "search.recent": {
+            "node": "#/$defs/node:search.recent",
+            "props": "#/$defs/SearchRecent",
+            "domain": "Search"
+          },
+          "search.results": {
+            "node": "#/$defs/node:search.results",
+            "props": "#/$defs/SearchResults",
+            "domain": "Search"
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/signature-example/resources/schema/signature-example.schema.json
+++ b/packages/signature-example/resources/schema/signature-example.schema.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/signature-example/v1.json",
+  "title": "Lattice signature-example wire types",
+  "$defs": {
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "Signature": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "signature",
+        "domain": "SignatureExample",
+        "php": "Lattice\\SignatureExample\\Components\\Signature"
+      }
+    },
+    "node:signature": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "signature"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Signature"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "signature",
+        "php": "Lattice\\SignatureExample\\Components\\Signature"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "SignatureExampleNodeType": [
+        "signature"
+      ],
+      "NodeType": [
+        "signature"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "signature": {
+            "node": "#/$defs/node:signature",
+            "props": "#/$defs/Signature",
+            "domain": "SignatureExample"
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/table/resources/schema/table.schema.json
+++ b/packages/table/resources/schema/table.schema.json
@@ -1,0 +1,2777 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/table/v1.json",
+  "title": "Lattice table wire types",
+  "$defs": {
+    "BadgeColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "colors": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "dark": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "readOnly": true
+                  },
+                  "kind": {
+                    "$ref": "#/$defs/ColorKind",
+                    "readOnly": true
+                  },
+                  "value": {
+                    "type": "string",
+                    "readOnly": true
+                  }
+                },
+                "required": [
+                  "dark",
+                  "kind",
+                  "value"
+                ],
+                "x-lattice": {
+                  "kind": "value-object",
+                  "php": "Lattice\\Core\\Color"
+                }
+              },
+              "x-lattice": {
+                "keys": "integer|string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "colors",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.badge",
+        "php": "Lattice\\Table\\Columns\\BadgeColumn"
+      }
+    },
+    "BooleanColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.boolean",
+        "php": "Lattice\\Table\\Columns\\BooleanColumn"
+      }
+    },
+    "ColorKind": {
+      "type": "string",
+      "enum": [
+        "named",
+        "css"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorKind"
+      }
+    },
+    "Column": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "common-props",
+        "family": "column",
+        "php": "Lattice\\Table\\Columns\\Column"
+      }
+    },
+    "ColumnAlign": {
+      "type": "string",
+      "enum": [
+        "start",
+        "center",
+        "end"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\ColumnAlign"
+      }
+    },
+    "ColumnFilter": {
+      "type": "object",
+      "properties": {
+        "clauseOptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ColumnFilterOption"
+          },
+          "readOnly": true
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FilterControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "defaultOperator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "multiple": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "operators": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "contains",
+              "starts_with",
+              "ends_with",
+              "eq",
+              "neq",
+              "gt",
+              "gte",
+              "lt",
+              "lte",
+              "in",
+              "not_in",
+              "before",
+              "after",
+              "empty",
+              "filled"
+            ],
+            "x-lattice": {
+              "kind": "enum",
+              "php": "Lattice\\Core\\Enums\\Op"
+            }
+          },
+          "readOnly": true
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          },
+          "readOnly": true
+        },
+        "searchable": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/$defs/FilterType",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "clauseOptions",
+        "control",
+        "defaultOperator",
+        "multiple",
+        "operators",
+        "options",
+        "searchable",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Columns\\ColumnFilter"
+      }
+    },
+    "ColumnFilterOption": {
+      "type": "object",
+      "properties": {
+        "clauses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ColumnFilterOptionClause"
+          },
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "clauses",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Columns\\ColumnFilterOption"
+      }
+    },
+    "ColumnFilterOptionClause": {
+      "type": "object",
+      "properties": {
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Columns\\ColumnFilterOptionClause"
+      }
+    },
+    "ColumnNode": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "column"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "DateRangeFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.date-range",
+        "php": "Lattice\\Table\\Filters\\DateRangeFilter"
+      }
+    },
+    "Filter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "common-props",
+        "family": "filter",
+        "php": "Lattice\\Table\\Filters\\Filter"
+      }
+    },
+    "FilterClause": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "readOnly": true
+        },
+        "operator": {
+          "type": "string",
+          "enum": [
+            "contains",
+            "starts_with",
+            "ends_with",
+            "eq",
+            "neq",
+            "gt",
+            "gte",
+            "lt",
+            "lte",
+            "in",
+            "not_in",
+            "before",
+            "after",
+            "empty",
+            "filled"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Core\\Enums\\Op"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "field",
+        "operator",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\FilterClause"
+      }
+    },
+    "FilterControl": {
+      "type": "string",
+      "enum": [
+        "filter.select",
+        "filter.ternary",
+        "filter.date-range",
+        "filter.toggle"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\FilterControl"
+      }
+    },
+    "FilterIndicator": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "filter",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\Filters\\FilterIndicator"
+      }
+    },
+    "FilterNode": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "filter"
+      }
+    },
+    "FilterType": {
+      "type": "string",
+      "enum": [
+        "text",
+        "number",
+        "date",
+        "boolean"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\FilterType"
+      }
+    },
+    "IconColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "colors": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "dark": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "readOnly": true
+                  },
+                  "kind": {
+                    "$ref": "#/$defs/ColorKind",
+                    "readOnly": true
+                  },
+                  "value": {
+                    "type": "string",
+                    "readOnly": true
+                  }
+                },
+                "required": [
+                  "dark",
+                  "kind",
+                  "value"
+                ],
+                "x-lattice": {
+                  "kind": "value-object",
+                  "php": "Lattice\\Core\\Color"
+                }
+              },
+              "x-lattice": {
+                "keys": "integer|string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icons": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "x-lattice": {
+                "keys": "integer|string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "colors",
+        "filter",
+        "hiddenByDefault",
+        "icon",
+        "icons",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.icon",
+        "php": "Lattice\\Table\\Columns\\IconColumn"
+      }
+    },
+    "ImageColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "circular": {
+          "type": "boolean"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "previewable": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "circular",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "previewable",
+        "size",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.image",
+        "php": "Lattice\\Table\\Columns\\ImageColumn"
+      }
+    },
+    "MoneyColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "currency": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "currencyField": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maximumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "copyable",
+        "currency",
+        "currencyField",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "maximumFractionDigits",
+        "minimumFractionDigits",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.money",
+        "php": "Lattice\\Table\\Columns\\MoneyColumn"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "NumberColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "compact": {
+          "type": "boolean"
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maximumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "percent",
+                "kilogram",
+                "gram",
+                "kilometer",
+                "meter",
+                "byte",
+                "kilobyte",
+                "megabyte",
+                "gigabyte",
+                "millisecond",
+                "second",
+                "minute",
+                "hour",
+                "celsius",
+                "fahrenheit"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\NumberFormatUnit"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "compact",
+        "copyable",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "maximumFractionDigits",
+        "minimumFractionDigits",
+        "options",
+        "sortable",
+        "toggleable",
+        "unit",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.number",
+        "php": "Lattice\\Table\\Columns\\NumberColumn"
+      }
+    },
+    "PaginationType": {
+      "type": "string",
+      "enum": [
+        "none",
+        "simple",
+        "table",
+        "infinite"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\PaginationType"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "SelectFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "multiple": {
+          "type": "boolean"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "searchable": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "label",
+        "multiple",
+        "options",
+        "placeholder",
+        "searchable"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.select",
+        "php": "Lattice\\Table\\Filters\\SelectFilter"
+      }
+    },
+    "SortDirection": {
+      "type": "string",
+      "enum": [
+        "asc",
+        "desc"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Table\\Enums\\SortDirection"
+      }
+    },
+    "StackColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.stack",
+        "php": "Lattice\\Table\\Columns\\StackColumn"
+      }
+    },
+    "Table": {
+      "type": "object",
+      "properties": {
+        "actionsLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bulkActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ColumnNode"
+          }
+        },
+        "data": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emptyLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FilterNode"
+          }
+        },
+        "layout": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazy": {
+          "type": "boolean"
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TablePagination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "perPageOptions": {
+          "type": "array",
+          "items": {
+            "type": [
+              "integer",
+              "string"
+            ]
+          }
+        },
+        "query": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TableQuery"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resizableColumns": {
+          "type": "boolean"
+        },
+        "resizeIndicator": {
+          "type": "boolean"
+        },
+        "searchable": {
+          "type": "boolean"
+        },
+        "striped": {
+          "type": "boolean"
+        },
+        "toolbar": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "actionsLabel",
+        "bulkActions",
+        "columns",
+        "data",
+        "emptyLabel",
+        "endpoint",
+        "filters",
+        "layout",
+        "lazy",
+        "pagination",
+        "perPageOptions",
+        "query",
+        "ref",
+        "resizableColumns",
+        "resizeIndicator",
+        "searchable",
+        "striped",
+        "toolbar"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "table",
+        "domain": "Table",
+        "php": "Lattice\\Table\\Components\\Table"
+      }
+    },
+    "TablePagination": {
+      "type": "object",
+      "properties": {
+        "currentPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "from": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "hasMore": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "lastPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/$defs/PaginationType",
+          "readOnly": true
+        },
+        "nextPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "perPage": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "to": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "total": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "currentPage",
+        "from",
+        "hasMore",
+        "lastPage",
+        "mode",
+        "nextPage",
+        "perPage",
+        "to",
+        "total"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TablePagination"
+      }
+    },
+    "TableQuery": {
+      "type": "object",
+      "properties": {
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FilterClause"
+          },
+          "readOnly": true
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PaginationType"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "page": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "perPage": {
+          "type": "integer",
+          "readOnly": true
+        },
+        "search": {
+          "type": "string",
+          "readOnly": true
+        },
+        "sorts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableSort"
+          },
+          "readOnly": true
+        },
+        "tableFilterIndicators": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FilterIndicator"
+          },
+          "readOnly": true
+        },
+        "tableFilters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "filters",
+        "mode",
+        "page",
+        "perPage",
+        "search",
+        "sorts",
+        "tableFilterIndicators",
+        "tableFilters"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TableQuery"
+      }
+    },
+    "TableResult": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "readOnly": true
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TablePagination"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "query": {
+          "$ref": "#/$defs/TableQuery",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "data",
+        "pagination",
+        "query"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TableResult"
+      }
+    },
+    "TableSort": {
+      "type": "object",
+      "properties": {
+        "direction": {
+          "$ref": "#/$defs/SortDirection",
+          "readOnly": true
+        },
+        "key": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "direction",
+        "key"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Table\\TableSort"
+      }
+    },
+    "TernaryFilter": {
+      "type": "object",
+      "properties": {
+        "falseLabel": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": "string"
+        },
+        "trueLabel": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "falseLabel",
+        "label",
+        "placeholder",
+        "trueLabel"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.ternary",
+        "php": "Lattice\\Table\\Filters\\TernaryFilter"
+      }
+    },
+    "TextColumn": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "$ref": "#/$defs/ColumnAlign"
+        },
+        "badge": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "colorKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "colorKey"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "date": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dateStyle": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "full",
+                        "long",
+                        "medium",
+                        "short"
+                      ],
+                      "x-lattice": {
+                        "kind": "enum",
+                        "php": "Lattice\\Ui\\Enums\\DateTimeStyle"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "timeStyle": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "full",
+                        "long",
+                        "medium",
+                        "short"
+                      ],
+                      "x-lattice": {
+                        "kind": "enum",
+                        "php": "Lattice\\Ui\\Enums\\DateTimeStyle"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "dateStyle",
+                "timeStyle"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ColumnFilter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hiddenByDefault": {
+          "type": "boolean"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "link": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "external": {
+                  "type": "boolean"
+                },
+                "href": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "external",
+                "href"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multiple": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "sortable": {
+          "type": "boolean"
+        },
+        "toggleable": {
+          "type": "boolean"
+        },
+        "width": {
+          "type": "string",
+          "enum": [
+            "xs",
+            "sm",
+            "md",
+            "lg",
+            "xl"
+          ],
+          "x-lattice": {
+            "kind": "enum",
+            "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+          }
+        }
+      },
+      "required": [
+        "align",
+        "badge",
+        "copyable",
+        "date",
+        "filter",
+        "hiddenByDefault",
+        "label",
+        "link",
+        "multiple",
+        "options",
+        "sortable",
+        "toggleable",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "column",
+        "wireType": "column.text",
+        "php": "Lattice\\Table\\Columns\\TextColumn"
+      }
+    },
+    "ToggleFilter": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "filter",
+        "wireType": "filter.toggle",
+        "php": "Lattice\\Table\\Filters\\ToggleFilter"
+      }
+    },
+    "column:column.badge": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.badge"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BadgeColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.badge",
+        "php": "Lattice\\Table\\Columns\\BadgeColumn"
+      }
+    },
+    "column:column.boolean": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BooleanColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.boolean",
+        "php": "Lattice\\Table\\Columns\\BooleanColumn"
+      }
+    },
+    "column:column.icon": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.icon"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/IconColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.icon",
+        "php": "Lattice\\Table\\Columns\\IconColumn"
+      }
+    },
+    "column:column.image": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.image"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ImageColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.image",
+        "php": "Lattice\\Table\\Columns\\ImageColumn"
+      }
+    },
+    "column:column.money": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.money"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/MoneyColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.money",
+        "php": "Lattice\\Table\\Columns\\MoneyColumn"
+      }
+    },
+    "column:column.number": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.number"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/NumberColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.number",
+        "php": "Lattice\\Table\\Columns\\NumberColumn"
+      }
+    },
+    "column:column.stack": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.stack"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/StackColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.stack",
+        "php": "Lattice\\Table\\Columns\\StackColumn"
+      }
+    },
+    "column:column.text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "column.text"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextColumn"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "column",
+        "wireType": "column.text",
+        "php": "Lattice\\Table\\Columns\\TextColumn"
+      }
+    },
+    "filter:filter.date-range": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.date-range"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateRangeFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.date-range",
+        "php": "Lattice\\Table\\Filters\\DateRangeFilter"
+      }
+    },
+    "filter:filter.select": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.select"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SelectFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.select",
+        "php": "Lattice\\Table\\Filters\\SelectFilter"
+      }
+    },
+    "filter:filter.ternary": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.ternary"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TernaryFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.ternary",
+        "php": "Lattice\\Table\\Filters\\TernaryFilter"
+      }
+    },
+    "filter:filter.toggle": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "filter.toggle"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ToggleFilter"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "key",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "filter",
+        "wireType": "filter.toggle",
+        "php": "Lattice\\Table\\Filters\\ToggleFilter"
+      }
+    },
+    "node:table": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "table"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Table"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "table",
+        "php": "Lattice\\Table\\Components\\Table"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "TableNodeType": [
+        "table"
+      ],
+      "NodeType": [
+        "table"
+      ],
+      "ColumnNodeType": [
+        "column.badge",
+        "column.boolean",
+        "column.icon",
+        "column.image",
+        "column.money",
+        "column.number",
+        "column.stack",
+        "column.text"
+      ],
+      "FilterNodeType": [
+        "filter.date-range",
+        "filter.select",
+        "filter.ternary",
+        "filter.toggle"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "table": {
+            "node": "#/$defs/node:table",
+            "props": "#/$defs/Table",
+            "domain": "Table",
+            "interactive": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {
+          "column.badge": {
+            "node": "#/$defs/column:column.badge",
+            "props": "#/$defs/BadgeColumn"
+          },
+          "column.boolean": {
+            "node": "#/$defs/column:column.boolean",
+            "props": "#/$defs/BooleanColumn"
+          },
+          "column.icon": {
+            "node": "#/$defs/column:column.icon",
+            "props": "#/$defs/IconColumn"
+          },
+          "column.image": {
+            "node": "#/$defs/column:column.image",
+            "props": "#/$defs/ImageColumn"
+          },
+          "column.money": {
+            "node": "#/$defs/column:column.money",
+            "props": "#/$defs/MoneyColumn"
+          },
+          "column.number": {
+            "node": "#/$defs/column:column.number",
+            "props": "#/$defs/NumberColumn"
+          },
+          "column.stack": {
+            "node": "#/$defs/column:column.stack",
+            "props": "#/$defs/StackColumn",
+            "container": true
+          },
+          "column.text": {
+            "node": "#/$defs/column:column.text",
+            "props": "#/$defs/TextColumn"
+          }
+        }
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {
+          "filter.date-range": {
+            "node": "#/$defs/filter:filter.date-range",
+            "props": "#/$defs/DateRangeFilter"
+          },
+          "filter.select": {
+            "node": "#/$defs/filter:filter.select",
+            "props": "#/$defs/SelectFilter"
+          },
+          "filter.ternary": {
+            "node": "#/$defs/filter:filter.ternary",
+            "props": "#/$defs/TernaryFilter"
+          },
+          "filter.toggle": {
+            "node": "#/$defs/filter:filter.toggle",
+            "props": "#/$defs/ToggleFilter"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/tree/resources/schema/tree.schema.json
+++ b/packages/tree/resources/schema/tree.schema.json
@@ -1,0 +1,1232 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/tree/v1.json",
+  "title": "Lattice tree wire types",
+  "$defs": {
+    "Action": {
+      "type": "object",
+      "properties": {
+        "confirmation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Confirmation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:form"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazyForm": {
+          "type": "boolean"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalSide": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "end"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Side"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl",
+                "3xl"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\ModalWidth"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmation",
+        "emphasis",
+        "endpoint",
+        "form",
+        "icon",
+        "label",
+        "lazyForm",
+        "method",
+        "modalSide",
+        "modalWidth",
+        "ref",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\Action"
+      }
+    },
+    "BulkAction": {
+      "type": "object",
+      "properties": {
+        "confirmation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Confirmation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "form": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:form"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazyForm": {
+          "type": "boolean"
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalSide": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "end"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Side"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "modalWidth": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "sm",
+                "md",
+                "lg",
+                "xl",
+                "2xl",
+                "3xl"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\ModalWidth"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "confirmation",
+        "emphasis",
+        "endpoint",
+        "form",
+        "icon",
+        "label",
+        "lazyForm",
+        "method",
+        "modalSide",
+        "modalWidth",
+        "ref",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "action.bulk",
+        "domain": "Actions",
+        "php": "Lattice\\Actions\\Components\\BulkAction"
+      }
+    },
+    "Button": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buttonType": {
+          "$ref": "#/$defs/ButtonType"
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Emphasis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Variant"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "buttonType",
+        "effects",
+        "emphasis",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "button",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "ButtonType": {
+      "type": "string",
+      "enum": [
+        "button",
+        "submit",
+        "reset"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ButtonType"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Confirmation": {
+      "type": "object",
+      "properties": {
+        "cancelLabel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "confirmLabel": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "cancelLabel",
+        "confirmLabel",
+        "description",
+        "title"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Actions\\Confirmation"
+      }
+    },
+    "Effect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "effect"
+      }
+    },
+    "Emphasis": {
+      "type": "string",
+      "enum": [
+        "solid",
+        "outline",
+        "ghost",
+        "link"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Emphasis"
+      }
+    },
+    "Form": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errorBag": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\HttpMethod"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "precognitive": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resetOnError": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resetOnSuccess": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "state": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitButton": {
+          "type": "boolean"
+        },
+        "submitButtons": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/node:button"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitEmphasis": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "solid",
+                "outline",
+                "ghost",
+                "link"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Emphasis"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitJustify": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "start",
+                "center",
+                "end",
+                "between",
+                "around",
+                "evenly"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Justify"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "submitLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "submitVariant": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "primary",
+                "secondary",
+                "success",
+                "info",
+                "warning",
+                "danger"
+              ],
+              "x-lattice": {
+                "kind": "enum",
+                "php": "Lattice\\Ui\\Enums\\Variant"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "validationSummaryLabel": {
+          "type": "string"
+        },
+        "validationTimeout": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "errorBag",
+        "method",
+        "precognitive",
+        "ref",
+        "resetOnError",
+        "resetOnSuccess",
+        "state",
+        "status",
+        "submitButton",
+        "submitButtons",
+        "submitEmphasis",
+        "submitJustify",
+        "submitLabel",
+        "submitVariant",
+        "validationSummaryLabel",
+        "validationTimeout"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "form",
+        "domain": "Form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\HttpMethod"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "Tree": {
+      "type": "object",
+      "properties": {
+        "activeId": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "activePath": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "defaultExpanded": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "endpoint": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lazy": {
+          "type": "boolean"
+        },
+        "moveAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:action"
+            },
+            {
+              "$ref": "#/$defs/node:action.bulk"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TreeNodeData"
+          }
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rememberState": {
+          "type": "boolean"
+        },
+        "revision": {
+          "type": [
+            "integer",
+            "string",
+            "null"
+          ]
+        },
+        "selectAction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/node:action"
+            },
+            {
+              "$ref": "#/$defs/node:action.bulk"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "activeId",
+        "activePath",
+        "defaultExpanded",
+        "endpoint",
+        "lazy",
+        "moveAction",
+        "nodes",
+        "ref",
+        "rememberState",
+        "revision",
+        "selectAction"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tree",
+        "php": "Lattice\\Tree\\Tree"
+      }
+    },
+    "TreeNodeData": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TreeNodeData"
+          },
+          "readOnly": true
+        },
+        "disabled": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "hasChildren": {
+          "type": "boolean",
+          "readOnly": true
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "label": {
+          "type": "string",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "children",
+        "disabled",
+        "hasChildren",
+        "href",
+        "id",
+        "label",
+        "schema"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Tree\\TreeNodeData"
+      }
+    },
+    "Variant": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "danger"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Variant"
+      }
+    },
+    "node:action": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Action"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action",
+        "php": "Lattice\\Actions\\Components\\Action"
+      }
+    },
+    "node:action.bulk": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "action.bulk"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BulkAction"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "action.bulk",
+        "php": "Lattice\\Actions\\Components\\BulkAction"
+      }
+    },
+    "node:button": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "button"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Button"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "button",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "node:form": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "form"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Form"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "form",
+        "php": "Lattice\\Form\\Components\\Form"
+      }
+    },
+    "node:tree": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tree"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tree"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tree",
+        "php": "Lattice\\Tree\\Tree"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "NodeType": [
+        "tree"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "tree": {
+            "node": "#/$defs/node:tree",
+            "props": "#/$defs/Tree",
+            "interactive": true
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {}
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/packages/ui/resources/schema/ui.schema.json
+++ b/packages/ui/resources/schema/ui.schema.json
@@ -1,0 +1,4258 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lattice-php.dev/schema/ui/v1.json",
+  "title": "Lattice ui wire types",
+  "$defs": {
+    "Align": {
+      "type": "string",
+      "enum": [
+        "center",
+        "left",
+        "start",
+        "stretch"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Align"
+      }
+    },
+    "Avatar": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shape": {
+          "$ref": "#/$defs/AvatarShape"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "src": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "shape",
+        "size",
+        "src"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "avatar",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Avatar"
+      }
+    },
+    "AvatarShape": {
+      "type": "string",
+      "enum": [
+        "circle",
+        "rounded"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\AvatarShape"
+      }
+    },
+    "Badge": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "color",
+        "label"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "badge",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Badge"
+      }
+    },
+    "BadgeEntry": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "color",
+        "description",
+        "label",
+        "name",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.badge",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\BadgeEntry"
+      }
+    },
+    "BooleanEntry": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "falseIcon": {
+          "type": "string"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "trueIcon": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "description",
+        "falseIcon",
+        "label",
+        "name",
+        "trueIcon",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.boolean",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\BooleanEntry"
+      }
+    },
+    "Breakpoint": {
+      "type": "string",
+      "enum": [
+        "default",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Breakpoint"
+      }
+    },
+    "Button": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "buttonType": {
+          "$ref": "#/$defs/ButtonType"
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "emphasis": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Emphasis"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "variant": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Variant"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "buttonType",
+        "effects",
+        "emphasis",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "button",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "ButtonType": {
+      "type": "string",
+      "enum": [
+        "button",
+        "submit",
+        "reset"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ButtonType"
+      }
+    },
+    "Callout": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dismissible": {
+          "type": "boolean"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Translatable"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "title": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Translatable"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unique": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "variant": {
+          "$ref": "#/$defs/Variant"
+        }
+      },
+      "required": [
+        "action",
+        "dismissible",
+        "message",
+        "title",
+        "unique",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "callout",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Callout"
+      }
+    },
+    "Card": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headerActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "description",
+        "headerActions",
+        "title",
+        "tooltip"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "card",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Card"
+      }
+    },
+    "Chart": {
+      "type": "object",
+      "properties": {
+        "categoryFormat": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateFormat"
+            },
+            {
+              "$ref": "#/$defs/NumberFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "categoryKey": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "grid": {
+          "type": "boolean"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "legend": {
+          "type": "boolean"
+        },
+        "series": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ChartSeries"
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": "boolean"
+        },
+        "valueFormat": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "xAxis": {
+          "type": "boolean"
+        },
+        "yAxis": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "categoryFormat",
+        "categoryKey",
+        "data",
+        "description",
+        "grid",
+        "height",
+        "legend",
+        "series",
+        "title",
+        "tooltip",
+        "valueFormat",
+        "xAxis",
+        "yAxis"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "chart",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Chart"
+      }
+    },
+    "ChartSeries": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "readOnly": true
+        },
+        "dataKey": {
+          "type": "string",
+          "readOnly": true
+        },
+        "innerRadius": {
+          "type": "string",
+          "readOnly": true
+        },
+        "maxValue": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "readOnly": true
+        },
+        "nameKey": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "stackId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/$defs/ChartSeriesType",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "color",
+        "dataKey",
+        "innerRadius",
+        "maxValue",
+        "name",
+        "nameKey",
+        "stackId",
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\Values\\ChartSeries"
+      }
+    },
+    "ChartSeriesType": {
+      "type": "string",
+      "enum": [
+        "area",
+        "bar",
+        "distribution",
+        "gauge",
+        "line",
+        "pie"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ChartSeriesType"
+      }
+    },
+    "CloseModal": {
+      "type": "object",
+      "properties": {
+        "modal": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "modal"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "close-modal",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\CloseModal"
+      }
+    },
+    "CodeBlock": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "language": {
+          "$ref": "#/$defs/CodeBlockLanguage"
+        },
+        "lineNumbers": {
+          "type": "boolean"
+        },
+        "maxHeight": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "wrap": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "code",
+        "copyable",
+        "language",
+        "lineNumbers",
+        "maxHeight",
+        "wrap"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "code-block",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\CodeBlock"
+      }
+    },
+    "CodeBlockLanguage": {
+      "type": "string",
+      "enum": [
+        "text",
+        "json",
+        "javascript",
+        "shell",
+        "php"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\CodeBlockLanguage"
+      }
+    },
+    "Collapsible": {
+      "type": "object",
+      "properties": {
+        "collapsed": {
+          "type": "boolean"
+        },
+        "rememberState": {
+          "type": "boolean"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "collapsed",
+        "rememberState",
+        "tooltip",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "collapsible",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Collapsible"
+      }
+    },
+    "ColorKind": {
+      "type": "string",
+      "enum": [
+        "named",
+        "css"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Core\\Enums\\ColorKind"
+      }
+    },
+    "ColumnWidth": {
+      "type": "string",
+      "enum": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ColumnWidth"
+      }
+    },
+    "CommonNodeProps": {
+      "type": "object",
+      "properties": {
+        "dataBindings": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hideWhenCollapsed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "ComponentEntry": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "description",
+        "label",
+        "name",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.component",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\ComponentEntry"
+      }
+    },
+    "DateEntry": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "$ref": "#/$defs/DateFormat"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {}
+      },
+      "required": [
+        "description",
+        "format",
+        "label",
+        "name",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.date",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\DateEntry"
+      }
+    },
+    "DateFormat": {
+      "type": "object",
+      "properties": {
+        "dateStyle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateTimeStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "kind": {
+          "type": "string"
+        },
+        "month": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeStyle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateTimeStyle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "year": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "dateStyle",
+        "kind",
+        "month",
+        "timeStyle",
+        "year"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\Values\\DateFormat"
+      }
+    },
+    "DateTimeStyle": {
+      "type": "string",
+      "enum": [
+        "full",
+        "long",
+        "medium",
+        "short"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\DateTimeStyle"
+      }
+    },
+    "DescriptionList": {
+      "type": "object",
+      "properties": {
+        "bleed": {
+          "type": "boolean"
+        },
+        "divided": {
+          "type": "boolean"
+        },
+        "emptyLabel": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semantic": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bleed",
+        "divided",
+        "emptyLabel",
+        "semantic"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "description-list",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\DescriptionList"
+      }
+    },
+    "Download": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "download",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Download"
+      }
+    },
+    "Effect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "effect"
+      }
+    },
+    "Emphasis": {
+      "type": "string",
+      "enum": [
+        "solid",
+        "outline",
+        "ghost",
+        "link"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Emphasis"
+      }
+    },
+    "FloatingPanel": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "offset": {
+          "type": "integer"
+        },
+        "placement": {
+          "$ref": "#/$defs/FloatingPlacement"
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "label",
+        "offset",
+        "placement",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "floating-panel",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\FloatingPanel"
+      }
+    },
+    "FloatingPlacement": {
+      "type": "string",
+      "enum": [
+        "bottom-end",
+        "bottom-start",
+        "top-end",
+        "top-start"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\FloatingPlacement"
+      }
+    },
+    "Gap": {
+      "type": "string",
+      "enum": [
+        "none",
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Gap"
+      }
+    },
+    "Grid": {
+      "type": "object",
+      "properties": {
+        "columns": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": [
+                  "integer",
+                  "string"
+                ]
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "columns"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "grid",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Grid"
+      }
+    },
+    "Heading": {
+      "type": "object",
+      "properties": {
+        "copyable": {
+          "type": "boolean"
+        },
+        "level": {
+          "type": "integer"
+        },
+        "text": {
+          "type": "string"
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "copyable",
+        "level",
+        "text",
+        "tooltip"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "heading",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Heading"
+      }
+    },
+    "Height": {
+      "type": "string",
+      "enum": [
+        "full",
+        "screen"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Height"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\HttpMethod"
+      }
+    },
+    "Icon": {
+      "type": "object",
+      "properties": {
+        "class": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        }
+      },
+      "required": [
+        "class",
+        "color",
+        "name",
+        "size"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "icon",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Icon"
+      }
+    },
+    "Image": {
+      "type": "object",
+      "properties": {
+        "alt": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "circular": {
+          "type": "boolean"
+        },
+        "previewable": {
+          "type": "boolean"
+        },
+        "size": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "src": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "alt",
+        "circular",
+        "previewable",
+        "size",
+        "src"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "image",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Image"
+      }
+    },
+    "Justify": {
+      "type": "string",
+      "enum": [
+        "start",
+        "center",
+        "end",
+        "between",
+        "around",
+        "evenly"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Justify"
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "effects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Effect"
+          }
+        },
+        "href": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "icon": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suffix": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "icon": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "icon",
+                "text"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Support\\Affix"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tabIndex": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "effects",
+        "href",
+        "icon",
+        "label",
+        "method",
+        "prefix",
+        "suffix",
+        "tabIndex"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "link",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Link"
+      }
+    },
+    "LocaleChange": {
+      "type": "object",
+      "properties": {
+        "locale": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "locale"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "locale-change",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\LocaleChange"
+      }
+    },
+    "Modal": {
+      "type": "object",
+      "properties": {
+        "closeLabel": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "height": {
+          "$ref": "#/$defs/ModalHeight"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "side": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Side"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "$ref": "#/$defs/ModalWidth"
+        }
+      },
+      "required": [
+        "closeLabel",
+        "description",
+        "height",
+        "open",
+        "ref",
+        "side",
+        "title",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "modal",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Modal"
+      }
+    },
+    "ModalHeight": {
+      "type": "string",
+      "enum": [
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl",
+        "3xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ModalHeight"
+      }
+    },
+    "ModalWidth": {
+      "type": "string",
+      "enum": [
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl",
+        "3xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ModalWidth"
+      }
+    },
+    "Node": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "type": "object"
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "x-lattice": {
+        "kind": "envelope",
+        "family": "component"
+      }
+    },
+    "NumberFormat": {
+      "type": "object",
+      "properties": {
+        "currency": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "type": "string"
+        },
+        "maximumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimumFractionDigits": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "notation": {
+          "type": "string"
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NumberFormatUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "currency",
+        "kind",
+        "maximumFractionDigits",
+        "minimumFractionDigits",
+        "notation",
+        "unit"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\Values\\NumberFormat"
+      }
+    },
+    "NumberFormatUnit": {
+      "type": "string",
+      "enum": [
+        "percent",
+        "kilogram",
+        "gram",
+        "kilometer",
+        "meter",
+        "byte",
+        "kilobyte",
+        "megabyte",
+        "gigabyte",
+        "millisecond",
+        "second",
+        "minute",
+        "hour",
+        "celsius",
+        "fahrenheit"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\NumberFormatUnit"
+      }
+    },
+    "OpenModal": {
+      "type": "object",
+      "properties": {
+        "modal": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "modal"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "open-modal",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\OpenModal"
+      }
+    },
+    "Orientation": {
+      "type": "string",
+      "enum": [
+        "horizontal",
+        "vertical"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Orientation"
+      }
+    },
+    "Placement": {
+      "type": "string",
+      "enum": [
+        "top",
+        "bottom",
+        "right"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Placement"
+      }
+    },
+    "Progress": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "type": "number"
+        },
+        "shape": {
+          "$ref": "#/$defs/ProgressShape"
+        },
+        "showValue": {
+          "type": "boolean"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "color",
+        "max",
+        "shape",
+        "showValue",
+        "size",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "progress",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Progress"
+      }
+    },
+    "ProgressShape": {
+      "type": "string",
+      "enum": [
+        "bar",
+        "circle"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\ProgressShape"
+      }
+    },
+    "RawBlock": {
+      "type": "object",
+      "properties": {
+        "html": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "html"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "raw-block",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\RawBlock"
+      }
+    },
+    "Redirect": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "redirect",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Redirect"
+      }
+    },
+    "ReloadComponent": {
+      "type": "object",
+      "properties": {
+        "component": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "component"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "reload-component",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ReloadComponent"
+      }
+    },
+    "ReloadPage": {
+      "type": "object",
+      "properties": {
+        "full": {
+          "type": "boolean",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "full"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "reload-page",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ReloadPage"
+      }
+    },
+    "ResetForm": {
+      "type": "object",
+      "properties": {
+        "form": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "form"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "reset-form",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ResetForm"
+      }
+    },
+    "RetractCallout": {
+      "type": "object",
+      "properties": {
+        "unique": {
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "unique"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "retract-callout",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\RetractCallout"
+      }
+    },
+    "Schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Node"
+      }
+    },
+    "Section": {
+      "type": "object",
+      "properties": {
+        "collapsed": {
+          "type": "boolean"
+        },
+        "collapsible": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "headerActions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        },
+        "rememberState": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tooltip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "collapsed",
+        "collapsible",
+        "description",
+        "headerActions",
+        "rememberState",
+        "title",
+        "tooltip"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "section",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Section"
+      }
+    },
+    "SegmentedControl": {
+      "type": "object",
+      "properties": {
+        "emits": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "readOnly": true
+              },
+              "label": {
+                "type": "string",
+                "readOnly": true
+              },
+              "value": {
+                "type": "string",
+                "readOnly": true
+              }
+            },
+            "required": [
+              "data",
+              "label",
+              "value"
+            ],
+            "x-lattice": {
+              "kind": "value-object",
+              "php": "Lattice\\Core\\Option"
+            }
+          }
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "emits",
+        "label",
+        "name",
+        "options",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "segmented-control",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\SegmentedControl"
+      }
+    },
+    "Separator": {
+      "type": "object",
+      "properties": {
+        "bleed": {
+          "type": "boolean"
+        },
+        "orientation": {
+          "$ref": "#/$defs/Orientation"
+        }
+      },
+      "required": [
+        "bleed",
+        "orientation"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "separator",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Separator"
+      }
+    },
+    "Side": {
+      "type": "string",
+      "enum": [
+        "start",
+        "end"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Side"
+      }
+    },
+    "Size": {
+      "type": "string",
+      "enum": [
+        "xs",
+        "sm",
+        "md",
+        "lg",
+        "xl",
+        "2xl",
+        "3xl",
+        "4xl"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Size"
+      }
+    },
+    "Stack": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Align"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "direction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StackDirection"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "float": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Side"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gap": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Gap"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "height": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Height"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "justify": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Justify"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "width": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Width"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "align",
+        "direction",
+        "float",
+        "gap",
+        "height",
+        "justify",
+        "width"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "stack",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Stack"
+      }
+    },
+    "StackDirection": {
+      "type": "string",
+      "enum": [
+        "row",
+        "column"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\StackDirection"
+      }
+    },
+    "Tab": {
+      "type": "object",
+      "properties": {
+        "confirm": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "redirectUrl": {
+                  "type": "string"
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "timeout": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "redirectUrl",
+                "required",
+                "timeout"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "confirm",
+        "label",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tab",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Tab"
+      }
+    },
+    "Tabs": {
+      "type": "object",
+      "properties": {
+        "activeValue": {
+          "type": "string"
+        },
+        "alignment": {
+          "$ref": "#/$defs/TabsAlignment"
+        },
+        "defaultValue": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orientation": {
+          "$ref": "#/$defs/Orientation"
+        },
+        "queryKey": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "activeValue",
+        "alignment",
+        "defaultValue",
+        "orientation",
+        "queryKey"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tabs",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Tabs"
+      }
+    },
+    "TabsAlignment": {
+      "type": "string",
+      "enum": [
+        "start",
+        "center",
+        "end",
+        "stretch"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\TabsAlignment"
+      }
+    },
+    "Text": {
+      "type": "object",
+      "properties": {
+        "align": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Align"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "color": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "dark": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "readOnly": true
+                },
+                "kind": {
+                  "$ref": "#/$defs/ColorKind",
+                  "readOnly": true
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true
+                }
+              },
+              "required": [
+                "dark",
+                "kind",
+                "value"
+              ],
+              "x-lattice": {
+                "kind": "value-object",
+                "php": "Lattice\\Core\\Color"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "copyable": {
+          "type": "boolean"
+        },
+        "size": {
+          "$ref": "#/$defs/Size"
+        },
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "align",
+        "color",
+        "copyable",
+        "size",
+        "text"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "text",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Text"
+      }
+    },
+    "TextEntry": {
+      "type": "object",
+      "properties": {
+        "copyable": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "placeholder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {}
+      },
+      "required": [
+        "copyable",
+        "description",
+        "label",
+        "name",
+        "placeholder",
+        "value"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "entry.text",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Entries\\TextEntry"
+      }
+    },
+    "Toast": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Node"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "dismissible": {
+          "type": "boolean"
+        },
+        "duration": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "message": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Translatable"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "persistent": {
+          "type": "boolean"
+        },
+        "variant": {
+          "$ref": "#/$defs/Variant"
+        }
+      },
+      "required": [
+        "action",
+        "dismissible",
+        "duration",
+        "message",
+        "persistent",
+        "variant"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "toast",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\Toast"
+      }
+    },
+    "ToggleSidebar": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "readOnly": true
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "effect",
+        "wireType": "toggle-sidebar",
+        "php": "Lattice\\Ui\\Effects\\Builtin\\ToggleSidebar"
+      }
+    },
+    "Tooltip": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trigger": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Node"
+          }
+        }
+      },
+      "required": [
+        "content",
+        "trigger"
+      ],
+      "x-lattice": {
+        "kind": "props",
+        "family": "component",
+        "wireType": "tooltip",
+        "domain": "Ui",
+        "php": "Lattice\\Ui\\Components\\Tooltip"
+      }
+    },
+    "Translatable": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "payload": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "replacements": {
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "boolean",
+              "number",
+              "integer",
+              "string"
+            ]
+          }
+        }
+      },
+      "required": [
+        "key",
+        "payload",
+        "replacements"
+      ],
+      "x-lattice": {
+        "kind": "value-object",
+        "php": "Lattice\\Ui\\I18n\\Values\\Translatable"
+      }
+    },
+    "Variant": {
+      "type": "string",
+      "enum": [
+        "primary",
+        "secondary",
+        "success",
+        "info",
+        "warning",
+        "danger"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Variant"
+      }
+    },
+    "Width": {
+      "type": "string",
+      "enum": [
+        "full",
+        "auto",
+        "sm",
+        "md",
+        "lg",
+        "fill"
+      ],
+      "x-lattice": {
+        "kind": "enum",
+        "php": "Lattice\\Ui\\Enums\\Width"
+      }
+    },
+    "effect:callout": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "callout"
+        },
+        "props": {
+          "$ref": "#/$defs/Callout"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "callout"
+      }
+    },
+    "effect:close-modal": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "close-modal"
+        },
+        "props": {
+          "$ref": "#/$defs/CloseModal"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "close-modal"
+      }
+    },
+    "effect:download": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "download"
+        },
+        "props": {
+          "$ref": "#/$defs/Download"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "download"
+      }
+    },
+    "effect:locale-change": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "locale-change"
+        },
+        "props": {
+          "$ref": "#/$defs/LocaleChange"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "locale-change"
+      }
+    },
+    "effect:open-modal": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "open-modal"
+        },
+        "props": {
+          "$ref": "#/$defs/OpenModal"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "open-modal"
+      }
+    },
+    "effect:redirect": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "redirect"
+        },
+        "props": {
+          "$ref": "#/$defs/Redirect"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "redirect"
+      }
+    },
+    "effect:reload-component": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "reload-component"
+        },
+        "props": {
+          "$ref": "#/$defs/ReloadComponent"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "reload-component"
+      }
+    },
+    "effect:reload-page": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "reload-page"
+        },
+        "props": {
+          "$ref": "#/$defs/ReloadPage"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "reload-page"
+      }
+    },
+    "effect:reset-form": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "reset-form"
+        },
+        "props": {
+          "$ref": "#/$defs/ResetForm"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "reset-form"
+      }
+    },
+    "effect:retract-callout": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "retract-callout"
+        },
+        "props": {
+          "$ref": "#/$defs/RetractCallout"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "retract-callout"
+      }
+    },
+    "effect:toast": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "toast"
+        },
+        "props": {
+          "$ref": "#/$defs/Toast"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "toast"
+      }
+    },
+    "effect:toggle-sidebar": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "toggle-sidebar"
+        },
+        "props": {
+          "$ref": "#/$defs/ToggleSidebar"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "effect",
+        "wireType": "toggle-sidebar"
+      }
+    },
+    "node:avatar": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "avatar"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Avatar"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "avatar",
+        "php": "Lattice\\Ui\\Components\\Avatar"
+      }
+    },
+    "node:badge": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "badge"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Badge"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "badge",
+        "php": "Lattice\\Ui\\Components\\Badge"
+      }
+    },
+    "node:button": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "button"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Button"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "button",
+        "php": "Lattice\\Ui\\Components\\Button"
+      }
+    },
+    "node:card": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "card"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Card"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "card",
+        "php": "Lattice\\Ui\\Components\\Card"
+      }
+    },
+    "node:chart": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "chart"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Chart"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "chart",
+        "php": "Lattice\\Ui\\Components\\Chart"
+      }
+    },
+    "node:code-block": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "code-block"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/CodeBlock"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "code-block",
+        "php": "Lattice\\Ui\\Components\\CodeBlock"
+      }
+    },
+    "node:collapsible": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "collapsible"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Collapsible"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "collapsible",
+        "php": "Lattice\\Ui\\Components\\Collapsible"
+      }
+    },
+    "node:description-list": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "description-list"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DescriptionList"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "description-list",
+        "php": "Lattice\\Ui\\Components\\DescriptionList"
+      }
+    },
+    "node:entry.badge": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.badge"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BadgeEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.badge",
+        "php": "Lattice\\Ui\\Components\\Entries\\BadgeEntry"
+      }
+    },
+    "node:entry.boolean": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/BooleanEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.boolean",
+        "php": "Lattice\\Ui\\Components\\Entries\\BooleanEntry"
+      }
+    },
+    "node:entry.component": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.component"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/ComponentEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.component",
+        "php": "Lattice\\Ui\\Components\\Entries\\ComponentEntry"
+      }
+    },
+    "node:entry.date": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.date"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/DateEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.date",
+        "php": "Lattice\\Ui\\Components\\Entries\\DateEntry"
+      }
+    },
+    "node:entry.text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "entry.text"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/TextEntry"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "entry.text",
+        "php": "Lattice\\Ui\\Components\\Entries\\TextEntry"
+      }
+    },
+    "node:floating-panel": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "floating-panel"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/FloatingPanel"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "floating-panel",
+        "php": "Lattice\\Ui\\Components\\FloatingPanel"
+      }
+    },
+    "node:grid": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "grid"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Grid"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "grid",
+        "php": "Lattice\\Ui\\Components\\Grid"
+      }
+    },
+    "node:heading": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "heading"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Heading"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "heading",
+        "php": "Lattice\\Ui\\Components\\Heading"
+      }
+    },
+    "node:icon": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "icon"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Icon"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "icon",
+        "php": "Lattice\\Ui\\Components\\Icon"
+      }
+    },
+    "node:image": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "image"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Image"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "image",
+        "php": "Lattice\\Ui\\Components\\Image"
+      }
+    },
+    "node:link": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "link"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Link"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "link",
+        "php": "Lattice\\Ui\\Components\\Link"
+      }
+    },
+    "node:modal": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "modal"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Modal"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "modal",
+        "php": "Lattice\\Ui\\Components\\Modal"
+      }
+    },
+    "node:progress": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "progress"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Progress"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "progress",
+        "php": "Lattice\\Ui\\Components\\Progress"
+      }
+    },
+    "node:raw-block": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "raw-block"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/RawBlock"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "raw-block",
+        "php": "Lattice\\Ui\\Components\\RawBlock"
+      }
+    },
+    "node:section": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "section"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Section"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "section",
+        "php": "Lattice\\Ui\\Components\\Section"
+      }
+    },
+    "node:segmented-control": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "segmented-control"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/SegmentedControl"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "segmented-control",
+        "php": "Lattice\\Ui\\Components\\SegmentedControl"
+      }
+    },
+    "node:separator": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "separator"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Separator"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "separator",
+        "php": "Lattice\\Ui\\Components\\Separator"
+      }
+    },
+    "node:stack": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "stack"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Stack"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "stack",
+        "php": "Lattice\\Ui\\Components\\Stack"
+      }
+    },
+    "node:tab": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tab"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tab"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tab",
+        "php": "Lattice\\Ui\\Components\\Tab"
+      }
+    },
+    "node:tabs": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tabs"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tabs"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tabs",
+        "php": "Lattice\\Ui\\Components\\Tabs"
+      }
+    },
+    "node:text": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "text"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Text"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "text",
+        "php": "Lattice\\Ui\\Components\\Text"
+      }
+    },
+    "node:tooltip": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "tooltip"
+        },
+        "id": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "props": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Tooltip"
+            },
+            {
+              "$ref": "#/$defs/CommonNodeProps"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "#/$defs/Schema"
+        }
+      },
+      "required": [
+        "type",
+        "props"
+      ],
+      "x-lattice": {
+        "kind": "strict",
+        "family": "component",
+        "wireType": "tooltip",
+        "php": "Lattice\\Ui\\Components\\Tooltip"
+      }
+    }
+  },
+  "x-lattice": {
+    "domains": {
+      "UiNodeType": [
+        "avatar",
+        "badge",
+        "button",
+        "card",
+        "chart",
+        "code-block",
+        "collapsible",
+        "description-list",
+        "entry.badge",
+        "entry.boolean",
+        "entry.component",
+        "entry.date",
+        "entry.text",
+        "floating-panel",
+        "grid",
+        "heading",
+        "icon",
+        "image",
+        "link",
+        "modal",
+        "progress",
+        "raw-block",
+        "section",
+        "segmented-control",
+        "separator",
+        "stack",
+        "tab",
+        "tabs",
+        "text",
+        "tooltip"
+      ],
+      "NodeType": [
+        "avatar",
+        "badge",
+        "button",
+        "card",
+        "chart",
+        "code-block",
+        "collapsible",
+        "description-list",
+        "entry.badge",
+        "entry.boolean",
+        "entry.component",
+        "entry.date",
+        "entry.text",
+        "floating-panel",
+        "grid",
+        "heading",
+        "icon",
+        "image",
+        "link",
+        "modal",
+        "progress",
+        "raw-block",
+        "section",
+        "segmented-control",
+        "separator",
+        "stack",
+        "tab",
+        "tabs",
+        "text",
+        "tooltip"
+      ]
+    },
+    "families": {
+      "component": {
+        "envelope": "Node",
+        "strict": "#/$defs/ComponentNode",
+        "propsInterface": "ComponentProps",
+        "propsMap": "ComponentPropsMap",
+        "types": {
+          "avatar": {
+            "node": "#/$defs/node:avatar",
+            "props": "#/$defs/Avatar",
+            "domain": "Ui"
+          },
+          "badge": {
+            "node": "#/$defs/node:badge",
+            "props": "#/$defs/Badge",
+            "domain": "Ui"
+          },
+          "button": {
+            "node": "#/$defs/node:button",
+            "props": "#/$defs/Button",
+            "domain": "Ui"
+          },
+          "card": {
+            "node": "#/$defs/node:card",
+            "props": "#/$defs/Card",
+            "domain": "Ui",
+            "container": true
+          },
+          "chart": {
+            "node": "#/$defs/node:chart",
+            "props": "#/$defs/Chart",
+            "domain": "Ui"
+          },
+          "code-block": {
+            "node": "#/$defs/node:code-block",
+            "props": "#/$defs/CodeBlock",
+            "domain": "Ui"
+          },
+          "collapsible": {
+            "node": "#/$defs/node:collapsible",
+            "props": "#/$defs/Collapsible",
+            "domain": "Ui",
+            "container": true
+          },
+          "description-list": {
+            "node": "#/$defs/node:description-list",
+            "props": "#/$defs/DescriptionList",
+            "domain": "Ui",
+            "container": true
+          },
+          "entry.badge": {
+            "node": "#/$defs/node:entry.badge",
+            "props": "#/$defs/BadgeEntry",
+            "domain": "Ui",
+            "container": true
+          },
+          "entry.boolean": {
+            "node": "#/$defs/node:entry.boolean",
+            "props": "#/$defs/BooleanEntry",
+            "domain": "Ui",
+            "container": true
+          },
+          "entry.component": {
+            "node": "#/$defs/node:entry.component",
+            "props": "#/$defs/ComponentEntry",
+            "domain": "Ui",
+            "container": true
+          },
+          "entry.date": {
+            "node": "#/$defs/node:entry.date",
+            "props": "#/$defs/DateEntry",
+            "domain": "Ui",
+            "container": true
+          },
+          "entry.text": {
+            "node": "#/$defs/node:entry.text",
+            "props": "#/$defs/TextEntry",
+            "domain": "Ui",
+            "container": true
+          },
+          "floating-panel": {
+            "node": "#/$defs/node:floating-panel",
+            "props": "#/$defs/FloatingPanel",
+            "domain": "Ui",
+            "container": true
+          },
+          "grid": {
+            "node": "#/$defs/node:grid",
+            "props": "#/$defs/Grid",
+            "domain": "Ui",
+            "container": true
+          },
+          "heading": {
+            "node": "#/$defs/node:heading",
+            "props": "#/$defs/Heading",
+            "domain": "Ui"
+          },
+          "icon": {
+            "node": "#/$defs/node:icon",
+            "props": "#/$defs/Icon",
+            "domain": "Ui"
+          },
+          "image": {
+            "node": "#/$defs/node:image",
+            "props": "#/$defs/Image",
+            "domain": "Ui"
+          },
+          "link": {
+            "node": "#/$defs/node:link",
+            "props": "#/$defs/Link",
+            "domain": "Ui"
+          },
+          "modal": {
+            "node": "#/$defs/node:modal",
+            "props": "#/$defs/Modal",
+            "domain": "Ui",
+            "container": true,
+            "interactive": true
+          },
+          "progress": {
+            "node": "#/$defs/node:progress",
+            "props": "#/$defs/Progress",
+            "domain": "Ui"
+          },
+          "raw-block": {
+            "node": "#/$defs/node:raw-block",
+            "props": "#/$defs/RawBlock",
+            "domain": "Ui"
+          },
+          "section": {
+            "node": "#/$defs/node:section",
+            "props": "#/$defs/Section",
+            "domain": "Ui",
+            "container": true
+          },
+          "segmented-control": {
+            "node": "#/$defs/node:segmented-control",
+            "props": "#/$defs/SegmentedControl",
+            "domain": "Ui"
+          },
+          "separator": {
+            "node": "#/$defs/node:separator",
+            "props": "#/$defs/Separator",
+            "domain": "Ui"
+          },
+          "stack": {
+            "node": "#/$defs/node:stack",
+            "props": "#/$defs/Stack",
+            "domain": "Ui",
+            "container": true
+          },
+          "tab": {
+            "node": "#/$defs/node:tab",
+            "props": "#/$defs/Tab",
+            "domain": "Ui",
+            "container": true
+          },
+          "tabs": {
+            "node": "#/$defs/node:tabs",
+            "props": "#/$defs/Tabs",
+            "domain": "Ui",
+            "container": true
+          },
+          "text": {
+            "node": "#/$defs/node:text",
+            "props": "#/$defs/Text",
+            "domain": "Ui"
+          },
+          "tooltip": {
+            "node": "#/$defs/node:tooltip",
+            "props": "#/$defs/Tooltip",
+            "domain": "Ui"
+          }
+        }
+      },
+      "effect": {
+        "envelope": "Effect",
+        "strict": "#/$defs/EffectStrict",
+        "propsInterface": "EffectProps",
+        "propsMap": "EffectPropsMap",
+        "types": {
+          "callout": {
+            "node": "#/$defs/effect:callout",
+            "props": "#/$defs/Callout"
+          },
+          "close-modal": {
+            "node": "#/$defs/effect:close-modal",
+            "props": "#/$defs/CloseModal"
+          },
+          "download": {
+            "node": "#/$defs/effect:download",
+            "props": "#/$defs/Download"
+          },
+          "locale-change": {
+            "node": "#/$defs/effect:locale-change",
+            "props": "#/$defs/LocaleChange"
+          },
+          "open-modal": {
+            "node": "#/$defs/effect:open-modal",
+            "props": "#/$defs/OpenModal"
+          },
+          "redirect": {
+            "node": "#/$defs/effect:redirect",
+            "props": "#/$defs/Redirect"
+          },
+          "reload-component": {
+            "node": "#/$defs/effect:reload-component",
+            "props": "#/$defs/ReloadComponent"
+          },
+          "reload-page": {
+            "node": "#/$defs/effect:reload-page",
+            "props": "#/$defs/ReloadPage"
+          },
+          "reset-form": {
+            "node": "#/$defs/effect:reset-form",
+            "props": "#/$defs/ResetForm"
+          },
+          "retract-callout": {
+            "node": "#/$defs/effect:retract-callout",
+            "props": "#/$defs/RetractCallout"
+          },
+          "toast": {
+            "node": "#/$defs/effect:toast",
+            "props": "#/$defs/Toast"
+          },
+          "toggle-sidebar": {
+            "node": "#/$defs/effect:toggle-sidebar",
+            "props": "#/$defs/ToggleSidebar"
+          }
+        }
+      },
+      "editor-extension": {
+        "envelope": "EditorExtension",
+        "strict": "#/$defs/EditorExtensionStrict",
+        "propsInterface": "EditorExtensionProps",
+        "propsMap": "EditorExtensionPropsMap",
+        "types": {}
+      },
+      "column": {
+        "envelope": "ColumnNode",
+        "strict": "#/$defs/ColumnNodeStrict",
+        "propsInterface": "ColumnProps",
+        "propsMap": "ColumnPropsMap",
+        "types": {}
+      },
+      "filter": {
+        "envelope": "FilterNode",
+        "strict": "#/$defs/FilterNodeStrict",
+        "propsInterface": "FilterProps",
+        "propsMap": "FilterPropsMap",
+        "types": {}
+      }
+    }
+  }
+}

--- a/tests/Feature/Schema/FlatSchemaDocumentsTest.php
+++ b/tests/Feature/Schema/FlatSchemaDocumentsTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+use Opis\JsonSchema\Validator;
+
+/**
+ * @return list<string>
+ */
+function committedSchemaPaths(): array
+{
+    return glob(dirname(__DIR__, 3).'/packages/*/resources/schema/*.schema.json') ?: [];
+}
+
+it('commits every per-package schema file without a single cross-document $ref', function (): void {
+    foreach (committedSchemaPaths() as $path) {
+        $json = (string) file_get_contents($path);
+
+        expect($json)->not->toContain('https://lattice-php.dev/schema/', basename($path).' contains a cross-document $ref');
+    }
+})->skip(fn (): bool => committedSchemaPaths() === [], 'no committed schema files found');
+
+it('validates a real node payload against the committed table.schema.json standalone, with no other file registered', function (): void {
+    $path = dirname(__DIR__, 3).'/packages/table/resources/schema/table.schema.json';
+    $document = json_decode((string) file_get_contents($path), true);
+
+    $validator = new Validator;
+    $validator->resolver()?->registerRaw(json_decode((string) file_get_contents($path)), $document['$id']);
+
+    $result = $validator->validate(
+        json_decode((string) json_encode([
+            'type' => 'column.boolean',
+            'key' => 'active',
+            'props' => [
+                'align' => 'start', 'filter' => null, 'hiddenByDefault' => false,
+                'label' => 'Active', 'options' => [], 'sortable' => true, 'toggleable' => true, 'width' => 'md',
+            ],
+        ])),
+        $document['$id'].'#/$defs/column:column.boolean',
+    );
+
+    expect($result->isValid())->toBeTrue();
+});
+
+it('carries its own copy of the envelope core in every file that references node-shaped props', function (): void {
+    foreach (committedSchemaPaths() as $path) {
+        $json = (string) file_get_contents($path);
+        $document = json_decode($json, true);
+
+        if (! str_contains($json, '"$ref":"#/$defs/Node"') && ! str_contains($json, '"$ref": "#/$defs/Node"')) {
+            continue;
+        }
+
+        expect($document['$defs'])->toHaveKeys(['Node', 'Schema'], basename($path).' references Node without carrying the envelope core');
+    }
+})->skip(fn (): bool => committedSchemaPaths() === [], 'no committed schema files found');
+
+it('inlines a cross-package value object directly into a component/column/filter def instead of leaving a pointer', function (): void {
+    $path = dirname(__DIR__, 3).'/packages/table/resources/schema/table.schema.json';
+    $document = json_decode((string) file_get_contents($path), true);
+
+    $colors = $document['$defs']['BadgeColumn']['properties']['colors'];
+
+    expect(json_encode($colors))->toContain('Lattice\\\\Core\\\\Color')
+        ->and($document['$defs'])->not->toHaveKey('Color');
+});

--- a/tests/Feature/Schema/PackageDocumentsTest.php
+++ b/tests/Feature/Schema/PackageDocumentsTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Core\Wire\WireModelBuilder;
+
+it('emits one document per wire package, restricted to that package\'s own classes', function (): void {
+    $documents = app(WireModelBuilder::class)->buildAll(includeFrameworkEnvelope: true)['documents'];
+
+    expect($documents)->toHaveKeys(['lattice', 'core', 'ui', 'action', 'form', 'table'])
+        ->and($documents['table']['$id'])->toBe('https://lattice-php.dev/schema/table/v1.json')
+        ->and($documents['table']['$defs'])->not->toHaveKey('Color');
+});
+
+it('points a foreign class at a local pointer the internal document itself cannot resolve', function (): void {
+    $documents = app(WireModelBuilder::class)->buildAll(includeFrameworkEnvelope: true)['documents'];
+
+    $json = (string) json_encode($documents['table']['$defs'], JSON_UNESCAPED_SLASHES);
+
+    expect($json)->toContain('"$ref":"#/$defs/Color"')
+        ->and($json)->not->toContain('https://lattice-php.dev/schema/');
+});
+
+it('keeps PagePayload, envelopes, and the remote-manifest contract in the lattice document only', function (): void {
+    $documents = app(WireModelBuilder::class)->buildAll(includeFrameworkEnvelope: true)['documents'];
+    $lattice = $documents['lattice'];
+
+    expect($lattice['$defs'])->toHaveKeys(['PagePayload', 'Node', 'ColumnNode', 'FilterNode', 'Schema', 'CommonNodeProps', 'ComponentNode', 'RemoteManifest'])
+        ->and($lattice['x-lattice']['families'])->toHaveKeys(['component', 'effect', 'editor-extension', 'column', 'filter']);
+
+    foreach ($documents as $shortName => $document) {
+        if ($shortName === 'lattice') {
+            continue;
+        }
+
+        expect($document['$defs'])->not->toHaveKey('PagePayload')
+            ->and($document['$defs'])->not->toHaveKey('Node');
+    }
+});
+
+it('emits a schema document for tree from its own discover dirs', function (): void {
+    $documents = app(WireModelBuilder::class)->buildAll(includeFrameworkEnvelope: true)['documents'];
+
+    expect($documents)->toHaveKey('tree')
+        ->and($documents['tree']['$id'])->toBe('https://lattice-php.dev/schema/tree/v1.json')
+        ->and($documents['tree']['$defs'])->toHaveKeys(['Tree', 'node:tree']);
+
+    $json = (string) json_encode($documents['tree'], JSON_UNESCAPED_SLASHES);
+
+    expect($json)->toContain('"$ref":"#/$defs/CommonNodeProps"');
+});
+
+it('points a node def in another package at the same local pointer form through a nullable prop union', function (): void {
+    $documents = app(WireModelBuilder::class)->buildAll(includeFrameworkEnvelope: true)['documents'];
+
+    $json = (string) json_encode($documents['action'], JSON_UNESCAPED_SLASHES);
+
+    expect($documents['action']['$defs'])->not->toHaveKey('node:form')
+        ->and($json)->toContain('"$ref":"#/$defs/node:form"');
+});

--- a/tests/Feature/Schema/SchemaBundleTest.php
+++ b/tests/Feature/Schema/SchemaBundleTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Core\JsonSchema\SchemaBundler;
+use Lattice\Media\Tables\Filters\MediaTypeFilter;
+use Lattice\Table\Filters\SelectFilter;
+
+it('merges every document\'s $defs directly into the base document, keeping the base\'s other top-level keys', function (): void {
+    $base = ['$schema' => 'https://json-schema.org/draft/2020-12/schema', '$id' => 'https://lattice-php.dev/schema/lattice/v1.json', 'title' => 'Lattice wire protocol', '$defs' => ['Node' => ['type' => 'object']]];
+    $documents = [
+        ['$defs' => ['Button' => ['type' => 'object', 'properties' => []]]],
+        ['$defs' => ['Table' => ['type' => 'object', 'properties' => []]]],
+    ];
+
+    $bundle = new SchemaBundler()->bundle($base, $documents);
+
+    expect($bundle['$id'])->toBe('https://lattice-php.dev/schema/lattice/v1.json')
+        ->and($bundle['title'])->toBe('Lattice wire protocol')
+        ->and($bundle['$defs'])->toHaveKeys(['Node', 'Button', 'Table']);
+});
+
+it('collapses an identical def recurring across documents silently, the envelope core case', function (): void {
+    $node = ['type' => 'object', 'properties' => ['schema' => ['$ref' => '#/$defs/Schema']]];
+    $base = ['$defs' => []];
+    $documents = [
+        ['$defs' => ['Node' => $node]],
+        ['$defs' => ['Node' => $node]],
+    ];
+
+    $bundle = new SchemaBundler()->bundle($base, $documents);
+
+    expect($bundle['$defs']['Node'])->toBe($node);
+});
+
+it('keeps whichever document is processed first when two classes declare the same strict wire type', function (): void {
+    $tableFilter = ['type' => 'object', 'properties' => ['type' => ['const' => 'filter.select']], 'x-lattice' => ['kind' => 'strict', 'php' => SelectFilter::class]];
+    $mediaFilter = ['type' => 'object', 'properties' => ['type' => ['const' => 'filter.select']], 'x-lattice' => ['kind' => 'strict', 'php' => MediaTypeFilter::class]];
+    $base = ['$defs' => []];
+    $documents = [
+        ['$defs' => ['filter:filter.select' => $tableFilter]],
+        ['$defs' => ['filter:filter.select' => $mediaFilter]],
+    ];
+
+    $bundle = new SchemaBundler()->bundle($base, $documents);
+
+    expect($bundle['$defs']['filter:filter.select'])->toBe($tableFilter);
+});
+
+it('throws when two unrelated defs claim the same name outside the known strict-collision case', function (): void {
+    $base = ['$defs' => []];
+    $documents = [
+        ['$defs' => ['Button' => ['type' => 'object', 'x-lattice' => ['kind' => 'value-object', 'php' => 'App\First']]]],
+        ['$defs' => ['Button' => ['type' => 'string', 'x-lattice' => ['kind' => 'enum', 'php' => 'App\Second']]]],
+    ];
+
+    new SchemaBundler()->bundle($base, $documents);
+})->throws(LogicException::class, 'Schema definition name [Button] is claimed by two different defs');

--- a/tests/Feature/Schema/SchemaCommandTest.php
+++ b/tests/Feature/Schema/SchemaCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Lattice\Core\Wire\WireSource;
+use Lattice\Core\Wire\WireSourceCatalog;
+use Lattice\Support\Schema\ExportSchemaProfile;
+use Lattice\Support\Schema\SchemaProfile;
+
+use function Pest\Laravel\artisan;
+
+// Restore the default profile; the workbench binds BaseSchemaProfile.
+beforeEach(function (): void {
+    app()->bind(SchemaProfile::class, ExportSchemaProfile::class);
+});
+
+it('merges the app\'s own document directly into the flat bundle, marked with x-lattice.origin app', function (): void {
+    withScaffoldWorkspace(function (): void {
+        $output = base_path('lattice.schema.json');
+
+        config()->set('lattice.schema.output', $output);
+        bindAppWireSource(dirname(__DIR__, 2).'/Fixtures/TypeScript');
+
+        artisan('lattice:schema')->assertSuccessful();
+
+        $document = json_decode((string) file_get_contents($output), true);
+
+        expect($document['$id'])->toBe('https://lattice-php.dev/schema/lattice/v1.json')
+            ->and($document['$defs'])->toHaveKeys(['SampleComponent', 'node:sample.widget', 'Button'])
+            ->and($document['$defs']['SampleComponent']['x-lattice']['origin'])->toBe('app')
+            ->and($document['$defs']['Button'])->not->toHaveKey('origin');
+    });
+});
+
+it('merges every installed wire package directly into the flat bundle when no root source is declared', function (): void {
+    withScaffoldWorkspace(function (): void {
+        $output = base_path('lattice.schema.json');
+
+        config()->set('lattice.schema.output', $output);
+
+        artisan('lattice:schema')->assertSuccessful();
+
+        $document = json_decode((string) file_get_contents($output), true);
+
+        expect($document['$defs'])->toHaveKeys(['Signature', 'Button', 'Table'])
+            ->and($document['$defs'])->not->toHaveKey('SampleComponent');
+    });
+});
+
+it('merges an installed package\'s COMMITTED schema file, never reflecting its vendor PHP', function (): void {
+    withScaffoldWorkspace(function (): void {
+        $output = base_path('lattice.schema.json');
+
+        config()->set('lattice.schema.output', $output);
+
+        $catalog = WireSourceCatalog::fromApplication();
+        $table = collect($catalog->discover())->firstWhere('shortName', 'table');
+
+        if (! $table instanceof WireSource) {
+            throw new RuntimeException('The table wire source was not discovered.');
+        }
+
+        $original = File::get($table->schemaPath());
+
+        try {
+            // Adds a def, doesn't touch or remove any existing one: framework's
+            // own committed lattice.schema.json is itself already the full flat
+            // merge (built once, at release time), so it independently carries
+            // a copy of table's OTHER defs too — the merge is per-def, not
+            // per-package, so it can't "erase" what framework's base already
+            // has. Only an ADDITION unambiguously proves the read came from
+            // table's fresh committed file (no PHP class named "Doctored"
+            // could ever be reflected into existence).
+            $doctored = json_decode($original, true);
+            $doctored['$defs']['Doctored'] = ['type' => 'string'];
+            File::put($table->schemaPath(), (string) json_encode($doctored));
+
+            artisan('lattice:schema')->assertSuccessful();
+
+            $document = json_decode((string) file_get_contents($output), true);
+
+            expect($document['$defs'])->toHaveKey('Doctored');
+        } finally {
+            File::put($table->schemaPath(), $original);
+        }
+    });
+});

--- a/tests/Feature/Schema/SchemaDocumentSnapshotTest.php
+++ b/tests/Feature/Schema/SchemaDocumentSnapshotTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+
+use function Pest\Laravel\artisan;
+
+it('keeps every committed .schema.json in sync with the builder', function (): void {
+    $root = dirname(__DIR__, 3);
+    $output = sys_get_temp_dir().'/lattice-package-tests/wire-schema-'.getmypid();
+
+    config()->set('lattice.schema.base_output', $output);
+
+    try {
+        artisan('lattice:schema')->assertSuccessful();
+
+        expect(file_get_contents($output.'/lattice.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/framework/resources/schema/lattice.schema.json'));
+        expect(file_get_contents($output.'/core/core.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/core/resources/schema/core.schema.json'));
+        expect(file_get_contents($output.'/ui/ui.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/ui/resources/schema/ui.schema.json'));
+        expect(file_get_contents($output.'/form/form.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/form/resources/schema/form.schema.json'));
+        expect(file_get_contents($output.'/table/table.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/table/resources/schema/table.schema.json'));
+        expect(file_get_contents($output.'/action/action.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/action/resources/schema/action.schema.json'));
+        expect(file_get_contents($output.'/media/media.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/media/resources/schema/media.schema.json'));
+        expect(file_get_contents($output.'/tree/tree.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/tree/resources/schema/tree.schema.json'));
+        expect(file_get_contents($output.'/calendar/calendar.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/calendar/resources/schema/calendar.schema.json'));
+        expect(file_get_contents($output.'/search/search.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/search/resources/schema/search.schema.json'));
+        expect(file_get_contents($output.'/api-reference/api-reference.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/api-reference/resources/schema/api-reference.schema.json'));
+        expect(file_get_contents($output.'/signature-example/signature-example.schema.json'))
+            ->toBe(file_get_contents($root.'/packages/signature-example/resources/schema/signature-example.schema.json'));
+    } finally {
+        File::deleteDirectory($output);
+    }
+});

--- a/tests/Feature/Schema/SchemaDocumentTest.php
+++ b/tests/Feature/Schema/SchemaDocumentTest.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+use Opis\JsonSchema\Validator;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+/**
+ * @return array<string, mixed>
+ */
+function schemaDocument(): array
+{
+    static $document = null;
+
+    return $document ??= json_decode(
+        (string) file_get_contents(dirname(__DIR__, 3).'/packages/framework/resources/schema/lattice.schema.json'),
+        true,
+    );
+}
+
+function schemaValidator(): Validator
+{
+    $document = schemaDocument();
+    $validator = new Validator;
+    $validator->resolver()?->registerRaw(
+        json_decode((string) json_encode($document)),
+        $document['$id'],
+    );
+
+    return $validator;
+}
+
+/**
+ * @param  string  $pointer  a bare `$defs` key — the merged document is flat, so every def is directly addressable
+ */
+function validateAgainst(string $pointer, mixed $data): bool
+{
+    return schemaValidator()
+        ->validate(json_decode((string) json_encode($data)), schemaDocument()['$id'].'#/$defs/'.$pointer)
+        ->isValid();
+}
+
+it('validates a real workbench page payload against the PagePayload entry point', function (): void {
+    withoutVite();
+    $this->actingAs(workbenchTestUser());
+
+    $page = get('/')->assertOk()->viewData('page');
+
+    expect(validateAgainst('PagePayload', $page['props']['lattice']))->toBeTrue();
+});
+
+it('accepts a well-formed remote manifest', function (): void {
+    $manifest = [
+        [
+            'type' => 'remote.data-list',
+            'id' => 'todos',
+            'props' => ['audience' => 'todos-api', 'dataEndpoint' => 'https://api.example.com/todos'],
+            'schema' => [
+                ['type' => 'badge', 'props' => ['label' => 'Open']],
+            ],
+        ],
+    ];
+
+    expect(validateAgainst('RemoteManifest', $manifest))->toBeTrue()
+        ->and(validateAgainst('RemoteManifest', ['version' => 1, 'schema' => $manifest]))->toBeTrue();
+});
+
+it('rejects a remote manifest smuggling server-trusted props or missing its audience', function (): void {
+    $forbiddenRef = [[
+        'type' => 'remote.data-list',
+        'id' => 'todos',
+        'props' => ['audience' => 'todos-api', 'ref' => 'forged'],
+    ]];
+
+    $missingAudience = [[
+        'type' => 'remote.data-list',
+        'id' => 'todos',
+        'props' => ['dataEndpoint' => 'https://api.example.com/todos'],
+    ]];
+
+    expect(validateAgainst('RemoteManifest', $forbiddenRef))->toBeFalse()
+        ->and(validateAgainst('RemoteManifest', $missingAudience))->toBeFalse();
+});
+
+it('rejects a node whose props violate its type schema', function (): void {
+    expect(validateAgainst('node:button', [
+        'type' => 'button',
+        'props' => ['label' => 'Save'],
+    ]))->toBeFalse()
+        ->and(validateAgainst('ComponentNode', [
+            'type' => 'not-a-real-type',
+            'props' => [],
+        ]))->toBeFalse();
+});
+
+it('covers every type the generated TypeScript module exports', function (): void {
+    $document = schemaDocument();
+    $defs = $document['$defs'];
+
+    $generated = (string) file_get_contents(dirname(__DIR__, 3).'/packages/framework/resources/js/types/generated.ts');
+
+    preg_match_all('/^export type (\w+)/m', $generated, $matches);
+
+    $synthesized = array_keys($document['x-lattice']['domains']);
+
+    foreach ($document['x-lattice']['families'] as $family) {
+        $synthesized[] = $family['propsMap'];
+    }
+
+    $allowed = [...array_keys($defs), ...$synthesized];
+    $missing = array_diff($matches[1], $allowed);
+
+    expect(array_values($missing))->toBe([]);
+});

--- a/tests/Unit/Core/JsonSchema/FlatProjectionTest.php
+++ b/tests/Unit/Core/JsonSchema/FlatProjectionTest.php
@@ -1,0 +1,156 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Core\JsonSchema\FlatProjection;
+
+it('inlines value objects and enums into component props', function (): void {
+    $universe = [
+        'Color' => ['type' => 'object', 'properties' => ['kind' => ['enum' => ['named', 'css']]]],
+        'BadgeProps' => ['type' => 'object', 'properties' => ['color' => ['$ref' => '#/$defs/Color']]],
+    ];
+    $doc = ['$id' => 'x', '$defs' => ['BadgeProps' => $universe['BadgeProps']]];
+
+    $projected = new FlatProjection()->project($doc, $universe);
+
+    expect($projected['$defs']['BadgeProps']['properties']['color']['properties']['kind']['enum'])
+        ->toBe(['named', 'css'])
+        ->and(json_encode($projected))->not->toContain('Color');
+});
+
+it('keeps recursive envelope defs as intra-document refs', function (): void {
+    $universe = ['Node' => ['type' => 'object', 'properties' => ['children' => ['items' => ['$ref' => '#/$defs/Node']]]]];
+    $doc = ['$id' => 'x', '$defs' => ['CardProps' => ['properties' => ['body' => ['$ref' => '#/$defs/Node']]]]];
+
+    $projected = new FlatProjection()->project($doc, $universe);
+
+    expect($projected['$defs']['CardProps']['properties']['body'])->toBe(['$ref' => '#/$defs/Node'])
+        ->and($projected['$defs'])->toHaveKey('Node');
+});
+
+it('resolves cross-document refs from the universe and inlines them', function (): void {
+    $universe = [
+        'Op' => ['type' => 'string', 'enum' => ['eq', 'neq']],
+        'FilterProps' => ['type' => 'object', 'properties' => ['operator' => ['$ref' => 'https://lattice-php.dev/schema/core/v1.json#/$defs/Op']]],
+    ];
+    $doc = ['$id' => 'x', '$defs' => ['FilterProps' => $universe['FilterProps']]];
+
+    $projected = new FlatProjection()->project($doc, $universe);
+
+    expect($projected['$defs']['FilterProps']['properties']['operator'])->toBe(['type' => 'string', 'enum' => ['eq', 'neq']])
+        ->and(json_encode($projected))->not->toContain('https://lattice-php.dev/schema/');
+});
+
+it('detects indirect cycles dynamically and falls back to an intra-document ref', function (): void {
+    $universe = [
+        'A' => ['type' => 'object', 'properties' => ['b' => ['$ref' => '#/$defs/B']]],
+        'B' => ['type' => 'object', 'properties' => ['a' => ['$ref' => '#/$defs/A']]],
+    ];
+    $doc = ['$id' => 'x', '$defs' => ['RootProps' => ['properties' => ['start' => ['$ref' => '#/$defs/A']]]]];
+
+    $projected = new FlatProjection()->project($doc, $universe);
+
+    expect($projected['$defs']['RootProps']['properties']['start'])->toBe(['$ref' => '#/$defs/A'])
+        ->and($projected['$defs']['A']['properties']['b']['properties']['a'])->toBe(['$ref' => '#/$defs/A'])
+        ->and($projected['$defs'])->toHaveKey('A');
+});
+
+it('keeps $ref sibling keywords like readOnly when a ref is inlined', function (): void {
+    $universe = ['SortDirection' => ['type' => 'string', 'enum' => ['asc', 'desc']]];
+    $doc = ['$id' => 'x', '$defs' => ['SortProps' => ['properties' => ['direction' => ['$ref' => '#/$defs/SortDirection', 'readOnly' => true]]]]];
+
+    $projected = new FlatProjection()->project($doc, $universe);
+
+    expect($projected['$defs']['SortProps']['properties']['direction'])->toBe([
+        'type' => 'string',
+        'enum' => ['asc', 'desc'],
+        'readOnly' => true,
+    ]);
+});
+
+it('copies a foreign strict node envelope once instead of inlining it at every use site', function (): void {
+    $universe = [
+        'FormProps' => ['type' => 'object', 'properties' => ['label' => ['type' => 'string']]],
+        'node:form' => ['type' => 'object', 'properties' => ['type' => ['const' => 'form'], 'props' => ['$ref' => '#/$defs/FormProps']], 'x-lattice' => ['kind' => 'strict']],
+    ];
+    $doc = ['$id' => 'x', '$defs' => ['ActionProps' => ['properties' => [
+        'target' => ['anyOf' => [['$ref' => '#/$defs/node:form'], ['type' => 'null']]],
+        'fallback' => ['$ref' => '#/$defs/node:form'],
+    ]]]];
+
+    $projected = new FlatProjection()->project($doc, $universe);
+
+    expect($projected['$defs']['ActionProps']['properties']['target']['anyOf'][0])->toBe(['$ref' => '#/$defs/node:form'])
+        ->and($projected['$defs']['ActionProps']['properties']['fallback'])->toBe(['$ref' => '#/$defs/node:form'])
+        ->and($projected['$defs']['node:form']['properties']['props'])->toBe(['type' => 'object', 'properties' => ['label' => ['type' => 'string']]]);
+});
+
+it('copies a foreign props def once so two documents pulling it in agree on its shape', function (): void {
+    $universe = [
+        'HttpMethod' => ['type' => 'string', 'enum' => ['get', 'post'], 'x-lattice' => ['kind' => 'enum']],
+        'Button' => ['type' => 'object', 'properties' => ['method' => ['$ref' => '#/$defs/HttpMethod']], 'x-lattice' => ['kind' => 'props']],
+    ];
+    $docA = ['$id' => 'a', '$defs' => ['ActionProps' => ['properties' => ['button' => ['$ref' => '#/$defs/Button']]]]];
+    $docB = ['$id' => 'b', '$defs' => ['ModalProps' => ['properties' => ['button' => ['$ref' => '#/$defs/Button']]]]];
+
+    $projectedA = new FlatProjection()->project($docA, $universe);
+    $projectedB = new FlatProjection()->project($docB, $universe);
+
+    expect($projectedA['$defs']['ActionProps']['properties']['button'])->toBe(['$ref' => '#/$defs/Button'])
+        ->and($projectedA['$defs']['Button'])->toBe($projectedB['$defs']['Button']);
+});
+
+it('keeps a same-origin sibling of a foreign copy-once def local too, so every puller agrees on its shape', function (): void {
+    $universe = [
+        'Confirmation' => ['type' => 'object', 'properties' => ['label' => ['type' => 'string']]],
+        'Action' => ['type' => 'object', 'properties' => ['confirmation' => ['$ref' => '#/$defs/Confirmation']], 'x-lattice' => ['kind' => 'props']],
+    ];
+    $defOrigins = ['Confirmation' => 'action', 'Action' => 'action'];
+
+    $actionDoc = ['$id' => 'action', '$defs' => ['Action' => $universe['Action'], 'Confirmation' => $universe['Confirmation']]];
+    $latticeDoc = ['$id' => 'lattice', '$defs' => ['ComponentNode' => ['oneOf' => [['$ref' => '#/$defs/Action']]]]];
+
+    $projectedAction = new FlatProjection()->project($actionDoc, $universe, $defOrigins, 'action');
+    $projectedLattice = new FlatProjection()->project($latticeDoc, $universe, $defOrigins, 'lattice');
+
+    expect($projectedAction['$defs']['Action'])->toBe($projectedLattice['$defs']['Action'])
+        ->and($projectedAction['$defs']['Confirmation'])->toBe($projectedLattice['$defs']['Confirmation'])
+        ->and($projectedLattice['$defs']['Action']['properties']['confirmation'])->toBe(['$ref' => '#/$defs/Confirmation']);
+});
+
+it('does not let one same-origin promotion leak into an unrelated, differently-origined reference to the same def', function (): void {
+    $universe = [
+        'Orientation' => ['type' => 'string', 'enum' => ['horizontal', 'vertical'], 'x-lattice' => ['kind' => 'enum']],
+        'Tabs' => ['type' => 'object', 'properties' => ['orientation' => ['$ref' => '#/$defs/Orientation']], 'x-lattice' => ['kind' => 'props']],
+        'Wizard' => ['type' => 'object', 'properties' => ['orientation' => ['$ref' => '#/$defs/Orientation']], 'x-lattice' => ['kind' => 'props']],
+    ];
+    $defOrigins = ['Orientation' => 'ui', 'Tabs' => 'ui', 'Wizard' => 'form'];
+
+    $doc = ['$id' => 'lattice', '$defs' => ['ComponentNode' => ['oneOf' => [
+        ['$ref' => '#/$defs/Tabs'],
+        ['$ref' => '#/$defs/Wizard'],
+    ]]]];
+
+    $projected = new FlatProjection()->project($doc, $universe, $defOrigins, 'lattice');
+
+    expect($projected['$defs']['Tabs']['properties']['orientation'])->toBe(['$ref' => '#/$defs/Orientation'])
+        ->and($projected['$defs']['Wizard']['properties']['orientation'])->toBe([
+            'type' => 'string',
+            'enum' => ['horizontal', 'vertical'],
+            'x-lattice' => ['kind' => 'enum'],
+        ]);
+});
+
+it('leaves same-document refs to sibling roots untouched', function (): void {
+    $doc = [
+        '$id' => 'x',
+        '$defs' => [
+            'Align' => ['type' => 'string', 'enum' => ['start', 'end']],
+            'ColumnProps' => ['properties' => ['align' => ['$ref' => '#/$defs/Align']]],
+        ],
+    ];
+
+    $projected = new FlatProjection()->project($doc, $doc['$defs']);
+
+    expect($projected['$defs']['ColumnProps']['properties']['align'])->toBe(['$ref' => '#/$defs/Align'])
+        ->and($projected['$defs']['Align'])->toBe(['type' => 'string', 'enum' => ['start', 'end']]);
+});

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -17,6 +17,7 @@ use Laravel\Roster\ProjectManager;
 use Laravel\Roster\ProjectScan;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Search\Contracts\SearchHistoryRecorder;
+use Lattice\Support\Schema\SchemaProfile;
 use Lattice\Support\TypeScript\TypeScriptProfile;
 use Lattice\Theme\Swatch;
 use Lattice\Theme\Theme;
@@ -26,6 +27,7 @@ use Workbench\App\Search\SessionSearchHistoryRecorder;
 use Workbench\App\Support\BoostConfig;
 use Workbench\App\Support\BoostGuidelineComposer;
 use Workbench\App\Support\BoostSkillComposer;
+use Workbench\App\Support\Schema\BaseSchemaProfile;
 use Workbench\App\Support\TypeScript\BaseProfile;
 use Workbench\App\Timelines\ProjectPlanTimelineAdapter;
 
@@ -48,8 +50,9 @@ class WorkbenchServiceProvider extends ServiceProvider
         $this->app->singleton(ProjectPlanTimelineAdapter::class);
         $this->app->singleton(SearchHistoryRecorder::class, SessionSearchHistoryRecorder::class);
 
-        // Rebind so lattice:typescript regenerates the package's own built-in artifacts.
+        // Rebind so lattice:typescript/lattice:schema regenerate the package's own built-in artifacts.
         $this->app->bind(TypeScriptProfile::class, BaseProfile::class);
+        $this->app->bind(SchemaProfile::class, BaseSchemaProfile::class);
         $this->useWorkbenchDatabase();
         $this->readBoostConfigFromPackageRoot();
         $this->serveLatticeTranslations();

--- a/workbench/app/Support/Schema/BaseSchemaProfile.php
+++ b/workbench/app/Support/Schema/BaseSchemaProfile.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Support\Schema;
+
+use Illuminate\Support\Facades\File;
+use Lattice\Core\JsonSchema\FlatProjection;
+use Lattice\Core\JsonSchema\SchemaBundler;
+use Lattice\Core\JsonSchema\SchemaDocumentWriter;
+use Lattice\Core\Wire\WireModelBuilder;
+use Lattice\Core\Wire\WireSourceCatalog;
+use Lattice\Support\Schema\SchemaProfile;
+
+/**
+ * The package's own dev profile: regenerates every wire package's committed
+ * schema document (`WireSource::schemaPath()`) — each a flat, self-contained
+ * projection of `buildAll()`'s internal wire model — then merges those flat
+ * documents into the committed monorepo bundle artifact. Bound in the
+ * workbench so lattice:schema rebuilds the published contract; workbench-only,
+ * so this build code never ships.
+ *
+ * Mirrors `Workbench\App\Support\TypeScript\BaseProfile`'s per-source
+ * `base_output` override so the snapshot test regenerates every artifact into
+ * a scratch dir instead of rewriting the committed ones mid-suite.
+ */
+final readonly class BaseSchemaProfile implements SchemaProfile
+{
+    /**
+     * A wire source's short name doesn't always match its package directory
+     * under packages/ — only `lattice-php/lattice` (short name `lattice`)
+     * diverges, living in packages/framework.
+     */
+    private const array PACKAGE_DIRS = ['lattice' => 'framework'];
+
+    private const string FRAMEWORK_SOURCE = 'lattice';
+
+    public function __construct(
+        private WireSourceCatalog $catalog,
+        private SchemaBundler $bundler,
+    ) {}
+
+    public function run(WireModelBuilder $builder, SchemaDocumentWriter $writer): string
+    {
+        $packageRoot = dirname(__DIR__, 4);
+        $model = $builder->buildAll(includeFrameworkEnvelope: true);
+        $documents = $model['documents'];
+        $defOrigins = $model['defOrigins'];
+
+        $universe = [];
+
+        foreach ($documents as $document) {
+            foreach ($document['$defs'] as $name => $def) {
+                $universe[$name] ??= $def;
+            }
+        }
+
+        $projector = new FlatProjection;
+        $flatDocuments = [];
+
+        foreach ($documents as $shortName => $document) {
+            $flatDocuments[$shortName] = $projector->project($document, $universe, $defOrigins, $shortName);
+        }
+
+        $configuredOutput = config('lattice.schema.base_output');
+        $pathFor = static fn (string $shortName): string => is_string($configuredOutput) && $configuredOutput !== ''
+            ? $configuredOutput.($shortName === self::FRAMEWORK_SOURCE ? '' : '/'.$shortName).'/'.$shortName.'.schema.json'
+            : $packageRoot.'/packages/'.(self::PACKAGE_DIRS[$shortName] ?? $shortName).'/resources/schema/'.$shortName.'.schema.json';
+
+        $written = 0;
+
+        foreach ($this->catalog->discover() as $source) {
+            if ($source->isRoot || $source->shortName === self::FRAMEWORK_SOURCE) {
+                continue;
+            }
+
+            $document = $flatDocuments[$source->shortName] ?? null;
+
+            if ($document === null) {
+                continue;
+            }
+
+            $path = $pathFor($source->shortName);
+            File::ensureDirectoryExists(dirname($path));
+            File::put($path, $writer->write($document));
+            $written++;
+        }
+
+        $framework = $flatDocuments[self::FRAMEWORK_SOURCE] ?? ['$schema' => 'https://json-schema.org/draft/2020-12/schema', '$defs' => []];
+        $others = array_values(array_filter(
+            $flatDocuments,
+            static fn (string $shortName): bool => $shortName !== self::FRAMEWORK_SOURCE,
+            ARRAY_FILTER_USE_KEY,
+        ));
+        $bundle = $this->bundler->bundle($framework, $others);
+
+        $bundlePath = $pathFor(self::FRAMEWORK_SOURCE);
+        File::ensureDirectoryExists(dirname($bundlePath));
+        File::put($bundlePath, $writer->write($bundle));
+
+        return sprintf('Regenerated %d wire package schema document(s) and the bundle → %s', $written, $bundlePath);
+    }
+}


### PR DESCRIPTION
Revives the schema-artifact layer from the stale `feat/wire-schema-documents` branch, ported onto the core wire model (#454).

- `Lattice\Core\JsonSchema\{FlatProjection, SchemaBundler, SchemaDocumentWriter}`: every wire source gets a flat, self-contained committed document at `packages/<name>/resources/schema/<name>.schema.json` (12 files, no cross-document refs — only the recursive envelope core is copy-once per file), merged into `packages/framework/resources/schema/lattice.schema.json` (356 defs, npm-exported as `@lattice-php/lattice/schema/lattice.schema.json`).
- `lattice:schema` exports a consumer app's merged document (committed vendor docs + fresh reflection of the app's own discover paths, app defs marked `origin: "app"`); `composer types` chains schema → typescript.
- Fixes a real gap: `buildAll()` per-source documents never emitted the envelope core, strict unions, or the `RemoteManifest` contract despite the docblock claiming so. Opt-in via `$includeFrameworkEnvelope` so TypeScript emission stays byte-identical (those defs are hand-written on the TS side).
- Tests: opis/json-schema (dev) validates the merged document and a real captured page payload against `#/$defs/PagePayload`; snapshot test byte-compares the committed artifact; CI regenerates and diffs all schema files alongside generated.ts.
- Docs: new `advanced/wire-protocol` page (entry points, `x-lattice` vocabulary, structured-output usage, `lattice:schema`).

Gates: full Pest suite (1714 passed), PHPStan level 8 both configs, `composer types` idempotent, `npm run check` green, docs build green.