### PR TITLE
feat(media): make media() without a collection span every attachment

### DIFF
--- a/packages/media/src/Models/Concerns/HasMedia.php
+++ b/packages/media/src/Models/Concerns/HasMedia.php
@@ -13,16 +13,21 @@ use Lattice\Media\Models\Media;
 trait HasMedia
 {
     /**
+     * Without a collection this is the unfiltered relation over every
+     * attachment — the pivot's `collection` says where each row belongs, so
+     * eager loads and API includes can expose all media at once.
+     *
      * @return MorphToMany<Media, $this, Attachment>
      */
-    public function media(string $collection = 'default'): MorphToMany
+    public function media(?string $collection = null): MorphToMany
     {
-        return $this->morphToMany(Media::modelClass(), 'attachable', 'media_attachments', null, 'media_id')
+        $relation = $this->morphToMany(Media::modelClass(), 'attachable', 'media_attachments', null, 'media_id')
             ->using(Attachment::class)
             ->withPivot(['id', 'collection', 'sort_order', 'meta'])
             ->withTimestamps()
-            ->wherePivot('collection', $collection)
             ->orderByPivot('sort_order');
+
+        return $collection === null ? $relation : $relation->wherePivot('collection', $collection);
     }
 
     /**

--- a/tests/Feature/Media/HasMediaTest.php
+++ b/tests/Feature/Media/HasMediaTest.php
@@ -57,6 +57,21 @@ test('collections are isolated from each other', function (): void {
     expect($product->refresh()->media('manuals')->count())->toBe(1);
 });
 
+test('media without a collection spans every attachment with its pivot collection', function (): void {
+    $product = Product::factory()->create();
+    $image = Media::factory()->create();
+    $manual = Media::factory()->document()->create();
+
+    $product->syncMedia([$image->getKey()], 'images');
+    $product->syncMedia([$manual->getKey()], 'manuals');
+
+    $attachments = $product->media()->get()
+        ->mapWithKeys(fn (Media $media): array => [$media->getKey() => $media->pivot?->getAttribute('collection')])
+        ->all();
+
+    expect($attachments)->toBe([$image->getKey() => 'images', $manual->getKey() => 'manuals']);
+});
+
 test('firstMediaUrl returns the first attachment url or null', function (): void {
     Storage::fake('public');
     $product = Product::factory()->create();


### PR DESCRIPTION
Für den artisan-os-Product-API-Include: `media()` ohne Argument ist jetzt die ungefilterte Relation über alle Attachments — das Pivot trägt die `collection` je Zeile, Clients filtern daran. Mit explizitem Argument bleibt das bisherige `wherePivot('collection', …)`-Verhalten; die Schreib-Helper (`syncMedia`, `mediaPickerValue`, `firstMediaUrl`) behalten ihr explizites `'default'`.

Verhaltensänderung nur für argumentlose `media()`-Aufrufe (vorher: `'default'`-Collection; im Monorepo und in artisan-os gibt es keine solchen Aufrufer).

Neuer Test: ungefilterte Relation liefert beide Collections mit Pivot-Collection. Media-Suite 158 grün, Pint + PHPStan sauber.