### PR TITLE
fix(ui): nested grid span inheritance and vertical tabs on mobile

### DIFF
--- a/docs/content/docs/components/tabs.mdx
+++ b/docs/content/docs/components/tabs.mdx
@@ -43,10 +43,10 @@ See the [enums reference](/advanced/enums/) for the full `Orientation` and `Tabs
 
 ## Responsive behavior
 
-Below the `md` breakpoint, tabs with more than three entries collapse into a native select — both
-orientations — so long tab strips stay usable on small screens. Selecting an option switches panels
-exactly like clicking the tab, including the password-confirmation redirect for gated tabs. With
-three or fewer tabs the strip is kept as-is.
+Below the `md` breakpoint, tabs collapse into a native select: vertical tabs always (a side rail
+does not fit a phone), horizontal tabs once they have more than three entries. Selecting an option
+switches panels exactly like clicking the tab, including the password-confirmation redirect for
+gated tabs. A horizontal strip with three or fewer tabs is kept as-is.
 
 ## Password-confirmed tabs
 

--- a/packages/core/resources/js/registry.ts
+++ b/packages/core/resources/js/registry.ts
@@ -53,10 +53,36 @@ export function eagerComponent<TType extends string>(
   };
 }
 
+const CHUNK_RETRY_DELAY_MS = 250;
+
+/**
+ * React.lazy caches a rejected loader forever, so one transient chunk-fetch
+ * failure (a flaky network, a briefly overloaded server) would leave the
+ * subtree permanently broken. One delayed retry recovers those; a persistent
+ * failure still surfaces the original error.
+ */
+function withChunkRetry(
+  load: () => Promise<RendererComponentModule>,
+): () => Promise<RendererComponentModule> {
+  return async () => {
+    try {
+      return await load();
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, CHUNK_RETRY_DELAY_MS));
+
+      try {
+        return await load();
+      } catch {
+        throw error;
+      }
+    }
+  };
+}
+
 export function lazyComponent<TType extends string>(
   load: () => Promise<RendererComponentModule<TType>>,
 ): LazyComponentRegistration {
-  const erasedLoader = load as unknown as () => Promise<RendererComponentModule>;
+  const erasedLoader = withChunkRetry(load as unknown as () => Promise<RendererComponentModule>);
 
   return {
     component: lazy(erasedLoader),

--- a/packages/core/resources/js/renderer.test.tsx
+++ b/packages/core/resources/js/renderer.test.tsx
@@ -140,6 +140,33 @@ describe("Renderer", () => {
     expect(screen.getByTestId("everywhere").parentElement).not.toHaveClass("contents");
   });
 
+  it("recovers a lazy component whose chunk fails to load once", async () => {
+    const LazyProbe: RendererComponent<"test.lazy"> = ({ node }) => (
+      <section>{node.props?.label as string | undefined}</section>
+    );
+    let attempts = 0;
+    const registry = createRegistry({
+      components: {
+        "test.lazy": lazyComponent<"test.lazy">(() => {
+          attempts++;
+
+          return attempts === 1
+            ? Promise.reject(new Error("Failed to fetch dynamically imported module"))
+            : Promise.resolve({ default: LazyProbe });
+        }),
+      },
+      name: "test",
+    });
+
+    renderWithRegistry(
+      <Renderer nodes={[{ id: "flaky-node", props: { label: "Recovered" }, type: "test.lazy" }]} />,
+      registry,
+    );
+
+    expect(await screen.findByText("Recovered", undefined, { timeout: 3000 })).toBeVisible();
+    expect(attempts).toBe(2);
+  });
+
   it("suspends to an empty fallback while a lazy chunk is loading", () => {
     const registry = createRegistry({
       components: {

--- a/packages/ui/resources/css/lattice.css
+++ b/packages/ui/resources/css/lattice.css
@@ -366,6 +366,22 @@
  * class scanning and the prebuilt standalone bundle.
  */
 @utility lt-grid {
+  /* Custom properties inherit, so a nested grid would otherwise pick up an
+     ancestor grid-item's span (e.g. a columnSpanFull card stretching every
+     field of a grid inside it). Reset at each grid boundary; inline values on
+     this element and its own items still win. */
+  --lt-grid-cols-default: initial;
+  --lt-grid-cols-sm: initial;
+  --lt-grid-cols-md: initial;
+  --lt-grid-cols-lg: initial;
+  --lt-grid-cols-xl: initial;
+  --lt-grid-cols-2xl: initial;
+  --lt-col-span-default: initial;
+  --lt-col-span-sm: initial;
+  --lt-col-span-md: initial;
+  --lt-col-span-lg: initial;
+  --lt-col-span-xl: initial;
+  --lt-col-span-2xl: initial;
   grid-template-columns: var(--lt-grid-cols-default, none);
 
   & > [data-slot="grid-item"] {

--- a/packages/ui/resources/js/components/grid.browser.test.tsx
+++ b/packages/ui/resources/js/components/grid.browser.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/core/registry";
+import { Renderer } from "@lattice-php/core/renderer";
+import { renderWithRegistry, TextProbe } from "@lattice-php/core/test-support";
+import GridComponent from "./grid";
+
+const registry = createRegistry({
+  components: {
+    grid: eagerComponent(GridComponent),
+    text: eagerComponent(TextProbe),
+  },
+  name: "test/grid",
+});
+
+describe("Grid in a browser", () => {
+  it("does not leak a full column span into a nested grid", async () => {
+    const screen = await renderWithRegistry(
+      <Renderer
+        nodes={[
+          {
+            id: "outer",
+            props: { columns: { default: 2 } },
+            type: "grid",
+            schema: [
+              {
+                id: "inner",
+                props: { columns: { default: 2 }, columnSpan: { default: "full" } },
+                type: "grid",
+                schema: [
+                  { id: "a", props: { text: "Field A" }, type: "text" },
+                  { id: "b", props: { text: "Field B" }, type: "text" },
+                ],
+              },
+            ],
+          },
+        ]}
+      />,
+      registry,
+    );
+
+    await expect.element(screen.getByText("Field A")).toBeVisible();
+
+    const innerGrid = document.querySelectorAll(".lt-grid")[1] as HTMLElement;
+    const [itemA, itemB] = Array.from(innerGrid.children) as HTMLElement[];
+
+    expect(getComputedStyle(itemA).gridColumn).toBe("auto");
+    expect(getComputedStyle(itemB).gridColumn).toBe("auto");
+    expect(itemB.getBoundingClientRect().x).toBeGreaterThan(itemA.getBoundingClientRect().x);
+  });
+});

--- a/packages/ui/resources/js/components/tabs.test.tsx
+++ b/packages/ui/resources/js/components/tabs.test.tsx
@@ -188,12 +188,23 @@ describe("Lattice tabs component", () => {
     expect(visit).not.toHaveBeenCalled();
   });
 
-  it("keeps the tablist on mobile with three or fewer tabs", () => {
+  it("keeps a horizontal tablist on mobile with three or fewer tabs", () => {
     stubMatchMedia(false);
     renderTabs();
 
     expect(screen.getByRole("tablist")).toBeInTheDocument();
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("always collapses vertical tabs to a select on mobile", () => {
+    stubMatchMedia(false);
+    renderTabs({ orientation: "vertical" }, [
+      tab("Overview", "overview"),
+      tab("Details", "details"),
+    ]);
+
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Tabs" })).toHaveValue("overview");
   });
 
   it("visits the query url when the mobile select picks a confirmed tab", () => {

--- a/packages/ui/resources/js/components/tabs.tsx
+++ b/packages/ui/resources/js/components/tabs.tsx
@@ -153,7 +153,9 @@ export const TabsComponent: RendererComponent<"tabs"> = ({ children, node }) => 
   );
 
   const isDesktop = useMediaQuery("(min-width: 768px)", true);
-  const collapseToSelect = !isDesktop && tabs.length > SELECT_COLLAPSE_THRESHOLD;
+  // A side rail cannot work on a phone regardless of tab count, so vertical
+  // tabs always collapse below md; horizontal strips only when they overflow.
+  const collapseToSelect = !isDesktop && (isVertical || tabs.length > SELECT_COLLAPSE_THRESHOLD);
 
   const contextValue = useMemo(
     () => ({ activeValue, hasTablist: !collapseToSelect, setActiveValue: selectTabValue }),


### PR DESCRIPTION
Two follow-up fixes surfaced while adopting the 0.53.0 rail chrome in Artisan OS:

**Nested grid span inheritance.** CSS custom properties inherit, so a grid nested inside a `columnSpanFull` item picked up the ancestor's `1 / -1` span for its own items — a two-column field grid inside a full-width card rendered stacked. The `--lt-grid-cols-*` / `--lt-col-span-*` variables now reset at each `.lt-grid` boundary (inline values on the grid and its own items still win). Browser test asserts the nested items keep `grid-column: auto` and sit side by side; it fails without the reset.

**Vertical tabs on phones.** A side rail cannot work below `md` regardless of tab count — a two-tab vertical rail still squeezed the content to ~200px. Vertical tabs now always collapse to the native select on mobile; horizontal strips keep the more-than-three threshold.

Validated with the ui unit + browser suites and end-to-end against Artisan OS's product edit page.

**Flake hardening.** The recurring `ProductFormTest` CI failure ("Failed to fetch dynamically imported module") had a real amplifier: React.lazy caches a rejected loader forever, so one transient chunk-fetch failure left the subtree permanently broken until the 15s assertion timeout. The lazy component loader now retries once after 250ms — recovering transient failures in CI and in real flaky networks — while persistent failures still surface the original error. Covered by a renderer test (loader fails once, component renders on retry).