### PR TITLE
feat: vertical rail chrome — tabs, search disclosure, topbar breadcrumbs, sidebar footer, responsive visibility

### DIFF
--- a/docs/content/docs/components/layout.mdx
+++ b/docs/content/docs/components/layout.mdx
@@ -78,6 +78,14 @@ Any child component or field controls how many columns it covers with `->columnS
   matching `columns` maps when a grid gets narrow.
 </Info>
 
+## Responsive visibility
+
+Every component can opt out of rendering at a breakpoint range: `->hiddenFrom(Breakpoint::Md)`
+hides it at `md` and up, `->visibleFrom(Breakpoint::Md)` shows it only from `md` up. The toggle is
+CSS-only (a `display: contents` wrapper), so it is layout-transparent inside flex and grid parents —
+use it for chrome that differs between mobile and desktop, like a logo mark that only appears in a
+mobile topbar.
+
 ## Card
 
 `Card::make('Title', 'Description')` wraps children in a bordered panel. Both arguments are optional —

--- a/docs/content/docs/components/tabs.mdx
+++ b/docs/content/docs/components/tabs.mdx
@@ -31,13 +31,22 @@ open.
 
 ## Orientation and alignment
 
-- `->orientation(Orientation::Vertical)` moves the strip to the side of the panels.
+- `->orientation(Orientation::Vertical)` moves the strip to the side of the panels. Vertical tabs
+  render as a fixed-width rail on the page background — no pill panel — with the active item marked
+  by a primary accent bar and a subtle background.
 - `->alignment(TabsAlignment::…)` controls how the strip sits. Horizontal tabs default to `Stretch`
   (tabs share the full width); `Start`, `Center`, and `End` shrink the strip to its content and pin it
   left, center, or right. Vertical tabs only read `End` — it moves the strip to the right of the
   panels; every other value keeps it on the left.
 
 See the [enums reference](/advanced/enums/) for the full `Orientation` and `TabsAlignment` cases.
+
+## Responsive behavior
+
+Below the `md` breakpoint, tabs with more than three entries collapse into a native select — both
+orientations — so long tab strips stay usable on small screens. Selecting an option switches panels
+exactly like clicking the tab, including the password-confirmation redirect for gated tabs. With
+three or fewer tabs the strip is kept as-is.
 
 ## Password-confirmed tabs
 

--- a/docs/content/docs/core/navigation.md
+++ b/docs/content/docs/core/navigation.md
@@ -153,27 +153,25 @@ Stack::make('app-main')->width(Width::Fill)->schema([
 
 ## Pinning a sidebar footer
 
-To keep navigation at the top of the sidebar and a user menu pinned to the bottom, wrap them in a
-full-height `Stack` with `->justify(Justify::Between)`. A column `Stack` lays out as a grid by default;
-giving it a `justify` switches it to a flex column so the space distributes:
+To keep navigation at the top of the sidebar and, say, a user menu pinned to the bottom, pass the
+bottom components to `->footer([...])`:
 
 ```php
-use Lattice\Ui\Enums\Justify;
 use Lattice\Ui\Enums\Placement;
-use Lattice\Ui\Enums\Width;
 use Lattice\Ui\Components\RawBlock;
-use Lattice\Ui\Components\Stack;
 use Lattice\Ui\Components\Text;
 use Lattice\Layouts\Components\Dropdown;
 use Lattice\Layouts\Components\Menu;
 use Lattice\Layouts\Components\MenuItem;
 use Lattice\Layouts\Components\Sidebar;
 
-Sidebar::make('app-sidebar')->collapsible()->items([
-    Stack::make('sidebar-body')->width(Width::Fill)->justify(Justify::Between)->schema([
+Sidebar::make('app-sidebar')->collapsible()
+    ->items([
         Menu::make('sidebar')->items([
             MenuItem::fromPage(HomePage::class)->icon('house'),
         ]),
+    ])
+    ->footer([
         Dropdown::make('user-menu')
             ->placement(Placement::Top)
             ->trigger([
@@ -183,6 +181,7 @@ Sidebar::make('app-sidebar')->collapsible()->items([
             ->items([
                 MenuItem::make('Log out')->href(route('logout', absolute: false))->method(HttpMethod::Post),
             ]),
-    ]),
-]);
+    ]);
 ```
+
+Give dropdowns in the footer `Placement::Top` so they open upward.

--- a/docs/content/docs/packages/search.mdx
+++ b/docs/content/docs/packages/search.mdx
@@ -27,6 +27,17 @@ run `php artisan lattice:assets` after installation.
 There is no npm package — Composer is the only install.
 :::
 
+## The search dialog
+
+`SearchBox::make()` renders a trigger button that opens the search dialog (also reachable via
+`⌘K`/`Ctrl+K`). The dialog opens compact — just the input, plus recent selections when a
+`SearchHistoryRecorder` is bound — and expands into the three-pane layout (categories, results,
+preview) once a query is typed. Inside a collapsed sidebar the trigger shrinks to an icon-only
+button; the keyboard shortcut keeps working.
+
+Pass your own `->schema([...])` of `SearchInput`, `SearchResults`, `SearchCategories`,
+`SearchRecent`, and `SearchPreview` components to replace the default composition entirely.
+
 ## Translations
 
 The component's strings ship with inline English defaults. With

--- a/packages/core/resources/js/renderer.test.tsx
+++ b/packages/core/resources/js/renderer.test.tsx
@@ -104,6 +104,42 @@ describe("Renderer", () => {
     expect(screen.queryByText("Hidden")).not.toBeInTheDocument();
   });
 
+  it("wraps responsive visibility in a layout-transparent span", () => {
+    const registry = createRegistry({
+      components: {
+        "test.component": eagerComponent(TestComponent),
+      },
+      name: "test",
+    });
+
+    renderWithRegistry(
+      <Renderer
+        nodes={[
+          {
+            id: "mobile-only",
+            props: { hiddenFrom: "md", label: "Mobile only" },
+            type: "test.component",
+          },
+          {
+            id: "desktop-only",
+            props: { label: "Desktop only", visibleFrom: "md" },
+            type: "test.component",
+          },
+          {
+            id: "everywhere",
+            props: { label: "Everywhere" },
+            type: "test.component",
+          },
+        ]}
+      />,
+      registry,
+    );
+
+    expect(screen.getByTestId("mobile-only").parentElement).toHaveClass("contents", "md:hidden");
+    expect(screen.getByTestId("desktop-only").parentElement).toHaveClass("hidden", "md:contents");
+    expect(screen.getByTestId("everywhere").parentElement).not.toHaveClass("contents");
+  });
+
   it("suspends to an empty fallback while a lazy chunk is loading", () => {
     const registry = createRegistry({
       components: {

--- a/packages/core/resources/js/renderer.tsx
+++ b/packages/core/resources/js/renderer.tsx
@@ -7,6 +7,46 @@ import { useComponentRegistry } from "./registry-context";
 
 const warnedMissingTypes = new Set<string>();
 
+const HIDDEN_FROM_CLASS: Record<string, string> = {
+  sm: "sm:hidden",
+  md: "md:hidden",
+  lg: "lg:hidden",
+  xl: "xl:hidden",
+  "2xl": "2xl:hidden",
+};
+
+const VISIBLE_FROM_CLASS: Record<string, string> = {
+  sm: "sm:contents",
+  md: "md:contents",
+  lg: "lg:contents",
+  xl: "xl:contents",
+  "2xl": "2xl:contents",
+};
+
+/**
+ * A `display: contents` wrapper stays transparent to the parent layout, so the
+ * responsive visibility classes can toggle any node without disturbing flex or
+ * grid parents.
+ */
+function responsiveVisibilityClass(props: Node["props"]): string | null {
+  const hiddenFrom = HIDDEN_FROM_CLASS[(props as { hiddenFrom?: string })?.hiddenFrom ?? ""];
+  const visibleFrom = VISIBLE_FROM_CLASS[(props as { visibleFrom?: string })?.visibleFrom ?? ""];
+
+  if (visibleFrom && hiddenFrom) {
+    return `hidden ${visibleFrom} ${hiddenFrom}`;
+  }
+
+  if (visibleFrom) {
+    return `hidden ${visibleFrom}`;
+  }
+
+  if (hiddenFrom) {
+    return `contents ${hiddenFrom}`;
+  }
+
+  return null;
+}
+
 function warnMissingComponent(type: string): void {
   if (!import.meta.env.DEV || warnedMissingTypes.has(type)) {
     return;
@@ -86,10 +126,16 @@ const NodeRenderer = memo(function NodeRenderer({ node }: { node: Node }) {
 
   const Component = registration.component;
   const children = node.schema?.length ? <Renderer nodes={node.schema} /> : null;
-  const renderedComponent = <Component node={node}>{children}</Component>;
+  let renderedComponent = <Component node={node}>{children}</Component>;
 
   if (registration.mode === "lazy") {
-    return <Suspense fallback={null}>{renderedComponent}</Suspense>;
+    renderedComponent = <Suspense fallback={null}>{renderedComponent}</Suspense>;
+  }
+
+  const visibilityClass = responsiveVisibilityClass(node.props);
+
+  if (visibilityClass) {
+    return <span className={visibilityClass}>{renderedComponent}</span>;
   }
 
   return renderedComponent;

--- a/packages/framework/resources/js/layout/components/breadcrumbs.tsx
+++ b/packages/framework/resources/js/layout/components/breadcrumbs.tsx
@@ -17,7 +17,7 @@ const BreadcrumbsComponent: RendererComponent<"breadcrumbs"> = ({ node }) => {
   return (
     <nav
       aria-label={t("common.breadcrumb", "Breadcrumb")}
-      className="px-4 pt-4"
+      className="min-w-0"
       data-lattice-component={nodeIdentity(node)}
     >
       <ol className="flex items-center gap-2 text-sm text-lt-muted-fg">
@@ -26,13 +26,13 @@ const BreadcrumbsComponent: RendererComponent<"breadcrumbs"> = ({ node }) => {
 
           return (
             <Fragment key={crumb.href}>
-              <li>
+              <li className="min-w-0">
                 {isLast ? (
-                  <span aria-current="page" className="text-lt-fg">
+                  <span aria-current="page" className="block truncate text-lt-fg">
                     {crumb.title}
                   </span>
                 ) : (
-                  <Link className="hover:text-lt-fg" href={crumb.href}>
+                  <Link className="block truncate hover:text-lt-fg" href={crumb.href}>
                     {crumb.title}
                   </Link>
                 )}

--- a/packages/framework/resources/js/layout/components/breadcrumbs.tsx
+++ b/packages/framework/resources/js/layout/components/breadcrumbs.tsx
@@ -17,7 +17,7 @@ const BreadcrumbsComponent: RendererComponent<"breadcrumbs"> = ({ node }) => {
   return (
     <nav
       aria-label={t("common.breadcrumb", "Breadcrumb")}
-      className="min-w-0"
+      className="min-w-0 flex-1"
       data-lattice-component={nodeIdentity(node)}
     >
       <ol className="flex items-center gap-2 text-sm text-lt-muted-fg">

--- a/packages/framework/resources/js/layout/components/sidebar-footer.tsx
+++ b/packages/framework/resources/js/layout/components/sidebar-footer.tsx
@@ -1,0 +1,10 @@
+import type { RendererComponent } from "@lattice-php/core/types";
+import { nodeIdentity } from "@lattice-php/core/test-id";
+
+const SidebarFooterComponent: RendererComponent<"sidebar.footer"> = ({ children, node }) => (
+  <div className="mt-auto flex flex-col gap-4" data-lattice-component={nodeIdentity(node)}>
+    {children}
+  </div>
+);
+
+export default SidebarFooterComponent;

--- a/packages/framework/resources/js/layout/components/sidebar.test.tsx
+++ b/packages/framework/resources/js/layout/components/sidebar.test.tsx
@@ -6,9 +6,13 @@ import { Renderer } from "@lattice-php/core/renderer";
 import { renderWithRegistry } from "@lattice-php/core/test-support";
 import type { Node } from "@lattice-php/core/types";
 import SidebarComponent from "./sidebar";
+import SidebarFooterComponent from "./sidebar-footer";
 
 const registry = createRegistry({
-  components: { sidebar: eagerComponent(SidebarComponent) },
+  components: {
+    sidebar: eagerComponent(SidebarComponent),
+    "sidebar.footer": eagerComponent(SidebarFooterComponent),
+  },
   name: "test/sidebar",
 });
 
@@ -65,5 +69,22 @@ describe("Sidebar", () => {
     dispatchToggle();
 
     expect(window.localStorage.getItem("lattice:sidebar:app-sidebar")).toBeNull();
+  });
+
+  it("pins footer children to the bottom of the sidebar", () => {
+    const node: Node = {
+      id: "app-sidebar",
+      props: { collapsible: false, rememberState: false },
+      schema: [{ id: "footer", props: {}, type: "sidebar.footer" }],
+      type: "sidebar",
+    };
+
+    renderWithRegistry(<Renderer nodes={[node]} />, registry);
+
+    const footer = screen
+      .getByRole("complementary")
+      .querySelector('[data-lattice-component="footer"]');
+    expect(footer).not.toBeNull();
+    expect(footer).toHaveClass("mt-auto");
   });
 });

--- a/packages/framework/resources/js/layout/plugin.ts
+++ b/packages/framework/resources/js/layout/plugin.ts
@@ -7,6 +7,7 @@ import MenuComponent from "./components/menu";
 import MenuItemComponent from "./components/menu-item";
 import OutletComponent from "./components/outlet";
 import SidebarComponent from "./components/sidebar";
+import SidebarFooterComponent from "./components/sidebar-footer";
 import TopbarComponent from "./components/topbar";
 
 export const layoutComponents: Plugin = {
@@ -18,6 +19,7 @@ export const layoutComponents: Plugin = {
     "menu-item": eagerComponent(MenuItemComponent),
     outlet: eagerComponent(OutletComponent),
     sidebar: eagerComponent(SidebarComponent),
+    "sidebar.footer": eagerComponent(SidebarFooterComponent),
     topbar: eagerComponent(TopbarComponent),
   } satisfies ComponentRegistryFor<LayoutNodeType>,
   name: "lattice/layout",

--- a/packages/framework/resources/js/types/generated.ts
+++ b/packages/framework/resources/js/types/generated.ts
@@ -28,6 +28,7 @@ export type ComponentPropsMap = {
   outlet: Outlet;
   "remote.data-list": DataList;
   sidebar: Sidebar;
+  "sidebar.footer": SidebarFooter;
   topbar: Topbar;
 };
 export type DataList = {
@@ -117,6 +118,7 @@ export type LayoutNodeType =
   | "menu-item"
   | "outlet"
   | "sidebar"
+  | "sidebar.footer"
   | "topbar";
 export type Listen = {
   readonly channel: string;
@@ -209,6 +211,7 @@ export type NodeType =
   | "segmented-control"
   | "separator"
   | "sidebar"
+  | "sidebar.footer"
   | "signature"
   | "stack"
   | "tab"
@@ -269,6 +272,7 @@ export type Sidebar = {
   collapsible: boolean;
   rememberState: boolean;
 };
+export type SidebarFooter = Record<string, never>;
 export type SignatureExampleNodeType = "signature";
 export type TableNodeType = "table";
 export type Topbar = {

--- a/packages/framework/src/Layouts/Components/Sidebar.php
+++ b/packages/framework/src/Layouts/Components/Sidebar.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Layouts\Components;
 
 use Lattice\Core\Attributes\AsComponent;
+use Lattice\Ui\Components\Component;
 use Lattice\Ui\Components\ContainerComponent;
 use Lattice\Ui\Contracts\SchemaEntry;
 
@@ -17,6 +18,8 @@ class Sidebar extends ContainerComponent
     public bool $collapsible = false;
 
     public bool $rememberState = true;
+
+    protected ?SidebarFooter $footerNode = null;
 
     public static function make(?string $key = null): static
     {
@@ -37,5 +40,28 @@ class Sidebar extends ContainerComponent
     public function items(array $components): static
     {
         return $this->schema($components);
+    }
+
+    /**
+     * Pin components to the bottom of the sidebar, below the items.
+     *
+     * @param  array<int, SchemaEntry>  $components
+     */
+    public function footer(array $components): static
+    {
+        $this->footerNode = SidebarFooter::make()->schema($components);
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, Component>
+     */
+    #[\Override]
+    protected function resolvedChildren(): array
+    {
+        $children = parent::resolvedChildren();
+
+        return ! $this->footerNode instanceof SidebarFooter ? $children : [...$children, $this->footerNode];
     }
 }

--- a/packages/framework/src/Layouts/Components/SidebarFooter.php
+++ b/packages/framework/src/Layouts/Components/SidebarFooter.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Layouts\Components;
+
+use Lattice\Core\Attributes\AsComponent;
+use Lattice\Ui\Components\ContainerComponent;
+
+/**
+ * The bottom-pinned region of a sidebar. Built via {@see Sidebar::footer()}.
+ */
+#[AsComponent('sidebar.footer')]
+class SidebarFooter extends ContainerComponent
+{
+    public static function make(?string $key = null): static
+    {
+        return new static($key);
+    }
+}

--- a/packages/search/resources/js/components/search-box.tsx
+++ b/packages/search/resources/js/components/search-box.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useId, useState, type ReactNode } from "react";
+import { useCollapsed } from "@lattice-php/core/collapsed-context";
 import type { Node, RendererComponent } from "@lattice-php/core/types";
 import { Dialog, DialogContent, DialogTitle } from "@lattice-php/ui/dialog";
 import { Icon } from "@lattice-php/ui/icons";
 import { useT } from "@lattice-php/ui/i18n";
-import { SearchProvider } from "../context";
+import { SearchProvider, useSearchContext } from "../context";
 import type { SearchNodeType } from "../types";
 import { useSearch } from "../use-search";
 import SearchCategories from "./categories";
@@ -30,15 +31,26 @@ function isEditingTarget(target: EventTarget | null): boolean {
 }
 
 function DefaultComposition(): ReactNode {
+  const { query } = useSearchContext();
+  const expanded = query.trim() !== "";
+
+  if (!expanded) {
+    return (
+      <div className="flex max-h-[min(36rem,calc(100dvh-2rem))] flex-col">
+        <SearchInput node={slotNode("search.input")}>{null}</SearchInput>
+        <SearchRecent node={slotNode("search.recent")}>{null}</SearchRecent>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-[min(36rem,calc(100dvh-2rem))] flex-col">
+    <div className="flex max-h-[min(36rem,calc(100dvh-2rem))] flex-col">
       <SearchInput node={slotNode("search.input")}>{null}</SearchInput>
-      <div className="grid min-h-0 flex-1 grid-rows-[auto_1fr] md:grid-cols-[12rem_minmax(0,1fr)_16rem] md:grid-rows-1">
+      <div className="grid min-h-80 flex-1 grid-rows-[auto_1fr] md:grid-cols-[12rem_minmax(0,1fr)_16rem] md:grid-rows-1">
         <div className="border-b border-lt-border md:border-e md:border-b-0">
           <SearchCategories node={slotNode("search.categories")}>{null}</SearchCategories>
         </div>
         <div className="min-h-0 overflow-hidden">
-          <SearchRecent node={slotNode("search.recent")}>{null}</SearchRecent>
           <SearchResults node={slotNode("search.results")}>{null}</SearchResults>
         </div>
         <div className="hidden border-s border-lt-border md:block">
@@ -52,6 +64,7 @@ function DefaultComposition(): ReactNode {
 const SearchBox: RendererComponent<"search.box"> = ({ node, children }) => {
   const { endpoint, placeholder, title, shortcut, perPage } = node.props;
   const { t } = useT("search");
+  const collapsed = useCollapsed();
   const [open, setOpen] = useState(false);
   const instanceId = useId();
   const search = useSearch({ endpoint, perPage });
@@ -94,14 +107,21 @@ const SearchBox: RendererComponent<"search.box"> = ({ node, children }) => {
     <>
       <button
         {...(shortcut ? { "aria-keyshortcuts": "Meta+K Control+K" } : {})}
-        className="flex min-h-11 w-full max-w-sm items-center gap-2 rounded-lt border border-lt-border bg-lt-bg px-3 text-sm text-lt-muted-fg shadow-lt-xs hover:bg-lt-muted/60 focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[length:var(--lt-ring-width)]"
+        {...(collapsed ? { "aria-label": placeholderText } : {})}
+        className={
+          collapsed
+            ? "flex size-9 items-center justify-center rounded-lt border border-lt-border bg-lt-bg text-lt-muted-fg shadow-lt-xs hover:bg-lt-muted/60 focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[length:var(--lt-ring-width)]"
+            : "flex min-h-11 w-full max-w-sm items-center gap-2 rounded-lt border border-lt-border bg-lt-bg px-3 text-sm text-lt-muted-fg shadow-lt-xs hover:bg-lt-muted/60 focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 focus-visible:ring-[length:var(--lt-ring-width)]"
+        }
         data-test="search-trigger"
         onClick={() => setOpen(true)}
         type="button"
       >
         <Icon name="search" aria-hidden="true" className="size-lt-icon-sm" />
-        <span className="min-w-0 flex-1 truncate text-start">{placeholderText}</span>
-        {shortcut ? (
+        {collapsed ? null : (
+          <span className="min-w-0 flex-1 truncate text-start">{placeholderText}</span>
+        )}
+        {!collapsed && shortcut ? (
           <kbd className="rounded-lt-xs border border-lt-border px-1.5 py-0.5 text-xs">⌘K</kbd>
         ) : null}
       </button>

--- a/packages/search/resources/js/search.test.tsx
+++ b/packages/search/resources/js/search.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { CollapsedContext } from "@lattice-php/core/collapsed-context";
 import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
 import { defaultNavigation, NavigationProvider } from "@lattice-php/ui/navigation";
 import SearchBox from "./components/search-box";
@@ -118,6 +119,57 @@ it("opens the keyboard-focused result only after the server re-resolves it", asy
   await waitFor(() => expect(visit).toHaveBeenCalledWith("/safe"));
   const selection = fetch.mock.calls.find(([, init]) => init?.method === "POST");
   expect(selection?.[1]?.body).toBe(JSON.stringify({ category: "products", id: "2" }));
+});
+
+it("opens compact and expands the result grid once a query is typed", async () => {
+  stubSearchFetch((url) => {
+    if (url.searchParams.has("recent")) {
+      return jsonResponse(searchResponse([], { mode: "recent" }));
+    }
+
+    return jsonResponse(searchResponse([deskLamp], { category: "products" }));
+  });
+  renderSearch();
+
+  fireEvent.click(screen.getByTestId("search-trigger"));
+
+  expect(screen.getByRole("searchbox")).toBeInTheDocument();
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+  fireEvent.change(screen.getByRole("searchbox"), { target: { value: "desk" } });
+
+  expect(await screen.findByRole("option", { name: /Desk Lamp/ })).toBeInTheDocument();
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+  fireEvent.change(screen.getByRole("searchbox"), { target: { value: "" } });
+
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+});
+
+it("renders an icon-only trigger inside a collapsed container", () => {
+  stubSearchFetch(() => jsonResponse(searchResponse([], { mode: "recent" })));
+  const node = fakeNode({
+    type: "search.box",
+    id: "global-search",
+    props: { endpoint: "/lattice/search", perPage: 20, shortcut: true },
+  });
+
+  render(
+    <NavigationProvider adapter={{ ...defaultNavigation, visit }}>
+      <CollapsedContext.Provider value={true}>
+        <SearchBox node={node}>{null}</SearchBox>
+      </CollapsedContext.Provider>
+    </NavigationProvider>,
+  );
+
+  const trigger = screen.getByTestId("search-trigger");
+  expect(trigger).toHaveAccessibleName("Search…");
+  expect(trigger).not.toHaveTextContent("Search…");
+  expect(trigger).not.toHaveTextContent("⌘K");
+
+  fireEvent.click(trigger);
+
+  expect(screen.getByRole("searchbox")).toBeInTheDocument();
 });
 
 it("appends the next result page", async () => {

--- a/packages/ui/resources/js/combobox.browser.test.tsx
+++ b/packages/ui/resources/js/combobox.browser.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { useState } from "react";
+import { Combobox } from "./combobox";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+
+const options = Array.from({ length: 40 }, (_, index) => ({
+  data: {},
+  label: `Option ${index + 1}`,
+  value: `option-${index + 1}`,
+}));
+
+function DialogWithCombobox() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open>
+      <DialogContent>
+        <DialogTitle>Webhook</DialogTitle>
+        <Combobox
+          multiple
+          onSelect={() => {}}
+          open={open}
+          onOpenChange={setOpen}
+          options={options}
+          selected={[]}
+          showSearch={false}
+          testId="events"
+          trigger={<span>Select…</span>}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+describe("Combobox in a browser", () => {
+  it("keeps wheel scrolling alive inside a modal dialog", async () => {
+    const screen = await render(<DialogWithCombobox />);
+
+    await screen.getByRole("button", { name: "Select…" }).click();
+    await expect.element(screen.getByRole("listbox")).toBeVisible();
+
+    const listbox = screen.getByRole("listbox").element();
+    const wheel = new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 120 });
+    listbox.dispatchEvent(wheel);
+
+    expect(wheel.defaultPrevented).toBe(false);
+
+    listbox.scrollTop = 100;
+    expect(listbox.scrollTop).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/resources/js/combobox.browser.test.tsx
+++ b/packages/ui/resources/js/combobox.browser.test.tsx
@@ -33,6 +33,29 @@ function DialogWithCombobox() {
   );
 }
 
+function PageWithCombobox({ onSubmit }: { onSubmit: () => void }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <Combobox
+        multiple
+        onSelect={() => {}}
+        open={open}
+        onOpenChange={setOpen}
+        options={options}
+        selected={[]}
+        showSearch={false}
+        testId="events"
+        trigger={<span>Select…</span>}
+      />
+      <button onClick={onSubmit} type="button">
+        Save
+      </button>
+    </div>
+  );
+}
+
 describe("Combobox in a browser", () => {
   it("keeps wheel scrolling alive inside a modal dialog", async () => {
     const screen = await render(<DialogWithCombobox />);
@@ -48,5 +71,17 @@ describe("Combobox in a browser", () => {
 
     listbox.scrollTop = 100;
     expect(listbox.scrollTop).toBeGreaterThan(0);
+  });
+
+  it("lets an outside click land in one go when not inside a dialog", async () => {
+    let submitted = 0;
+    const screen = await render(<PageWithCombobox onSubmit={() => submitted++} />);
+
+    await screen.getByRole("button", { name: "Select…" }).click();
+    await expect.element(screen.getByRole("listbox")).toBeVisible();
+
+    await screen.getByRole("button", { name: "Save" }).click();
+
+    expect(submitted).toBe(1);
   });
 });

--- a/packages/ui/resources/js/combobox.tsx
+++ b/packages/ui/resources/js/combobox.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "./icons";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useT } from "./i18n";
 import type { Option } from "@lattice-php/core/types";
 import { cn } from "./lib/utils";
@@ -70,6 +70,12 @@ function Combobox({
 }) {
   const { t } = useT("lattice");
   const [query, setQuery] = useState("");
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [inDialog, setInDialog] = useState(false);
+
+  useLayoutEffect(() => {
+    setInDialog(Boolean(triggerRef.current?.closest('[role="dialog"]')));
+  }, []);
 
   function commitCreate(raw: string): void {
     const tokens = raw
@@ -128,12 +134,18 @@ function Combobox({
   }
 
   return (
-    // Modal so the popover owns the scroll lock: inside a modal dialog the
-    // dialog's lock would otherwise swallow wheel events over the portaled
-    // option list, leaving only the scrollbar draggable.
-    <Popover modal open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+    // Modal inside a dialog so the popover owns the scroll lock there: the
+    // dialog's own lock would otherwise swallow wheel events over the portaled
+    // option list, leaving only the scrollbar draggable. Outside dialogs the
+    // popover stays non-modal so a click on e.g. the submit button lands in
+    // one go while a multi-select is still open.
+    <Popover
+      modal={inDialog}
+      open={open}
+      onOpenChange={(next) => (next ? onOpenChange(true) : close())}
+    >
       <PopoverTrigger asChild>
-        <button type="button" className={triggerClassName} {...triggerProps}>
+        <button type="button" className={triggerClassName} ref={triggerRef} {...triggerProps}>
           {trigger}
         </button>
       </PopoverTrigger>

--- a/packages/ui/resources/js/combobox.tsx
+++ b/packages/ui/resources/js/combobox.tsx
@@ -128,7 +128,10 @@ function Combobox({
   }
 
   return (
-    <Popover open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+    // Modal so the popover owns the scroll lock: inside a modal dialog the
+    // dialog's lock would otherwise swallow wheel events over the portaled
+    // option list, leaving only the scrollbar draggable.
+    <Popover modal open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
       <PopoverTrigger asChild>
         <button type="button" className={triggerClassName} {...triggerProps}>
           {trigger}

--- a/packages/ui/resources/js/components/tabs.test.tsx
+++ b/packages/ui/resources/js/components/tabs.test.tsx
@@ -58,9 +58,28 @@ function renderTabs(
   );
 }
 
+function stubMatchMedia(matches: boolean): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      addEventListener: vi.fn(),
+      matches,
+      removeEventListener: vi.fn(),
+    }),
+  );
+}
+
+const fourTabs = [
+  tab("Overview", "overview"),
+  tab("Details", "details"),
+  tab("History", "history"),
+  tab("Danger", "danger"),
+];
+
 describe("Lattice tabs component", () => {
   beforeEach(() => {
     visit.mockClear();
+    vi.unstubAllGlobals();
     window.history.replaceState({}, "", "/settings");
   });
 
@@ -136,6 +155,59 @@ describe("Lattice tabs component", () => {
 
     fireEvent.keyDown(overview, { key: "ArrowLeft" });
     expect(history).toHaveFocus();
+  });
+
+  it("marks the active vertical tab with the rail accent", () => {
+    renderTabs({ orientation: "vertical" });
+
+    const tablist = screen.getByRole("tablist");
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    const details = screen.getByRole("tab", { name: "Details" });
+
+    expect(tablist).toHaveClass("w-44", "flex-col", "self-start");
+    expect(tablist).not.toHaveClass("bg-lt-muted");
+    expect(overview.className).toContain("before:bg-lt-primary");
+    expect(details.className).not.toContain("before:bg-lt-primary");
+  });
+
+  it("collapses to a native select on mobile with more than three tabs", () => {
+    stubMatchMedia(false);
+    renderTabs({ orientation: "vertical" }, fourTabs);
+
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+    const select = screen.getByRole("combobox", { name: "Tabs" });
+    expect(select).toHaveValue("overview");
+    expect(screen.getByText("Overview panel")).toBeVisible();
+
+    fireEvent.change(select, { target: { value: "details" } });
+
+    expect(select).toHaveValue("details");
+    expect(screen.getByText("Details panel")).toBeVisible();
+    expect(screen.getByText("Overview panel")).not.toBeVisible();
+    expect(window.location.search).toBe("?tabs=details");
+    expect(visit).not.toHaveBeenCalled();
+  });
+
+  it("keeps the tablist on mobile with three or fewer tabs", () => {
+    stubMatchMedia(false);
+    renderTabs();
+
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("visits the query url when the mobile select picks a confirmed tab", () => {
+    stubMatchMedia(false);
+    renderTabs({ activeValue: "overview" }, [
+      ...fourTabs.slice(0, 3),
+      tab("Danger", "danger", { confirm: { required: true } }),
+    ]);
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Tabs" }), {
+      target: { value: "danger" },
+    });
+
+    expect(visit).toHaveBeenCalledWith("/settings?tabs=danger", { preserveScroll: true });
   });
 
   it("lays out vertical tabs and roves focus with up and down arrows", () => {

--- a/packages/ui/resources/js/components/tabs.tsx
+++ b/packages/ui/resources/js/components/tabs.tsx
@@ -11,12 +11,15 @@ import type { KeyboardEvent, ReactNode } from "react";
 import type { Node, RendererComponent } from "@lattice-php/core/types";
 import type { Tab } from "../generated";
 import { cn } from "../lib/utils";
+import { useMediaQuery } from "../lib/use-media-query";
+import { NativeSelect } from "../native-select";
 import { useNavigation } from "../navigation";
 import { pillClassName } from "../pill";
 import { UI_NAMESPACE, useT } from "../i18n";
 
 type TabsContextValue = {
   activeValue: string;
+  hasTablist: boolean;
   setActiveValue: (value: string) => void;
 };
 
@@ -28,11 +31,23 @@ function useTabsContext(): TabsContextValue {
   if (!context) {
     return {
       activeValue: "",
+      hasTablist: true,
       setActiveValue: () => {},
     };
   }
 
   return context;
+}
+
+const SELECT_COLLAPSE_THRESHOLD = 3;
+
+function verticalTabClassName(active: boolean): string {
+  return cn(
+    "relative rounded-lt-sm px-3 py-2.5 text-left text-sm font-medium transition-colors",
+    active
+      ? "bg-lt-muted text-lt-fg before:absolute before:inset-y-2 before:left-0 before:w-1 before:rounded-full before:bg-lt-primary"
+      : "text-lt-muted-fg hover:bg-lt-muted/60 hover:text-lt-fg",
+  );
 }
 
 type TabItem = {
@@ -137,9 +152,12 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
     [selectTab, tabs],
   );
 
+  const isDesktop = useMediaQuery("(min-width: 768px)", true);
+  const collapseToSelect = !isDesktop && tabs.length > SELECT_COLLAPSE_THRESHOLD;
+
   const contextValue = useMemo(
-    () => ({ activeValue, setActiveValue: selectTabValue }),
-    [activeValue, selectTabValue],
+    () => ({ activeValue, hasTablist: !collapseToSelect, setActiveValue: selectTabValue }),
+    [activeValue, collapseToSelect, selectTabValue],
   );
 
   function onTablistKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
@@ -185,62 +203,78 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
       <div
         className={cn(
           "gap-6",
-          isVertical ? cn("flex", alignment === "end" && "flex-row-reverse") : "grid",
+          isVertical && !collapseToSelect
+            ? cn("flex", alignment === "end" && "flex-row-reverse")
+            : "grid",
         )}
         data-lattice-tabs={node.key ?? node.id}
       >
-        <div
-          aria-label={t("common.tabs", "Tabs")}
-          aria-orientation={orientation}
-          className={cn(
-            "gap-1 rounded-lt bg-lt-muted p-1",
-            isVertical && "flex flex-col",
-            isStretched && "flex w-full",
-            !isVertical &&
-              !isStretched &&
-              cn("inline-flex w-fit max-w-full overflow-x-auto", {
-                "justify-self-center": alignment === "center",
-                "justify-self-end": alignment === "end",
-              }),
-          )}
-          ref={tablistRef}
-          role="tablist"
-        >
-          {tabs.map((tab) => {
-            const isActive = activeValue === tab.value;
-
-            return (
-              <button
-                aria-controls={`${tab.value}-panel`}
-                aria-selected={isActive}
-                data-test={`tab-${tab.value}`}
-                className={cn(
-                  pillClassName(isActive),
-                  isVertical && "text-left",
-                  isStretched && "flex-1",
-                )}
-                id={`${tab.value}-tab`}
-                key={tab.value}
-                onClick={() => selectTab(tab)}
-                onKeyDown={onTablistKeyDown}
-                role="tab"
-                tabIndex={isActive ? 0 : -1}
-                type="button"
-              >
+        {collapseToSelect ? (
+          <NativeSelect
+            aria-label={t("common.tabs", "Tabs")}
+            data-test="tabs-select"
+            onChange={(event) => selectTabValue(event.target.value)}
+            value={activeValue}
+          >
+            {tabs.map((tab) => (
+              <option key={tab.value} value={tab.value}>
                 {tab.label}
-              </button>
-            );
-          })}
-        </div>
+              </option>
+            ))}
+          </NativeSelect>
+        ) : (
+          <div
+            aria-label={t("common.tabs", "Tabs")}
+            aria-orientation={orientation}
+            className={cn(
+              "gap-1",
+              isVertical ? "flex w-44 shrink-0 flex-col self-start" : "rounded-lt bg-lt-muted p-1",
+              isStretched && "flex w-full",
+              !isVertical &&
+                !isStretched &&
+                cn("inline-flex w-fit max-w-full overflow-x-auto", {
+                  "justify-self-center": alignment === "center",
+                  "justify-self-end": alignment === "end",
+                }),
+            )}
+            ref={tablistRef}
+            role="tablist"
+          >
+            {tabs.map((tab) => {
+              const isActive = activeValue === tab.value;
 
-        <div className={cn("min-w-0", isVertical && "flex-1")}>{children}</div>
+              return (
+                <button
+                  aria-controls={`${tab.value}-panel`}
+                  aria-selected={isActive}
+                  data-test={`tab-${tab.value}`}
+                  className={cn(
+                    isVertical ? verticalTabClassName(isActive) : pillClassName(isActive),
+                    isStretched && "flex-1",
+                  )}
+                  id={`${tab.value}-tab`}
+                  key={tab.value}
+                  onClick={() => selectTab(tab)}
+                  onKeyDown={onTablistKeyDown}
+                  role="tab"
+                  tabIndex={isActive ? 0 : -1}
+                  type="button"
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <div className={cn("min-w-0", isVertical && !collapseToSelect && "flex-1")}>{children}</div>
       </div>
     </TabsContext.Provider>
   );
 };
 
 const TabComponent: RendererComponent<"tab"> = ({ children, node }) => {
-  const { activeValue } = useTabsContext();
+  const { activeValue, hasTablist } = useTabsContext();
   const value = node.props.value;
   const isActive = activeValue === value;
   const [hasOpened, setHasOpened] = useState(isActive);
@@ -253,7 +287,8 @@ const TabComponent: RendererComponent<"tab"> = ({ children, node }) => {
 
   return (
     <section
-      aria-labelledby={`${value}-tab`}
+      aria-label={hasTablist ? undefined : node.props.label}
+      aria-labelledby={hasTablist ? `${value}-tab` : undefined}
       className={cn("space-y-8", !isActive && "hidden")}
       hidden={!isActive}
       id={`${value}-panel`}

--- a/packages/ui/src/Components/Component.php
+++ b/packages/ui/src/Components/Component.php
@@ -27,6 +27,10 @@ abstract class Component implements CanBeHidden, JsonSerializable, Renderable, S
 
     protected bool $hideWhenCollapsed = false;
 
+    protected ?Breakpoint $hiddenFrom = null;
+
+    protected ?Breakpoint $visibleFrom = null;
+
     /**
      * Breakpoint => span toward the nearest Grid ancestor.
      *
@@ -51,6 +55,34 @@ abstract class Component implements CanBeHidden, JsonSerializable, Renderable, S
     public function hideWhenCollapsed(bool $hide = true): static
     {
         $this->hideWhenCollapsed = $hide;
+
+        return $this;
+    }
+
+    /**
+     * Hide this component at the given breakpoint and above.
+     */
+    public function hiddenFrom(Breakpoint $breakpoint): static
+    {
+        if ($breakpoint === Breakpoint::Default) {
+            throw new InvalidArgumentException('hiddenFrom(Breakpoint::Default) would hide the component everywhere; use when() or remove it instead.');
+        }
+
+        $this->hiddenFrom = $breakpoint;
+
+        return $this;
+    }
+
+    /**
+     * Show this component only at the given breakpoint and above.
+     */
+    public function visibleFrom(Breakpoint $breakpoint): static
+    {
+        if ($breakpoint === Breakpoint::Default) {
+            throw new InvalidArgumentException('visibleFrom(Breakpoint::Default) is always visible; remove the call instead.');
+        }
+
+        $this->visibleFrom = $breakpoint;
 
         return $this;
     }
@@ -125,6 +157,14 @@ abstract class Component implements CanBeHidden, JsonSerializable, Renderable, S
 
         if ($this->hideWhenCollapsed) {
             $props['hideWhenCollapsed'] = true;
+        }
+
+        if ($this->hiddenFrom instanceof Breakpoint) {
+            $props['hiddenFrom'] = $this->hiddenFrom->value;
+        }
+
+        if ($this->visibleFrom instanceof Breakpoint) {
+            $props['visibleFrom'] = $this->visibleFrom->value;
         }
 
         if ($this->columnSpan !== null) {

--- a/tests/Feature/Layouts/SidebarFooterTest.php
+++ b/tests/Feature/Layouts/SidebarFooterTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Layouts\Components\Menu;
+use Lattice\Layouts\Components\MenuItem;
+use Lattice\Layouts\Components\Sidebar;
+use Lattice\Ui\Components\Text;
+
+test('a sidebar serializes footer components in a trailing footer node', function (): void {
+    $sidebar = Sidebar::make('app-sidebar')
+        ->items([
+            Menu::make('main')->items([MenuItem::make('Home')->href('/')]),
+        ])
+        ->footer([
+            Text::make('Tenant switcher'),
+        ]);
+
+    $wire = wire($sidebar);
+
+    expect($wire['type'])->toBe('sidebar')
+        ->and($wire['schema'][0]['type'])->toBe('menu')
+        ->and($wire['schema'][1]['type'])->toBe('sidebar.footer')
+        ->and($wire['schema'][1]['schema'][0]['type'])->toBe('text');
+});
+
+test('sidebar footer components serialize regardless of call order', function (): void {
+    $sidebar = Sidebar::make('app-sidebar')
+        ->footer([Text::make('Tenant switcher')])
+        ->items([
+            Menu::make('main')->items([MenuItem::make('Home')->href('/')]),
+        ]);
+
+    $wire = wire($sidebar);
+
+    expect($wire['schema'][0]['type'])->toBe('menu')
+        ->and($wire['schema'][1]['type'])->toBe('sidebar.footer');
+});
+
+test('a sidebar without a footer serializes no footer node', function (): void {
+    $wire = wire(Sidebar::make('app-sidebar')->items([
+        Menu::make('main')->items([MenuItem::make('Home')->href('/')]),
+    ]));
+
+    expect($wire['schema'])->toHaveCount(1)
+        ->and($wire['schema'][0]['type'])->toBe('menu');
+});

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -23,6 +23,7 @@ use Lattice\Ui\Components\Separator;
 use Lattice\Ui\Components\Stack;
 use Lattice\Ui\Components\Text;
 use Lattice\Ui\Enums\AvatarShape;
+use Lattice\Ui\Enums\Breakpoint;
 use Lattice\Ui\Enums\CodeBlockLanguage;
 use Lattice\Ui\Enums\FloatingPlacement;
 use Lattice\Ui\Enums\Gap;
@@ -426,4 +427,27 @@ test('a description list drops to list semantics once an entry can disclose', fu
 
     expect($plain['props']['semantic'])->toBe('description-list')
         ->and($disclosing['props']['semantic'])->toBe('list');
+});
+
+test('components serialize responsive visibility breakpoints', function (): void {
+    $wire = wire(Text::make('Mobile only')->hiddenFrom(Breakpoint::Md));
+
+    expect($wire['props']['hiddenFrom'])->toBe('md')
+        ->and($wire['props'])->not->toHaveKey('visibleFrom');
+
+    $wire = wire(Text::make('Desktop only')->visibleFrom(Breakpoint::Lg));
+
+    expect($wire['props']['visibleFrom'])->toBe('lg')
+        ->and($wire['props'])->not->toHaveKey('hiddenFrom');
+
+    expect(wire(Text::make('Everywhere'))['props'])
+        ->not->toHaveKey('hiddenFrom')
+        ->not->toHaveKey('visibleFrom');
+});
+
+test('responsive visibility rejects the default breakpoint', function (): void {
+    expect(fn (): Text => Text::make('x')->hiddenFrom(Breakpoint::Default))
+        ->toThrow(InvalidArgumentException::class);
+    expect(fn (): Text => Text::make('x')->visibleFrom(Breakpoint::Default))
+        ->toThrow(InvalidArgumentException::class);
 });

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -96,7 +96,6 @@ class AppLayout extends LayoutDefinition
                         ->width(Width::Fill)
                         ->schema([
                             $this->topbar(),
-                            Breadcrumbs::make(),
                             Outlet::make(),
                             RawBlock::make('chat-scroll-clearance')->html('<div class="h-24" aria-hidden="true"></div>'),
                         ]),
@@ -192,6 +191,7 @@ class AppLayout extends LayoutDefinition
                 ->icon('panel-left')
                 ->emphasis(Emphasis::Ghost)
                 ->effects(Effects::toggleSidebar('app-sidebar')),
+            Breadcrumbs::make(),
             SearchBox::make('global-search'),
             Stack::make('topbar-end')
                 ->direction(StackDirection::Row)

--- a/workbench/app/Layouts/ChatLayout.php
+++ b/workbench/app/Layouts/ChatLayout.php
@@ -5,7 +5,6 @@ namespace Workbench\App\Layouts;
 
 use Illuminate\Http\Request;
 use Lattice\Core\Attributes\AsLayout;
-use Lattice\Layouts\Components\Breadcrumbs;
 use Lattice\Layouts\Components\Outlet;
 use Lattice\Ui\Components\Stack;
 use Lattice\Ui\Enums\Gap;
@@ -29,7 +28,6 @@ final class ChatLayout extends AppLayout
                         ->width(Width::Fill)
                         ->schema([
                             $this->topbar(),
-                            Breadcrumbs::make(),
                             Outlet::make(),
                         ]),
                     Stack::make('chat-rail')


### PR DESCRIPTION
Unified "vertical rail" chrome for Lattice consumers, in four pieces:

**Tabs (ui):** Vertical tablists drop the segmented-pill panel for a transparent fixed-width rail — active item gets a subtle background plus a primary accent bar, hover stays muted. Below `md`, tabs with more than three entries collapse into a `NativeSelect`; selection reuses the exact tab-switching logic including the password-confirmation visit.

**Search:** The dialog opens compact (input + recent) and only mounts the categories/results/preview grid once a query is typed; the fixed 36rem height is now a max height. Inside a collapsed sidebar the trigger renders icon-only while ⌘K stays mounted.

**Layouts (framework):** Breadcrumbs lose their hardcoded padding and truncate, so they sit inside the topbar; both workbench layouts moved them there. New `Sidebar::footer()` pins components to the sidebar bottom via a `sidebar.footer` node.

**Responsive visibility (core/ui):** `->hiddenFrom(Breakpoint::X)` / `->visibleFrom(Breakpoint::X)` on every component, rendered as a CSS-only `display: contents` wrapper — layout-transparent in flex/grid parents.

Validated with `composer check`, `npm run check`, both browser suites, and end-to-end against Artisan OS via composer path repos + `LATTICE_SOURCE=1` (desktop, collapsed sidebar, and mobile Playwright smoke tests).
