### PR TITLE
chore: add package worktree tooling

### DIFF
--- a/.ai/guidelines/testing.md
+++ b/.ai/guidelines/testing.md
@@ -45,6 +45,13 @@ the same for Pest and Vitest. Do not write — and delete on sight:
 - **Implementation-detail pins**: mock call wiring, React element internals, DOM nesting, render counts — except where
   fine-grained subscription is the module's documented contract.
 
+## Keep behavior in its owning package
+
+Before writing a test, identify the lowest package that owns the behavior. Reusable behavior belongs in that
+package's Pest or Vitest suite, not in framework, workbench, docs, or every consumer. If an external dependency owns
+the behavior, add or fix its upstream test instead of creating a Lattice test as a substitute. Keep cross-package
+integration, Lattice-specific adapters, and local configuration coverage at their observable consumer boundary.
+
 ## Test helpers (TypeScript)
 
 - Reuse the owned helpers before writing local ones: `@lattice-php/core/test-support` (`fakeNode`,

--- a/.ai/skills/test-audit/SKILL.md
+++ b/.ai/skills/test-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-audit
-description: Use when auditing or cleaning up the Lattice test suites (Pest or Vitest) — duplicated or misplaced test helpers, low-value or obsolete tests, jsdom tests fighting the environment, suite-wide config drift — or when asked to "get rid of useless tests", align testing across packages, or consolidate test infrastructure.
+description: Use when auditing or cleaning up the Lattice test suites (Pest or Vitest) — duplicated or misplaced test helpers, low-value or obsolete tests, tests owned by another package or library, jsdom tests fighting the environment, suite-wide config drift — or when asked to "get rid of useless tests", align testing across packages, or consolidate test infrastructure.
 ---
 
 # Test Suite Audit & Cleanup
@@ -34,6 +34,9 @@ Not for writing individual new tests — the Testing guideline covers that bar d
    - Which configs actually run in CI? (`.github/workflows/` is the truth — locally-runnable configs that CI never
      executes are drift factories and delete candidates.)
    - Inventory helper modules and setup files; diff near-duplicates.
+   - Map package ownership before judging coverage. Reusable behavior belongs in the lowest Lattice
+     package that owns it; behavior owned by an external dependency belongs in that upstream suite.
+     Cross-package integration and Lattice-specific configuration remain locally owned.
    - Trace helper imports across packages. An upward import (leaf package pulling framework test sources) or a
      sideways copy-paste is a relocation finding.
    - Grep for inline duplication clusters: fetch/XHR stubs, router and Inertia mocks, `matchMedia`/`ResizeObserver`
@@ -47,14 +50,17 @@ Not for writing individual new tests — the Testing guideline covers that bar d
      duplicate).
    - **TRIM** — the test is sound but carries dead assertions (class pins, redundant absence checks) or duplicates a
      sibling; also collapse N near-identical tests into one `it.each`/dataset.
-   - **MOVE** — the subject lives in another package/layer, or the behavior is already owned there.
+   - **MOVE** — the subject or reusable behavior belongs in another package or external library.
+     Name the owning package and its exact surviving or required test.
    - **CONVERT** — the test fights its environment: jsdom → Vitest browser project, or a Pest feature test asserting
      UI → Pest browser test.
    Also collect **exemplars** — the suite's best tests define the house style the survivors should match.
 
 4. **Verify before deleting — the iron rule.** A test dies only when its behavior is worthless *or* has exactly one
-   surviving owner, named in the verdict. A CONVERT deletes the original only after its replacement passes. Never
-   batch-delete on category alone; the audit lists are hypotheses until checked against the surviving suite.
+   surviving owner, named in the verdict. If behavior lacks coverage in its owning package or library, add the test
+   there before deleting the misplaced test; never retain a consumer or aggregate-package test as a substitute. A
+   CONVERT deletes the original only after its replacement passes. Never batch-delete on category alone; the audit
+   lists are hypotheses until checked against the surviving suite.
 
 5. **Apply in ordered commits.** Order matters:
    1. *Config consolidation first* — otherwise you centralize helpers into N drifting places again.
@@ -78,6 +84,7 @@ Not for writing individual new tests — the Testing guideline covers that bar d
 | Sound test + dead class/absence assertions | TRIM | sidebar `md:*` mirrors next to `data-collapsed` |
 | N clones differing by one value | TRIM to `it.each`/dataset | invalid-date matrices, effect-bridge tests |
 | Framework test whose subject is a ui/form component | MOVE (often DELETE: already covered there) | menu-item-action vs button-action |
+| Consumer test re-proving another package or library's reusable contract | MOVE; add or identify owning coverage, then DELETE here | framework test for a leaf-package contract |
 | Stubbed `getBoundingClientRect`/`matchMedia`, prototype patches, hand-invoked drag callbacks | CONVERT to browser | tree-move, file-upload, table resize |
 | Fake timers around debounce feeding real UI | CONVERT (poll real timing) | precognitive typing test |
 
@@ -92,6 +99,10 @@ Not for writing individual new tests — the Testing guideline covers that bar d
 - **Agents recreate deleted patterns from "sibling convention".** After a purge, an unguided agent asked to test a
   presentational component will rebuild the exact class-pinning file you deleted. The Testing guideline is the
   counterweight — point implementation subagents at it explicitly.
+- **Consumer tests become a substitute package suite.** Do not add or keep a test in framework,
+  workbench, docs, or another consumer because owning coverage is missing. Put reusable behavior in
+  the lowest owning package; keep only cross-package integration and local configuration coverage
+  at the consumer boundary.
 - **Browser failure artifacts** (`__screenshots__/`, `.vitest-attachments/`) appear on red runs — keep them
   gitignored and out of commits (`git add -A` after a red browser run is how they sneak in).
 - **A test that only passes because the environment is fake** (all-zero rects making any pixel number "correct",

--- a/.ai/skills/worktrees/SKILL.md
+++ b/.ai/skills/worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktrees
-description: Use when creating, preparing, listing, switching between, or removing git worktrees for the Lattice package, especially when multiple agents work in parallel. Covers safe multi-agent branch isolation, the sibling worktree layout, Testbench dependency setup, the required verification gates, and cleanup.
+description: Use when creating, preparing, listing, switching between, or removing git worktrees for the Lattice package, especially when multiple agents work in parallel. Covers the project worktree scripts, safe multi-agent branch isolation, the sibling layout, Testbench setup, verification gates, and cleanup.
 ---
 
 # Lattice Worktrees
@@ -55,42 +55,23 @@ Rules:
 - Pick a unique slug and branch name, usually `<task>-<short-slug>`. Do not reuse an existing
   `lattice-<slug>` path or existing branch unless the user explicitly asks.
 
-## Create
+## Create with the project script
 
-Create from a clean base branch (usually `main`) or current `HEAD`. Run from the repo root so `..`
-resolves to the parent directory:
+Use the project script from the repo root. It creates the sibling worktree from `main`; the branch
+defaults to the worktree name when omitted:
 
-```bash
-git fetch origin --prune
-git worktree add ../lattice-<slug> -b <branch> main
-cd ../lattice-<slug>
+```shell
+bin/create-worktree.sh <slug> [branch]
 ```
 
-Examples:
+The script creates `../lattice-<slug>`, installs Composer and npm dependencies, refreshes the
+Boost-generated local agent context, and builds the workbench frontend. Testbench provisions the
+`workbench/` skeleton and its SQLite database on demand; there is no Herd site, app `.env`, key
+generation, or manual migration step.
 
-```bash
-git worktree add ../lattice-dropdown -b feat/dropdown-collapsible main
-git worktree add ../lattice-current-fix -b fix/current-fix HEAD
-```
-
-Continue an existing branch only when that is the intent:
-
-```bash
-git worktree add ../lattice-<slug> <branch>
-```
-
-## Set up
-
-Each worktree needs its own ignored dependencies. Always install both stacks:
-
-```bash
-composer install
-npm install
-```
-
-That is the whole setup. Testbench provisions the `workbench/` skeleton and its SQLite database on
-demand (via `composer post-autoload-dump` and the test bootstrap); there is no app `.env`, key
-generation, or manual `migrate` step to run.
+Use raw `git worktree add` only when the script cannot express the requested operation, such as
+continuing an existing branch or intentionally branching from a commit other than `main`. Reproduce
+the script's dependency installation and build steps in that exceptional worktree.
 
 `npm install` refreshes the Laravel Boost guidelines and skills after the frontend package graph is
 installed, so package-detected skills such as React, Inertia, and Tailwind are available in fresh
@@ -140,19 +121,19 @@ git worktree list --porcelain
 
 Use porcelain output when deciding what belongs to another agent.
 
-## Remove
+## Remove with the project script
 
-Only remove a worktree that belongs to your task and has no needed changes.
+Only remove a worktree that belongs to your task and has no needed changes. Run from the main repo
+root:
 
-```bash
-cd <repo-root>
-git -C ../lattice-<slug> status --short
-git worktree remove ../lattice-<slug>
-git worktree prune
+```shell
+bin/delete-worktree.sh <slug>
 ```
 
-Never use `git worktree remove --force` unless the user explicitly says to discard that worktree's
-uncommitted changes.
+The script refuses dirty worktrees and deletes the associated branch only when Git considers it
+merged. Use `bin/delete-worktree.sh <slug> --force` only when the user explicitly says to discard
+that worktree's uncommitted changes and branch. Do not bypass the script with
+`git worktree remove --force`.
 
 ## Multi-Agent Safety
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,7 @@
 /CLAUDE.md export-ignore
 /_ide_helper.php export-ignore
 /artisan export-ignore
+/bin/** export-ignore
 /astro.config.mjs export-ignore
 /boost.json export-ignore
 /package-lock.json export-ignore

--- a/bin/create-worktree.sh
+++ b/bin/create-worktree.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: bin/create-worktree.sh <name> [branch]" >&2
+    exit 1
+fi
+
+name="$1"
+branch="${2:-$1}"
+
+if [[ ! "$name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "error: <name> may only contain letters, numbers, dots, dashes, underscores" >&2
+    exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+worktree_dir="$(dirname "$repo_root")/lattice-$name"
+
+if [[ -e "$worktree_dir" ]]; then
+    echo "error: $worktree_dir already exists" >&2
+    exit 1
+fi
+
+git -C "$repo_root" worktree add "$worktree_dir" -b "$branch" main
+cd "$worktree_dir"
+
+composer install
+npm install
+npm run build

--- a/bin/delete-worktree.sh
+++ b/bin/delete-worktree.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: bin/delete-worktree.sh <name> [--force]" >&2
+    exit 1
+fi
+
+name="$1"
+force=false
+
+if [[ "${2:-}" == "--force" ]]; then
+    force=true
+elif [[ $# -eq 2 ]]; then
+    echo "error: the only supported option is --force" >&2
+    exit 1
+fi
+
+if [[ ! "$name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "error: <name> may only contain letters, numbers, dots, dashes, underscores" >&2
+    exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+worktree_dir="$(dirname "$repo_root")/lattice-$name"
+
+branch="$(git -C "$repo_root" worktree list --porcelain | awk -v dir="$worktree_dir" '
+    $1 == "worktree" { path = $2 }
+    $1 == "branch" && path == dir { sub("refs/heads/", "", $2); print $2 }
+')"
+
+if [[ -z "$branch" ]]; then
+    echo "error: $worktree_dir is not a registered git worktree" >&2
+    exit 1
+fi
+
+if [[ "$force" != true ]] && [[ -n "$(git -C "$worktree_dir" status --porcelain)" ]]; then
+    echo "error: $worktree_dir has uncommitted changes — commit/stash them or rerun with --force" >&2
+    exit 1
+fi
+
+if [[ "$force" == true ]]; then
+    git -C "$repo_root" worktree remove "$worktree_dir" --force
+    git -C "$repo_root" branch -D "$branch"
+else
+    git -C "$repo_root" worktree remove "$worktree_dir"
+    git -C "$repo_root" branch -d "$branch"
+fi
+
+git -C "$repo_root" worktree prune


### PR DESCRIPTION
Adds repository scripts for creating and removing fully prepared sibling worktrees without app- or Herd-specific setup. The worktree skill now makes those scripts the default and keeps the helpers out of Composer archives.

Also strengthens the testing guideline and audit workflow so reusable behavior is tested in its lowest owning package or upstream library instead of being duplicated in consumers.

Checks: skill validation, Bash syntax and argument guards, `git diff --check`, and the full pre-push PHP/npm gate.
