### PR TITLE
feat(media): categories, scoped pickers, label overrides, and an upload-only mode

### DIFF
--- a/docs/content/docs/packages/media.mdx
+++ b/docs/content/docs/packages/media.mdx
@@ -61,6 +61,49 @@ $product->firstMediaUrl('gallery');
 
 Validate submitted ids with `Lattice\Media\Rules\AttachableMedia`.
 
+## Categories
+
+A category partitions the media pool itself — unlike a collection, which groups attachments per
+record. Scope a library or picker to one and its listing shows only that category's media while
+every upload through it is stamped with the category:
+
+```php
+MediaLibrary::make()->category('imports');
+
+MediaPicker::make('file')->category('imports');
+```
+
+An unscoped library or picker shows only uncategorized media, so a categorized pool — import
+files, say — never surfaces next to regular media anywhere it was not explicitly requested.
+
+:::note
+The scope travels in the sealed component reference, not as a request parameter — a client cannot
+widen or switch it.
+:::
+
+## Upload-only picking
+
+`uploadOnly()` skips the library entirely: the button opens the file dialog directly and the
+fresh upload becomes the picked value. No browse endpoint is exposed for the field, so existing
+media stay invisible. Combined with a category and an upload label this makes a self-contained
+"upload an import file" field:
+
+```php
+MediaPicker::make('file')
+    ->category('imports')
+    ->uploadOnly()
+    ->uploadLabel(__('imports.upload'));
+```
+
+## Labels
+
+Both buttons a picker renders can be relabeled: `pickerLabel()` names the trigger that opens the
+browse dialog, `uploadLabel()` (also on `MediaLibrary`) names the upload button:
+
+```php
+MediaPicker::make('file')->pickerLabel('Choose import')->uploadLabel('Upload import file');
+```
+
 ## Rich editor images
 
 The package registers a `media-image` [rich editor](/forms/fields/rich-editor/) extension.

--- a/docs/content/docs/packages/media.mdx
+++ b/docs/content/docs/packages/media.mdx
@@ -138,7 +138,9 @@ after upload and after attach — as does anything stored under a generic mime t
 upload can record one for a real image; the job probes the bytes and skips what is not an image.
 `$media->previewConversion()` (`thumb` by default) is what the grid, the picker and the detail
 slideout preview; `$media->url('thumb')` reads any of them and falls back to the original when it
-was never generated.
+was never generated. Each derivative records its byte size in the conversion map alongside its
+path and dimensions; for maps recorded before sizes existed, `media:conversions --missing`
+backfills them from a disk stat without regenerating anything.
 
 Defaults live on the model. Subclass it, point `media.model` at your class, and return callbacks
 over Laravel's immutable `Illuminate\Image\Image` — each one must return the transformed image.

--- a/packages/media/database/migrations/2026_08_14_000001_add_category_to_media_table.php
+++ b/packages/media/database/migrations/2026_08_14_000001_add_category_to_media_table.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('media', function (Blueprint $table): void {
+            $table->string('category')->nullable()->index()->after('mime_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('media', function (Blueprint $table): void {
+            $table->dropColumn('category');
+        });
+    }
+};

--- a/packages/media/resources/js/components/library-view.tsx
+++ b/packages/media/resources/js/components/library-view.tsx
@@ -13,10 +13,10 @@ import type { BulkAction } from "@lattice-php/table/lib/bulk";
 import type { TableNode } from "@lattice-php/table/types";
 import { Button } from "@lattice-php/ui/button";
 import { Checkbox } from "@lattice-php/ui/checkbox";
-import { IconButton } from "@lattice-php/ui/icon-button";
 import { Input } from "@lattice-php/ui/input";
 import { NativeSelect } from "@lattice-php/ui/native-select";
 import { DetailPanel } from "./detail-panel";
+import { UploadList } from "./upload-list";
 import { useMediaUpload } from "./use-media-upload";
 
 const SEARCH_DEBOUNCE_MS = 300;
@@ -187,48 +187,7 @@ export function LibraryView({ node, pick }: { node: Node; pick?: PickMode }) {
         )}
       </div>
 
-      {uploads.length > 0 && (
-        <ul className="flex flex-wrap gap-2">
-          {uploads.map((item) => (
-            <li
-              className="flex max-w-64 items-center gap-2 rounded-lt-sm border border-lt-border bg-lt-surface px-2 py-1 text-sm"
-              key={item.id}
-            >
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-lt-fg">{item.name}</span>
-                {item.status === "error" && (
-                  <span
-                    className="block truncate text-xs text-lt-danger"
-                    data-test="media-upload-reason"
-                  >
-                    {item.reason ?? t("media.library.upload-failed", "Upload failed")}
-                  </span>
-                )}
-              </span>
-              {item.status === "error" ? (
-                <>
-                  <IconButton
-                    data-test="media-upload-retry"
-                    icon="rotate-ccw"
-                    label={t("media.library.upload-retry", "Retry {{name}}", { name: item.name })}
-                    onClick={() => retry(item)}
-                  />
-                  <IconButton
-                    data-test="media-upload-dismiss"
-                    icon="x"
-                    label={t("media.library.upload-dismiss", "Dismiss {{name}}", {
-                      name: item.name,
-                    })}
-                    onClick={() => dismiss(item.id)}
-                  />
-                </>
-              ) : (
-                <span className="text-lt-muted-fg">{`${item.progress}%`}</span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+      <UploadList dismiss={dismiss} retry={retry} uploads={uploads} />
 
       {rows.length === 0 && table.hasLoaded ? (
         <p className="py-12 text-center text-sm text-lt-muted-fg" data-test="media-empty">

--- a/packages/media/resources/js/components/upload-list.tsx
+++ b/packages/media/resources/js/components/upload-list.tsx
@@ -1,0 +1,62 @@
+import { IconButton } from "@lattice-php/ui/icon-button";
+import { useT } from "@lattice-php/ui/i18n";
+import type { UploadItem } from "./use-media-upload";
+
+export function UploadList({
+  uploads,
+  retry,
+  dismiss,
+}: {
+  uploads: UploadItem[];
+  retry: (item: UploadItem) => void;
+  dismiss: (id: string) => void;
+}) {
+  const { t } = useT("media");
+
+  if (uploads.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {uploads.map((item) => (
+        <li
+          className="flex max-w-64 items-center gap-2 rounded-lt-sm border border-lt-border bg-lt-surface px-2 py-1 text-sm"
+          key={item.id}
+        >
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-lt-fg">{item.name}</span>
+            {item.status === "error" && (
+              <span
+                className="block truncate text-xs text-lt-danger"
+                data-test="media-upload-reason"
+              >
+                {item.reason ?? t("media.library.upload-failed", "Upload failed")}
+              </span>
+            )}
+          </span>
+          {item.status === "error" ? (
+            <>
+              <IconButton
+                data-test="media-upload-retry"
+                icon="rotate-ccw"
+                label={t("media.library.upload-retry", "Retry {{name}}", { name: item.name })}
+                onClick={() => retry(item)}
+              />
+              <IconButton
+                data-test="media-upload-dismiss"
+                icon="x"
+                label={t("media.library.upload-dismiss", "Dismiss {{name}}", {
+                  name: item.name,
+                })}
+                onClick={() => dismiss(item.id)}
+              />
+            </>
+          ) : (
+            <span className="text-lt-muted-fg">{`${item.progress}%`}</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/media/resources/js/components/use-media-upload.test.ts
+++ b/packages/media/resources/js/components/use-media-upload.test.ts
@@ -50,6 +50,21 @@ function file(name: string): File {
   return new File(["bytes"], name, { type: "image/jpeg" });
 }
 
+function mediaBody(ids: number[]): string {
+  return JSON.stringify({
+    data: {
+      media: ids.map((id) => ({
+        id,
+        name: `media-${id}.jpg`,
+        url: null,
+        preview_url: null,
+        mime_type: "image/jpeg",
+      })),
+    },
+    effects: [{ type: "reload-component", props: { component: "media.library" } }],
+  });
+}
+
 function renderUpload(signed = false) {
   return renderHook(() =>
     useMediaUpload({ endpoint: "/lattice/actions/media-upload", ref: "ref-1", signed }),
@@ -353,6 +368,108 @@ describe("useMediaUpload", () => {
     });
 
     expect(FakeXhr.instances).toEqual([]);
+  });
+
+  it("hands the settled batch's media descriptors to onUploaded once", async () => {
+    const onUploaded = vi.fn();
+    const { result } = renderHook(() =>
+      useMediaUpload({
+        endpoint: "/lattice/actions/media-upload",
+        ref: "ref-1",
+        signed: false,
+        onUploaded,
+      }),
+    );
+
+    act(() => result.current.addFiles([file("alpha.jpg"), file("beta.jpg")]));
+
+    await waitFor(() => expect(FakeXhr.instances).toHaveLength(2));
+    await act(async () => {
+      FakeXhr.instances[0].succeed(200, mediaBody([1]));
+      FakeXhr.instances[1].succeed(200, mediaBody([2]));
+    });
+
+    await waitFor(() => expect(onUploaded).toHaveBeenCalledTimes(1));
+
+    expect(onUploaded).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 1, name: "media-1.jpg" }),
+      expect.objectContaining({ id: 2, name: "media-2.jpg" }),
+    ]);
+  });
+
+  it("keeps onUploaded silent when every file fails", async () => {
+    const onUploaded = vi.fn();
+    const { result } = renderHook(() =>
+      useMediaUpload({
+        endpoint: "/lattice/actions/media-upload",
+        ref: "ref-1",
+        signed: false,
+        onUploaded,
+      }),
+    );
+
+    act(() => result.current.addFiles([file("alpha.jpg")]));
+
+    await waitFor(() => expect(FakeXhr.instances).toHaveLength(1));
+    await act(async () => {
+      FakeXhr.instances[0].succeed(422, JSON.stringify({ message: "Too big." }));
+    });
+
+    await waitFor(() => expect(result.current.uploads[0].status).toBe("error"));
+
+    expect(onUploaded).not.toHaveBeenCalled();
+  });
+
+  it("dedupes the signed finalize batch so onUploaded sees each row once", async () => {
+    const onUploaded = vi.fn();
+    apiFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            key: "tmp/a.jpg",
+            url: "https://storage.test/a",
+            headers: {},
+            method: "PUT",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            key: "tmp/b.jpg",
+            url: "https://storage.test/b",
+            headers: {},
+            method: "PUT",
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(mediaBody([1, 2]), { status: 200 }));
+
+    const { result } = renderHook(() =>
+      useMediaUpload({
+        endpoint: "/lattice/actions/media-upload",
+        ref: "ref-1",
+        signed: true,
+        onUploaded,
+      }),
+    );
+
+    act(() => result.current.addFiles([file("a.jpg"), file("b.jpg")]));
+
+    await waitFor(() => expect(FakeXhr.instances).toHaveLength(2));
+    await act(async () => {
+      FakeXhr.instances[0].succeed(204, "");
+      FakeXhr.instances[1].succeed(204, "");
+    });
+
+    await waitFor(() => expect(onUploaded).toHaveBeenCalledTimes(1));
+
+    expect(onUploaded.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ id: 1 }),
+      expect.objectContaining({ id: 2 }),
+    ]);
   });
 
   it("ignores a null selection", () => {

--- a/packages/media/resources/js/components/use-media-upload.ts
+++ b/packages/media/resources/js/components/use-media-upload.ts
@@ -17,10 +17,20 @@ export type UploadItem = {
   file: File;
 };
 
+export type UploadedMedia = {
+  id: number;
+  name: string;
+  url: string | null;
+  preview_url: string | null;
+  mime_type: string;
+};
+
 export type UploadTarget = {
   endpoint: string;
   ref: string;
   signed: boolean;
+  /** Called once per settled batch with the display descriptors of every stored upload. */
+  onUploaded?: (media: UploadedMedia[]) => void;
 };
 
 export type MediaUpload = {
@@ -32,11 +42,15 @@ export type MediaUpload = {
 
 type Settled = {
   ok: boolean;
-  body: { message?: string; errors?: Record<string, string[]> };
+  body: {
+    message?: string;
+    errors?: Record<string, string[]>;
+    data?: { media?: UploadedMedia[] };
+  };
   reload?: ActionEffect;
 };
 
-type Outcome = { ok: boolean; reload?: ActionEffect };
+type Outcome = { ok: boolean; reload?: ActionEffect; media?: UploadedMedia[] };
 
 /** Laravel reports a rejected file under `files.<index>`; `message` covers request-level failures. */
 function reasonFor({ body }: Settled, index: number): string | undefined {
@@ -50,7 +64,7 @@ function reasonFor({ body }: Settled, index: number): string | undefined {
  * batch has settled, brings the new rows into the grid — so `uploads` only
  * ever holds in-flight and failed files.
  */
-export function useMediaUpload({ endpoint, ref, signed }: UploadTarget): MediaUpload {
+export function useMediaUpload({ endpoint, ref, signed, onUploaded }: UploadTarget): MediaUpload {
   const dispatch = useEffectDispatcher();
   const { t } = useT("media");
   const [uploads, setUploads] = useState<UploadItem[]>([]);
@@ -127,7 +141,7 @@ export function useMediaUpload({ endpoint, ref, signed }: UploadTarget): MediaUp
 
     settle(item, settled, 0);
 
-    return { ok: settled.ok, reload: settled.reload };
+    return { ok: settled.ok, reload: settled.reload, media: settled.body.data?.media };
   }
 
   async function signAndPut(item: UploadItem): Promise<string | null> {
@@ -185,7 +199,12 @@ export function useMediaUpload({ endpoint, ref, signed }: UploadTarget): MediaUp
       .filter((_, index) => keys[index] !== null)
       .forEach((item, index) => settle(item, settled, index));
 
-    return keys.map((key) => ({ ok: key !== null && settled.ok, reload: settled.reload }));
+    // Every ok outcome carries the batch's media: the collector dedupes by id.
+    return keys.map((key) => ({
+      ok: key !== null && settled.ok,
+      reload: settled.reload,
+      media: key !== null && settled.ok ? settled.body.data?.media : undefined,
+    }));
   }
 
   async function run(items: UploadItem[]): Promise<void> {
@@ -209,6 +228,19 @@ export function useMediaUpload({ endpoint, ref, signed }: UploadTarget): MediaUp
       },
       ...(reload ? [reload] : []),
     ]);
+
+    const uploaded = [
+      ...new Map(
+        outcomes
+          .filter((outcome) => outcome.ok)
+          .flatMap((outcome) => outcome.media ?? [])
+          .map((item) => [item.id, item]),
+      ).values(),
+    ];
+
+    if (uploaded.length > 0) {
+      onUploaded?.(uploaded);
+    }
   }
 
   function addFiles(incoming: FileList | File[] | null): void {

--- a/packages/media/resources/js/generated.ts
+++ b/packages/media/resources/js/generated.ts
@@ -37,6 +37,7 @@ export type MediaPicker = {
   maxFiles: number | null;
   multiple: boolean;
   name: string;
+  pickerLabel: string | null;
   prefillRefreshOn: string[] | null;
   prefillResetOn: string[] | null;
   readOnly: boolean;
@@ -52,6 +53,7 @@ export type MediaPicker = {
       }[]
     | null;
   tooltip: string | null;
+  uploadOnly: boolean;
   value: unknown;
 };
 export type MediaTypeFilter = {

--- a/packages/media/resources/js/media-picker.test.tsx
+++ b/packages/media/resources/js/media-picker.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { UploadTarget, UploadedMedia } from "./components/use-media-upload";
 import { createRegistry, eagerComponent, RegistryContext } from "@lattice-php/core";
 import type { RendererComponent, Schema } from "@lattice-php/core/types";
 import { FormProvider } from "@lattice-php/form/hooks/context";
@@ -9,6 +10,25 @@ import { fakeNode } from "@lattice-php/core/test-support";
 import { fakeFormContext } from "@lattice-php/form/test-support";
 import { libraryRow } from "./test-support";
 import MediaPickerComponent from "./media-picker";
+
+const upload = vi.hoisted(() => ({
+  lastTarget: undefined as
+    | undefined
+    | { endpoint: string; onUploaded?: (media: unknown[]) => void },
+  addFiles: vi.fn(),
+}));
+
+vi.mock("./components/use-media-upload", () => ({
+  useMediaUpload: (target: { endpoint: string }) => {
+    upload.lastTarget = target;
+
+    return { uploads: [], addFiles: upload.addFiles, retry: vi.fn(), dismiss: vi.fn() };
+  },
+}));
+
+function settleUpload(media: UploadedMedia[]): void {
+  act(() => (upload.lastTarget as UploadTarget).onUploaded?.(media));
+}
 
 const CaptionField: RendererComponent<"field.text-input"> = ({ node }) => {
   const scope = useFieldScope();
@@ -42,6 +62,22 @@ function librarySchema(rows: ReturnType<typeof libraryRow>[]): Schema {
       type: "media.library",
       props: { picker: true, accept: null, signed: false },
       schema: [{ type: "table", props: { columns: [], data: rows } }],
+    },
+  ] as Schema;
+}
+
+function uploadOnlySchema(label: string | null = null): Schema {
+  return [
+    {
+      type: "media.library",
+      props: { picker: true, accept: "text/csv", signed: false },
+      schema: [
+        {
+          type: "action",
+          key: "media-upload",
+          props: { endpoint: "/lattice/actions/media.upload", ref: "ref-upload", label },
+        },
+      ],
     },
   ] as Schema;
 }
@@ -334,6 +370,53 @@ describe("MediaPickerComponent", () => {
     const input = screen.getByTestId("caption-input");
     expect(input).toHaveAttribute("name", "gallery[0][caption]");
     expect(input).toHaveValue("Front");
+  });
+
+  it("prefers the wire pickerLabel over the translated trigger label", () => {
+    renderPicker({ pickerLabel: "Choose import" });
+
+    expect(screen.getByTestId("media-picker-open")).toHaveTextContent("Choose import");
+  });
+
+  it("upload-only mode picks the settled upload without offering the library", () => {
+    const { container } = renderPicker({ uploadOnly: true, selected: [] }, uploadOnlySchema());
+
+    expect(screen.queryByTestId("media-picker-open")).toBeNull();
+    expect(screen.queryByTestId("media-picker-dialog")).toBeNull();
+
+    settleUpload([
+      { id: 42, name: "import.csv", url: null, preview_url: null, mime_type: "text/csv" },
+    ]);
+
+    expect(container.querySelector('input[type="hidden"][name="cover"]')).toHaveValue("42");
+    expect(screen.getByTestId("media-picker-item")).toHaveTextContent("import.csv");
+  });
+
+  it("upload-only single mode replaces the previous pick with the fresh upload", () => {
+    const { container } = renderPicker({ uploadOnly: true }, uploadOnlySchema());
+
+    settleUpload([
+      { id: 42, name: "import.csv", url: null, preview_url: null, mime_type: "text/csv" },
+    ]);
+
+    expect(container.querySelector('input[type="hidden"][name="cover"]')).toHaveValue("42");
+    expect(screen.getAllByTestId("media-picker-item")).toHaveLength(1);
+  });
+
+  it("upload-only mode labels the button from the upload action and forwards the file selection", () => {
+    renderPicker({ uploadOnly: true, selected: [] }, uploadOnlySchema("Upload import file"));
+
+    const button = screen.getByTestId("media-picker-upload");
+    expect(button).toHaveTextContent("Upload import file");
+    expect(upload.lastTarget?.endpoint).toBe("/lattice/actions/media.upload");
+
+    const input = screen.getByTestId("media-picker-upload-input");
+    expect(input).toHaveAttribute("accept", "text/csv");
+
+    const selected = new File(["a;b"], "rows.csv", { type: "text/csv" });
+    fireEvent.change(input, { target: { files: [selected] } });
+
+    expect(upload.addFiles).toHaveBeenCalledWith(expect.objectContaining({ 0: selected }));
   });
 
   it("omits per-item template fields when the picker is disabled", () => {

--- a/packages/media/resources/js/media-picker.tsx
+++ b/packages/media/resources/js/media-picker.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { RenderNode } from "@lattice-php/core";
-import type { RendererComponent } from "@lattice-php/core/types";
+import type { Node, RendererComponent } from "@lattice-php/core/types";
 import { SimpleField } from "@lattice-php/form/components/fields/simple-field";
 import { FieldScopeProvider } from "@lattice-php/form/hooks/field-scope";
 import { translate, useT } from "@lattice-php/ui/i18n";
@@ -8,6 +8,8 @@ import { Button } from "@lattice-php/ui/button";
 import { Dialog, DialogContent, DialogHeader } from "@lattice-php/ui/dialog";
 import { IconButton } from "@lattice-php/ui/icon-button";
 import { LibraryView, type MediaRow } from "./components/library-view";
+import { UploadList } from "./components/upload-list";
+import { useMediaUpload, type UploadedMedia } from "./components/use-media-upload";
 
 type Picked = {
   id: number;
@@ -25,7 +27,9 @@ const MediaPickerComponent: RendererComponent<"field.media-picker"> = ({ node })
   const [picked, setPicked] = useState<Picked[]>(
     (props.selected ?? []).map((entry) => ({ ...entry, values: entry.values ?? {} })),
   );
-  const libraryNode = node.schema?.find((child) => child.type === "media.library");
+  const libraryNode = node.schema?.find((child) => child.type === "media.library") as
+    | Node<"media.library">
+    | undefined;
   const template = node.schema?.filter((child) => child.type !== "media.library") ?? [];
   const hasFields = template.length > 0;
   const multiple = props.multiple;
@@ -122,17 +126,36 @@ const MediaPickerComponent: RendererComponent<"field.media-picker"> = ({ node })
               </ul>
             )}
 
-            <Button
-              className="self-start"
-              data-test="media-picker-open"
-              disabled={locked}
-              onClick={() => setOpen(true)}
-              type="button"
-            >
-              {t("media.picker.open", "Choose from library")}
-            </Button>
+            {props.uploadOnly ? (
+              <UploadOnlyPicker
+                disabled={locked}
+                libraryNode={libraryNode}
+                multiple={multiple}
+                onUploaded={(media) => {
+                  const incoming = media.map((item) => ({ ...item, values: {} }));
+                  const merged = multiple
+                    ? [
+                        ...picked.filter((entry) => !incoming.some((item) => item.id === entry.id)),
+                        ...incoming,
+                      ]
+                    : incoming.slice(0, 1);
 
-            {open && libraryNode && (
+                  apply(multiple && maxFiles !== null ? merged.slice(0, maxFiles) : merged);
+                }}
+              />
+            ) : (
+              <Button
+                className="self-start"
+                data-test="media-picker-open"
+                disabled={locked}
+                onClick={() => setOpen(true)}
+                type="button"
+              >
+                {props.pickerLabel ?? t("media.picker.open", "Choose from library")}
+              </Button>
+            )}
+
+            {open && !props.uploadOnly && libraryNode && (
               <Dialog onOpenChange={setOpen} open>
                 <DialogContent
                   aria-describedby={undefined}
@@ -177,5 +200,64 @@ const MediaPickerComponent: RendererComponent<"field.media-picker"> = ({ node })
     </SimpleField>
   );
 };
+
+/**
+ * The upload-only face of the picker: the button opens the file dialog
+ * directly and the settled batch is picked via onUploaded — the library grid
+ * never renders, so other media stay out of sight.
+ */
+function UploadOnlyPicker({
+  libraryNode,
+  multiple,
+  disabled,
+  onUploaded,
+}: {
+  libraryNode: Node<"media.library"> | undefined;
+  multiple: boolean;
+  disabled: boolean;
+  onUploaded: (media: UploadedMedia[]) => void;
+}) {
+  const { t } = useT("media");
+  const uploadNode = libraryNode?.schema?.find((child) => child.key === "media-upload") as
+    | Node<"action">
+    | undefined;
+  const { uploads, addFiles, retry, dismiss } = useMediaUpload({
+    endpoint: uploadNode?.props.endpoint ?? "",
+    ref: uploadNode?.props.ref ?? "",
+    signed: libraryNode?.props.signed ?? false,
+    onUploaded,
+  });
+  const fileInput = useRef<HTMLInputElement>(null);
+  const label = uploadNode?.props.label ?? t("media.actions.upload.label", "Upload");
+  const busy = uploads.some((item) => item.status === "uploading");
+
+  return (
+    <>
+      <Button
+        className="self-start"
+        data-test="media-picker-upload"
+        disabled={disabled || busy}
+        onClick={() => fileInput.current?.click()}
+        type="button"
+      >
+        {label}
+      </Button>
+      <input
+        accept={libraryNode?.props.accept ?? undefined}
+        aria-label={label}
+        className="sr-only"
+        data-test="media-picker-upload-input"
+        multiple={multiple}
+        onChange={(event) => {
+          addFiles(event.target.files);
+          event.target.value = "";
+        }}
+        ref={fileInput}
+        type="file"
+      />
+      <UploadList dismiss={dismiss} retry={retry} uploads={uploads} />
+    </>
+  );
+}
 
 export default MediaPickerComponent;

--- a/packages/media/src/Actions/UploadMediaAction.php
+++ b/packages/media/src/Actions/UploadMediaAction.php
@@ -63,17 +63,29 @@ final class UploadMediaAction extends FormActionDefinition
         return $validated;
     }
 
+    /**
+     * The payload carries full display descriptors, not bare ids: an
+     * upload-only picker selects the fresh rows straight from this response
+     * without a follow-up fetch.
+     */
     public function handle(Request $request): ActionResult
     {
         $data = $this->validate($request);
-        $ids = [];
+        $media = array_map(
+            // A sync queue has already generated the conversions by now, on its
+            // own instances — refresh so the descriptors see them.
+            static fn (Media $item): array => [
+                'id' => (int) $item->refresh()->getKey(),
+                'name' => $item->name,
+                'url' => $item->url(),
+                'preview_url' => $item->previewUrl(),
+                'mime_type' => $item->mime_type,
+            ],
+            $this->storeUploads($data['files'] ?? []),
+        );
 
-        foreach ($this->storeUploads($data['files'] ?? []) as $media) {
-            $ids[] = $media->getKey();
-        }
-
-        return ActionResult::success(['media' => $ids])
-            ->toast(__('media::media.actions.upload.toast', ['count' => count($ids)]), Variant::Success)
+        return ActionResult::success(['media' => $media])
+            ->toast(__('media::media.actions.upload.toast', ['count' => count($media)]), Variant::Success)
             ->reloadComponent('media.library');
     }
 
@@ -128,6 +140,7 @@ final class UploadMediaAction extends FormActionDefinition
                 'path' => $path,
                 'name' => $file->getClientOriginalName(),
                 'mime_type' => $file->getMimeType() ?? 'application/octet-stream',
+                'category' => $this->contextStringOrNull('category'),
                 'size' => $file->getSize(),
                 'uploaded_by' => auth()->id(),
             ]);
@@ -144,6 +157,7 @@ final class UploadMediaAction extends FormActionDefinition
                     'path' => $upload['path'],
                     'name' => $upload['name'],
                     'mime_type' => $upload['mime_type'] ?? 'application/octet-stream',
+                    'category' => $this->contextStringOrNull('category'),
                     'size' => $upload['size'] ?? 0,
                     'uploaded_by' => auth()->id(),
                 ]);

--- a/packages/media/src/Components/MediaLibrary.php
+++ b/packages/media/src/Components/MediaLibrary.php
@@ -24,6 +24,12 @@ final class MediaLibrary extends ContainerComponent
 
     protected ?string $disk = null;
 
+    protected ?string $category = null;
+
+    protected ?string $uploadLabel = null;
+
+    protected bool $uploadOnly = false;
+
     /** @var list<string> */
     protected array $uploadRules = [];
 
@@ -65,6 +71,37 @@ final class MediaLibrary extends ContainerComponent
     }
 
     /**
+     * Scope the library to one category: the list shows only that category's
+     * media and every upload is stamped with it. Without a category the
+     * library shows only uncategorized media, so categorized pools stay
+     * invisible everywhere they are not explicitly requested.
+     */
+    public function category(?string $category): static
+    {
+        $this->category = $category;
+
+        return $this->schema([]);
+    }
+
+    public function uploadLabel(string $label): static
+    {
+        $this->uploadLabel = $label;
+
+        return $this->schema([]);
+    }
+
+    /**
+     * Compose only the upload action: no table child means no browse endpoint
+     * exists for this instance at all, not merely a hidden grid.
+     */
+    public function uploadOnly(bool $uploadOnly = true): static
+    {
+        $this->uploadOnly = $uploadOnly;
+
+        return $this->schema([]);
+    }
+
+    /**
      * Validation rules every uploaded file must pass, on top of the accepted
      * types and the size cap.
      *
@@ -95,12 +132,20 @@ final class MediaLibrary extends ContainerComponent
     protected function resolvedChildren(): array
     {
         if ($this->children === []) {
-            $children = [
-                Table::use(MediaTable::class),
-                Action::use(UploadMediaAction::class, $this->uploadContext())->key('media-upload'),
-            ];
+            $upload = Action::use(UploadMediaAction::class, $this->uploadContext())->key('media-upload');
 
-            if (! $this->picker) {
+            if ($this->uploadLabel !== null) {
+                $upload->label($this->uploadLabel);
+            }
+
+            $children = $this->uploadOnly
+                ? [$upload]
+                : [
+                    Table::use(MediaTable::class, $this->category === null ? [] : ['category' => $this->category]),
+                    $upload,
+                ];
+
+            if (! $this->picker && ! $this->uploadOnly) {
                 $children[] = Action::use(UpdateMediaAction::class)->key('media-update');
                 $children[] = Action::use(DeleteMediaAction::class)->key('media-delete');
             }
@@ -130,6 +175,10 @@ final class MediaLibrary extends ContainerComponent
 
         if ($this->uploadRules !== []) {
             $context['upload_rules'] = $this->uploadRules;
+        }
+
+        if ($this->category !== null) {
+            $context['category'] = $this->category;
         }
 
         return $context;

--- a/packages/media/src/Console/Commands/GenerateConversionsCommand.php
+++ b/packages/media/src/Console/Commands/GenerateConversionsCommand.php
@@ -84,9 +84,14 @@ final class GenerateConversionsCommand extends Command
             return true;
         }
 
+        $generated = $media->conversions();
         $wanted = $names === [] ? array_keys($media->defaultConversions()) : $names;
 
-        return array_diff($wanted, array_keys($media->conversions())) !== [];
+        if (array_diff($wanted, array_keys($generated)) !== []) {
+            return true;
+        }
+
+        return array_any(array_intersect_key($generated, array_flip($wanted)), fn (array $conversion): bool => ! isset($conversion['size']));
     }
 
     /**

--- a/packages/media/src/Forms/Components/MediaPicker.php
+++ b/packages/media/src/Forms/Components/MediaPicker.php
@@ -23,6 +23,10 @@ class MediaPicker extends Field implements ProvidesRowFields
 
     public ?int $maxFiles = null;
 
+    public ?string $pickerLabel = null;
+
+    public bool $uploadOnly = false;
+
     /** @var list<Field> */
     protected array $attachmentFields = [];
 
@@ -56,6 +60,58 @@ class MediaPicker extends Field implements ProvidesRowFields
         $this->maxFiles = $maxFiles;
 
         return $this;
+    }
+
+    /**
+     * Scope the picker to one category: the browse dialog lists only that
+     * category's media and every upload is stamped with it. Without a
+     * category the picker sees only uncategorized media.
+     */
+    public function category(?string $category): static
+    {
+        $this->library()->category($category);
+
+        return $this;
+    }
+
+    /** The label of the button opening the browse dialog. */
+    public function pickerLabel(string $label): static
+    {
+        $this->pickerLabel = $label;
+
+        return $this;
+    }
+
+    public function uploadLabel(string $label): static
+    {
+        $this->library()->uploadLabel($label);
+
+        return $this;
+    }
+
+    /**
+     * Skip the library entirely: the button opens the file dialog directly
+     * and the fresh upload is picked as the value. No browse endpoint is
+     * exposed, so other media stay invisible. The button is labeled by
+     * uploadLabel().
+     */
+    public function uploadOnly(bool $uploadOnly = true): static
+    {
+        $this->uploadOnly = $uploadOnly;
+        $this->library()->uploadOnly($uploadOnly);
+
+        return $this;
+    }
+
+    protected function library(): MediaLibrary
+    {
+        foreach ($this->children as $child) {
+            if ($child instanceof MediaLibrary) {
+                return $child;
+            }
+        }
+
+        throw new LogicException('The media picker lost its embedded media library.');
     }
 
     /**

--- a/packages/media/src/Jobs/GenerateMediaConversions.php
+++ b/packages/media/src/Jobs/GenerateMediaConversions.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Lattice\Media\Models\Media;
 use RuntimeException;
+use Throwable;
 
 final class GenerateMediaConversions implements ShouldQueue
 {
@@ -58,13 +59,19 @@ final class GenerateMediaConversions implements ShouldQueue
             return;
         }
 
-        $generated = $this->media->conversions();
+        $generated = $this->withBackfilledSizes($this->media->conversions());
         $missing = array_diff_key($this->conversions(), $generated);
 
         // Nothing to generate still leaves the dimensions to record: a media
         // converted before this column existed, or one whose conversions were
-        // all renamed away, only learns its size from the probe below.
+        // all renamed away, only learns its size from the probe below. Byte
+        // sizes are cheaper — a map recorded before they existed learns them
+        // from disk stats alone, without ever reading the source.
         if ($missing === [] && $this->media->width !== null) {
+            if ($generated !== $this->media->conversions()) {
+                $this->media->mergeMeta(['conversions' => $generated]);
+            }
+
             return;
         }
 
@@ -127,7 +134,7 @@ final class GenerateMediaConversions implements ShouldQueue
      * gets a fresh instance over the same bytes rather than a shared one.
      *
      * @param  Closure(Image): mixed  $conversion  what the consumer promises is only checked at runtime
-     * @return array{path: string, width: int, height: int}
+     * @return array{path: string, width: int, height: int, size: int}
      */
     private function generate(string $name, Closure $conversion, string $bytes): array
     {
@@ -143,7 +150,33 @@ final class GenerateMediaConversions implements ShouldQueue
             throw new RuntimeException("Storing the [{$name}] media conversion at [{$path}] failed.");
         }
 
-        return ['path' => $path, 'width' => $image->width(), 'height' => $image->height()];
+        return [
+            'path' => $path,
+            'width' => $image->width(),
+            'height' => $image->height(),
+            'size' => Storage::disk($this->media->disk)->size($path),
+        ];
+    }
+
+    /**
+     * @param  array<string, array{path: string, width: int, height: int, size?: int}>  $generated
+     * @return array<string, array{path: string, width: int, height: int, size?: int}>
+     */
+    private function withBackfilledSizes(array $generated): array
+    {
+        foreach ($generated as $name => $conversion) {
+            if (isset($conversion['size'])) {
+                continue;
+            }
+
+            try {
+                $generated[$name]['size'] = Storage::disk($this->media->disk)->size($conversion['path']);
+            } catch (Throwable) {
+                // A derivative gone from the disk keeps its entry size-less; --force rebuilds it.
+            }
+        }
+
+        return $generated;
     }
 
     /**

--- a/packages/media/src/Models/Media.php
+++ b/packages/media/src/Models/Media.php
@@ -20,7 +20,7 @@ use Throwable;
  * @property string $mime_type
  * @property string|null $category
  * @property int $size
- * @property array{width?: int, height?: int, alt?: string, conversions?: array<string, array{path: string, width: int, height: int}>}|null $meta
+ * @property array{width?: int, height?: int, alt?: string, conversions?: array<string, array{path: string, width: int, height: int, size?: int}>}|null $meta
  * @property-read int|null $width
  * @property-read int|null $height
  * @property-read string|null $alt
@@ -141,9 +141,11 @@ class Media extends Model
     }
 
     /**
-     * The generated derivative map, keyed by conversion name.
+     * The generated derivative map, keyed by conversion name. `size` (bytes)
+     * is absent on entries recorded before it existed until the job backfills
+     * them.
      *
-     * @return array<string, array{path: string, width: int, height: int}>
+     * @return array<string, array{path: string, width: int, height: int, size?: int}>
      */
     public function conversions(): array
     {

--- a/packages/media/src/Models/Media.php
+++ b/packages/media/src/Models/Media.php
@@ -18,6 +18,7 @@ use Throwable;
  * @property string $path
  * @property string $name
  * @property string $mime_type
+ * @property string|null $category
  * @property int $size
  * @property array{width?: int, height?: int, alt?: string, conversions?: array<string, array{path: string, width: int, height: int}>}|null $meta
  * @property-read int|null $width

--- a/packages/media/src/Tables/MediaTable.php
+++ b/packages/media/src/Tables/MediaTable.php
@@ -78,11 +78,21 @@ final class MediaTable extends EloquentTableDefinition
     }
 
     /**
+     * The category scope rides the sealed context, so a client request can
+     * never widen it. Unscoped instances see only uncategorized media:
+     * categorized pools surface exclusively through a library that asks for
+     * them.
+     *
      * @return Builder<Media>
      */
     public function builder(TableQuery $query): Builder
     {
         $builder = Media::modelQuery()->withCount('attachments');
+        $category = $this->contextStringOrNull('category');
+
+        $category === null
+            ? $builder->whereNull('category')
+            : $builder->where('category', $category);
 
         if ($query->sorts === []) {
             $builder->latest('id');

--- a/tests/Feature/Media/CollectionConversionsTest.php
+++ b/tests/Feature/Media/CollectionConversionsTest.php
@@ -91,7 +91,12 @@ test("the collection's conversion is generated on top of the defaults", function
 
     expect(array_keys($media->conversions()))->toEqualCanonicalizing(['thumb', 'card'])
         ->and($media->conversions()['card'] ?? null)
-        ->toBe(['path' => 'media/conversions/shot-card.webp', 'width' => 1200, 'height' => 800])
+        ->toBe([
+            'path' => 'media/conversions/shot-card.webp',
+            'width' => 1200,
+            'height' => 800,
+            'size' => Storage::disk('public')->size('media/conversions/shot-card.webp'),
+        ])
         ->and(Storage::disk('public')->exists((string) $media->conversionPath('thumb')))->toBeTrue()
         ->and(Storage::disk('public')->exists((string) $media->conversionPath('card')))->toBeTrue();
 });

--- a/tests/Feature/Media/GenerateConversionsCommandTest.php
+++ b/tests/Feature/Media/GenerateConversionsCommandTest.php
@@ -111,6 +111,21 @@ test('missing covers a complete map whose dimensions were never recorded', funct
         ->and($media->conversions())->toBe($map);
 });
 
+test('missing covers a complete map whose byte sizes were never recorded', function (): void {
+    $media = fakeImageMedia();
+    artisan('media:conversions')->assertSuccessful();
+    $media->refresh();
+
+    $sizeless = $media->conversions();
+    unset($sizeless['thumb']['size']);
+    $media->mergeMeta(['conversions' => $sizeless]);
+
+    artisan('media:conversions --missing')->assertSuccessful();
+
+    expect($media->refresh()->conversions()['thumb']['size'] ?? null)
+        ->toBe(Storage::disk('public')->size('media/conversions/source-thumb.webp'));
+});
+
 test('a media whose stored mime is generic is still reached by the command', function (): void {
     $media = fakeImageMedia();
     $media->update(['mime_type' => 'application/octet-stream']);

--- a/tests/Feature/Media/GenerateMediaConversionsTest.php
+++ b/tests/Feature/Media/GenerateMediaConversionsTest.php
@@ -64,7 +64,12 @@ test('the default thumb conversion is generated and recorded', function (): void
     expect($media->width)->toBe(600)
         ->and($media->height)->toBe(400)
         ->and($media->conversions()['thumb'] ?? null)
-        ->toBe(['path' => 'media/conversions/source-thumb.webp', 'width' => 400, 'height' => 400])
+        ->toBe([
+            'path' => 'media/conversions/source-thumb.webp',
+            'width' => 400,
+            'height' => 400,
+            'size' => Storage::disk('public')->size('media/conversions/source-thumb.webp'),
+        ])
         ->and(Storage::disk('public')->get('media/conversions/source-thumb.webp'))->toStartWith('RIFF');
 });
 
@@ -89,6 +94,26 @@ test('a media with every conversion and its dimensions recorded never reads the 
     new GenerateMediaConversions($media)->handle();
 
     expect($media->refresh()->conversionPath('thumb'))->toBe('x.webp');
+});
+
+test('a size-less conversion entry is backfilled from a disk stat without reading the source', function (): void {
+    $media = fakeImageMedia();
+    writeToDisk('media/conversions/source-thumb.webp', 'RIFF-derivative-bytes');
+    $media->update(['meta' => [
+        'conversions' => ['thumb' => ['path' => 'media/conversions/source-thumb.webp', 'width' => 400, 'height' => 400]],
+        'width' => 320,
+        'height' => 200,
+    ]]);
+    unreadableDisk();
+
+    new GenerateMediaConversions($media)->handle();
+
+    expect($media->refresh()->conversions()['thumb'])->toBe([
+        'path' => 'media/conversions/source-thumb.webp',
+        'width' => 400,
+        'height' => 400,
+        'size' => strlen('RIFF-derivative-bytes'),
+    ]);
 });
 
 test('a complete map with no recorded dimensions is probed without touching the map', function (): void {

--- a/tests/Feature/Media/MediaLibraryComponentTest.php
+++ b/tests/Feature/Media/MediaLibraryComponentTest.php
@@ -179,6 +179,41 @@ test('signed uploads cannot enforce dimension rules because the server never see
     expect(Media::query()->count())->toBe(1);
 });
 
+test('a category scope narrows the listing and stamps every upload', function (): void {
+    Media::factory()->create(['name' => 'photo.jpg']);
+    Media::factory()->create(['name' => 'import.csv', 'category' => 'imports']);
+
+    $node = wire(MediaLibrary::make()->category('imports'));
+    $table = (array) collect((array) $node['schema'])->firstWhere('type', 'table');
+
+    $this->latticeGet($table['props']['endpoint'], $table)
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.name', 'import.csv');
+
+    $upload = uploadNode($node);
+
+    $this->postJson(
+        $upload['props']['endpoint'],
+        ['files' => [UploadedFile::fake()->image('fresh.jpg')]],
+        $this->latticeHeaders($upload),
+    )->assertOk();
+
+    expect(Media::query()->where('name', 'fresh.jpg')->sole()->category)->toBe('imports');
+});
+
+test('upload-only mode composes just the upload action', function (): void {
+    $node = wire(MediaLibrary::make()->picker()->uploadOnly());
+
+    expect($node['schema'])->toHaveCount(1)
+        ->and($node['schema'][0]['key'])->toBe('media-upload');
+});
+
+test('an upload label override reaches the upload action node', function (): void {
+    expect(uploadNode(wire(MediaLibrary::make()->uploadLabel('Import file')))['props']['label'])
+        ->toBe('Import file');
+});
+
 test('an instance accept narrows what the upload endpoint takes', function (): void {
     Storage::fake('public');
 

--- a/tests/Feature/Media/MediaPickerFieldTest.php
+++ b/tests/Feature/Media/MediaPickerFieldTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
 use Lattice\Form\Components\TextInput;
 use Lattice\Form\FormData;
@@ -54,6 +55,39 @@ test('the media picker carries the library as its child schema', function (): vo
         ->and($node['props']['multiple'])->toBeFalse()
         ->and($node['schema'][0]['type'])->toBe('media.library')
         ->and($node['schema'][0]['props']['picker'])->toBeTrue();
+});
+
+test('picker fluents reach the wire props and the embedded library', function (): void {
+    $node = wire(
+        MediaPicker::make('file')
+            ->category('imports')
+            ->uploadOnly()
+            ->uploadLabel('Upload import file')
+            ->pickerLabel('Choose import'),
+    );
+
+    expect($node['props']['uploadOnly'])->toBeTrue()
+        ->and($node['props']['pickerLabel'])->toBe('Choose import');
+
+    $library = $node['schema'][0];
+
+    expect($library['type'])->toBe('media.library')
+        ->and($library['schema'])->toHaveCount(1)
+        ->and($library['schema'][0]['key'])->toBe('media-upload')
+        ->and($library['schema'][0]['props']['label'])->toBe('Upload import file');
+});
+
+test('an upload through a category-scoped picker stamps the category', function (): void {
+    $node = wire(MediaPicker::make('file')->category('imports'));
+    $upload = (array) collect((array) $node['schema'][0]['schema'])->firstWhere('key', 'media-upload');
+
+    $this->postJson(
+        $upload['props']['endpoint'],
+        ['files' => [UploadedFile::fake()->image('import.jpg')]],
+        $this->latticeHeaders($upload),
+    )->assertOk();
+
+    expect(Media::query()->sole()->category)->toBe('imports');
 });
 
 test('the attachable rule rejects unknown ids and accepts existing media', function (): void {

--- a/tests/Feature/Media/MediaTableTest.php
+++ b/tests/Feature/Media/MediaTableTest.php
@@ -59,6 +59,35 @@ test('search matches names and the type filter narrows by mime prefix', function
         ->assertJsonPath('data.0.name', 'photo.jpg');
 });
 
+test('an unscoped table hides categorized media', function (): void {
+    Media::factory()->create(['name' => 'photo.jpg']);
+    Media::factory()->create(['name' => 'import.csv', 'category' => 'imports']);
+
+    $this->loadTable(MediaTable::class)
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.name', 'photo.jpg');
+});
+
+test('a sealed category context narrows the table to that category', function (): void {
+    Media::factory()->create(['name' => 'photo.jpg']);
+    Media::factory()->create(['name' => 'import.csv', 'category' => 'imports']);
+    Media::factory()->create(['name' => 'report.csv', 'category' => 'exports']);
+
+    $this->loadTable(MediaTable::class, context: ['category' => 'imports'])
+        ->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.name', 'import.csv');
+});
+
+test('request parameters cannot widen the category scope beyond the sealed context', function (): void {
+    Media::factory()->create(['name' => 'import.csv', 'category' => 'imports']);
+
+    $this->loadTable(MediaTable::class, ['category' => 'imports'])
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
 test('guests cannot query the media table', function (): void {
     $ref = $this->latticeRef(wire(Table::use(MediaTable::class)));
 

--- a/tests/Feature/Media/UploadMediaActionTest.php
+++ b/tests/Feature/Media/UploadMediaActionTest.php
@@ -227,6 +227,40 @@ test('a signed upload ends with a real derivative object on s3', function (): vo
     }
 })->group('rustfs');
 
+test('a sealed category context stamps every multipart upload', function (): void {
+    $this->callAction(
+        UploadMediaAction::class,
+        ['files' => [UploadedFile::fake()->image('import.jpg')]],
+        ['category' => 'imports'],
+    )->assertOk();
+
+    expect(Media::query()->sole()->category)->toBe('imports');
+});
+
+test('signed uploads inherit the sealed category once finalized', function (): void {
+    config()->set('media.signed_uploads', true);
+    Storage::disk('public')->put('tmp/abc123.jpg', 'bytes');
+
+    $this->callAction(UploadMediaAction::class, ['files' => ['tmp/abc123.jpg']], ['category' => 'imports'])
+        ->assertOk();
+
+    expect(Media::query()->sole()->category)->toBe('imports');
+});
+
+test('the upload response carries full display descriptors', function (): void {
+    $response = $this->callAction(UploadMediaAction::class, [
+        'files' => [UploadedFile::fake()->image('team.jpg', 100, 100)],
+    ])->assertOk();
+
+    $media = Media::query()->sole();
+
+    $response->assertJsonPath('data.media.0.id', $media->getKey())
+        ->assertJsonPath('data.media.0.name', 'team.jpg')
+        ->assertJsonPath('data.media.0.mime_type', 'image/jpeg')
+        ->assertJsonPath('data.media.0.url', $media->url())
+        ->assertJsonPath('data.media.0.preview_url', $media->previewUrl());
+});
+
 test('multipart uploads queue their conversions', function (): void {
     Bus::fake();
 


### PR DESCRIPTION
Adds media categories and the picker modes needed to host special-purpose files (e.g. import uploads) without them surfacing next to regular media.

- **Categories**: new nullable, indexed `category` column on `media`. `MediaLibrary`/`MediaPicker::category('imports')` scope the listing and stamp every upload. The scope rides the sealed table/upload context, so a client cannot widen or switch it. Unscoped instances list only uncategorized media, keeping categorized pools invisible everywhere they are not explicitly requested (no behavior change for existing data — everything is uncategorized).
- **Label overrides**: `uploadLabel()` (library + picker) relabels the upload button via the action node's `label` the client already reads; `pickerLabel()` relabels the browse trigger.
- **Upload-only mode**: `MediaPicker::uploadOnly()` composes only the upload action — no browse endpoint exists for the field. The button opens the file dialog directly and the fresh upload is picked automatically; the upload response now returns full display descriptors instead of bare ids, threaded through a new `onUploaded` callback on `useMediaUpload`. The upload progress list is extracted into a shared `UploadList` used by both the library grid and the upload-only picker.
- **Derivative byte sizes**: every generated conversion entry records its `size` in bytes next to path and dimensions. Legacy maps are backfilled from a disk stat alone (the job never reads the source for it), and `media:conversions --missing` counts size-less entries as pending work.

Typical Artisan-OS usage:

```php
MediaPicker::make('file')
    ->category('imports')
    ->uploadOnly()
    ->uploadLabel(__('imports.upload'));
```

Validated with the full Pest suite (1693 passed), PHPStan (both configs), `npm run check`, the media browser tests, and the docs build. New coverage: sealed-context scoping (incl. the request-parameter bypass attempt), upload category stamping (multipart + signed), upload response shape, fluent delegation, upload-only rendering/auto-pick, and `onUploaded` batching/dedupe.

