### PR TITLE
Add Lattice package lifecycle commands

### DIFF
--- a/docs/content/docs/core/artisan-commands.md
+++ b/docs/content/docs/core/artisan-commands.md
@@ -10,6 +10,25 @@ application with:
 php artisan list lattice
 ```
 
+## Package setup and updates
+
+After requiring `lattice-php/lattice` through Composer, synchronize its frontend packages:
+
+```bash
+php artisan lattice:install
+```
+
+The installer adds published npm counterparts for the installed Lattice Composer packages and lists any remaining Vite, CSS, or React wiring. In an application without `package.json`, it publishes the standalone no-build assets instead.
+
+Use `lattice:update` to move every installed Lattice package to the latest stable coordinated release:
+
+```bash
+php artisan lattice:update --dry-run
+php artisan lattice:update
+```
+
+The dry run shows package versions and planned package-manager commands without changing files. See [Installation](/introduction/installation/) and [No-Build Installation](/introduction/no-build/) for the complete workflows.
+
 ## Definition generators
 
 These commands create PHP-only definition classes under `app/`. Each accepts a required `name`

--- a/docs/content/docs/introduction/installation.md
+++ b/docs/content/docs/introduction/installation.md
@@ -32,6 +32,14 @@ composer require lattice-php/lattice
 
 The service provider is registered automatically through Laravel package discovery, so there is nothing to add to `bootstrap/providers.php`.
 
+Run the installer after Composer finishes:
+
+```bash
+php artisan lattice:install
+```
+
+The installer finds every installed `lattice-php/*` Composer package and installs its published `@lattice-php/*` counterpart when one is needed. Composer-only component packages are skipped. It then checks the frontend entry points and lists any remaining wiring steps without rewriting your application files.
+
 Publish `config/lattice.php` to customize discovery paths, endpoints, and middleware:
 
 ```bash
@@ -50,6 +58,8 @@ The browser needs the Lattice React renderer to turn the server's component tree
 npm install @lattice-php/lattice
 ```
 
+You can run this command manually instead of `php artisan lattice:install`. The Artisan installer is useful when your application has multiple Lattice packages because it keeps their published frontend counterparts aligned automatically.
+
 The renderer's UI libraries (Radix, TipTap, i18n, and styling utilities) come with it. `react`, `react-dom`, and `@inertiajs/react` are required peer dependencies you already have in a Laravel React app; `@laravel/echo-react` and `pusher-js` are optional peers, needed only if you use Lattice's [realtime](/core/realtime/) layer. Styling is driven by Tailwind CSS v4:
 
 ```bash
@@ -65,6 +75,22 @@ Lattice targets React 19, Inertia v3, Tailwind 4, and TipTap 3. The npm package 
 Keep the Composer and npm package lines aligned. For pre-1.0 releases, install the same `0.x` minor line on both sides, e.g. `lattice-php/lattice:^0.7` with `@lattice-php/lattice@^0.7`. From 1.0 onward, keep the major versions matched, such as `1.x` with `1.x` or `2.x` with `2.x`.
 
 The split is intentional: React, React DOM, and Inertia stay as peer dependencies so the application owns its SPA runtime, while Lattice bundles its renderer internals.
+
+### Updating Lattice
+
+Preview available updates without changing files:
+
+```bash
+php artisan lattice:update --dry-run
+```
+
+Run the update when you are ready:
+
+```bash
+php artisan lattice:update
+```
+
+The command updates every installed `lattice-php/*` package to the latest stable Lattice release, raises direct Composer constraints to that release line, and updates or installs the corresponding npm packages. It stops before changing files if the Composer and npm releases do not match.
 
 ### Configure Vite
 

--- a/docs/content/docs/introduction/no-build.mdx
+++ b/docs/content/docs/introduction/no-build.mdx
@@ -15,12 +15,14 @@ Require the Composer package as usual, then publish the prebuilt bundle:
 
 ```bash
 composer require lattice-php/lattice
-php artisan lattice:assets
+php artisan lattice:install
 ```
 
-`lattice:assets` copies the bundle that ships inside the Composer package into `public/vendor/lattice/` — the JS entry, its lazily-loaded chunks, the compiled stylesheet, the icon sprite, and a `manifest.json` that pins their versions.
+Without a `package.json`, `lattice:install` selects the no-build path and publishes the standalone bundle. You can also run `php artisan lattice:assets` directly. Both commands copy the bundle that ships inside the Composer package into `public/vendor/lattice/` — the JS entry, its lazily-loaded chunks, the compiled stylesheet, the icon sprite, and a `manifest.json` that pins their versions.
 
-Re-run it after every `composer update` that touches `lattice-php/lattice`. The bundle version must match the installed package; in debug mode, the `@latticeHead` directive throws if they drift, so a stale bundle fails loudly instead of silently serving old JS. Automate the republish by adding it to your `post-autoload-dump` script in `composer.json`:
+Use `php artisan lattice:update` for future updates. It updates all installed Lattice Composer packages and republishes the bundle when its version is stale. Run `php artisan lattice:update --dry-run` first to preview the changes.
+
+The bundle version must match the installed package; in debug mode, the `@latticeHead` directive throws if they drift, so a stale bundle fails loudly instead of silently serving old JS. If you update packages through Composer directly, automate the republish by adding `lattice:assets` to your `post-autoload-dump` script in `composer.json`:
 
 ```json
 "scripts": {

--- a/packages/framework/resources/boost/guidelines/core.blade.php
+++ b/packages/framework/resources/boost/guidelines/core.blade.php
@@ -77,6 +77,8 @@ Drop a form or a table into the tree with `Form::use(MyForm::class)` and `Table:
 | `php artisan lattice:layout {name}` | Scaffold a layout class. |
 | `php artisan lattice:fragment {name}` | Scaffold a fragment class. |
 | `php artisan lattice:remote-source {name}` | Scaffold a remote source class. |
+| `php artisan lattice:install` | Install matching npm packages or publish the no-build assets. |
+| `php artisan lattice:update {--dry-run}` | Update all installed Lattice Composer and npm packages. |
 | `php artisan lattice:component {name} {--type=}` | Scaffold a custom Lattice UI component (PHP + React). |
 | `php artisan lattice:field {name} {--type=}` | Scaffold a custom form field (PHP + React). |
 | `php artisan lattice:column {name} {--type=}` | Scaffold a custom table column (PHP + React). |

--- a/packages/framework/src/Console/Commands/InstallCommand.php
+++ b/packages/framework/src/Console/Commands/InstallCommand.php
@@ -37,7 +37,7 @@ final class InstallCommand extends Command
 
         try {
             foreach ($plan->npmCommands as $command) {
-                $this->components->task('Installing Lattice npm packages', fn () => $packages->run($command));
+                $this->components->task('Installing Lattice npm packages', fn () => $packages->runNpm($command));
             }
         } catch (LatticePackageManagerException $exception) {
             $this->components->error($exception->getMessage());

--- a/packages/framework/src/Console/Commands/InstallCommand.php
+++ b/packages/framework/src/Console/Commands/InstallCommand.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Console\Commands;
+
+use Illuminate\Console\Command;
+use Lattice\Support\Packages\LatticePackageManager;
+use Lattice\Support\Packages\LatticePackageManagerException;
+
+final class InstallCommand extends Command
+{
+    protected $signature = 'lattice:install';
+
+    protected $description = 'Install the frontend packages or standalone assets for the installed Lattice packages';
+
+    public function handle(LatticePackageManager $packages): int
+    {
+        try {
+            $plan = $packages->installPlan();
+        } catch (LatticePackageManagerException $exception) {
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if (! $plan->npmEnabled) {
+            if ($plan->publishAssets && $this->call('lattice:assets') !== self::SUCCESS) {
+                return self::FAILURE;
+            }
+
+            if (! $plan->publishAssets) {
+                $this->components->info('The Lattice standalone assets are already current.');
+            }
+
+            return self::SUCCESS;
+        }
+
+        try {
+            foreach ($plan->npmCommands as $command) {
+                $this->components->task('Installing Lattice npm packages', fn () => $packages->run($command));
+            }
+        } catch (LatticePackageManagerException $exception) {
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->components->info($plan->npmCommands === []
+            ? 'The Lattice frontend packages are already installed.'
+            : 'Installed the Lattice frontend packages.');
+
+        $steps = $packages->missingFrontendSteps();
+
+        if ($steps === []) {
+            $this->components->info('The Lattice frontend wiring is already in place.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->warn('Complete the frontend wiring:');
+        $this->components->bulletList($steps);
+        $this->line('  See https://latticephp.com/introduction/installation/');
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/framework/src/Console/Commands/UpdateCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateCommand.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Console\Commands;
+
+use Illuminate\Console\Command;
+use Lattice\Support\Packages\LatticePackageManager;
+use Lattice\Support\Packages\LatticePackageManagerException;
+
+final class UpdateCommand extends Command
+{
+    protected $signature = 'lattice:update {--dry-run : Show available updates without changing files}';
+
+    protected $description = 'Update installed Composer and npm Lattice packages to the latest stable release';
+
+    public function handle(LatticePackageManager $packages): int
+    {
+        try {
+            $plan = $packages->updatePlan();
+        } catch (LatticePackageManagerException $exception) {
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->table(['Ecosystem', 'Package', 'Installed', 'Latest', 'Action'], $plan->rows());
+
+        $composerOnly = $plan->composerOnlyPackages();
+
+        if ($composerOnly !== []) {
+            $this->components->info('Composer-only packages: '.implode(', ', $composerOnly).'.');
+        }
+
+        if (! $plan->hasChanges()) {
+            $this->components->info('Lattice is already up to date.');
+
+            return self::SUCCESS;
+        }
+
+        if ((bool) $this->option('dry-run')) {
+            foreach ([...$plan->composerCommands, ...$plan->npmCommands] as $command) {
+                $this->line('  '.implode(' ', $command));
+            }
+
+            if ($plan->publishAssets) {
+                $this->line('  php artisan lattice:assets');
+            }
+
+            $this->components->info('Dry run complete. No files were changed.');
+
+            return self::SUCCESS;
+        }
+
+        $composerUpdated = false;
+
+        try {
+            foreach ($plan->composerCommands as $command) {
+                $this->components->task('Updating Lattice Composer packages', fn () => $packages->run($command));
+                $composerUpdated = true;
+            }
+        } catch (LatticePackageManagerException $exception) {
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        try {
+            foreach ($plan->npmCommands as $command) {
+                $this->components->task('Updating Lattice npm packages', fn () => $packages->run($command));
+            }
+        } catch (LatticePackageManagerException $exception) {
+            $prefix = $composerUpdated ? 'Composer packages were updated, but the npm update failed. ' : '';
+            $this->components->error($prefix.$exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($plan->publishAssets && $this->call('lattice:assets') !== self::SUCCESS) {
+            return self::FAILURE;
+        }
+
+        $this->components->info("Updated Lattice packages to {$plan->targetVersion}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/framework/src/Console/Commands/UpdateCommand.php
+++ b/packages/framework/src/Console/Commands/UpdateCommand.php
@@ -55,7 +55,7 @@ final class UpdateCommand extends Command
 
         try {
             foreach ($plan->composerCommands as $command) {
-                $this->components->task('Updating Lattice Composer packages', fn () => $packages->run($command));
+                $this->components->task('Updating Lattice Composer packages', fn () => $packages->runComposer($command));
                 $composerUpdated = true;
             }
         } catch (LatticePackageManagerException $exception) {
@@ -66,7 +66,7 @@ final class UpdateCommand extends Command
 
         try {
             foreach ($plan->npmCommands as $command) {
-                $this->components->task('Updating Lattice npm packages', fn () => $packages->run($command));
+                $this->components->task('Updating Lattice npm packages', fn () => $packages->runNpm($command));
             }
         } catch (LatticePackageManagerException $exception) {
             $prefix = $composerUpdated ? 'Composer packages were updated, but the npm update failed. ' : '';

--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -16,6 +16,7 @@ use Inertia\ResponseFactory;
 use Lattice\Actions\ActionServiceProvider;
 use Lattice\Console\Commands\DiscoverCacheCommand;
 use Lattice\Console\Commands\DiscoverClearCommand;
+use Lattice\Console\Commands\InstallCommand;
 use Lattice\Console\Commands\MakeColumnCommand;
 use Lattice\Console\Commands\MakeComponentCommand;
 use Lattice\Console\Commands\MakeDefinitionCommand;
@@ -23,6 +24,7 @@ use Lattice\Console\Commands\MakeFieldCommand;
 use Lattice\Console\Commands\PruneNotificationsCommand;
 use Lattice\Console\Commands\PublishAssetsCommand;
 use Lattice\Console\Commands\TypeScriptCommand;
+use Lattice\Console\Commands\UpdateCommand;
 use Lattice\Core\Attributes\AsFragment;
 use Lattice\Core\Attributes\AsLayout;
 use Lattice\Core\Attributes\AsRemoteSource;
@@ -69,8 +71,10 @@ final class LatticeServiceProvider extends PackageServiceProvider
                 MakeColumnCommand::class,
                 DiscoverCacheCommand::class,
                 DiscoverClearCommand::class,
+                InstallCommand::class,
                 PruneNotificationsCommand::class,
                 PublishAssetsCommand::class,
+                UpdateCommand::class,
             ]);
     }
 

--- a/packages/framework/src/Support/Packages/LatticePackageManager.php
+++ b/packages/framework/src/Support/Packages/LatticePackageManager.php
@@ -1,0 +1,603 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support\Packages;
+
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Support\Facades\Process;
+use JsonException;
+use Throwable;
+
+final readonly class LatticePackageManager
+{
+    public function __construct(private ?string $basePath = null) {}
+
+    public function installPlan(): LatticePackagePlan
+    {
+        $composerPackages = $this->installedComposerPackages();
+        $targetVersion = $this->mainPackageVersion($composerPackages);
+
+        if (! is_file($this->path('package.json'))) {
+            return new LatticePackagePlan(
+                targetVersion: $targetVersion,
+                packages: $this->statesWithoutNpm($composerPackages, $targetVersion),
+                composerCommands: [],
+                npmCommands: [],
+                npmEnabled: false,
+                publishAssets: ! $this->publishedAssetsAreCurrent($targetVersion),
+            );
+        }
+
+        $states = $this->packageStates(
+            $composerPackages,
+            static fn (array $package): string => $package['version'],
+        );
+
+        return new LatticePackagePlan(
+            targetVersion: $targetVersion,
+            packages: $states,
+            composerCommands: [],
+            npmCommands: $this->npmCommands($states),
+            npmEnabled: true,
+            publishAssets: false,
+        );
+    }
+
+    public function updatePlan(): LatticePackagePlan
+    {
+        $composerPackages = $this->installedComposerPackages();
+        $targetVersion = $this->latestStableVersion();
+
+        if (! is_file($this->path('package.json'))) {
+            $states = $this->statesWithoutNpm($composerPackages, $targetVersion);
+
+            return new LatticePackagePlan(
+                targetVersion: $targetVersion,
+                packages: $states,
+                composerCommands: $this->composerCommands($states),
+                npmCommands: [],
+                npmEnabled: false,
+                publishAssets: ! $this->publishedAssetsAreCurrent($targetVersion),
+            );
+        }
+
+        $states = $this->packageStates(
+            $composerPackages,
+            static fn (): string => $targetVersion,
+        );
+
+        return new LatticePackagePlan(
+            targetVersion: $targetVersion,
+            packages: $states,
+            composerCommands: $this->composerCommands($states),
+            npmCommands: $this->npmCommands($states),
+            npmEnabled: true,
+            publishAssets: false,
+        );
+    }
+
+    /** @param list<string> $command */
+    public function run(array $command): void
+    {
+        $result = $this->invoke($command, 600);
+
+        if ($result->failed()) {
+            throw new LatticePackageManagerException($this->failureMessage($command, $result));
+        }
+    }
+
+    /** @return list<string> */
+    public function missingFrontendSteps(): array
+    {
+        $steps = [];
+        $viteFiles = glob($this->path('vite.config.*')) ?: [];
+        $cssFiles = glob($this->path('resources/css/*.css')) ?: [];
+        $entryFiles = glob($this->path('resources/js/app.*')) ?: [];
+
+        if (! $this->filesContain($viteFiles, '@lattice-php/lattice/vite')) {
+            $steps[] = 'Add the lattice() plugin from [@lattice-php/lattice/vite] to your Vite configuration.';
+        }
+
+        if (! $this->filesContain($cssFiles, '@lattice-php/lattice/css')) {
+            $steps[] = 'Import [@lattice-php/lattice/css] after Tailwind in your application stylesheet.';
+        }
+
+        if (! $this->filesContain($entryFiles, 'createLatticeApp') && ! $this->filesContain($entryFiles, 'createPageResolver')) {
+            $steps[] = 'Boot the Inertia React application with createLatticeApp().';
+        }
+
+        return $steps;
+    }
+
+    /**
+     * @return list<array{name: string, version: string, direct: bool, section: 'require'|'require-dev'|null}>
+     */
+    private function installedComposerPackages(): array
+    {
+        $manifest = $this->jsonFile($this->path('composer.json'));
+        $result = $this->process(['composer', 'show', '--format=json', 'lattice-php/*']);
+        $data = $this->decodeObject($result->output(), 'Composer package list');
+        $installed = $data['installed'] ?? null;
+
+        if (! is_array($installed)) {
+            throw new LatticePackageManagerException('Composer did not return an installed Lattice package list.');
+        }
+
+        $packages = [];
+
+        foreach ($installed as $package) {
+            if (! is_array($package) || ! is_string($package['name'] ?? null) || ! is_string($package['version'] ?? null)) {
+                continue;
+            }
+
+            $name = $package['name'];
+
+            if (! str_starts_with($name, 'lattice-php/')) {
+                continue;
+            }
+
+            $version = $this->stableVersion($package['version']);
+
+            if ($version === null) {
+                throw new LatticePackageManagerException("Installed Lattice package [{$name}] does not use a stable semantic version.");
+            }
+
+            $section = match (true) {
+                isset($manifest['require'][$name]) => 'require',
+                isset($manifest['require-dev'][$name]) => 'require-dev',
+                default => null,
+            };
+
+            $packages[] = [
+                'name' => $name,
+                'version' => $version,
+                'direct' => $section !== null,
+                'section' => $section,
+            ];
+        }
+
+        usort($packages, static fn (array $left, array $right): int => $left['name'] <=> $right['name']);
+
+        if ($packages === []) {
+            throw new LatticePackageManagerException('No installed [lattice-php/*] Composer packages were found.');
+        }
+
+        return $packages;
+    }
+
+    private function latestStableVersion(): string
+    {
+        $result = $this->process(['composer', 'show', '--all', '--format=json', 'lattice-php/lattice']);
+        $data = $this->decodeObject($result->output(), 'Composer release list');
+        $versions = $data['versions'] ?? null;
+
+        if (! is_array($versions)) {
+            throw new LatticePackageManagerException('Composer did not return available Lattice releases.');
+        }
+
+        $stable = [];
+
+        foreach ($versions as $version) {
+            if (! is_string($version)) {
+                continue;
+            }
+
+            $normalized = $this->stableVersion($version);
+
+            if ($normalized !== null) {
+                $stable[] = $normalized;
+            }
+        }
+
+        usort($stable, $this->compareVersions(...));
+
+        $latest = array_pop($stable);
+
+        if (! is_string($latest)) {
+            throw new LatticePackageManagerException('No stable Lattice release was found.');
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @param  list<array{name: string, version: string, direct: bool, section: 'require'|'require-dev'|null}>  $composerPackages
+     * @param  callable(array{name: string, version: string, direct: bool, section: 'require'|'require-dev'|null}): string  $targetVersion
+     * @return list<LatticePackageState>
+     */
+    private function packageStates(array $composerPackages, callable $targetVersion): array
+    {
+        $published = [];
+
+        foreach ($composerPackages as $package) {
+            $npmName = $this->npmName($package['name']);
+            $target = $targetVersion($package);
+
+            if ($this->npmReleaseExists($npmName, $target)) {
+                $published[$npmName] = $target;
+            }
+        }
+
+        $installedNpm = $this->installedNpmVersions(array_keys($published));
+        $npmSections = $this->npmSections();
+        $states = [];
+
+        foreach ($composerPackages as $package) {
+            $npmName = $this->npmName($package['name']);
+
+            $states[] = new LatticePackageState(
+                composerName: $package['name'],
+                npmName: $npmName,
+                installedComposerVersion: $package['version'],
+                targetVersion: $targetVersion($package),
+                directComposerDependency: $package['direct'],
+                composerSection: $package['section'],
+                npmPublished: isset($published[$npmName]),
+                installedNpmVersion: $installedNpm[$npmName] ?? null,
+                npmSection: $npmSections[$npmName] ?? null,
+            );
+        }
+
+        return $states;
+    }
+
+    /**
+     * @param  list<array{name: string, version: string, direct: bool, section: 'require'|'require-dev'|null}>  $composerPackages
+     * @return list<LatticePackageState>
+     */
+    private function statesWithoutNpm(array $composerPackages, string $targetVersion): array
+    {
+        return array_map(
+            fn (array $package): LatticePackageState => new LatticePackageState(
+                composerName: $package['name'],
+                npmName: $this->npmName($package['name']),
+                installedComposerVersion: $package['version'],
+                targetVersion: $targetVersion,
+                directComposerDependency: $package['direct'],
+                composerSection: $package['section'],
+                npmPublished: false,
+                installedNpmVersion: null,
+                npmSection: null,
+            ),
+            $composerPackages,
+        );
+    }
+
+    /**
+     * @param  list<array{name: string, version: string, direct: bool, section: 'require'|'require-dev'|null}>  $packages
+     */
+    private function mainPackageVersion(array $packages): string
+    {
+        foreach ($packages as $package) {
+            if ($package['name'] === 'lattice-php/lattice') {
+                return $package['version'];
+            }
+        }
+
+        throw new LatticePackageManagerException('The [lattice-php/lattice] Composer package is not installed.');
+    }
+
+    private function npmReleaseExists(string $package, string $targetVersion): bool
+    {
+        $command = [
+            'npm',
+            'view',
+            "{$package}@{$targetVersion}",
+            'version',
+            '--json',
+        ];
+        $result = $this->invoke($command, 60);
+
+        if ($result->failed()) {
+            if (str_contains($result->errorOutput(), 'E404')) {
+                return false;
+            }
+
+            throw new LatticePackageManagerException($this->failureMessage($command, $result));
+        }
+
+        $data = $this->decode($result->output(), "npm release [{$package}]");
+        $version = match (true) {
+            is_string($data) => $data,
+            is_array($data) && is_string($data[0] ?? null) => $data[0],
+            default => null,
+        };
+
+        if ($version !== $targetVersion) {
+            throw new LatticePackageManagerException("npm package [{$package}] did not report the required release [{$targetVersion}].");
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $packages
+     * @return array<string, string>
+     */
+    private function installedNpmVersions(array $packages): array
+    {
+        if ($packages === []) {
+            return [];
+        }
+
+        sort($packages);
+        $command = ['npm', 'ls', '--all', '--json', ...$packages];
+        $result = $this->invoke($command, 60);
+
+        try {
+            $data = $this->decodeObject($result->output(), 'installed npm package list');
+        } catch (LatticePackageManagerException $exception) {
+            if ($result->failed()) {
+                throw new LatticePackageManagerException($this->failureMessage($command, $result), $exception->getCode(), previous: $exception);
+            }
+
+            throw $exception;
+        }
+
+        $versions = [];
+        $dependencies = $data['dependencies'] ?? [];
+
+        if (is_array($dependencies)) {
+            $this->collectNpmVersions($dependencies, $versions);
+        }
+
+        return $versions;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $dependencies
+     * @param  array<string, string>  $versions
+     */
+    private function collectNpmVersions(array $dependencies, array &$versions): void
+    {
+        foreach ($dependencies as $name => $dependency) {
+            if (! is_string($name) || ! is_array($dependency)) {
+                continue;
+            }
+
+            if (str_starts_with($name, '@lattice-php/') && is_string($dependency['version'] ?? null)) {
+                $versions[$name] ??= $dependency['version'];
+            }
+
+            if (is_array($dependency['dependencies'] ?? null)) {
+                $this->collectNpmVersions($dependency['dependencies'], $versions);
+            }
+        }
+    }
+
+    /** @return array<string, 'dependencies'|'devDependencies'> */
+    private function npmSections(): array
+    {
+        $manifest = $this->jsonFile($this->path('package.json'));
+        $sections = [];
+
+        foreach (['dependencies', 'devDependencies'] as $section) {
+            if (! is_array($manifest[$section] ?? null)) {
+                continue;
+            }
+
+            foreach ($manifest[$section] as $package => $constraint) {
+                if (is_string($package) && str_starts_with($package, '@lattice-php/')) {
+                    $sections[$package] = $section;
+                }
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param  list<LatticePackageState>  $states
+     * @return list<list<string>>
+     */
+    private function composerCommands(array $states): array
+    {
+        if (! array_any($states, static fn (LatticePackageState $state): bool => $state->composerNeedsUpdate())) {
+            return [];
+        }
+
+        $groups = ['require' => [], 'require-dev' => []];
+
+        foreach ($states as $state) {
+            if (! $state->directComposerDependency || $state->composerSection === null) {
+                continue;
+            }
+
+            $groups[$state->composerSection][] = $state->composerName.':'.$this->composerConstraint($state->targetVersion);
+        }
+
+        $commands = [];
+
+        foreach ($groups as $section => $packages) {
+            if ($packages === []) {
+                continue;
+            }
+
+            $command = ['composer', 'require', ...$packages, '--with-all-dependencies', '--no-interaction'];
+
+            if ($section === 'require-dev') {
+                $command[] = '--dev';
+            }
+
+            $commands[] = $command;
+        }
+
+        return $commands;
+    }
+
+    /**
+     * @param  list<LatticePackageState>  $states
+     * @return list<list<string>>
+     */
+    private function npmCommands(array $states): array
+    {
+        $groups = ['dependencies' => [], 'devDependencies' => []];
+
+        foreach ($states as $state) {
+            if (! $state->npmNeedsUpdate() || (! $state->directComposerDependency && $state->npmSection === null)) {
+                continue;
+            }
+
+            $section = $state->npmSection ?? match ($state->composerSection) {
+                'require-dev' => 'devDependencies',
+                default => 'dependencies',
+            };
+            $groups[$section][] = $state->npmName.'@'.$this->npmConstraint($state->targetVersion);
+        }
+
+        $commands = [];
+
+        foreach ($groups as $section => $packages) {
+            if ($packages === []) {
+                continue;
+            }
+
+            $commands[] = [
+                'npm',
+                'install',
+                $section === 'devDependencies' ? '--save-dev' : '--save-prod',
+                ...$packages,
+            ];
+        }
+
+        return $commands;
+    }
+
+    private function composerConstraint(string $version): string
+    {
+        [$major, $minor] = array_map(intval(...), explode('.', $version));
+
+        return $major === 0 ? "^0.{$minor}" : "^{$major}";
+    }
+
+    private function npmConstraint(string $version): string
+    {
+        [$major, $minor] = array_map(intval(...), explode('.', $version));
+
+        return $major === 0 ? "^0.{$minor}.0" : "^{$major}.0.0";
+    }
+
+    private function stableVersion(string $version): ?string
+    {
+        return preg_match('/(?:^|\\s|\\*)v?(\\d+\\.\\d+\\.\\d+)(?:\\s|$)/', trim($version), $matches) === 1
+            ? $matches[1]
+            : null;
+    }
+
+    private function npmName(string $composerName): string
+    {
+        return '@lattice-php/'.substr($composerName, strlen('lattice-php/'));
+    }
+
+    private function compareVersions(string $left, string $right): int
+    {
+        return version_compare($left, $right);
+    }
+
+    private function publishedAssetsAreCurrent(string $targetVersion): bool
+    {
+        $path = trim((string) config('lattice.frontend.path'));
+        $manifest = public_path($path.'/manifest.json');
+
+        if (! is_file($manifest)) {
+            return false;
+        }
+
+        try {
+            $data = $this->jsonFile($manifest);
+        } catch (LatticePackageManagerException) {
+            return false;
+        }
+
+        return ($data['version'] ?? null) === $targetVersion;
+    }
+
+    /** @param list<string> $files */
+    private function filesContain(array $files, string $needle): bool
+    {
+        foreach ($files as $file) {
+            $contents = file_get_contents($file);
+
+            if (is_string($contents) && str_contains($contents, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param list<string> $command */
+    private function process(array $command): ProcessResult
+    {
+        $result = $this->invoke($command, 60);
+
+        if ($result->failed()) {
+            throw new LatticePackageManagerException($this->failureMessage($command, $result));
+        }
+
+        return $result;
+    }
+
+    /** @param list<string> $command */
+    private function invoke(array $command, int $timeout): ProcessResult
+    {
+        try {
+            return Process::path($this->path())->timeout($timeout)->run($command);
+        } catch (Throwable $exception) {
+            throw new LatticePackageManagerException('Process ['.implode(' ', $command).'] could not be started. '.$exception->getMessage(), $exception->getCode(), previous: $exception);
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function jsonFile(string $path): array
+    {
+        if (! is_file($path)) {
+            throw new LatticePackageManagerException("Required manifest [{$path}] was not found.");
+        }
+
+        $contents = file_get_contents($path);
+
+        if (! is_string($contents)) {
+            throw new LatticePackageManagerException("Manifest [{$path}] could not be read.");
+        }
+
+        return $this->decodeObject($contents, "manifest [{$path}]");
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeObject(string $json, string $source): array
+    {
+        $data = $this->decode($json, $source);
+
+        if (! is_array($data)) {
+            throw new LatticePackageManagerException("Invalid JSON object returned for {$source}.");
+        }
+
+        return $data;
+    }
+
+    private function decode(string $json, string $source): mixed
+    {
+        try {
+            return json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new LatticePackageManagerException("Invalid JSON returned for {$source}.", $exception->getCode(), previous: $exception);
+        }
+    }
+
+    /** @param list<string> $command */
+    private function failureMessage(array $command, ProcessResult $result): string
+    {
+        $details = trim($result->errorOutput()) ?: trim($result->output());
+        $message = 'Process ['.implode(' ', $command).'] failed.';
+
+        return $details === '' ? $message : $message.' '.$details;
+    }
+
+    private function path(string $path = ''): string
+    {
+        $basePath = $this->basePath ?? base_path();
+
+        return $path === '' ? $basePath : $basePath.'/'.$path;
+    }
+}

--- a/packages/framework/src/Support/Packages/LatticePackageManager.php
+++ b/packages/framework/src/Support/Packages/LatticePackageManager.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 namespace Lattice\Support\Packages;
 
 use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Support\Composer;
 use Illuminate\Support\Facades\Process;
 use JsonException;
 use Throwable;
 
 final readonly class LatticePackageManager
 {
-    public function __construct(private ?string $basePath = null) {}
+    public function __construct(
+        private Composer $composer,
+        private ?string $basePath = null,
+    ) {}
 
     public function installPlan(): LatticePackagePlan
     {
@@ -77,7 +81,36 @@ final readonly class LatticePackageManager
     }
 
     /** @param list<string> $command */
-    public function run(array $command): void
+    public function runComposer(array $command): void
+    {
+        if (array_slice($command, 0, 2) !== ['composer', 'require']) {
+            throw new LatticePackageManagerException('Only Composer require commands can be executed.');
+        }
+
+        $arguments = array_slice($command, 2);
+        $dev = in_array('--dev', $arguments, true);
+        $arguments = array_values(array_filter($arguments, static fn (string $argument): bool => $argument !== '--dev'));
+        $output = '';
+
+        $successful = $this->composer()
+            ->requirePackages(
+                $arguments,
+                $dev,
+                static function (string $type, string $line) use (&$output): void {
+                    $output .= $line;
+                },
+            );
+
+        if (! $successful) {
+            $message = 'Process ['.implode(' ', $command).'] failed.';
+            $details = trim($output);
+
+            throw new LatticePackageManagerException($details === '' ? $message : $message.' '.$details);
+        }
+    }
+
+    /** @param list<string> $command */
+    public function runNpm(array $command): void
     {
         $result = $this->invoke($command, 600);
 
@@ -115,7 +148,7 @@ final readonly class LatticePackageManager
     private function installedComposerPackages(): array
     {
         $manifest = $this->jsonFile($this->path('composer.json'));
-        $result = $this->process(['composer', 'show', '--format=json', 'lattice-php/*']);
+        $result = $this->process($this->composerCommand(['show', '--format=json', 'lattice-php/*']));
         $data = $this->decodeObject($result->output(), 'Composer package list');
         $installed = $data['installed'] ?? null;
 
@@ -167,7 +200,7 @@ final readonly class LatticePackageManager
 
     private function latestStableVersion(): string
     {
-        $result = $this->process(['composer', 'show', '--all', '--format=json', 'lattice-php/lattice']);
+        $result = $this->process($this->composerCommand(['show', '--all', '--format=json', 'lattice-php/lattice']));
         $data = $this->decodeObject($result->output(), 'Composer release list');
         $versions = $data['versions'] ?? null;
 
@@ -492,6 +525,20 @@ final readonly class LatticePackageManager
     private function compareVersions(string $left, string $right): int
     {
         return version_compare($left, $right);
+    }
+
+    /**
+     * @param  list<string>  $arguments
+     * @return list<string>
+     */
+    private function composerCommand(array $arguments): array
+    {
+        return array_values([...$this->composer()->findComposer(), ...$arguments]);
+    }
+
+    private function composer(): Composer
+    {
+        return $this->composer->setWorkingPath($this->path());
     }
 
     private function publishedAssetsAreCurrent(string $targetVersion): bool

--- a/packages/framework/src/Support/Packages/LatticePackageManagerException.php
+++ b/packages/framework/src/Support/Packages/LatticePackageManagerException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support\Packages;
+
+use RuntimeException;
+
+final class LatticePackageManagerException extends RuntimeException {}

--- a/packages/framework/src/Support/Packages/LatticePackagePlan.php
+++ b/packages/framework/src/Support/Packages/LatticePackagePlan.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support\Packages;
+
+final readonly class LatticePackagePlan
+{
+    /**
+     * @param  list<LatticePackageState>  $packages
+     * @param  list<list<string>>  $composerCommands
+     * @param  list<list<string>>  $npmCommands
+     */
+    public function __construct(
+        public string $targetVersion,
+        public array $packages,
+        public array $composerCommands,
+        public array $npmCommands,
+        public bool $npmEnabled,
+        public bool $publishAssets,
+    ) {}
+
+    public function hasChanges(): bool
+    {
+        return $this->composerCommands !== [] || $this->npmCommands !== [] || $this->publishAssets;
+    }
+
+    /** @return list<list<string>> */
+    public function rows(): array
+    {
+        $rows = [];
+
+        foreach ($this->packages as $package) {
+            $rows[] = [
+                'Composer',
+                $package->composerName,
+                $package->installedComposerVersion,
+                $package->targetVersion,
+                $package->composerNeedsUpdate() ? 'update' : 'current',
+            ];
+
+            if (! $this->npmEnabled || ! $package->npmPublished) {
+                continue;
+            }
+
+            $rows[] = [
+                'npm',
+                $package->npmName,
+                $package->installedNpmVersion ?? 'missing',
+                $package->targetVersion,
+                match (true) {
+                    $package->installedNpmVersion === null => 'install',
+                    $package->npmNeedsUpdate() => 'update',
+                    default => 'current',
+                },
+            ];
+        }
+
+        if (! $this->npmEnabled) {
+            $rows[] = [
+                'Assets',
+                'public Lattice bundle',
+                $this->publishAssets ? 'stale or missing' : $this->targetVersion,
+                $this->targetVersion,
+                $this->publishAssets ? 'publish' : 'current',
+            ];
+        }
+
+        return $rows;
+    }
+
+    /** @return list<string> */
+    public function composerOnlyPackages(): array
+    {
+        if (! $this->npmEnabled) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (LatticePackageState $package): string => $package->composerName,
+            array_filter($this->packages, static fn (LatticePackageState $package): bool => ! $package->npmPublished),
+        ));
+    }
+}

--- a/packages/framework/src/Support/Packages/LatticePackageState.php
+++ b/packages/framework/src/Support/Packages/LatticePackageState.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support\Packages;
+
+final readonly class LatticePackageState
+{
+    public function __construct(
+        public string $composerName,
+        public string $npmName,
+        public string $installedComposerVersion,
+        public string $targetVersion,
+        public bool $directComposerDependency,
+        public ?string $composerSection,
+        public bool $npmPublished,
+        public ?string $installedNpmVersion,
+        public ?string $npmSection,
+    ) {}
+
+    public function composerNeedsUpdate(): bool
+    {
+        return version_compare($this->installedComposerVersion, $this->targetVersion, '!=');
+    }
+
+    public function npmNeedsUpdate(): bool
+    {
+        return $this->npmPublished && $this->installedNpmVersion !== $this->targetVersion;
+    }
+}

--- a/tests/Feature/Console/LatticePackageCommandsTest.php
+++ b/tests/Feature/Console/LatticePackageCommandsTest.php
@@ -1,0 +1,207 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+
+use function Pest\Laravel\artisan;
+
+beforeEach(function (): void {
+    $this->originalBasePath = base_path();
+    $this->projectPath = sys_get_temp_dir().'/lattice-package-command-'.uniqid();
+
+    File::ensureDirectoryExists($this->projectPath.'/resources/css');
+    File::ensureDirectoryExists($this->projectPath.'/resources/js');
+    File::put($this->projectPath.'/composer.json', json_encode([
+        'require' => [
+            'lattice-php/lattice' => '^0.52',
+            'lattice-php/media' => '^0.52',
+        ],
+    ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+    File::put($this->projectPath.'/package.json', json_encode([
+        'dependencies' => [
+            '@lattice-php/lattice' => '^0.52.0',
+        ],
+    ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+    app()->setBasePath($this->projectPath);
+});
+
+afterEach(function (): void {
+    app()->setBasePath($this->originalBasePath);
+    File::deleteDirectory($this->projectPath);
+});
+
+it('reports when every installed Lattice package is current', function (): void {
+    Process::fake(fn (PendingProcess $process) => match ($process->command) {
+        ['composer', 'show', '--format=json', 'lattice-php/*'] => Process::result(output: composerPackages('0.53.0')),
+        ['composer', 'show', '--all', '--format=json', 'lattice-php/lattice'] => Process::result(output: composerReleases('0.53.0')),
+        ['npm', 'view', '@lattice-php/core@0.53.0', 'version', '--json'],
+        ['npm', 'view', '@lattice-php/lattice@0.53.0', 'version', '--json'] => Process::result(output: '"0.53.0"'),
+        ['npm', 'view', '@lattice-php/media@0.53.0', 'version', '--json'] => Process::result(errorOutput: 'npm error code E404', exitCode: 1),
+        ['npm', 'ls', '--all', '--json', '@lattice-php/core', '@lattice-php/lattice'] => Process::result(output: npmPackages('0.53.0')),
+        default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
+    });
+    Process::preventStrayProcesses();
+
+    artisan('lattice:update')
+        ->expectsOutputToContain('Lattice is already up to date.')
+        ->assertSuccessful();
+
+    Process::assertNotRan(fn (PendingProcess $process): bool => in_array($process->command[1] ?? null, ['require', 'install'], true));
+});
+
+it('updates Composer packages and their published npm counterparts', function (): void {
+    Process::fake(fn (PendingProcess $process) => match ($process->command) {
+        ['composer', 'show', '--format=json', 'lattice-php/*'] => Process::result(output: composerPackages('0.52.1')),
+        ['composer', 'show', '--all', '--format=json', 'lattice-php/lattice'] => Process::result(output: composerReleases('0.53.0', '0.52.1')),
+        ['npm', 'view', '@lattice-php/core@0.53.0', 'version', '--json'],
+        ['npm', 'view', '@lattice-php/lattice@0.53.0', 'version', '--json'] => Process::result(output: '"0.53.0"'),
+        ['npm', 'view', '@lattice-php/media@0.53.0', 'version', '--json'] => Process::result(errorOutput: 'npm error code E404', exitCode: 1),
+        ['npm', 'ls', '--all', '--json', '@lattice-php/core', '@lattice-php/lattice'] => Process::result(output: npmPackages('0.52.1')),
+        ['composer', 'require', 'lattice-php/lattice:^0.53', 'lattice-php/media:^0.53', '--with-all-dependencies', '--no-interaction'] => Process::result(),
+        ['npm', 'install', '--save-prod', '@lattice-php/lattice@^0.53.0'] => Process::result(),
+        default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
+    });
+    Process::preventStrayProcesses();
+
+    artisan('lattice:update')
+        ->expectsOutputToContain('Updated Lattice packages to 0.53.0.')
+        ->assertSuccessful();
+
+    Process::assertRan(fn (PendingProcess $process): bool => $process->command === [
+        'composer',
+        'require',
+        'lattice-php/lattice:^0.53',
+        'lattice-php/media:^0.53',
+        '--with-all-dependencies',
+        '--no-interaction',
+    ]);
+    Process::assertRan(fn (PendingProcess $process): bool => $process->command === [
+        'npm',
+        'install',
+        '--save-prod',
+        '@lattice-php/lattice@^0.53.0',
+    ]);
+});
+
+it('installs a missing npm counterpart without updating Composer', function (): void {
+    File::put($this->projectPath.'/package.json', json_encode(['dependencies' => []], JSON_THROW_ON_ERROR));
+
+    Process::fake(fn (PendingProcess $process) => match ($process->command) {
+        ['composer', 'show', '--format=json', 'lattice-php/*'] => Process::result(output: composerPackages('0.52.1')),
+        ['npm', 'view', '@lattice-php/core@0.52.1', 'version', '--json'],
+        ['npm', 'view', '@lattice-php/lattice@0.52.1', 'version', '--json'] => Process::result(output: '"0.52.1"'),
+        ['npm', 'view', '@lattice-php/media@0.52.1', 'version', '--json'] => Process::result(errorOutput: 'npm error code E404', exitCode: 1),
+        ['npm', 'ls', '--all', '--json', '@lattice-php/core', '@lattice-php/lattice'] => Process::result(output: npmPackages()),
+        ['npm', 'install', '--save-prod', '@lattice-php/lattice@^0.52.0'] => Process::result(),
+        default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
+    });
+    Process::preventStrayProcesses();
+
+    artisan('lattice:install')
+        ->expectsOutputToContain('Installed the Lattice frontend packages.')
+        ->expectsOutputToContain('Complete the frontend wiring')
+        ->assertSuccessful();
+
+    Process::assertNotRan(fn (PendingProcess $process): bool => ($process->command[0] ?? null) === 'composer' && ($process->command[1] ?? null) === 'require');
+});
+
+it('shows update work without changing packages during a dry run', function (): void {
+    Process::fake(fn (PendingProcess $process) => match ($process->command) {
+        ['composer', 'show', '--format=json', 'lattice-php/*'] => Process::result(output: composerPackages('0.52.1')),
+        ['composer', 'show', '--all', '--format=json', 'lattice-php/lattice'] => Process::result(output: composerReleases('0.53.0', '0.52.1')),
+        ['npm', 'view', '@lattice-php/core@0.53.0', 'version', '--json'],
+        ['npm', 'view', '@lattice-php/lattice@0.53.0', 'version', '--json'] => Process::result(output: '"0.53.0"'),
+        ['npm', 'view', '@lattice-php/media@0.53.0', 'version', '--json'] => Process::result(errorOutput: 'npm error code E404', exitCode: 1),
+        ['npm', 'ls', '--all', '--json', '@lattice-php/core', '@lattice-php/lattice'] => Process::result(output: npmPackages('0.52.1')),
+        default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
+    });
+    Process::preventStrayProcesses();
+
+    artisan('lattice:update', ['--dry-run' => true])
+        ->expectsOutputToContain('Dry run complete. No files were changed.')
+        ->expectsOutputToContain('composer require lattice-php/lattice:^0.53 lattice-php/media:^0.53')
+        ->expectsOutputToContain('npm install --save-prod @lattice-php/lattice@^0.53.0')
+        ->assertSuccessful();
+
+    Process::assertNotRan(fn (PendingProcess $process): bool => in_array($process->command[1] ?? null, ['require', 'install'], true));
+});
+
+it('publishes standalone assets when installing without an npm project', function (): void {
+    File::delete($this->projectPath.'/package.json');
+    $distPath = $this->projectPath.'/vendor/lattice-assets';
+    File::ensureDirectoryExists($distPath);
+    File::put($distPath.'/manifest.json', json_encode([
+        'version' => '0.52.1',
+        'files' => [],
+    ], JSON_THROW_ON_ERROR));
+    File::put($distPath.'/lattice.js', 'export {};');
+    config()->set('lattice.frontend.dist_path', $distPath);
+
+    Process::fake([
+        '*' => fn (PendingProcess $process) => match ($process->command) {
+            ['composer', 'show', '--format=json', 'lattice-php/*'] => Process::result(output: composerPackages('0.52.1')),
+            default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
+        },
+    ]);
+    Process::preventStrayProcesses();
+
+    artisan('lattice:install')
+        ->expectsOutputToContain('Published Lattice standalone assets 0.52.1')
+        ->assertSuccessful();
+
+    expect(json_decode(File::get($this->projectPath.'/public/vendor/lattice/manifest.json'), true)['version'])
+        ->toBe('0.52.1');
+    Process::assertNotRan(fn (PendingProcess $process): bool => ($process->command[0] ?? null) === 'npm');
+});
+
+it('stops before updating when an npm release does not match Composer', function (): void {
+    Process::fake(fn (PendingProcess $process) => match ($process->command) {
+        ['composer', 'show', '--format=json', 'lattice-php/*'] => Process::result(output: composerPackages('0.52.1')),
+        ['composer', 'show', '--all', '--format=json', 'lattice-php/lattice'] => Process::result(output: composerReleases('0.53.0', '0.52.1')),
+        ['npm', 'view', '@lattice-php/core@0.53.0', 'version', '--json'] => Process::result(output: '"0.53.0"'),
+        ['npm', 'view', '@lattice-php/lattice@0.53.0', 'version', '--json'] => Process::result(output: '"0.52.1"'),
+        default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
+    });
+    Process::preventStrayProcesses();
+
+    artisan('lattice:update')
+        ->expectsOutputToContain('did not report the required release [0.53.0]')
+        ->assertFailed();
+
+    Process::assertNotRan(fn (PendingProcess $process): bool => in_array($process->command[1] ?? null, ['require', 'install'], true));
+});
+
+function composerPackages(string $version): string
+{
+    return json_encode([
+        'installed' => [
+            ['name' => 'lattice-php/core', 'direct-dependency' => false, 'version' => $version],
+            ['name' => 'lattice-php/lattice', 'direct-dependency' => true, 'version' => $version],
+            ['name' => 'lattice-php/media', 'direct-dependency' => true, 'version' => $version],
+        ],
+    ], JSON_THROW_ON_ERROR);
+}
+
+function composerReleases(string ...$versions): string
+{
+    return json_encode(['versions' => $versions], JSON_THROW_ON_ERROR);
+}
+
+function npmPackages(?string $version = null): string
+{
+    $dependencies = [];
+
+    if ($version !== null) {
+        $dependencies['@lattice-php/lattice'] = [
+            'version' => $version,
+            'dependencies' => [
+                '@lattice-php/core' => ['version' => $version],
+            ],
+        ];
+    }
+
+    return json_encode(['dependencies' => $dependencies], JSON_THROW_ON_ERROR);
+}

--- a/tests/Feature/Console/LatticePackageCommandsTest.php
+++ b/tests/Feature/Console/LatticePackageCommandsTest.php
@@ -1,9 +1,12 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Composer;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
+use Symfony\Component\Console\Output\OutputInterface;
 
 use function Pest\Laravel\artisan;
 
@@ -16,6 +19,8 @@ beforeEach(function (): void {
     File::put($this->projectPath.'/composer.json', json_encode([
         'require' => [
             'lattice-php/lattice' => '^0.52',
+        ],
+        'require-dev' => [
             'lattice-php/media' => '^0.52',
         ],
     ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
@@ -26,6 +31,8 @@ beforeEach(function (): void {
     ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
 
     app()->setBasePath($this->projectPath);
+    $this->composer = new RecordingComposer(app(Filesystem::class), $this->projectPath);
+    app()->instance(Composer::class, $this->composer);
 });
 
 afterEach(function (): void {
@@ -60,7 +67,6 @@ it('updates Composer packages and their published npm counterparts', function ()
         ['npm', 'view', '@lattice-php/lattice@0.53.0', 'version', '--json'] => Process::result(output: '"0.53.0"'),
         ['npm', 'view', '@lattice-php/media@0.53.0', 'version', '--json'] => Process::result(errorOutput: 'npm error code E404', exitCode: 1),
         ['npm', 'ls', '--all', '--json', '@lattice-php/core', '@lattice-php/lattice'] => Process::result(output: npmPackages('0.52.1')),
-        ['composer', 'require', 'lattice-php/lattice:^0.53', 'lattice-php/media:^0.53', '--with-all-dependencies', '--no-interaction'] => Process::result(),
         ['npm', 'install', '--save-prod', '@lattice-php/lattice@^0.53.0'] => Process::result(),
         default => Process::result(errorOutput: 'Unexpected process: '.json_encode($process->command), exitCode: 1),
     });
@@ -70,14 +76,21 @@ it('updates Composer packages and their published npm counterparts', function ()
         ->expectsOutputToContain('Updated Lattice packages to 0.53.0.')
         ->assertSuccessful();
 
-    Process::assertRan(fn (PendingProcess $process): bool => $process->command === [
-        'composer',
-        'require',
-        'lattice-php/lattice:^0.53',
-        'lattice-php/media:^0.53',
-        '--with-all-dependencies',
-        '--no-interaction',
-    ]);
+    expect($this->composer->requirements)->toBe([[
+        'packages' => [
+            'lattice-php/lattice:^0.53',
+            '--with-all-dependencies',
+            '--no-interaction',
+        ],
+        'dev' => false,
+    ], [
+        'packages' => [
+            'lattice-php/media:^0.53',
+            '--with-all-dependencies',
+            '--no-interaction',
+        ],
+        'dev' => true,
+    ]]);
     Process::assertRan(fn (PendingProcess $process): bool => $process->command === [
         'npm',
         'install',
@@ -122,7 +135,8 @@ it('shows update work without changing packages during a dry run', function (): 
 
     artisan('lattice:update', ['--dry-run' => true])
         ->expectsOutputToContain('Dry run complete. No files were changed.')
-        ->expectsOutputToContain('composer require lattice-php/lattice:^0.53 lattice-php/media:^0.53')
+        ->expectsOutputToContain('composer require lattice-php/lattice:^0.53')
+        ->expectsOutputToContain('composer require lattice-php/media:^0.53 --with-all-dependencies --no-interaction --dev')
         ->expectsOutputToContain('npm install --save-prod @lattice-php/lattice@^0.53.0')
         ->assertSuccessful();
 
@@ -204,4 +218,27 @@ function npmPackages(?string $version = null): string
     }
 
     return json_encode(['dependencies' => $dependencies], JSON_THROW_ON_ERROR);
+}
+
+final class RecordingComposer extends Composer
+{
+    /** @var list<array{packages: list<string>, dev: bool}> */
+    public array $requirements = [];
+
+    public bool $successful = true;
+
+    #[Override]
+    public function requirePackages(
+        array $packages,
+        bool $dev = false,
+        Closure|OutputInterface|null $output = null,
+        $composerBinary = null,
+    ): bool {
+        $this->requirements[] = [
+            'packages' => array_values($packages),
+            'dev' => $dev,
+        ];
+
+        return $this->successful;
+    }
 }


### PR DESCRIPTION
## Summary

- add `lattice:install` to synchronize published npm counterparts or publish standalone assets
- add `lattice:update --dry-run` to inspect and update all installed Lattice packages to the latest stable release
- document the standard and no-build workflows and cover current, missing, update, dry-run, and registry-mismatch behavior

## Testing

- `composer test:parallel` (1,720 tests, 6,030 assertions)
- `./vendor/bin/pest tests/Feature/Console/LatticePackageCommandsTest.php`
- `composer analyse`
- `npm run docs:build`
- pre-push gate (`pint`, PHPStan, `npm run check`)
