### PR TITLE
feat(calendar): month-view drag-to-reschedule

### DIFF
--- a/docs/content/docs/packages/calendar.mdx
+++ b/docs/content/docs/packages/calendar.mdx
@@ -10,8 +10,8 @@ import Warning from "@components/Warning.astro";
 The calendar package renders one `Calendar` component with switchable views over a single event
 source: a **month grid** with multi-day event spanning, per-day overflow, and keyboard navigation,
 and a resource-planning **timeline** ("Plantafel") of resource rows against a day-granular date
-axis with drag-to-reschedule. Both views share the same adapter, endpoint, and client-side event
-cache — switching views reuses everything already loaded.
+axis. Both views support drag-to-reschedule and share the same adapter, endpoint, and client-side
+event cache — switching views reuses everything already loaded.
 
 ## Installation
 
@@ -150,7 +150,7 @@ final class ProjectPlanAdapter implements CalendarAdapter, ProvidesCalendarResou
   `['id' => ..., 'label' => ...]` rows or a closure returning the same shape, evaluated once per
   render. Timeline lanes lay out the events bound to a resource via `->resource()`; the month view
   shows every event regardless of binding.
-- **`ReschedulesCalendarEvents`** enables drag-to-reschedule in the timeline view. Without it the
+- **`ReschedulesCalendarEvents`** enables drag-to-reschedule in both views. Without it the
   calendar renders read-only and its `PATCH` endpoint responds `405`.
 
 ### Actions
@@ -179,6 +179,16 @@ navigates), <kbd>PageUp</kbd>/<kbd>PageDown</kbd> jump a month, and <kbd>Enter</
 action. Prev/next/today controls and the month title round out the header; navigating prefetches
 the adjacent months' grids.
 
+### Rescheduling
+
+With [`ReschedulesCalendarEvents`](#capabilities), dragging an event chip onto another day cell
+moves the event by whole days: the duration stays intact, all-day events shift their date bounds,
+and timed events keep their wall-clock times while only the dates move. Dragging any weekly
+segment of a multi-week event moves the whole event, anchored to the day the drag started on.
+Keyboard users can focus a chip and press <kbd>Control</kbd>+<kbd>Shift</kbd> with an arrow key:
+left/right moves by one day, up/down by one week. The optimistic update, rollback, and announced
+error handling match the [timeline's rescheduling](#rescheduling-and-resizing).
+
 ## Timeline view
 
 The timeline draws each resource's events as bars against a sticky month/calendar-week/day header,
@@ -190,13 +200,13 @@ their chevron. Overlapping same-resource events stack into lanes automatically, 
 
 Timeline lane layout is day-granular: a timed event occupies the calendar days it touches.
 
-### Rescheduling
+### Rescheduling and resizing
 
 Drag an event to a resource row to change its resource and dates in one operation, or drag either
 edge to resize. Keyboard users can focus an event and press <kbd>Control</kbd>+<kbd>Shift</kbd>
 with an arrow key: left/right moves by one day and up/down moves to the adjacent resource. The
 client updates immediately while the adapter runs, then either applies the returned event or rolls
-back and announces the adapter's translated error message. Each event represents one resource
+back and raises the adapter's translated error message as a toast. Each event represents one resource
 assignment — if one logical event belongs to several resources, return one event per assignment
 with a stable, unique ID.
 
@@ -216,9 +226,11 @@ definition gates both the initial render and every window fetch, mirroring
 them.
 
 `PATCH lattice/calendars/{calendar}` accepts `id`, `resourceId`, `start`, and `end`, then calls
-`reschedule($request)` on adapters implementing `ReschedulesCalendarEvents`. Its success response
-contains the updated event; failed Laravel validation responses are forwarded without replacing
-their translated message.
+`reschedule($request)` on adapters implementing `ReschedulesCalendarEvents`. `resourceId` is
+`null` for resource-less events, and `start`/`end` arrive in the event's own representation —
+`Y-m-d` bounds for all-day events, wall-clock datetimes for timed ones — so each adapter validates
+exactly the shapes it accepts. The success response contains the updated event; failed Laravel
+validation responses are forwarded without replacing their translated message.
 
 ## Translations
 

--- a/packages/calendar/composer.json
+++ b/packages/calendar/composer.json
@@ -1,38 +1,40 @@
 {
-    "$schema": "https://getcomposer.org/schema.json",
-    "name": "lattice-php/calendar",
-    "description": "Multi-view calendar component (month grid and resource timeline) for Lattice.",
-    "type": "library",
-    "license": "MIT",
-    "require": {
-        "php": "^8.4",
-        "illuminate/database": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/http": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/routing": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
-        "lattice-php/action": "self.version",
-        "lattice-php/core": "self.version",
-        "lattice-php/ui": "self.version"
-    },
-    "autoload": {
-        "psr-4": {
-            "Lattice\\Calendar\\": "src/"
-        }
-    },
-    "extra": {
-        "lattice": {
-            "plugin": "resources/js/plugin.ts",
-            "standalone": "dist/plugin.js",
-            "css": "resources/css/calendar.css",
-            "discover": ["src"]
-        },
-        "laravel": {
-            "providers": [
-                "Lattice\\Calendar\\CalendarServiceProvider"
-            ]
-        }
-    },
-    "config": {
-        "sort-packages": true
+  "$schema": "https://getcomposer.org/schema.json",
+  "name": "lattice-php/calendar",
+  "description": "Multi-view calendar component (month grid and resource timeline) for Lattice.",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": "^8.4",
+    "illuminate/database": "^11.0 || ^12.0 || ^13.0",
+    "illuminate/http": "^11.0 || ^12.0 || ^13.0",
+    "illuminate/routing": "^11.0 || ^12.0 || ^13.0",
+    "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+    "lattice-php/action": "self.version",
+    "lattice-php/core": "self.version",
+    "lattice-php/ui": "self.version"
+  },
+  "autoload": {
+    "psr-4": {
+      "Lattice\\Calendar\\": "src/"
     }
+  },
+  "extra": {
+    "lattice": {
+      "plugin": "resources/js/plugin.ts",
+      "standalone": "dist/plugin.js",
+      "css": "resources/css/calendar.css",
+      "discover": [
+        "src"
+      ]
+    },
+    "laravel": {
+      "providers": [
+        "Lattice\\Calendar\\CalendarServiceProvider"
+      ]
+    }
+  },
+  "config": {
+    "sort-packages": true
+  }
 }

--- a/packages/calendar/dist/plugin.js
+++ b/packages/calendar/dist/plugin.js
@@ -1,1109 +1,1807 @@
 import { useCallback as e, useEffect as t, useMemo as n, useRef as r, useState as i } from "react";
 import { Fragment as a, jsx as o, jsxs as s } from "react/jsx-runtime";
 //#region \0rolldown/runtime.js
-var c = Object.defineProperty, l = Object.getOwnPropertyDescriptor, u = Object.getOwnPropertyNames, d = Object.prototype.hasOwnProperty, f = (e, t, n) => () => {
-	if (n) throw n[0];
-	try {
-		return e && (t = e(e = 0)), t;
-	} catch (e) {
-		throw n = [e], e;
-	}
-}, p = (e, t) => {
-	let n = {};
-	for (var r in e) c(n, r, {
-		get: e[r],
-		enumerable: !0
-	});
-	return t || c(n, Symbol.toStringTag, { value: "Module" }), n;
-}, m = (e, t, n, r) => {
-	if (t && typeof t == "object" || typeof t == "function") for (var i = u(t), a = 0, o = i.length, s; a < o; a++) s = i[a], !d.call(e, s) && s !== n && c(e, s, {
-		get: ((e) => t[e]).bind(null, s),
-		enumerable: !(r = l(t, s)) || r.enumerable
-	});
-	return e;
-}, h = (e, t, n) => (m(e, t, "default"), n && m(n, t, "default")), g = /* @__PURE__ */ p({});
+var c = Object.defineProperty,
+  l = Object.getOwnPropertyDescriptor,
+  u = Object.getOwnPropertyNames,
+  d = Object.prototype.hasOwnProperty,
+  f = (e, t, n) => () => {
+    if (n) throw n[0];
+    try {
+      return (e && (t = e((e = 0))), t);
+    } catch (e) {
+      throw ((n = [e]), e);
+    }
+  },
+  p = (e, t) => {
+    let n = {};
+    for (var r in e)
+      c(n, r, {
+        get: e[r],
+        enumerable: !0,
+      });
+    return (t || c(n, Symbol.toStringTag, { value: "Module" }), n);
+  },
+  m = (e, t, n, r) => {
+    if ((t && typeof t == "object") || typeof t == "function")
+      for (var i = u(t), a = 0, o = i.length, s; a < o; a++)
+        ((s = i[a]),
+          !d.call(e, s) &&
+            s !== n &&
+            c(e, s, {
+              get: ((e) => t[e]).bind(null, s),
+              enumerable: !(r = l(t, s)) || r.enumerable,
+            }));
+    return e;
+  },
+  h = (e, t, n) => (m(e, t, "default"), n && m(n, t, "default")),
+  g = /* @__PURE__ */ p({});
 import * as _ from "@lattice-php/lattice/runtime";
 h(g, _);
-var v = f((() => {}));
+var v = f(() => {});
 //#endregion
 //#region resources/js/date-ranges.ts
 function y(e) {
-	if (e.length === 0) return [];
-	let t = [...e].sort((e, t) => e[0] < t[0] ? -1 : +(e[0] > t[0])), n = [[t[0][0], t[0][1]]];
-	for (let [e, r] of t.slice(1)) {
-		let t = n[n.length - 1];
-		e <= t[1] ? r > t[1] && (t[1] = r) : n.push([e, r]);
-	}
-	return n;
+  if (e.length === 0) return [];
+  let t = [...e].sort((e, t) => (e[0] < t[0] ? -1 : +(e[0] > t[0]))),
+    n = [[t[0][0], t[0][1]]];
+  for (let [e, r] of t.slice(1)) {
+    let t = n[n.length - 1];
+    e <= t[1] ? r > t[1] && (t[1] = r) : n.push([e, r]);
+  }
+  return n;
 }
 function b(e, t, n) {
-	if (t >= n) return [];
-	let r = y(e), i = [], a = t;
-	for (let [e, t] of r) if (!(t <= a) && (e >= n || (e > a && i.push([a, e]), a = t > a ? t < n ? t : n : a, a >= n))) break;
-	return a < n && i.push([a, n]), i;
+  if (t >= n) return [];
+  let r = y(e),
+    i = [],
+    a = t;
+  for (let [e, t] of r)
+    if (
+      !(t <= a) &&
+      (e >= n || (e > a && i.push([a, e]), (a = t > a ? (t < n ? t : n) : a), a >= n))
+    )
+      break;
+  return (a < n && i.push([a, n]), i);
 }
-var x = f((() => {}));
+var x = f(() => {});
 //#endregion
 //#region resources/js/calendar-state.ts
 function S(e) {
-	return typeof e == "object" && !!e && !Array.isArray(e);
+  return typeof e == "object" && !!e && !Array.isArray(e);
 }
 function C(e) {
-	if (!S(e) || !S(e.event)) return null;
-	let t = e.event;
-	return typeof t.id != "string" || typeof t.start != "string" || typeof t.end != "string" || typeof t.label != "string" || typeof t.allDay != "boolean" ? null : t;
+  if (!S(e) || !S(e.event)) return null;
+  let t = e.event;
+  return typeof t.id != "string" ||
+    typeof t.start != "string" ||
+    typeof t.end != "string" ||
+    typeof t.label != "string" ||
+    typeof t.allDay != "boolean"
+    ? null
+    : t;
 }
 function w(e) {
-	if (!S(e)) return null;
-	if (S(e.errors)) {
-		for (let t of Object.values(e.errors)) if (Array.isArray(t)) {
-			let e = t.find((e) => typeof e == "string");
-			if (e) return e;
-		}
-	}
-	return typeof e.message == "string" && e.message !== "" ? e.message : null;
+  if (!S(e)) return null;
+  if (S(e.errors)) {
+    for (let t of Object.values(e.errors))
+      if (Array.isArray(t)) {
+        let e = t.find((e) => typeof e == "string");
+        if (e) return e;
+      }
+  }
+  return typeof e.message == "string" && e.message !== "" ? e.message : null;
 }
 function T({ endpoint: t, componentRef: a, initialEvents: o, initialFrom: s, initialTo: c }) {
-	let [l, u] = i(() => new Map(o.map((e) => [e.id, e]))), [d, f] = i(!1), [p, m] = i(/* @__PURE__ */ new Set()), h = r([[s, c]]), _ = r(/* @__PURE__ */ new Map()), v = r(/* @__PURE__ */ new Set()), x = e((e, n) => {
-		if (!t || !a) return;
-		let r = b(h.current, e, n);
-		if (r.length === 0) return;
-		let i = r[0][0], o = r[r.length - 1][1], s = `${i}:${o}`;
-		if (_.current.has(s)) return;
-		let c = (0, g.apiJson)(`${t}?from=${i}&to=${o}`, { ref: a }).then(({ events: e }) => {
-			h.current = y([...h.current, [i, o]]), u((t) => {
-				let n = new Map(t);
-				for (let t of e) n.set(t.id, t);
-				return n;
-			});
-		}).catch(() => {}).finally(() => {
-			_.current.delete(s), f(_.current.size > 0);
-		});
-		_.current.set(s, c), f(!0);
-	}, [a, t]), S = e((e) => {
-		let t = [];
-		for (let n of l.values()) n.resourceId === e && t.push(n);
-		return t;
-	}, [l]), T = e(async (e) => {
-		let n = l.get(e.id);
-		if (!t || !a || !n || v.current.has(e.id)) return {
-			accepted: !1,
-			message: null
-		};
-		v.current.add(e.id), m(new Set(v.current)), u((t) => new Map(t).set(e.id, {
-			...n,
-			...e
-		}));
-		try {
-			let r = await (0, g.apiFetch)(t, {
-				body: JSON.stringify(e),
-				method: "PATCH",
-				ref: a,
-				throwOnError: !1
-			}), i = await r.json().catch(() => null), o = r.ok ? C(i) : null;
-			return o?.id === e.id ? (u((t) => new Map(t).set(e.id, o)), {
-				accepted: !0,
-				message: null
-			}) : (u((e) => new Map(e).set(n.id, n)), {
-				accepted: !1,
-				message: w(i)
-			});
-		} catch {
-			return u((e) => new Map(e).set(n.id, n)), {
-				accepted: !1,
-				message: null
-			};
-		} finally {
-			v.current.delete(e.id), m(new Set(v.current));
-		}
-	}, [
-		a,
-		t,
-		l
-	]), E = e((e) => p.has(e), [p]);
-	return n(() => ({
-		events: l,
-		eventsForResource: S,
-		ensureRange: x,
-		isRescheduling: E,
-		loading: d,
-		reschedule: T
-	}), [
-		l,
-		S,
-		x,
-		E,
-		d,
-		T
-	]);
+  let [l, u] = i(() => new Map(o.map((e) => [e.id, e]))),
+    [d, f] = i(!1),
+    [p, m] = i(/* @__PURE__ */ new Set()),
+    h = r([[s, c]]),
+    _ = r(/* @__PURE__ */ new Map()),
+    v = r(/* @__PURE__ */ new Set()),
+    x = e(
+      (e, n) => {
+        if (!t || !a) return;
+        let r = b(h.current, e, n);
+        if (r.length === 0) return;
+        let i = r[0][0],
+          o = r[r.length - 1][1],
+          s = `${i}:${o}`;
+        if (_.current.has(s)) return;
+        let c = (0, g.apiJson)(`${t}?from=${i}&to=${o}`, { ref: a })
+          .then(({ events: e }) => {
+            ((h.current = y([...h.current, [i, o]])),
+              u((t) => {
+                let n = new Map(t);
+                for (let t of e) n.set(t.id, t);
+                return n;
+              }));
+          })
+          .catch(() => {})
+          .finally(() => {
+            (_.current.delete(s), f(_.current.size > 0));
+          });
+        (_.current.set(s, c), f(!0));
+      },
+      [a, t],
+    ),
+    S = e(
+      (e) => {
+        let t = [];
+        for (let n of l.values()) n.resourceId === e && t.push(n);
+        return t;
+      },
+      [l],
+    ),
+    T = e(
+      async (e) => {
+        let n = l.get(e.id);
+        if (!t || !a || !n || v.current.has(e.id))
+          return {
+            accepted: !1,
+            message: null,
+          };
+        (v.current.add(e.id),
+          m(new Set(v.current)),
+          u((t) =>
+            new Map(t).set(e.id, {
+              ...n,
+              ...e,
+            }),
+          ));
+        try {
+          let r = await (0, g.apiFetch)(t, {
+              body: JSON.stringify(e),
+              method: "PATCH",
+              ref: a,
+              throwOnError: !1,
+            }),
+            i = await r.json().catch(() => null),
+            o = r.ok ? C(i) : null;
+          return o?.id === e.id
+            ? (u((t) => new Map(t).set(e.id, o)),
+              {
+                accepted: !0,
+                message: null,
+              })
+            : (u((e) => new Map(e).set(n.id, n)),
+              {
+                accepted: !1,
+                message: w(i),
+              });
+        } catch {
+          return (
+            u((e) => new Map(e).set(n.id, n)),
+            {
+              accepted: !1,
+              message: null,
+            }
+          );
+        } finally {
+          (v.current.delete(e.id), m(new Set(v.current)));
+        }
+      },
+      [a, t, l],
+    ),
+    E = e((e) => p.has(e), [p]);
+  return n(
+    () => ({
+      events: l,
+      eventsForResource: S,
+      ensureRange: x,
+      isRescheduling: E,
+      loading: d,
+      reschedule: T,
+    }),
+    [l, S, x, E, d, T],
+  );
 }
-var E = f((() => {
-	v(), x();
-}));
+var E = f(() => {
+  (v(), x());
+});
 //#endregion
 //#region resources/js/date-axis.ts
 function D(e) {
-	return /* @__PURE__ */ new Date(`${e}T12:00:00Z`);
+  return /* @__PURE__ */ new Date(`${e}T12:00:00Z`);
 }
 function O(e, t) {
-	let n = [], r = null, i = 0;
-	for (let a = 0; a < e; a++) {
-		let e = t(a);
-		e !== r && (r !== null && n.push({
-			start: i,
-			span: a - i,
-			label: r
-		}), r = e, i = a);
-	}
-	return r !== null && n.push({
-		start: i,
-		span: e - i,
-		label: r
-	}), n;
+  let n = [],
+    r = null,
+    i = 0;
+  for (let a = 0; a < e; a++) {
+    let e = t(a);
+    e !== r &&
+      (r !== null &&
+        n.push({
+          start: i,
+          span: a - i,
+          label: r,
+        }),
+      (r = e),
+      (i = a));
+  }
+  return (
+    r !== null &&
+      n.push({
+        start: i,
+        span: e - i,
+        label: r,
+      }),
+    n
+  );
 }
 function k(e, t, n, r) {
-	let i = new Intl.DateTimeFormat(n, {
-		month: "long",
-		year: "numeric"
-	}), a = [];
-	for (let n = 0; n < t; n++) {
-		let t = (0, g.addDays)(e, n), i = D(t), o = i.getUTCDay();
-		a.push({
-			index: n,
-			date: t,
-			weekday: o,
-			dayOfMonth: i.getUTCDate(),
-			isWeekend: o === 0 || o === 6,
-			isToday: t === r
-		});
-	}
-	return {
-		start: e,
-		days: a,
-		weeks: O(t, (e) => String((0, g.isoWeek)(a[e].date))),
-		months: O(t, (e) => i.format(D(a[e].date)))
-	};
+  let i = new Intl.DateTimeFormat(n, {
+      month: "long",
+      year: "numeric",
+    }),
+    a = [];
+  for (let n = 0; n < t; n++) {
+    let t = (0, g.addDays)(e, n),
+      i = D(t),
+      o = i.getUTCDay();
+    a.push({
+      index: n,
+      date: t,
+      weekday: o,
+      dayOfMonth: i.getUTCDate(),
+      isWeekend: o === 0 || o === 6,
+      isToday: t === r,
+    });
+  }
+  return {
+    start: e,
+    days: a,
+    weeks: O(t, (e) => String((0, g.isoWeek)(a[e].date))),
+    months: O(t, (e) => i.format(D(a[e].date))),
+  };
 }
 function A(e) {
-	let t = [...e].sort((e, t) => e.start - t.start || t.span - e.span || (e.order ?? e.id).localeCompare(t.order ?? t.id)), n = [], r = [];
-	for (let e of t) {
-		let t = e.start + e.span, i = n.findIndex((t) => t <= e.start);
-		i === -1 ? (i = n.length, n.push(t)) : n[i] = t, r.push({
-			...e,
-			lane: i
-		});
-	}
-	return {
-		bars: r,
-		laneCount: n.length
-	};
+  let t = [...e].sort(
+      (e, t) =>
+        e.start - t.start || t.span - e.span || (e.order ?? e.id).localeCompare(t.order ?? t.id),
+    ),
+    n = [],
+    r = [];
+  for (let e of t) {
+    let t = e.start + e.span,
+      i = n.findIndex((t) => t <= e.start);
+    (i === -1 ? ((i = n.length), n.push(t)) : (n[i] = t),
+      r.push({
+        ...e,
+        lane: i,
+      }));
+  }
+  return {
+    bars: r,
+    laneCount: n.length,
+  };
 }
-var j = f((() => {
-	v();
-}));
+var j = f(() => {
+  v();
+});
 //#endregion
 //#region resources/js/event-span.ts
 function M(e) {
-	if (e.allDay) return [e.start, e.end];
-	let t = e.start.slice(0, 10), n = e.end.slice(0, 10), r = e.end.endsWith("T00:00:00") ? n : (0, g.addDays)(n, 1);
-	return [t, r > t ? r : (0, g.addDays)(t, 1)];
+  if (e.allDay) return [e.start, e.end];
+  let t = e.start.slice(0, 10),
+    n = e.end.slice(0, 10),
+    r = e.end.endsWith("T00:00:00") ? n : (0, g.addDays)(n, 1);
+  return [t, r > t ? r : (0, g.addDays)(t, 1)];
 }
-var N = f((() => {
-	v();
-}));
+function N(e, t) {
+  let n = (e) => (0, g.addDays)(e.slice(0, 10), t) + e.slice(10);
+  return {
+    start: n(e.start),
+    end: n(e.end),
+  };
+}
+var P = f(() => {
+  v();
+});
 //#endregion
 //#region resources/js/month-grid.ts
-function P(e, t) {
-	let n = (0, g.startOfMonthISO)(e), r = (0, g.startOfWeekISO)(n, t);
-	return [r, (0, g.addDays)(r, (0, g.weeksInMonth)(n, t) * 7)];
+function F(e, t) {
+  let n = (0, g.startOfMonthISO)(e),
+    r = (0, g.startOfWeekISO)(n, t);
+  return [r, (0, g.addDays)(r, (0, g.weeksInMonth)(n, t) * 7)];
 }
-function F(e, t, n) {
-	let r = (0, g.startOfMonthISO)(e), i = (0, g.addMonths)(r, 1), [a, o] = P(r, t), s = [];
-	for (let e = a; e < o; e = (0, g.addDays)(e, 7)) {
-		let t = [];
-		for (let a = 0; a < 7; a++) {
-			let o = (0, g.addDays)(e, a), s = (/* @__PURE__ */ new Date(`${o}T12:00:00Z`)).getUTCDay();
-			t.push({
-				date: o,
-				dayOfMonth: Number(o.slice(8, 10)),
-				inMonth: o >= r && o < i,
-				isToday: o === n,
-				isWeekend: s === 0 || s === 6
-			});
-		}
-		s.push({
-			start: e,
-			days: t
-		});
-	}
-	return {
-		monthStart: r,
-		gridStart: a,
-		gridEnd: o,
-		weeks: s
-	};
-}
-function I(e, t) {
-	let n = (0, g.addDays)(t, 7), r = [];
-	for (let i of e) {
-		let [e, a] = M(i);
-		if (e >= n || a <= t) continue;
-		let o = Math.max(0, (0, g.daysBetween)(t, e)), s = Math.min(7, (0, g.daysBetween)(t, a));
-		r.push({
-			id: i.id,
-			start: o,
-			span: s - o,
-			order: `${i.allDay ? "0" : "1"}|${i.start}|${i.id}`,
-			continuesBefore: e < t,
-			continuesAfter: a > n,
-			event: i
-		});
-	}
-	let { bars: i, laneCount: a } = A(r);
-	return {
-		chips: i,
-		laneCount: a
-	};
+function I(e, t, n) {
+  let r = (0, g.startOfMonthISO)(e),
+    i = (0, g.addMonths)(r, 1),
+    [a, o] = F(r, t),
+    s = [];
+  for (let e = a; e < o; e = (0, g.addDays)(e, 7)) {
+    let t = [];
+    for (let a = 0; a < 7; a++) {
+      let o = (0, g.addDays)(e, a),
+        s = /* @__PURE__ */ new Date(`${o}T12:00:00Z`).getUTCDay();
+      t.push({
+        date: o,
+        dayOfMonth: Number(o.slice(8, 10)),
+        inMonth: o >= r && o < i,
+        isToday: o === n,
+        isWeekend: s === 0 || s === 6,
+      });
+    }
+    s.push({
+      start: e,
+      days: t,
+    });
+  }
+  return {
+    monthStart: r,
+    gridStart: a,
+    gridEnd: o,
+    weeks: s,
+  };
 }
 function L(e, t) {
-	let n = [
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0
-	], r = [];
-	for (let i of e) {
-		if (i.lane < t) {
-			r.push(i);
-			continue;
-		}
-		for (let e = i.start; e < i.start + i.span; e++) n[e]++;
-	}
-	return {
-		visible: r,
-		hiddenByDay: n
-	};
+  let n = (0, g.addDays)(t, 7),
+    r = [];
+  for (let i of e) {
+    let [e, a] = M(i);
+    if (e >= n || a <= t) continue;
+    let o = Math.max(0, (0, g.daysBetween)(t, e)),
+      s = Math.min(7, (0, g.daysBetween)(t, a));
+    r.push({
+      id: i.id,
+      start: o,
+      span: s - o,
+      order: `${i.allDay ? "0" : "1"}|${i.start}|${i.id}`,
+      continuesBefore: e < t,
+      continuesAfter: a > n,
+      event: i,
+    });
+  }
+  let { bars: i, laneCount: a } = A(r);
+  return {
+    chips: i,
+    laneCount: a,
+  };
+}
+function R(e, t) {
+  let n = [0, 0, 0, 0, 0, 0, 0],
+    r = [];
+  for (let i of e) {
+    if (i.lane < t) {
+      r.push(i);
+      continue;
+    }
+    for (let e = i.start; e < i.start + i.span; e++) n[e]++;
+  }
+  return {
+    visible: r,
+    hiddenByDay: n,
+  };
 }
 function ee(e, t) {
-	let n = (0, g.addDays)(t, 1), r = [];
-	for (let i of e) {
-		let [e, a] = M(i);
-		e < n && a > t && r.push(i);
-	}
-	return r.sort((e, t) => Number(t.allDay) - Number(e.allDay) || (e.start < t.start ? -1 : +(e.start > t.start)) || e.id.localeCompare(t.id));
+  let n = (0, g.addDays)(t, 1),
+    r = [];
+  for (let i of e) {
+    let [e, a] = M(i);
+    e < n && a > t && r.push(i);
+  }
+  return r.sort(
+    (e, t) =>
+      Number(t.allDay) - Number(e.allDay) ||
+      (e.start < t.start ? -1 : +(e.start > t.start)) ||
+      e.id.localeCompare(t.id),
+  );
 }
-var R = f((() => {
-	v(), j(), N();
-}));
+var z = f(() => {
+  (v(), j(), P());
+});
+//#endregion
+//#region resources/js/use-announced-reschedule.ts
+function te(t, n, r) {
+  let i = (0, g.useEffectDispatcher)();
+  return {
+    submitReschedule: e(
+      async (e) => {
+        let a = t.get(e.id);
+        if (!a) return;
+        let o = await n(e);
+        if (o.accepted) {
+          (0, g.announce)(r("calendar.rescheduled", "Rescheduled {{label}}", { label: a.label }));
+          return;
+        }
+        let s =
+          o.message ??
+          r("calendar.reschedule-failed", "Could not reschedule {{label}}", { label: a.label });
+        (i([
+          {
+            type: "toast",
+            props: {
+              message: s,
+              variant: "danger",
+            },
+          },
+        ]),
+          (0, g.announce)(s));
+      },
+      [i, t, n, r],
+    ),
+  };
+}
+var B = f(() => {
+  v();
+});
 //#endregion
 //#region resources/js/views/month-view.tsx
-function z(e) {
-	return /* @__PURE__ */ new Date(`${e}T12:00:00Z`);
+function V(e) {
+  return /* @__PURE__ */ new Date(`${e}T12:00:00Z`);
 }
-function te({ events: e, loading: a, locale: c, month: l, onDayClick: u, onEventClick: d, onNavigate: f, t: p, today: m }) {
-	let h = r(null), _ = r(null), [v, y] = i(null), b = n(() => F(l, c, m), [
-		l,
-		c,
-		m
-	]), x = n(() => [...e.values()], [e]), S = n(() => new Intl.DateTimeFormat(c, {
-		month: "long",
-		year: "numeric"
-	}).format(z(b.monthStart)), [b.monthStart, c]), C = n(() => new Intl.DateTimeFormat(c, { weekday: "short" }), [c]), w = n(() => new Intl.DateTimeFormat(c, { dateStyle: "full" }), [c]), T = (e) => e >= b.gridStart && e < b.gridEnd, E = v && T(v) ? v : T(m) ? m : b.monthStart;
-	function D(e) {
-		_.current = e, y(e), T(e) || f((0, g.startOfMonthISO)(e));
-	}
-	t(() => {
-		let e = _.current;
-		if (!e) return;
-		let t = h.current?.querySelector(`[data-date="${e}"]`);
-		t && (_.current = null, t.focus());
-	});
-	function O(e, t) {
-		let n;
-		switch (e.key) {
-			case "ArrowLeft":
-				n = (0, g.addDays)(t, -1);
-				break;
-			case "ArrowRight":
-				n = (0, g.addDays)(t, 1);
-				break;
-			case "ArrowUp":
-				n = (0, g.addDays)(t, -7);
-				break;
-			case "ArrowDown":
-				n = (0, g.addDays)(t, 7);
-				break;
-			case "PageUp":
-				n = (0, g.addMonths)(t, -1);
-				break;
-			case "PageDown":
-				n = (0, g.addMonths)(t, 1);
-				break;
-			case "Enter":
-			case " ":
-				u && e.target === e.currentTarget && (e.preventDefault(), u(t));
-				return;
-			default: return;
-		}
-		e.preventDefault(), D(n);
-	}
-	return /* @__PURE__ */ s("div", {
-		className: "lt-calendar-month",
-		ref: h,
-		children: [/* @__PURE__ */ s("div", {
-			className: "mb-2 flex items-center gap-1",
-			children: [
-				/* @__PURE__ */ o("button", {
-					"aria-label": p("calendar.previous", "Previous"),
-					className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
-					onClick: () => f((0, g.addMonths)(b.monthStart, -1)),
-					type: "button",
-					children: /* @__PURE__ */ o(g.Icon, {
-						className: "size-lt-icon-sm",
-						name: "chevron-left"
-					})
-				}),
-				/* @__PURE__ */ o("button", {
-					"aria-label": p("calendar.next", "Next"),
-					className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
-					onClick: () => f((0, g.addMonths)(b.monthStart, 1)),
-					type: "button",
-					children: /* @__PURE__ */ o(g.Icon, {
-						className: "size-lt-icon-sm",
-						name: "chevron-right"
-					})
-				}),
-				/* @__PURE__ */ o("button", {
-					className: "rounded-lt-sm px-2 py-1 text-sm hover:bg-lt-muted",
-					onClick: () => f((0, g.startOfMonthISO)(m)),
-					type: "button",
-					children: p("calendar.today", "Today")
-				}),
-				/* @__PURE__ */ o("h2", {
-					"aria-live": "polite",
-					className: "ml-2 text-sm font-semibold",
-					children: S
-				})
-			]
-		}), /* @__PURE__ */ s("div", {
-			"aria-busy": a,
-			"aria-label": S,
-			className: "overflow-hidden rounded-lt-sm border border-lt-border",
-			role: "grid",
-			children: [/* @__PURE__ */ o("div", {
-				className: "lt-calendar-weekdays border-b border-lt-border",
-				role: "row",
-				children: b.weeks[0].days.map((e) => /* @__PURE__ */ o("div", {
-					className: "px-2 py-1.5 text-xs font-medium text-lt-muted-fg",
-					role: "columnheader",
-					children: C.format(z(e.date))
-				}, e.date))
-			}), b.weeks.map((e, t) => /* @__PURE__ */ o(ne, {
-				dayFormatter: w,
-				eventList: x,
-				first: t === 0,
-				locale: c,
-				onCellKeyDown: O,
-				onDayClick: u,
-				onEventClick: d,
-				t: p,
-				tabStopDate: E,
-				week: e
-			}, e.start))]
-		})]
-	});
+function H({
+  canReschedule: a,
+  locale: c,
+  month: l,
+  onDayClick: u,
+  onEventClick: d,
+  onNavigate: f,
+  state: p,
+  t: m,
+  today: h,
+}) {
+  let _ = r(null),
+    v = r(null),
+    y = r(null),
+    [b, x] = i(null),
+    [S, C] = i(!1),
+    { events: w, isRescheduling: T, loading: E, reschedule: D } = p,
+    { submitReschedule: O } = te(w, D, m),
+    k = n(() => I(l, c, h), [l, c, h]),
+    A = n(() => [...w.values()], [w]),
+    j = n(
+      () =>
+        new Intl.DateTimeFormat(c, {
+          month: "long",
+          year: "numeric",
+        }).format(V(k.monthStart)),
+      [k.monthStart, c],
+    ),
+    P = n(() => new Intl.DateTimeFormat(c, { weekday: "short" }), [c]),
+    F = n(() => new Intl.DateTimeFormat(c, { dateStyle: "full" }), [c]),
+    L = (e) => e >= k.gridStart && e < k.gridEnd,
+    R = b && L(b) ? b : L(h) ? h : k.monthStart;
+  function ee(e) {
+    ((v.current = e), x(e), L(e) || f((0, g.startOfMonthISO)(e)));
+  }
+  (t(() => {
+    let e = v.current;
+    if (!e) return;
+    let t = _.current?.querySelector(`[data-date="${e}"]`);
+    t && ((v.current = null), t.focus());
+  }),
+    t(() => {
+      let e = y.current;
+      if (!e) return;
+      let t = _.current?.querySelector(`[data-test="calendar-event-${e}"]`);
+      t && ((y.current = null), t.focus());
+    }));
+  function z(e, t) {
+    let n;
+    switch (e.key) {
+      case "ArrowLeft":
+        n = (0, g.addDays)(t, -1);
+        break;
+      case "ArrowRight":
+        n = (0, g.addDays)(t, 1);
+        break;
+      case "ArrowUp":
+        n = (0, g.addDays)(t, -7);
+        break;
+      case "ArrowDown":
+        n = (0, g.addDays)(t, 7);
+        break;
+      case "PageUp":
+        n = (0, g.addMonths)(t, -1);
+        break;
+      case "PageDown":
+        n = (0, g.addMonths)(t, 1);
+        break;
+      case "Enter":
+      case " ":
+        u && e.target === e.currentTarget && (e.preventDefault(), u(t));
+        return;
+      default:
+        return;
+    }
+    (e.preventDefault(), ee(n));
+  }
+  function B(e, t) {
+    t !== 0 &&
+      O({
+        id: e.id,
+        resourceId: e.resourceId,
+        ...N(e, t),
+      });
+  }
+  function H(e, t) {
+    if (!a || T(t.id) || !e.ctrlKey || !e.shiftKey) return;
+    let n;
+    switch (e.key) {
+      case "ArrowLeft":
+        n = -1;
+        break;
+      case "ArrowRight":
+        n = 1;
+        break;
+      case "ArrowUp":
+        n = -7;
+        break;
+      case "ArrowDown":
+        n = 7;
+        break;
+      default:
+        return;
+    }
+    (e.preventDefault(), (y.current = t.id), B(t, n));
+  }
+  let U = e(
+    (e, t) => {
+      let n = e.id,
+        r = typeof e.grabOffsetDays == "number" ? e.grabOffsetDays : 0;
+      if (typeof n != "string") return;
+      let i = w.get(n);
+      if (!i) return;
+      let [a] = M(i),
+        o = (0, g.daysBetween)(a, (0, g.addDays)(t, -r));
+      o !== 0 &&
+        O({
+          id: i.id,
+          resourceId: i.resourceId,
+          ...N(i, o),
+        });
+    },
+    [w, O],
+  );
+  return /* @__PURE__ */ s("div", {
+    className: "lt-calendar-month",
+    "data-dragging": S ? "true" : void 0,
+    ref: _,
+    children: [
+      /* @__PURE__ */ s("div", {
+        className: "mb-2 flex items-center gap-1",
+        children: [
+          /* @__PURE__ */ o("button", {
+            "aria-label": m("calendar.previous", "Previous"),
+            className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
+            onClick: () => f((0, g.addMonths)(k.monthStart, -1)),
+            type: "button",
+            children: /* @__PURE__ */ o(g.Icon, {
+              className: "size-lt-icon-sm",
+              name: "chevron-left",
+            }),
+          }),
+          /* @__PURE__ */ o("button", {
+            "aria-label": m("calendar.next", "Next"),
+            className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
+            onClick: () => f((0, g.addMonths)(k.monthStart, 1)),
+            type: "button",
+            children: /* @__PURE__ */ o(g.Icon, {
+              className: "size-lt-icon-sm",
+              name: "chevron-right",
+            }),
+          }),
+          /* @__PURE__ */ o("button", {
+            className: "rounded-lt-sm px-2 py-1 text-sm hover:bg-lt-muted",
+            onClick: () => f((0, g.startOfMonthISO)(h)),
+            type: "button",
+            children: m("calendar.today", "Today"),
+          }),
+          /* @__PURE__ */ o("h2", {
+            "aria-live": "polite",
+            className: "ml-2 text-sm font-semibold",
+            children: j,
+          }),
+        ],
+      }),
+      /* @__PURE__ */ s("div", {
+        "aria-busy": E || [...w.keys()].some((e) => T(e)),
+        "aria-label": j,
+        className: "overflow-hidden rounded-lt-sm border border-lt-border",
+        role: "grid",
+        children: [
+          /* @__PURE__ */ o("div", {
+            className: "lt-calendar-weekdays border-b border-lt-border",
+            role: "row",
+            children: k.weeks[0].days.map((e) =>
+              /* @__PURE__ */ o(
+                "div",
+                {
+                  className: "px-2 py-1.5 text-xs font-medium text-lt-muted-fg",
+                  role: "columnheader",
+                  children: P.format(V(e.date)),
+                },
+                e.date,
+              ),
+            ),
+          }),
+          k.weeks.map((e, t) =>
+            /* @__PURE__ */ o(
+              ne,
+              {
+                canReschedule: a,
+                dayFormatter: F,
+                eventList: A,
+                first: t === 0,
+                isRescheduling: T,
+                locale: c,
+                onCellKeyDown: z,
+                onChipKeyDown: H,
+                onDayClick: u,
+                onDragStateChange: C,
+                onEventClick: d,
+                onEventDrop: U,
+                t: m,
+                tabStopDate: R,
+                week: e,
+              },
+              e.start,
+            ),
+          ),
+        ],
+      }),
+    ],
+  });
 }
-function ne({ dayFormatter: e, eventList: t, first: n, locale: r, onCellKeyDown: i, onDayClick: a, onEventClick: c, t: l, tabStopDate: u, week: d }) {
-	let { chips: f } = I(t, d.start), { visible: p, hiddenByDay: m } = L(f, 3);
-	return /* @__PURE__ */ s("div", {
-		className: (0, g.cn)("lt-calendar-week", !n && "border-t border-lt-border"),
-		role: "row",
-		children: [d.days.map((n, d) => /* @__PURE__ */ s("div", {
-			"aria-current": n.isToday ? "date" : void 0,
-			"aria-label": e.format(z(n.date)),
-			className: (0, g.cn)("lt-calendar-day", d > 0 && "border-l border-lt-border", n.isWeekend && "bg-lt-muted/40", !n.inMonth && "text-lt-muted-fg", a && "cursor-pointer"),
-			"data-date": n.date,
-			"data-test": `calendar-day-${n.date}`,
-			onClick: a ? () => a(n.date) : void 0,
-			onKeyDown: (e) => i(e, n.date),
-			role: "gridcell",
-			tabIndex: n.date === u ? 0 : -1,
-			children: [
-				/* @__PURE__ */ o("div", {
-					className: "flex justify-end px-1.5 pt-1",
-					children: /* @__PURE__ */ o("span", {
-						className: (0, g.cn)("flex size-6 items-center justify-center rounded-full text-xs", n.isToday && "bg-lt-primary font-semibold text-lt-primary-fg", !n.isToday && !n.inMonth && "text-lt-muted-fg"),
-						children: n.dayOfMonth
-					})
-				}),
-				/* @__PURE__ */ o("div", { className: "flex-1" }),
-				m[d] > 0 ? /* @__PURE__ */ o(ie, {
-					count: m[d],
-					date: n.date,
-					eventList: t,
-					label: e.format(z(n.date)),
-					locale: r,
-					onEventClick: c,
-					t: l
-				}) : null
-			]
-		}, n.date)), /* @__PURE__ */ o("div", {
-			"aria-hidden": !c || void 0,
-			className: "lt-calendar-chips",
-			children: p.map((e) => /* @__PURE__ */ o(re, {
-				chip: e,
-				locale: r,
-				onEventClick: c,
-				t: l
-			}, `${e.id}-${e.start}`))
-		})]
-	});
+function ne({
+  canReschedule: e,
+  dayFormatter: t,
+  eventList: n,
+  first: r,
+  isRescheduling: i,
+  locale: a,
+  onCellKeyDown: c,
+  onChipKeyDown: l,
+  onDayClick: u,
+  onDragStateChange: d,
+  onEventClick: f,
+  onEventDrop: p,
+  t: m,
+  tabStopDate: h,
+  week: _,
+}) {
+  let { chips: v } = L(n, _.start),
+    { visible: y, hiddenByDay: b } = R(v, 3);
+  return /* @__PURE__ */ s("div", {
+    className: (0, g.cn)("lt-calendar-week", !r && "border-t border-lt-border"),
+    role: "row",
+    children: [
+      _.days.map((r, i) =>
+        /* @__PURE__ */ o(
+          U,
+          {
+            ariaLabel: t.format(V(r.date)),
+            canReschedule: e,
+            day: r,
+            dayIndex: i,
+            onDayClick: u,
+            onEventDrop: p,
+            onKeyDown: c,
+            tabStop: r.date === h,
+            children:
+              b[i] > 0
+                ? /* @__PURE__ */ o(ie, {
+                    count: b[i],
+                    date: r.date,
+                    eventList: n,
+                    label: t.format(V(r.date)),
+                    locale: a,
+                    onEventClick: f,
+                    t: m,
+                  })
+                : null,
+          },
+          r.date,
+        ),
+      ),
+      /* @__PURE__ */ o("div", {
+        "aria-hidden": f || e ? void 0 : !0,
+        className: "lt-calendar-chips",
+        children: y.map((t) =>
+          /* @__PURE__ */ o(
+            re,
+            {
+              canReschedule: e,
+              chip: t,
+              isRescheduling: i(t.id),
+              locale: a,
+              onDragStateChange: d,
+              onEventClick: f,
+              onMoveKeyDown: l,
+              t: m,
+              weekStart: _.start,
+            },
+            `${t.id}-${t.start}`,
+          ),
+        ),
+      }),
+    ],
+  });
 }
-function B(e, t) {
-	return /* @__PURE__ */ s(a, { children: [e.allDay ? null : /* @__PURE__ */ o("span", {
-		className: "shrink-0 font-medium tabular-nums",
-		children: (0, g.formatWallTime)(e.start, t)
-	}), /* @__PURE__ */ o("span", {
-		className: "truncate",
-		children: e.label
-	})] });
+function U({
+  ariaLabel: e,
+  canReschedule: n,
+  children: a,
+  day: c,
+  dayIndex: l,
+  onDayClick: u,
+  onEventDrop: d,
+  onKeyDown: f,
+  tabStop: p,
+}) {
+  let m = r(null),
+    [h, _] = i(!1);
+  return (
+    t(() => {
+      let e = m.current;
+      if (!(!e || !n))
+        return (0, g.dropTargetForElements)({
+          canDrop: ({ source: e }) => e.data.type === K,
+          element: e,
+          onDragEnter: () => _(!0),
+          onDragLeave: () => _(!1),
+          onDrop: ({ source: e }) => {
+            (_(!1), d(e.data, c.date));
+          },
+        });
+    }, [n, c.date, d]),
+    /* @__PURE__ */ s("div", {
+      "aria-current": c.isToday ? "date" : void 0,
+      "aria-label": e,
+      className: (0, g.cn)(
+        "lt-calendar-day",
+        l > 0 && "border-l border-lt-border",
+        c.isWeekend && "bg-lt-muted/40",
+        !c.inMonth && "text-lt-muted-fg",
+        u && "cursor-pointer",
+        h && "bg-lt-primary/10",
+      ),
+      "data-date": c.date,
+      "data-test": `calendar-day-${c.date}`,
+      onClick: u ? () => u(c.date) : void 0,
+      onKeyDown: (e) => f(e, c.date),
+      ref: m,
+      role: "gridcell",
+      tabIndex: p ? 0 : -1,
+      children: [
+        /* @__PURE__ */ o("div", {
+          className: "flex justify-end px-1.5 pt-1",
+          children: /* @__PURE__ */ o("span", {
+            className: (0, g.cn)(
+              "flex size-6 items-center justify-center rounded-full text-xs",
+              c.isToday && "bg-lt-primary font-semibold text-lt-primary-fg",
+              !c.isToday && !c.inMonth && "text-lt-muted-fg",
+            ),
+            children: c.dayOfMonth,
+          }),
+        }),
+        /* @__PURE__ */ o("div", { className: "flex-1" }),
+        a,
+      ],
+    })
+  );
 }
-function V(e, t) {
-	return t("calendar.event-chip-label", "{{label}}, {{start}} to {{end}}", {
-		end: e.end,
-		label: e.label,
-		start: e.start
-	});
+function W(e, t) {
+  return /* @__PURE__ */ s(a, {
+    children: [
+      e.allDay
+        ? null
+        : /* @__PURE__ */ o("span", {
+            className: "shrink-0 font-medium tabular-nums",
+            children: (0, g.formatWallTime)(e.start, t),
+          }),
+      /* @__PURE__ */ o("span", {
+        className: "truncate",
+        children: e.label,
+      }),
+    ],
+  });
 }
-function re({ chip: e, locale: t, onEventClick: n, t: r }) {
-	let i = (0, g.toneProps)((0, g.coerceColor)(e.event.color) ?? (0, g.namedColor)("primary")), a = (0, g.cn)("lt-calendar-chip mx-1 mb-0.5 flex items-center gap-1 overflow-hidden px-1.5 text-left text-xs", i.className, e.continuesBefore ? "rounded-l-none" : "rounded-l-lt-xs", e.continuesAfter ? "rounded-r-none" : "rounded-r-lt-xs", n && "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-lt-primary"), s = {
-		gridColumn: `${e.start + 1} / span ${e.span}`,
-		gridRow: e.lane + 1,
-		...i.style
-	};
-	return n ? /* @__PURE__ */ o("button", {
-		"aria-label": V(e.event, r),
-		className: a,
-		"data-test": `calendar-event-${e.id}`,
-		onClick: () => n(e.event),
-		style: s,
-		title: e.event.label,
-		type: "button",
-		children: B(e.event, t)
-	}) : /* @__PURE__ */ o("div", {
-		className: a,
-		"data-test": `calendar-event-${e.id}`,
-		style: s,
-		children: B(e.event, t)
-	});
+function G(e, t, n = !1) {
+  return n
+    ? t(
+        "calendar.event-chip-label-reschedulable",
+        "{{label}}, {{start}} to {{end}}. Use Control Shift and arrow keys to reschedule.",
+        {
+          end: e.end,
+          label: e.label,
+          start: e.start,
+        },
+      )
+    : t("calendar.event-chip-label", "{{label}}, {{start}} to {{end}}", {
+        end: e.end,
+        label: e.label,
+        start: e.start,
+      });
+}
+function re({
+  canReschedule: e,
+  chip: n,
+  isRescheduling: i,
+  locale: a,
+  onDragStateChange: s,
+  onEventClick: c,
+  onMoveKeyDown: l,
+  t: u,
+  weekStart: d,
+}) {
+  let f = r(null),
+    { event: p, span: m, start: h } = n;
+  t(() => {
+    let t = f.current;
+    if (!t || !e) return;
+    let [n, r] = M(p),
+      a = (0, g.daysBetween)(n, r),
+      o = (0, g.daysBetween)(n, (0, g.addDays)(d, h));
+    return (0, g.draggable)({
+      canDrag: () => !i,
+      element: t,
+      getInitialData: ({ element: e, input: t }) => {
+        let n = e.getBoundingClientRect(),
+          r = n.width / m;
+        return {
+          grabOffsetDays: Math.max(0, Math.min(a - 1, o + Math.floor((t.clientX - n.left) / r))),
+          id: p.id,
+          type: K,
+        };
+      },
+      onDragStart: () => {
+        (s(!0),
+          (0, g.announce)(
+            u("calendar.dragging-day", "Moving {{label}}. Drop on a day.", { label: p.label }),
+          ));
+      },
+      onDrop: () => s(!1),
+    });
+  }, [e, p, i, s, m, h, u, d]);
+  let _ = (0, g.toneProps)((0, g.coerceColor)(n.event.color) ?? (0, g.namedColor)("primary")),
+    v = (0, g.cn)(
+      "lt-calendar-chip mx-1 mb-0.5 flex items-center gap-1 overflow-hidden px-1.5 text-left text-xs",
+      _.className,
+      n.continuesBefore ? "rounded-l-none" : "rounded-l-lt-xs",
+      n.continuesAfter ? "rounded-r-none" : "rounded-r-lt-xs",
+      (c || e) &&
+        "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-lt-primary",
+      c && "cursor-pointer",
+      e && !c && "cursor-grab",
+    ),
+    y = {
+      gridColumn: `${n.start + 1} / span ${n.span}`,
+      gridRow: n.lane + 1,
+      ..._.style,
+    };
+  return !c && !e
+    ? /* @__PURE__ */ o("div", {
+        className: v,
+        "data-end": n.event.end,
+        "data-start": n.event.start,
+        "data-test": `calendar-event-${n.id}`,
+        style: y,
+        children: W(n.event, a),
+      })
+    : /* @__PURE__ */ o("button", {
+        "aria-disabled": i || void 0,
+        "aria-keyshortcuts": e
+          ? "Control+Shift+ArrowLeft Control+Shift+ArrowRight Control+Shift+ArrowUp Control+Shift+ArrowDown"
+          : void 0,
+        "aria-label": G(n.event, u, e),
+        className: v,
+        "data-end": n.event.end,
+        "data-start": n.event.start,
+        "data-test": `calendar-event-${n.id}`,
+        onClick: c ? () => c(n.event) : void 0,
+        onKeyDown: (e) => l(e, n.event),
+        ref: f,
+        style: y,
+        title: n.event.label,
+        type: "button",
+        children: W(n.event, a),
+      });
 }
 function ie({ count: e, date: t, eventList: n, label: r, locale: i, onEventClick: a, t: c }) {
-	return /* @__PURE__ */ s(g.Popover, { children: [/* @__PURE__ */ o(g.PopoverTrigger, {
-		"aria-label": c("calendar.show-events-for-day", "Show all events on {{date}}", { date: r }),
-		className: "mx-1 mb-1 rounded-lt-xs px-1.5 py-0.5 text-left text-xs text-lt-muted-fg hover:bg-lt-muted",
-		"data-test": `calendar-more-${t}`,
-		onClick: (e) => e.stopPropagation(),
-		onKeyDown: (e) => e.stopPropagation(),
-		children: c("calendar.more-events", "+{{count}} more", { count: e })
-	}), /* @__PURE__ */ s(g.PopoverContent, {
-		className: "flex w-64 flex-col gap-1 p-2",
-		"data-test": `calendar-more-list-${t}`,
-		children: [/* @__PURE__ */ o("p", {
-			className: "px-1 text-xs font-medium text-lt-muted-fg",
-			children: r
-		}), ee(n, t).map((e) => {
-			let t = (0, g.toneProps)((0, g.coerceColor)(e.color) ?? (0, g.namedColor)("primary")), n = (0, g.cn)("lt-calendar-chip flex items-center gap-1 overflow-hidden rounded-lt-xs px-1.5 py-1 text-left text-xs", t.className, a && "cursor-pointer");
-			return a ? /* @__PURE__ */ o("button", {
-				"aria-label": V(e, c),
-				className: n,
-				onClick: () => a(e),
-				style: t.style,
-				type: "button",
-				children: B(e, i)
-			}, e.id) : /* @__PURE__ */ o("div", {
-				className: n,
-				style: t.style,
-				children: B(e, i)
-			}, e.id);
-		})]
-	})] });
+  return /* @__PURE__ */ s(g.Popover, {
+    children: [
+      /* @__PURE__ */ o(g.PopoverTrigger, {
+        "aria-label": c("calendar.show-events-for-day", "Show all events on {{date}}", { date: r }),
+        className:
+          "mx-1 mb-1 rounded-lt-xs px-1.5 py-0.5 text-left text-xs text-lt-muted-fg hover:bg-lt-muted",
+        "data-test": `calendar-more-${t}`,
+        onClick: (e) => e.stopPropagation(),
+        onKeyDown: (e) => e.stopPropagation(),
+        children: c("calendar.more-events", "+{{count}} more", { count: e }),
+      }),
+      /* @__PURE__ */ s(g.PopoverContent, {
+        className: "flex w-64 flex-col gap-1 p-2",
+        "data-test": `calendar-more-list-${t}`,
+        children: [
+          /* @__PURE__ */ o("p", {
+            className: "px-1 text-xs font-medium text-lt-muted-fg",
+            children: r,
+          }),
+          ee(n, t).map((e) => {
+            let t = (0, g.toneProps)((0, g.coerceColor)(e.color) ?? (0, g.namedColor)("primary")),
+              n = (0, g.cn)(
+                "lt-calendar-chip flex items-center gap-1 overflow-hidden rounded-lt-xs px-1.5 py-1 text-left text-xs",
+                t.className,
+                a && "cursor-pointer",
+              );
+            return a
+              ? /* @__PURE__ */ o(
+                  "button",
+                  {
+                    "aria-label": G(e, c),
+                    className: n,
+                    onClick: () => a(e),
+                    style: t.style,
+                    type: "button",
+                    children: W(e, i),
+                  },
+                  e.id,
+                )
+              : /* @__PURE__ */ o(
+                  "div",
+                  {
+                    className: n,
+                    style: t.style,
+                    children: W(e, i),
+                  },
+                  e.id,
+                );
+          }),
+        ],
+      }),
+    ],
+  });
 }
-var ae = f((() => {
-	v(), R();
-}));
+var K,
+  ae = f(() => {
+    (v(), z(), P(), B(), (K = "lattice-calendar-month-event"));
+  });
 //#endregion
 //#region resources/js/views/timeline-view.tsx
 function oe(e) {
-	return e === "start" || e === "end";
+  return e === "start" || e === "end";
 }
 function se(e) {
-	return e.flatMap((e) => {
-		if (e.resourceId === null) return [];
-		let [t, n] = M(e);
-		return [{
-			...e,
-			resourceId: e.resourceId,
-			dayStart: t,
-			dayEnd: n
-		}];
-	});
+  return e.flatMap((e) => {
+    if (e.resourceId === null) return [];
+    let [t, n] = M(e);
+    return [
+      {
+        ...e,
+        resourceId: e.resourceId,
+        dayStart: t,
+        dayEnd: n,
+      },
+    ];
+  });
 }
-function H(e, t, n) {
-	return t === "start" ? {
-		id: e.id,
-		resourceId: e.resourceId,
-		start: n < e.dayEnd ? n : (0, g.addDays)(e.dayEnd, -1),
-		end: e.dayEnd
-	} : {
-		id: e.id,
-		resourceId: e.resourceId,
-		start: e.dayStart,
-		end: n > e.dayStart ? n : (0, g.addDays)(e.dayStart, 1)
-	};
+function q(e, t, n) {
+  return t === "start"
+    ? {
+        id: e.id,
+        resourceId: e.resourceId,
+        start: n < e.dayEnd ? n : (0, g.addDays)(e.dayEnd, -1),
+        end: e.dayEnd,
+      }
+    : {
+        id: e.id,
+        resourceId: e.resourceId,
+        start: e.dayStart,
+        end: n > e.dayStart ? n : (0, g.addDays)(e.dayStart, 1),
+      };
 }
 function ce(e, t, n) {
-	let r = [];
-	for (let i of e) {
-		let e = Math.max(0, (0, g.daysBetween)(t, i.dayStart)), a = Math.min(n, (0, g.daysBetween)(t, i.dayEnd)) - e;
-		a > 0 && r.push({
-			id: i.id,
-			start: e,
-			span: a,
-			event: i
-		});
-	}
-	return A(r);
+  let r = [];
+  for (let i of e) {
+    let e = Math.max(0, (0, g.daysBetween)(t, i.dayStart)),
+      a = Math.min(n, (0, g.daysBetween)(t, i.dayEnd)) - e;
+    a > 0 &&
+      r.push({
+        id: i.id,
+        start: e,
+        span: a,
+        event: i,
+      });
+  }
+  return A(r);
 }
-function le({ canReschedule: t, days: r, from: a, groups: c, locale: l, onNavigate: u, state: d, t: f, today: p }) {
-	let [m, h] = i(q), [_, v] = i(/* @__PURE__ */ new Set()), [y, b] = i(null), { events: x, eventsForResource: S, isRescheduling: C, loading: w, reschedule: T } = d, E = n(() => c.flatMap((e) => e.resources), [c]), D = e((e) => se(S(e)), [S]), O = n(() => k(a, r, l, p), [
-		a,
-		r,
-		l,
-		p
-	]), A = O.days.length > 0 ? (O.days[0].weekday + 6) % 7 : 0, j = (0, g.daysBetween)(a, p), N = j >= 0 && j < r, P = n(() => new Intl.DateTimeFormat(l, { weekday: "short" }), [l]);
-	function F(e) {
-		v((t) => {
-			let n = new Set(t);
-			return n.has(e) ? n.delete(e) : n.add(e), n;
-		});
-	}
-	let I = e(async (e) => {
-		let t = x.get(e.id);
-		if (!t) return;
-		let [n, r] = M(t);
-		if (t.resourceId === e.resourceId && n === e.start && r === e.end) return;
-		b(null);
-		let i = await T(e);
-		if (i.accepted) {
-			(0, g.announce)(f("calendar.rescheduled", "Rescheduled {{label}}", { label: t.label }));
-			return;
-		}
-		let a = i.message ?? f("calendar.reschedule-failed", "Could not reschedule {{label}}", { label: t.label });
-		b(a), (0, g.announce)(a);
-	}, [
-		x,
-		T,
-		f
-	]), L = {
-		"--lt-timeline-day-width": `${m}px`,
-		"--lt-timeline-canvas-w": `calc(var(--lt-timeline-day-width) * ${r})`,
-		"--lt-timeline-weekend-offset": A
-	};
-	return /* @__PURE__ */ s("div", {
-		className: "lt-timeline",
-		children: [
-			/* @__PURE__ */ s("div", {
-				className: "mb-2 flex items-center gap-1",
-				children: [
-					/* @__PURE__ */ o("button", {
-						"aria-label": f("calendar.previous", "Previous"),
-						className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
-						onClick: () => u((0, g.addDays)(a, -7)),
-						type: "button",
-						children: /* @__PURE__ */ o(g.Icon, {
-							className: "size-lt-icon-sm",
-							name: "chevron-left"
-						})
-					}),
-					/* @__PURE__ */ o("button", {
-						"aria-label": f("calendar.next", "Next"),
-						className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
-						onClick: () => u((0, g.addDays)(a, Y)),
-						type: "button",
-						children: /* @__PURE__ */ o(g.Icon, {
-							className: "size-lt-icon-sm",
-							name: "chevron-right"
-						})
-					}),
-					/* @__PURE__ */ o("button", {
-						className: "rounded-lt-sm px-2 py-1 text-sm hover:bg-lt-muted",
-						onClick: () => u((0, g.addDays)(p, -7)),
-						type: "button",
-						children: f("calendar.today", "Today")
-					}),
-					/* @__PURE__ */ s("div", {
-						className: "ml-auto flex items-center gap-1",
-						children: [/* @__PURE__ */ o("button", {
-							"aria-label": f("calendar.zoom-out", "Zoom out"),
-							className: "rounded-lt-sm p-1.5 hover:bg-lt-muted disabled:pointer-events-none disabled:opacity-40",
-							disabled: m <= G,
-							onClick: () => h((e) => Math.max(G, e / J)),
-							type: "button",
-							children: /* @__PURE__ */ o(g.Icon, {
-								className: "size-lt-icon-sm",
-								name: "minus"
-							})
-						}), /* @__PURE__ */ o("button", {
-							"aria-label": f("calendar.zoom-in", "Zoom in"),
-							className: "rounded-lt-sm p-1.5 hover:bg-lt-muted disabled:pointer-events-none disabled:opacity-40",
-							disabled: m >= K,
-							onClick: () => h((e) => Math.min(K, e * J)),
-							type: "button",
-							children: /* @__PURE__ */ o(g.Icon, {
-								className: "size-lt-icon-sm",
-								name: "plus"
-							})
-						})]
-					})
-				]
-			}),
-			y ? /* @__PURE__ */ o("div", {
-				className: "mb-2 text-sm text-lt-danger",
-				role: "alert",
-				children: y
-			}) : null,
-			/* @__PURE__ */ o("div", {
-				"aria-busy": w || [...x.keys()].some((e) => C(e)),
-				className: "lt-timeline-scroll rounded-lt-sm border border-lt-border",
-				children: /* @__PURE__ */ s("div", {
-					className: "lt-timeline-grid",
-					style: L,
-					children: [
-						/* @__PURE__ */ o("div", { className: (0, g.cn)("lt-timeline-sticky-col lt-timeline-sticky-row lt-timeline-corner lt-timeline-row-months lt-timeline-header-cell") }),
-						/* @__PURE__ */ o("div", {
-							className: (0, g.cn)("lt-timeline-sticky-row lt-timeline-row-months lt-timeline-header-cell"),
-							children: O.months.map((e) => /* @__PURE__ */ o("div", {
-								className: "lt-timeline-segment flex items-center border-l border-lt-border px-2 text-xs font-medium text-lt-fg",
-								style: {
-									left: `calc(var(--lt-timeline-day-width) * ${e.start})`,
-									width: `calc(var(--lt-timeline-day-width) * ${e.span})`
-								},
-								children: e.label
-							}, `${e.start}-${e.label}`))
-						}),
-						/* @__PURE__ */ o("div", { className: (0, g.cn)("lt-timeline-sticky-col lt-timeline-sticky-row lt-timeline-corner lt-timeline-row-weeks lt-timeline-header-cell") }),
-						/* @__PURE__ */ o("div", {
-							className: (0, g.cn)("lt-timeline-sticky-row lt-timeline-row-weeks lt-timeline-header-cell"),
-							children: O.weeks.map((e) => /* @__PURE__ */ s("div", {
-								className: "lt-timeline-segment flex items-center border-l border-lt-border px-2 text-xs text-lt-muted-fg",
-								style: {
-									left: `calc(var(--lt-timeline-day-width) * ${e.start})`,
-									width: `calc(var(--lt-timeline-day-width) * ${e.span})`
-								},
-								children: [
-									f("calendar.week", "CW"),
-									" ",
-									e.label
-								]
-							}, `${e.start}-${e.label}`))
-						}),
-						/* @__PURE__ */ o("div", { className: (0, g.cn)("lt-timeline-sticky-col lt-timeline-sticky-row lt-timeline-corner lt-timeline-row-days lt-timeline-header-cell") }),
-						/* @__PURE__ */ o("div", {
-							className: (0, g.cn)("lt-timeline-sticky-row lt-timeline-row-days lt-timeline-header-cell"),
-							children: /* @__PURE__ */ o("div", {
-								className: "lt-timeline-days-row",
-								children: O.days.map((e) => /* @__PURE__ */ s("div", {
-									className: (0, g.cn)("lt-timeline-day flex flex-col items-center justify-center border-l border-lt-border text-xs", e.isWeekend && "bg-lt-muted text-lt-muted-fg", e.isToday && "font-semibold text-lt-primary"),
-									children: [/* @__PURE__ */ o("span", { children: P.format(/* @__PURE__ */ new Date(`${e.date}T12:00:00Z`)) }), /* @__PURE__ */ o("span", { children: e.dayOfMonth })]
-								}, e.date))
-							})
-						}),
-						c.map((e) => /* @__PURE__ */ o(ue, {
-							collapsed: _.has(e.key),
-							days: r,
-							entriesForResource: D,
-							from: a,
-							group: e,
-							isRescheduling: C,
-							onReschedule: I,
-							onToggle: () => F(e.key),
-							resources: E,
-							t: f,
-							canReschedule: t,
-							dayWidth: m
-						}, e.key)),
-						N ? /* @__PURE__ */ o("div", {
-							"aria-hidden": "true",
-							className: "lt-timeline-today-marker",
-							style: { left: `calc(var(--lt-timeline-label-w) + var(--lt-timeline-day-width) * ${j})` }
-						}) : null
-					]
-				})
-			})
-		]
-	});
+function le({
+  canReschedule: t,
+  days: r,
+  from: a,
+  groups: c,
+  locale: l,
+  onNavigate: u,
+  state: d,
+  t: f,
+  today: p,
+}) {
+  let [m, h] = i(pe),
+    [_, v] = i(/* @__PURE__ */ new Set()),
+    { events: y, eventsForResource: b, isRescheduling: x, loading: S, reschedule: C } = d,
+    { submitReschedule: w } = te(y, C, f),
+    T = n(() => c.flatMap((e) => e.resources), [c]),
+    E = e((e) => se(b(e)), [b]),
+    D = n(() => k(a, r, l, p), [a, r, l, p]),
+    O = D.days.length > 0 ? (D.days[0].weekday + 6) % 7 : 0,
+    A = (0, g.daysBetween)(a, p),
+    j = A >= 0 && A < r,
+    N = n(() => new Intl.DateTimeFormat(l, { weekday: "short" }), [l]);
+  function P(e) {
+    v((t) => {
+      let n = new Set(t);
+      return (n.has(e) ? n.delete(e) : n.add(e), n);
+    });
+  }
+  let F = e(
+      async (e) => {
+        let t = y.get(e.id);
+        if (!t) return;
+        let [n, r] = M(t);
+        (t.resourceId !== e.resourceId || n !== e.start || r !== e.end) && (await w(e));
+      },
+      [y, w],
+    ),
+    I = {
+      "--lt-timeline-day-width": `${m}px`,
+      "--lt-timeline-canvas-w": `calc(var(--lt-timeline-day-width) * ${r})`,
+      "--lt-timeline-weekend-offset": O,
+    };
+  return /* @__PURE__ */ s("div", {
+    className: "lt-timeline",
+    children: [
+      /* @__PURE__ */ s("div", {
+        className: "mb-2 flex items-center gap-1",
+        children: [
+          /* @__PURE__ */ o("button", {
+            "aria-label": f("calendar.previous", "Previous"),
+            className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
+            onClick: () => u((0, g.addDays)(a, -7)),
+            type: "button",
+            children: /* @__PURE__ */ o(g.Icon, {
+              className: "size-lt-icon-sm",
+              name: "chevron-left",
+            }),
+          }),
+          /* @__PURE__ */ o("button", {
+            "aria-label": f("calendar.next", "Next"),
+            className: "rounded-lt-sm p-1.5 hover:bg-lt-muted",
+            onClick: () => u((0, g.addDays)(a, me)),
+            type: "button",
+            children: /* @__PURE__ */ o(g.Icon, {
+              className: "size-lt-icon-sm",
+              name: "chevron-right",
+            }),
+          }),
+          /* @__PURE__ */ o("button", {
+            className: "rounded-lt-sm px-2 py-1 text-sm hover:bg-lt-muted",
+            onClick: () => u((0, g.addDays)(p, -7)),
+            type: "button",
+            children: f("calendar.today", "Today"),
+          }),
+          /* @__PURE__ */ s("div", {
+            className: "ml-auto flex items-center gap-1",
+            children: [
+              /* @__PURE__ */ o("button", {
+                "aria-label": f("calendar.zoom-out", "Zoom out"),
+                className:
+                  "rounded-lt-sm p-1.5 hover:bg-lt-muted disabled:pointer-events-none disabled:opacity-40",
+                disabled: m <= Y,
+                onClick: () => h((e) => Math.max(Y, e / Z)),
+                type: "button",
+                children: /* @__PURE__ */ o(g.Icon, {
+                  className: "size-lt-icon-sm",
+                  name: "minus",
+                }),
+              }),
+              /* @__PURE__ */ o("button", {
+                "aria-label": f("calendar.zoom-in", "Zoom in"),
+                className:
+                  "rounded-lt-sm p-1.5 hover:bg-lt-muted disabled:pointer-events-none disabled:opacity-40",
+                disabled: m >= X,
+                onClick: () => h((e) => Math.min(X, e * Z)),
+                type: "button",
+                children: /* @__PURE__ */ o(g.Icon, {
+                  className: "size-lt-icon-sm",
+                  name: "plus",
+                }),
+              }),
+            ],
+          }),
+        ],
+      }),
+      /* @__PURE__ */ o("div", {
+        "aria-busy": S || [...y.keys()].some((e) => x(e)),
+        className: "lt-timeline-scroll rounded-lt-sm border border-lt-border",
+        children: /* @__PURE__ */ s("div", {
+          className: "lt-timeline-grid",
+          style: I,
+          children: [
+            /* @__PURE__ */ o("div", {
+              className: (0, g.cn)(
+                "lt-timeline-sticky-col lt-timeline-sticky-row lt-timeline-corner lt-timeline-row-months lt-timeline-header-cell",
+              ),
+            }),
+            /* @__PURE__ */ o("div", {
+              className: (0, g.cn)(
+                "lt-timeline-sticky-row lt-timeline-row-months lt-timeline-header-cell",
+              ),
+              children: D.months.map((e) =>
+                /* @__PURE__ */ o(
+                  "div",
+                  {
+                    className:
+                      "lt-timeline-segment flex items-center border-l border-lt-border px-2 text-xs font-medium text-lt-fg",
+                    style: {
+                      left: `calc(var(--lt-timeline-day-width) * ${e.start})`,
+                      width: `calc(var(--lt-timeline-day-width) * ${e.span})`,
+                    },
+                    children: e.label,
+                  },
+                  `${e.start}-${e.label}`,
+                ),
+              ),
+            }),
+            /* @__PURE__ */ o("div", {
+              className: (0, g.cn)(
+                "lt-timeline-sticky-col lt-timeline-sticky-row lt-timeline-corner lt-timeline-row-weeks lt-timeline-header-cell",
+              ),
+            }),
+            /* @__PURE__ */ o("div", {
+              className: (0, g.cn)(
+                "lt-timeline-sticky-row lt-timeline-row-weeks lt-timeline-header-cell",
+              ),
+              children: D.weeks.map((e) =>
+                /* @__PURE__ */ s(
+                  "div",
+                  {
+                    className:
+                      "lt-timeline-segment flex items-center border-l border-lt-border px-2 text-xs text-lt-muted-fg",
+                    style: {
+                      left: `calc(var(--lt-timeline-day-width) * ${e.start})`,
+                      width: `calc(var(--lt-timeline-day-width) * ${e.span})`,
+                    },
+                    children: [f("calendar.week", "CW"), " ", e.label],
+                  },
+                  `${e.start}-${e.label}`,
+                ),
+              ),
+            }),
+            /* @__PURE__ */ o("div", {
+              className: (0, g.cn)(
+                "lt-timeline-sticky-col lt-timeline-sticky-row lt-timeline-corner lt-timeline-row-days lt-timeline-header-cell",
+              ),
+            }),
+            /* @__PURE__ */ o("div", {
+              className: (0, g.cn)(
+                "lt-timeline-sticky-row lt-timeline-row-days lt-timeline-header-cell",
+              ),
+              children: /* @__PURE__ */ o("div", {
+                className: "lt-timeline-days-row",
+                children: D.days.map((e) =>
+                  /* @__PURE__ */ s(
+                    "div",
+                    {
+                      className: (0, g.cn)(
+                        "lt-timeline-day flex flex-col items-center justify-center border-l border-lt-border text-xs",
+                        e.isWeekend && "bg-lt-muted text-lt-muted-fg",
+                        e.isToday && "font-semibold text-lt-primary",
+                      ),
+                      children: [
+                        /* @__PURE__ */ o("span", {
+                          children: N.format(/* @__PURE__ */ new Date(`${e.date}T12:00:00Z`)),
+                        }),
+                        /* @__PURE__ */ o("span", { children: e.dayOfMonth }),
+                      ],
+                    },
+                    e.date,
+                  ),
+                ),
+              }),
+            }),
+            c.map((e) =>
+              /* @__PURE__ */ o(
+                ue,
+                {
+                  collapsed: _.has(e.key),
+                  days: r,
+                  entriesForResource: E,
+                  from: a,
+                  group: e,
+                  isRescheduling: x,
+                  onReschedule: F,
+                  onToggle: () => P(e.key),
+                  resources: T,
+                  t: f,
+                  canReschedule: t,
+                  dayWidth: m,
+                },
+                e.key,
+              ),
+            ),
+            j
+              ? /* @__PURE__ */ o("div", {
+                  "aria-hidden": "true",
+                  className: "lt-timeline-today-marker",
+                  style: {
+                    left: `calc(var(--lt-timeline-label-w) + var(--lt-timeline-day-width) * ${A})`,
+                  },
+                })
+              : null,
+          ],
+        }),
+      }),
+    ],
+  });
 }
-function ue({ canReschedule: e, collapsed: t, dayWidth: n, days: r, entriesForResource: i, from: c, group: l, isRescheduling: u, onReschedule: d, onToggle: f, resources: p, t: m }) {
-	return /* @__PURE__ */ s(a, { children: [
-		/* @__PURE__ */ s("div", {
-			className: "lt-timeline-sticky-col flex items-center gap-1.5 border-t border-lt-border bg-lt-muted px-2 py-1.5 text-sm font-medium",
-			children: [/* @__PURE__ */ o("button", {
-				"aria-expanded": !t,
-				"aria-label": t ? m("calendar.expand-group", "Expand {{label}}", { label: l.label }) : m("calendar.collapse-group", "Collapse {{label}}", { label: l.label }),
-				onClick: f,
-				type: "button",
-				children: /* @__PURE__ */ o(g.Icon, {
-					className: (0, g.cn)("size-lt-icon-sm shrink-0 transition-transform", !t && "rotate-90"),
-					name: "chevron-right"
-				})
-			}), /* @__PURE__ */ o("span", { children: l.label })]
-		}),
-		/* @__PURE__ */ o("div", { className: "lt-timeline-group-header-canvas border-t border-lt-border bg-lt-muted" }),
-		t ? null : l.resources.map((t) => /* @__PURE__ */ o(U, {
-			canReschedule: e,
-			dayWidth: n,
-			days: r,
-			entriesForResource: i,
-			from: c,
-			isRescheduling: u,
-			onReschedule: d,
-			resource: t,
-			resources: p,
-			t: m
-		}, t.id))
-	] });
+function ue({
+  canReschedule: e,
+  collapsed: t,
+  dayWidth: n,
+  days: r,
+  entriesForResource: i,
+  from: c,
+  group: l,
+  isRescheduling: u,
+  onReschedule: d,
+  onToggle: f,
+  resources: p,
+  t: m,
+}) {
+  return /* @__PURE__ */ s(a, {
+    children: [
+      /* @__PURE__ */ s("div", {
+        className:
+          "lt-timeline-sticky-col flex items-center gap-1.5 border-t border-lt-border bg-lt-muted px-2 py-1.5 text-sm font-medium",
+        children: [
+          /* @__PURE__ */ o("button", {
+            "aria-expanded": !t,
+            "aria-label": t
+              ? m("calendar.expand-group", "Expand {{label}}", { label: l.label })
+              : m("calendar.collapse-group", "Collapse {{label}}", { label: l.label }),
+            onClick: f,
+            type: "button",
+            children: /* @__PURE__ */ o(g.Icon, {
+              className: (0, g.cn)(
+                "size-lt-icon-sm shrink-0 transition-transform",
+                !t && "rotate-90",
+              ),
+              name: "chevron-right",
+            }),
+          }),
+          /* @__PURE__ */ o("span", { children: l.label }),
+        ],
+      }),
+      /* @__PURE__ */ o("div", {
+        className: "lt-timeline-group-header-canvas border-t border-lt-border bg-lt-muted",
+      }),
+      t
+        ? null
+        : l.resources.map((t) =>
+            /* @__PURE__ */ o(
+              de,
+              {
+                canReschedule: e,
+                dayWidth: n,
+                days: r,
+                entriesForResource: i,
+                from: c,
+                isRescheduling: u,
+                onReschedule: d,
+                resource: t,
+                resources: p,
+                t: m,
+              },
+              t.id,
+            ),
+          ),
+    ],
+  });
 }
-function U({ canReschedule: e, dayWidth: n, days: c, entriesForResource: l, from: u, isRescheduling: d, onReschedule: f, resource: p, resources: m, t: h }) {
-	let { bars: _, laneCount: v } = ce(l(p.id), u, c), y = `calc(${Math.max(v, 1)} * var(--lt-timeline-lane-height))`, b = r(null), [x, S] = i(!1);
-	return t(() => {
-		let t = b.current;
-		if (!(!t || !e)) return (0, g.dropTargetForElements)({
-			canDrop: ({ source: e }) => e.data.type === X || e.data.type === Z && e.data.resourceId === p.id,
-			element: t,
-			getData: ({ element: e, input: t, source: r }) => {
-				if (r.data.type === Z) {
-					let i = typeof r.data.grabOffsetPx == "number" ? r.data.grabOffsetPx : 0, a = Math.round((t.clientX - e.getBoundingClientRect().left - i) / n);
-					return {
-						boundary: (0, g.addDays)(u, a),
-						type: Z
-					};
-				}
-				let i = typeof r.data.grabOffsetDays == "number" ? r.data.grabOffsetDays : 0, a = Math.floor((t.clientX - e.getBoundingClientRect().left) / n) - i;
-				return {
-					resourceId: p.id,
-					start: (0, g.addDays)(u, a),
-					type: X
-				};
-			},
-			onDragEnter: () => S(!0),
-			onDragLeave: () => S(!1),
-			onDrop: ({ self: e, source: t }) => {
-				if (S(!1), t.data.type === Z) {
-					let { edge: n, end: r, id: i, resourceId: a, start: o } = t.data, s = e.data.boundary;
-					if (!oe(n) || typeof s != "string" || typeof r != "string" || typeof i != "string" || typeof a != "string" || typeof o != "string") return;
-					f(H({
-						id: i,
-						resourceId: a,
-						dayStart: o,
-						dayEnd: r
-					}, n, s));
-					return;
-				}
-				let n = t.data.id, r = t.data.durationDays, i = e.data.resourceId, a = e.data.start;
-				typeof n == "string" && typeof r == "number" && typeof i == "string" && typeof a == "string" && f({
-					id: n,
-					resourceId: i,
-					start: a,
-					end: (0, g.addDays)(a, r)
-				});
-			}
-		});
-	}, [
-		e,
-		n,
-		u,
-		f,
-		p.id
-	]), /* @__PURE__ */ s(a, { children: [/* @__PURE__ */ o("div", {
-		className: "lt-timeline-sticky-col flex items-center border-t border-lt-border px-2 text-sm text-lt-fg",
-		style: { height: y },
-		children: p.label
-	}), /* @__PURE__ */ s("div", {
-		className: (0, g.cn)("lt-timeline-resource-canvas border-t border-lt-border", x && "bg-lt-primary/10"),
-		"data-test": `timeline-resource-${p.id}`,
-		ref: b,
-		style: { height: y },
-		children: [/* @__PURE__ */ o("div", {
-			className: "lt-timeline-weekend-strip",
-			"aria-hidden": "true"
-		}), _.map((t) => /* @__PURE__ */ o(de, {
-			bar: t,
-			canReschedule: e,
-			dayWidth: n,
-			days: c,
-			from: u,
-			isRescheduling: d(t.id),
-			onReschedule: f,
-			resource: p,
-			resources: m,
-			t: h
-		}, t.id))]
-	})] });
+function de({
+  canReschedule: e,
+  dayWidth: n,
+  days: c,
+  entriesForResource: l,
+  from: u,
+  isRescheduling: d,
+  onReschedule: f,
+  resource: p,
+  resources: m,
+  t: h,
+}) {
+  let { bars: _, laneCount: v } = ce(l(p.id), u, c),
+    y = `calc(${Math.max(v, 1)} * var(--lt-timeline-lane-height))`,
+    b = r(null),
+    [x, S] = i(!1);
+  return (
+    t(() => {
+      let t = b.current;
+      if (!(!t || !e))
+        return (0, g.dropTargetForElements)({
+          canDrop: ({ source: e }) =>
+            e.data.type === Q || (e.data.type === $ && e.data.resourceId === p.id),
+          element: t,
+          getData: ({ element: e, input: t, source: r }) => {
+            if (r.data.type === $) {
+              let i = typeof r.data.grabOffsetPx == "number" ? r.data.grabOffsetPx : 0,
+                a = Math.round((t.clientX - e.getBoundingClientRect().left - i) / n);
+              return {
+                boundary: (0, g.addDays)(u, a),
+                type: $,
+              };
+            }
+            let i = typeof r.data.grabOffsetDays == "number" ? r.data.grabOffsetDays : 0,
+              a = Math.floor((t.clientX - e.getBoundingClientRect().left) / n) - i;
+            return {
+              resourceId: p.id,
+              start: (0, g.addDays)(u, a),
+              type: Q,
+            };
+          },
+          onDragEnter: () => S(!0),
+          onDragLeave: () => S(!1),
+          onDrop: ({ self: e, source: t }) => {
+            if ((S(!1), t.data.type === $)) {
+              let { edge: n, end: r, id: i, resourceId: a, start: o } = t.data,
+                s = e.data.boundary;
+              if (
+                !oe(n) ||
+                typeof s != "string" ||
+                typeof r != "string" ||
+                typeof i != "string" ||
+                typeof a != "string" ||
+                typeof o != "string"
+              )
+                return;
+              f(
+                q(
+                  {
+                    id: i,
+                    resourceId: a,
+                    dayStart: o,
+                    dayEnd: r,
+                  },
+                  n,
+                  s,
+                ),
+              );
+              return;
+            }
+            let n = t.data.id,
+              r = t.data.durationDays,
+              i = e.data.resourceId,
+              a = e.data.start;
+            typeof n == "string" &&
+              typeof r == "number" &&
+              typeof i == "string" &&
+              typeof a == "string" &&
+              f({
+                id: n,
+                resourceId: i,
+                start: a,
+                end: (0, g.addDays)(a, r),
+              });
+          },
+        });
+    }, [e, n, u, f, p.id]),
+    /* @__PURE__ */ s(a, {
+      children: [
+        /* @__PURE__ */ o("div", {
+          className:
+            "lt-timeline-sticky-col flex items-center border-t border-lt-border px-2 text-sm text-lt-fg",
+          style: { height: y },
+          children: p.label,
+        }),
+        /* @__PURE__ */ s("div", {
+          className: (0, g.cn)(
+            "lt-timeline-resource-canvas border-t border-lt-border",
+            x && "bg-lt-primary/10",
+          ),
+          "data-test": `timeline-resource-${p.id}`,
+          ref: b,
+          style: { height: y },
+          children: [
+            /* @__PURE__ */ o("div", {
+              className: "lt-timeline-weekend-strip",
+              "aria-hidden": "true",
+            }),
+            _.map((t) =>
+              /* @__PURE__ */ o(
+                fe,
+                {
+                  bar: t,
+                  canReschedule: e,
+                  dayWidth: n,
+                  days: c,
+                  from: u,
+                  isRescheduling: d(t.id),
+                  onReschedule: f,
+                  resource: p,
+                  resources: m,
+                  t: h,
+                },
+                t.id,
+              ),
+            ),
+          ],
+        }),
+      ],
+    })
+  );
 }
-function de({ bar: e, canReschedule: n, dayWidth: a, days: c, from: l, isRescheduling: u, onReschedule: d, resource: f, resources: p, t: m }) {
-	let h = r(null), _ = r(null), [v, y] = i(!1), b = (0, g.daysBetween)(e.event.dayStart, e.event.dayEnd), x = Math.max(0, (0, g.daysBetween)(e.event.dayStart, l)), S = (0, g.addDays)(l, c), C = (0, g.toneProps)((0, g.coerceColor)(e.event.color) ?? (0, g.namedColor)("primary"));
-	t(() => {
-		let t = h.current, r = _.current;
-		if (!(!t || !r || !n)) return (0, g.draggable)({
-			canDrag: () => !u,
-			dragHandle: r,
-			element: t,
-			getInitialData: ({ element: t, input: n }) => ({
-				durationDays: b,
-				grabOffsetDays: Math.max(0, Math.min(b - 1, x + Math.floor((n.clientX - t.getBoundingClientRect().left) / a))),
-				id: e.id,
-				type: X
-			}),
-			onDragStart: () => {
-				y(!0), (0, g.announce)(m("calendar.dragging", "Moving {{label}}. Drop on a resource row.", { label: e.event.label }));
-			},
-			onDrop: () => y(!1)
-		});
-	}, [
-		e.event.label,
-		e.id,
-		n,
-		a,
-		b,
-		x,
-		u,
-		m
-	]);
-	function w(t) {
-		if (!n || u || !t.ctrlKey || !t.shiftKey) return;
-		let r = e.event.resourceId, i = e.event.dayStart, a = p.findIndex((e) => e.id === r);
-		switch (t.key) {
-			case "ArrowLeft":
-				i = (0, g.addDays)(i, -1);
-				break;
-			case "ArrowRight":
-				i = (0, g.addDays)(i, 1);
-				break;
-			case "ArrowUp":
-				r = p[a - 1]?.id ?? r;
-				break;
-			case "ArrowDown":
-				r = p[a + 1]?.id ?? r;
-				break;
-			default: return;
-		}
-		let o = (0, g.addDays)(i, b);
-		i < l || o > (0, g.addDays)(l, c) || (t.preventDefault(), d({
-			id: e.id,
-			resourceId: r,
-			start: i,
-			end: o
-		}));
-	}
-	return /* @__PURE__ */ s("div", {
-		className: (0, g.cn)("lt-timeline-bar rounded-lt-xs", C.className, v && "opacity-60"),
-		ref: h,
-		style: {
-			left: `calc(var(--lt-timeline-day-width) * ${e.start})`,
-			width: `calc(var(--lt-timeline-day-width) * ${e.span})`,
-			top: `calc(${e.lane} * var(--lt-timeline-lane-height))`,
-			height: "var(--lt-timeline-lane-height)",
-			...C.style
-		},
-		children: [
-			/* @__PURE__ */ o("button", {
-				"aria-disabled": !n || u,
-				"aria-keyshortcuts": "Control+Shift+ArrowLeft Control+Shift+ArrowRight Control+Shift+ArrowUp Control+Shift+ArrowDown",
-				"aria-label": m("calendar.entry-label", "{{label}}, {{resource}}, {{start}} to {{end}}. Use Control Shift and arrow keys to reschedule.", {
-					end: e.event.dayEnd,
-					label: e.event.label,
-					resource: f.label,
-					start: e.event.dayStart
-				}),
-				className: (0, g.cn)("h-full w-full overflow-hidden rounded-lt-xs px-1.5 py-1 text-left text-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lt-primary", n && "cursor-grab"),
-				"data-end": e.event.dayEnd,
-				"data-resource-id": e.event.resourceId,
-				"data-start": e.event.dayStart,
-				"data-test": `timeline-entry-${e.id}`,
-				onKeyDown: w,
-				ref: _,
-				title: e.event.label,
-				type: "button",
-				children: e.event.label
-			}),
-			n && e.event.dayStart >= l ? /* @__PURE__ */ o(W, {
-				edge: "start",
-				event: e.event,
-				from: l,
-				isRescheduling: u,
-				onReschedule: d,
-				t: m,
-				until: S
-			}) : null,
-			n && e.event.dayEnd <= S ? /* @__PURE__ */ o(W, {
-				edge: "end",
-				event: e.event,
-				from: l,
-				isRescheduling: u,
-				onReschedule: d,
-				t: m,
-				until: S
-			}) : null
-		]
-	});
+function fe({
+  bar: e,
+  canReschedule: n,
+  dayWidth: a,
+  days: c,
+  from: l,
+  isRescheduling: u,
+  onReschedule: d,
+  resource: f,
+  resources: p,
+  t: m,
+}) {
+  let h = r(null),
+    _ = r(null),
+    [v, y] = i(!1),
+    b = (0, g.daysBetween)(e.event.dayStart, e.event.dayEnd),
+    x = Math.max(0, (0, g.daysBetween)(e.event.dayStart, l)),
+    S = (0, g.addDays)(l, c),
+    C = (0, g.toneProps)((0, g.coerceColor)(e.event.color) ?? (0, g.namedColor)("primary"));
+  t(() => {
+    let t = h.current,
+      r = _.current;
+    if (!(!t || !r || !n))
+      return (0, g.draggable)({
+        canDrag: () => !u,
+        dragHandle: r,
+        element: t,
+        getInitialData: ({ element: t, input: n }) => ({
+          durationDays: b,
+          grabOffsetDays: Math.max(
+            0,
+            Math.min(b - 1, x + Math.floor((n.clientX - t.getBoundingClientRect().left) / a)),
+          ),
+          id: e.id,
+          type: Q,
+        }),
+        onDragStart: () => {
+          (y(!0),
+            (0, g.announce)(
+              m("calendar.dragging", "Moving {{label}}. Drop on a resource row.", {
+                label: e.event.label,
+              }),
+            ));
+        },
+        onDrop: () => y(!1),
+      });
+  }, [e.event.label, e.id, n, a, b, x, u, m]);
+  function w(t) {
+    if (!n || u || !t.ctrlKey || !t.shiftKey) return;
+    let r = e.event.resourceId,
+      i = e.event.dayStart,
+      a = p.findIndex((e) => e.id === r);
+    switch (t.key) {
+      case "ArrowLeft":
+        i = (0, g.addDays)(i, -1);
+        break;
+      case "ArrowRight":
+        i = (0, g.addDays)(i, 1);
+        break;
+      case "ArrowUp":
+        r = p[a - 1]?.id ?? r;
+        break;
+      case "ArrowDown":
+        r = p[a + 1]?.id ?? r;
+        break;
+      default:
+        return;
+    }
+    let o = (0, g.addDays)(i, b);
+    i < l ||
+      o > (0, g.addDays)(l, c) ||
+      (t.preventDefault(),
+      d({
+        id: e.id,
+        resourceId: r,
+        start: i,
+        end: o,
+      }));
+  }
+  return /* @__PURE__ */ s("div", {
+    className: (0, g.cn)("lt-timeline-bar rounded-lt-xs", C.className, v && "opacity-60"),
+    ref: h,
+    style: {
+      left: `calc(var(--lt-timeline-day-width) * ${e.start})`,
+      width: `calc(var(--lt-timeline-day-width) * ${e.span})`,
+      top: `calc(${e.lane} * var(--lt-timeline-lane-height))`,
+      height: "var(--lt-timeline-lane-height)",
+      ...C.style,
+    },
+    children: [
+      /* @__PURE__ */ o("button", {
+        "aria-disabled": !n || u,
+        "aria-keyshortcuts":
+          "Control+Shift+ArrowLeft Control+Shift+ArrowRight Control+Shift+ArrowUp Control+Shift+ArrowDown",
+        "aria-label": m(
+          "calendar.entry-label",
+          "{{label}}, {{resource}}, {{start}} to {{end}}. Use Control Shift and arrow keys to reschedule.",
+          {
+            end: e.event.dayEnd,
+            label: e.event.label,
+            resource: f.label,
+            start: e.event.dayStart,
+          },
+        ),
+        className: (0, g.cn)(
+          "h-full w-full overflow-hidden rounded-lt-xs px-1.5 py-1 text-left text-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lt-primary",
+          n && "cursor-grab",
+        ),
+        "data-end": e.event.dayEnd,
+        "data-resource-id": e.event.resourceId,
+        "data-start": e.event.dayStart,
+        "data-test": `timeline-entry-${e.id}`,
+        onKeyDown: w,
+        ref: _,
+        title: e.event.label,
+        type: "button",
+        children: e.event.label,
+      }),
+      n && e.event.dayStart >= l
+        ? /* @__PURE__ */ o(J, {
+            edge: "start",
+            event: e.event,
+            from: l,
+            isRescheduling: u,
+            onReschedule: d,
+            t: m,
+            until: S,
+          })
+        : null,
+      n && e.event.dayEnd <= S
+        ? /* @__PURE__ */ o(J, {
+            edge: "end",
+            event: e.event,
+            from: l,
+            isRescheduling: u,
+            onReschedule: d,
+            t: m,
+            until: S,
+          })
+        : null,
+    ],
+  });
 }
-function W({ edge: e, event: n, from: a, isRescheduling: s, onReschedule: c, t: l, until: u }) {
-	let d = r(null), [f, p] = i(!1), m = e === "start" ? n.dayStart : n.dayEnd;
-	t(() => {
-		let t = d.current;
-		if (t) return (0, g.draggable)({
-			canDrag: () => !s,
-			element: t,
-			getInitialData: ({ element: t, input: r }) => {
-				let i = t.getBoundingClientRect();
-				return {
-					edge: e,
-					end: n.dayEnd,
-					grabOffsetPx: r.clientX - (i.left + i.width / 2),
-					id: n.id,
-					resourceId: n.resourceId,
-					start: n.dayStart,
-					type: Z
-				};
-			},
-			onDragStart: () => {
-				p(!0), (0, g.announce)(l(e === "start" ? "calendar.resizing-start" : "calendar.resizing-end", e === "start" ? "Resizing start of {{label}}." : "Resizing end of {{label}}.", { label: n.label }));
-			},
-			onDrop: () => p(!1)
-		});
-	}, [
-		e,
-		n,
-		s,
-		l
-	]);
-	function h(t) {
-		if (s) return;
-		let r = t.key === "ArrowLeft" ? -1 : +(t.key === "ArrowRight");
-		if (r === 0) return;
-		let i = (0, g.addDays)(m, r);
-		e === "start" && i < a || e === "end" && i > u || (t.preventDefault(), c(H(n, e, i)));
-	}
-	let _ = (0, g.daysBetween)(a, m), v = e === "start" ? 0 : (0, g.daysBetween)(a, n.dayStart) + 1, y = e === "start" ? (0, g.daysBetween)(a, n.dayEnd) - 1 : (0, g.daysBetween)(a, u);
-	return /* @__PURE__ */ o("div", {
-		"aria-disabled": s,
-		"aria-keyshortcuts": "ArrowLeft ArrowRight",
-		"aria-label": l(e === "start" ? "calendar.resize-start" : "calendar.resize-end", e === "start" ? "Resize start of {{label}}" : "Resize end of {{label}}", { label: n.label }),
-		"aria-orientation": "vertical",
-		"aria-valuemax": y,
-		"aria-valuemin": v,
-		"aria-valuenow": _,
-		"aria-valuetext": m,
-		className: (0, g.cn)("absolute inset-y-0 z-[2] w-2 cursor-ew-resize touch-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lt-primary after:absolute after:inset-y-1 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-current after:opacity-50", e === "start" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2", f && "opacity-60"),
-		"data-test": `timeline-resize-${e}-${n.id}`,
-		onKeyDown: h,
-		ref: d,
-		role: "separator",
-		tabIndex: 0
-	});
+function J({ edge: e, event: n, from: a, isRescheduling: s, onReschedule: c, t: l, until: u }) {
+  let d = r(null),
+    [f, p] = i(!1),
+    m = e === "start" ? n.dayStart : n.dayEnd;
+  t(() => {
+    let t = d.current;
+    if (t)
+      return (0, g.draggable)({
+        canDrag: () => !s,
+        element: t,
+        getInitialData: ({ element: t, input: r }) => {
+          let i = t.getBoundingClientRect();
+          return {
+            edge: e,
+            end: n.dayEnd,
+            grabOffsetPx: r.clientX - (i.left + i.width / 2),
+            id: n.id,
+            resourceId: n.resourceId,
+            start: n.dayStart,
+            type: $,
+          };
+        },
+        onDragStart: () => {
+          (p(!0),
+            (0, g.announce)(
+              l(
+                e === "start" ? "calendar.resizing-start" : "calendar.resizing-end",
+                e === "start" ? "Resizing start of {{label}}." : "Resizing end of {{label}}.",
+                { label: n.label },
+              ),
+            ));
+        },
+        onDrop: () => p(!1),
+      });
+  }, [e, n, s, l]);
+  function h(t) {
+    if (s) return;
+    let r = t.key === "ArrowLeft" ? -1 : +(t.key === "ArrowRight");
+    if (r === 0) return;
+    let i = (0, g.addDays)(m, r);
+    (e === "start" && i < a) || (e === "end" && i > u) || (t.preventDefault(), c(q(n, e, i)));
+  }
+  let _ = (0, g.daysBetween)(a, m),
+    v = e === "start" ? 0 : (0, g.daysBetween)(a, n.dayStart) + 1,
+    y = e === "start" ? (0, g.daysBetween)(a, n.dayEnd) - 1 : (0, g.daysBetween)(a, u);
+  return /* @__PURE__ */ o("div", {
+    "aria-disabled": s,
+    "aria-keyshortcuts": "ArrowLeft ArrowRight",
+    "aria-label": l(
+      e === "start" ? "calendar.resize-start" : "calendar.resize-end",
+      e === "start" ? "Resize start of {{label}}" : "Resize end of {{label}}",
+      { label: n.label },
+    ),
+    "aria-orientation": "vertical",
+    "aria-valuemax": y,
+    "aria-valuemin": v,
+    "aria-valuenow": _,
+    "aria-valuetext": m,
+    className: (0, g.cn)(
+      "absolute inset-y-0 z-[2] w-2 cursor-ew-resize touch-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-lt-primary after:absolute after:inset-y-1 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-current after:opacity-50",
+      e === "start" ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2",
+      f && "opacity-60",
+    ),
+    "data-test": `timeline-resize-${e}-${n.id}`,
+    onKeyDown: h,
+    ref: d,
+    role: "separator",
+    tabIndex: 0,
+  });
 }
-var G, K, q, J, Y, X, Z, fe = f((() => {
-	v(), j(), N(), G = 10, K = 64, q = 24, J = 1.25, Y = 7, X = "lattice-calendar-entry", Z = "lattice-calendar-entry-resize";
-})), pe = /* @__PURE__ */ p({ default: () => $ });
-function me(e) {
-	let t = (0, g.startOfMonthISO)(e.date), n = e.views.includes("month") ? [(0, g.addDays)(t, -7), (0, g.addDays)((0, g.addMonths)(t, 1), 7)] : null, r = e.views.includes("timeline") ? [e.date, (0, g.addDays)(e.date, e.days)] : null;
-	return n === null || r === null ? n ?? r ?? [e.date, (0, g.addDays)(e.date, e.days)] : [n[0] < r[0] ? n[0] : r[0], n[1] > r[1] ? n[1] : r[1]];
+var Y,
+  X,
+  pe,
+  Z,
+  me,
+  Q,
+  $,
+  he = f(() => {
+    (v(),
+      j(),
+      P(),
+      B(),
+      (Y = 10),
+      (X = 64),
+      (pe = 24),
+      (Z = 1.25),
+      (me = 7),
+      (Q = "lattice-calendar-entry"),
+      ($ = "lattice-calendar-entry-resize"));
+  }),
+  ge = /* @__PURE__ */ p({ default: () => ye });
+function _e(e) {
+  let t = (0, g.startOfMonthISO)(e.date),
+    n = e.views.includes("month")
+      ? [(0, g.addDays)(t, -7), (0, g.addDays)((0, g.addMonths)(t, 1), 7)]
+      : null,
+    r = e.views.includes("timeline") ? [e.date, (0, g.addDays)(e.date, e.days)] : null;
+  return n === null || r === null
+    ? (n ?? r ?? [e.date, (0, g.addDays)(e.date, e.days)])
+    : [n[0] < r[0] ? n[0] : r[0], n[1] > r[1] ? n[1] : r[1]];
 }
-async function Q(e, t, n) {
-	let r = e.props.endpoint;
-	r && await (0, g.runAction)(() => (0, g.apiFetch)(r, {
-		body: JSON.stringify(t),
-		headers: { "Content-Type": "application/json" },
-		method: e.props.method ?? "post",
-		ref: e.props.ref ?? "",
-		throwOnError: !1
-	}), n);
+async function ve(e, t, n) {
+  let r = e.props.endpoint;
+  r &&
+    (await (0, g.runAction)(
+      () =>
+        (0, g.apiFetch)(r, {
+          body: JSON.stringify(t),
+          headers: { "Content-Type": "application/json" },
+          method: e.props.method ?? "post",
+          ref: e.props.ref ?? "",
+          throwOnError: !1,
+        }),
+      n,
+    ));
 }
-var $, he = f((() => {
-	v(), E(), R(), ae(), fe(), $ = ({ node: e }) => {
-		let t = (0, g.nodeIdentity)(e), { t: n, locale: r } = (0, g.useT)("calendar"), a = (0, g.useEffectDispatcher)(), { date: c, dayAction: l, days: u, defaultView: d, eventAction: f, views: p } = e.props, [m, h] = i(d), [_, v] = i(() => (0, g.startOfMonthISO)(c)), [y, b] = i(c), [x] = i(() => (0, g.todayISO)((0, g.currentTimezone)())), [[S, C]] = i(() => me(e.props)), w = T({
-			endpoint: e.props.endpoint,
-			componentRef: e.props.ref,
-			initialEvents: e.props.events,
-			initialFrom: S,
-			initialTo: C
-		});
-		function E(e) {
-			v(e);
-			let [t] = P((0, g.addMonths)(e, -1), r), [, n] = P((0, g.addMonths)(e, 1), r);
-			w.ensureRange(t, n);
-		}
-		function D(e) {
-			b(e), w.ensureRange(e, (0, g.addDays)(e, u));
-		}
-		let O = f ? (e) => {
-			Q(f, {
-				eventId: e.id,
-				...e.context
-			}, a);
-		} : null, k = l ? (e) => {
-			Q(l, { date: e }, a);
-		} : null, A = p.map((e) => ({
-			data: null,
-			value: e,
-			label: e === "month" ? n("calendar.view-month", "Month") : n("calendar.view-timeline", "Timeline")
-		}));
-		return /* @__PURE__ */ s("div", {
-			className: "lt-calendar",
-			"data-lattice-component": t,
-			children: [p.length > 1 ? /* @__PURE__ */ o("div", {
-				className: "mb-3",
-				children: /* @__PURE__ */ o(g.SegmentedPills, {
-					ariaLabel: n("calendar.view-switcher-label", "Calendar view"),
-					name: "calendar-view",
-					onSelect: (e) => h(e),
-					options: A,
-					value: m
-				})
-			}) : null, m === "month" ? /* @__PURE__ */ o(te, {
-				events: w.events,
-				loading: w.loading,
-				locale: r,
-				month: _,
-				onDayClick: k,
-				onEventClick: O,
-				onNavigate: E,
-				t: n,
-				today: x
-			}) : /* @__PURE__ */ o(le, {
-				canReschedule: e.props.endpoint !== null && e.props.ref !== null && e.props.reschedulable,
-				days: u,
-				from: y,
-				groups: e.props.groups,
-				locale: r,
-				onNavigate: D,
-				state: w,
-				t: n,
-				today: x
-			})]
-		});
-	};
-}));
+var ye,
+  be = f(() => {
+    (v(),
+      E(),
+      z(),
+      ae(),
+      he(),
+      (ye = ({ node: e }) => {
+        let t = (0, g.nodeIdentity)(e),
+          { t: n, locale: r } = (0, g.useT)("calendar"),
+          a = (0, g.useEffectDispatcher)(),
+          { date: c, dayAction: l, days: u, defaultView: d, eventAction: f, views: p } = e.props,
+          [m, h] = i(d),
+          [_, v] = i(() => (0, g.startOfMonthISO)(c)),
+          [y, b] = i(c),
+          [x] = i(() => (0, g.todayISO)((0, g.currentTimezone)())),
+          [[S, C]] = i(() => _e(e.props)),
+          w = T({
+            endpoint: e.props.endpoint,
+            componentRef: e.props.ref,
+            initialEvents: e.props.events,
+            initialFrom: S,
+            initialTo: C,
+          });
+        function E(e) {
+          v(e);
+          let [t] = F((0, g.addMonths)(e, -1), r),
+            [, n] = F((0, g.addMonths)(e, 1), r);
+          w.ensureRange(t, n);
+        }
+        function D(e) {
+          (b(e), w.ensureRange(e, (0, g.addDays)(e, u)));
+        }
+        let O = f
+            ? (e) => {
+                ve(
+                  f,
+                  {
+                    eventId: e.id,
+                    ...e.context,
+                  },
+                  a,
+                );
+              }
+            : null,
+          k = l
+            ? (e) => {
+                ve(l, { date: e }, a);
+              }
+            : null,
+          A = e.props.endpoint !== null && e.props.ref !== null && e.props.reschedulable,
+          j = p.map((e) => ({
+            data: null,
+            value: e,
+            label:
+              e === "month"
+                ? n("calendar.view-month", "Month")
+                : n("calendar.view-timeline", "Timeline"),
+          }));
+        return /* @__PURE__ */ s("div", {
+          className: "lt-calendar",
+          "data-lattice-component": t,
+          children: [
+            p.length > 1
+              ? /* @__PURE__ */ o("div", {
+                  className: "mb-3",
+                  children: /* @__PURE__ */ o(g.SegmentedPills, {
+                    ariaLabel: n("calendar.view-switcher-label", "Calendar view"),
+                    name: "calendar-view",
+                    onSelect: (e) => h(e),
+                    options: j,
+                    value: m,
+                  }),
+                })
+              : null,
+            m === "month"
+              ? /* @__PURE__ */ o(H, {
+                  canReschedule: A,
+                  locale: r,
+                  month: _,
+                  onDayClick: k,
+                  onEventClick: O,
+                  onNavigate: E,
+                  state: w,
+                  t: n,
+                  today: x,
+                })
+              : /* @__PURE__ */ o(le, {
+                  canReschedule: A,
+                  days: u,
+                  from: y,
+                  groups: e.props.groups,
+                  locale: r,
+                  onNavigate: D,
+                  state: w,
+                  t: n,
+                  today: x,
+                }),
+          ],
+        });
+      }));
+  });
 //#endregion
 //#region resources/js/plugin.ts
 v();
-var ge = {
-	name: "lattice/calendar",
-	components: { calendar: (0, g.lazyComponent)(() => Promise.resolve().then(() => (he(), pe))) },
-	i18n: { namespace: "calendar" }
+var xe = {
+  name: "lattice/calendar",
+  components: { calendar: (0, g.lazyComponent)(() => Promise.resolve().then(() => (be(), ge))) },
+  i18n: { namespace: "calendar" },
 };
 //#endregion
-export { ge as default };
+export { xe as default };

--- a/packages/calendar/lang/de/calendar.php
+++ b/packages/calendar/lang/de/calendar.php
@@ -11,6 +11,7 @@ return [
     'collapse-group' => ':label einklappen',
     'expand-group' => ':label ausklappen',
     'dragging' => ':label wird verschoben. Auf einer Ressourcenzeile ablegen.',
+    'dragging-day' => ':label wird verschoben. Auf einem Tag ablegen.',
     'resizing-start' => 'Start von :label wird angepasst.',
     'resizing-end' => 'Ende von :label wird angepasst.',
     'resize-start' => 'Start von :label anpassen',
@@ -24,4 +25,5 @@ return [
     'more-events' => '+:count weitere',
     'show-events-for-day' => 'Alle Termine am :date anzeigen',
     'event-chip-label' => ':label, :start bis :end',
+    'event-chip-label-reschedulable' => ':label, :start bis :end. Zum Umplanen Strg, Umschalt und die Pfeiltasten verwenden.',
 ];

--- a/packages/calendar/lang/en/calendar.php
+++ b/packages/calendar/lang/en/calendar.php
@@ -11,6 +11,7 @@ return [
     'collapse-group' => 'Collapse :label',
     'expand-group' => 'Expand :label',
     'dragging' => 'Moving :label. Drop on a resource row.',
+    'dragging-day' => 'Moving :label. Drop on a day.',
     'resizing-start' => 'Resizing start of :label.',
     'resizing-end' => 'Resizing end of :label.',
     'resize-start' => 'Resize start of :label',
@@ -24,4 +25,5 @@ return [
     'more-events' => '+:count more',
     'show-events-for-day' => 'Show all events on :date',
     'event-chip-label' => ':label, :start to :end',
+    'event-chip-label-reschedulable' => ':label, :start to :end. Use Control Shift and arrow keys to reschedule.',
 ];

--- a/packages/calendar/resources/css/calendar.css
+++ b/packages/calendar/resources/css/calendar.css
@@ -57,6 +57,14 @@
   pointer-events: auto;
 }
 
+/*
+ * Mid-drag the chips must not swallow the pointer either, so the day cells
+ * underneath stay hittable as drop targets wherever the cursor is.
+ */
+.lt-calendar-month[data-dragging] .lt-calendar-chip {
+  pointer-events: none;
+}
+
 .lt-timeline {
   --lt-timeline-lane-height: 2rem;
   --lt-timeline-header-row-h: 2rem;

--- a/packages/calendar/resources/js/calendar.browser.test.tsx
+++ b/packages/calendar/resources/js/calendar.browser.test.tsx
@@ -102,6 +102,114 @@ describe("calendar month view in a browser", () => {
     expect(JSON.parse(String(init.body))).toEqual({ date: "2026-08-13" });
   });
 
+  it("moves an event to another day by dragging its chip onto the day cell", async () => {
+    const event = calendarEvent({
+      id: "e1",
+      start: "2026-08-10",
+      end: "2026-08-11",
+      label: "Kickoff",
+    });
+    const updated = { ...event, start: "2026-08-12", end: "2026-08-13" };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ event: updated }));
+    vi.stubGlobal("fetch", fetchMock);
+    await renderMonth({ reschedulable: true, events: [event] });
+
+    await userEvent.dragAndDrop(
+      page.getByTestId("calendar-event-e1"),
+      page.getByTestId("calendar-day-2026-08-12"),
+    );
+
+    await expect
+      .element(page.getByTestId("calendar-event-e1"))
+      .toHaveAttribute("data-start", "2026-08-12");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/lattice/calendars/demo");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(String(init.body))).toEqual({
+      id: "e1",
+      resourceId: null,
+      start: "2026-08-12",
+      end: "2026-08-13",
+    });
+  });
+
+  it("moves the whole multi-week event when dragging a later weekly segment", async () => {
+    const event = calendarEvent({
+      id: "multi",
+      start: "2026-08-05",
+      end: "2026-08-15",
+      label: "Campaign",
+    });
+    const updated = { ...event, start: "2026-08-16", end: "2026-08-26" };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ event: updated }));
+    vi.stubGlobal("fetch", fetchMock);
+    await renderMonth({ reschedulable: true, events: [event] });
+
+    // Grab the second week's segment on its first day (Sunday 2026-08-09, four
+    // days into the event) and drop on 2026-08-20: the grab offset must keep
+    // the grabbed day under the cursor, shifting the start to 2026-08-16.
+    await userEvent.dragAndDrop(
+      page.getByTestId("calendar-event-multi").nth(1),
+      page.getByTestId("calendar-day-2026-08-20"),
+      { sourcePosition: { x: 5, y: 8 } },
+    );
+
+    await expect.poll(() => fetchMock.mock.calls.length).toBe(1);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      id: "multi",
+      resourceId: null,
+      start: "2026-08-16",
+      end: "2026-08-26",
+    });
+  });
+
+  it("rolls a rejected drag back and raises the translated rejection as a danger toast", async () => {
+    const event = calendarEvent({
+      id: "e1",
+      start: "2026-08-10",
+      end: "2026-08-11",
+      label: "Kickoff",
+    });
+    let rejectRequest: ((response: Response) => void) | undefined;
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          rejectRequest = resolve;
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const toastListener = vi.fn<(toastEvent: Event) => void>();
+    window.addEventListener("lattice:toast", toastListener);
+    await renderMonth({ reschedulable: true, events: [event] });
+
+    await userEvent.dragAndDrop(
+      page.getByTestId("calendar-event-e1"),
+      page.getByTestId("calendar-day-2026-08-12"),
+    );
+
+    await expect
+      .element(page.getByTestId("calendar-event-e1"))
+      .toHaveAttribute("data-start", "2026-08-12");
+
+    rejectRequest?.(
+      jsonResponse({ errors: { start: ["This event cannot move there."] } }, { status: 422 }),
+    );
+
+    await expect
+      .element(page.getByTestId("calendar-event-e1"))
+      .toHaveAttribute("data-start", "2026-08-10");
+    await expect.poll(() => toastListener.mock.calls.length).toBe(1);
+    expect((toastListener.mock.calls[0]?.[0] as CustomEvent).detail).toMatchObject({
+      message: "This event cannot move there.",
+      variant: "danger",
+    });
+
+    window.removeEventListener("lattice:toast", toastListener);
+  });
+
   it("switches between month and timeline views keeping the loaded events", async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/calendar/resources/js/calendar.test.tsx
+++ b/packages/calendar/resources/js/calendar.test.tsx
@@ -149,6 +149,83 @@ describe("CalendarComponent month view", () => {
     expect(JSON.parse(String(init.body))).toEqual({ eventId: "e1", kind: "meeting" });
   });
 
+  it("moves an all-day event by one day with Ctrl+Shift+Arrow, keeping its duration", async () => {
+    const event = calendarEvent({
+      id: "e1",
+      start: "2026-08-10",
+      end: "2026-08-12",
+      label: "Offsite",
+    });
+    fetchMock.mockResolvedValue(
+      jsonResponse({ event: { ...event, start: "2026-08-11", end: "2026-08-13" } }),
+    );
+    renderCalendar({ date: "2026-08-15", reschedulable: true, events: [event] });
+
+    fireEvent.keyDown(screen.getByTestId("calendar-event-e1"), {
+      ctrlKey: true,
+      key: "ArrowRight",
+      shiftKey: true,
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/lattice/calendars/demo");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(String(init.body))).toEqual({
+      id: "e1",
+      resourceId: null,
+      start: "2026-08-11",
+      end: "2026-08-13",
+    });
+  });
+
+  it("moves a timed event by a week with Ctrl+Shift+ArrowDown, preserving its wall-clock times", async () => {
+    const event = calendarEvent({
+      id: "timed",
+      start: "2026-08-10T09:30:00",
+      end: "2026-08-10T10:30:00",
+      allDay: false,
+      label: "Standup",
+    });
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        event: { ...event, start: "2026-08-17T09:30:00", end: "2026-08-17T10:30:00" },
+      }),
+    );
+    renderCalendar({ date: "2026-08-15", reschedulable: true, events: [event] });
+
+    fireEvent.keyDown(screen.getByTestId("calendar-event-timed"), {
+      ctrlKey: true,
+      key: "ArrowDown",
+      shiftKey: true,
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      id: "timed",
+      resourceId: null,
+      start: "2026-08-17T09:30:00",
+      end: "2026-08-17T10:30:00",
+    });
+  });
+
+  it("offers no reschedule affordance when the calendar is not reschedulable", () => {
+    renderCalendar({
+      date: "2026-08-15",
+      events: [calendarEvent({ id: "e1", start: "2026-08-10", end: "2026-08-12" })],
+    });
+
+    const chip = screen.getByTestId("calendar-event-e1");
+    expect(chip).not.toHaveAttribute("aria-keyshortcuts");
+
+    fireEvent.keyDown(chip, { ctrlKey: true, key: "ArrowRight", shiftKey: true });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("hides the view switcher for a single view", () => {
     renderCalendar({ date: today });
 

--- a/packages/calendar/resources/js/calendar.tsx
+++ b/packages/calendar/resources/js/calendar.tsx
@@ -127,6 +127,9 @@ const CalendarComponent: RendererComponent<"calendar"> = ({ node }) => {
       }
     : null;
 
+  const canReschedule =
+    node.props.endpoint !== null && node.props.ref !== null && node.props.reschedulable;
+
   const viewOptions: Option[] = views.map((view) => ({
     data: null,
     value: view,
@@ -152,21 +155,19 @@ const CalendarComponent: RendererComponent<"calendar"> = ({ node }) => {
 
       {activeView === "month" ? (
         <MonthView
-          events={state.events}
-          loading={state.loading}
+          canReschedule={canReschedule}
           locale={locale}
           month={month}
           onDayClick={onDayClick}
           onEventClick={onEventClick}
           onNavigate={navigateMonth}
+          state={state}
           t={t}
           today={today}
         />
       ) : (
         <TimelineView
-          canReschedule={
-            node.props.endpoint !== null && node.props.ref !== null && node.props.reschedulable
-          }
+          canReschedule={canReschedule}
           days={days}
           from={timelineFrom}
           groups={node.props.groups}

--- a/packages/calendar/resources/js/event-span.test.ts
+++ b/packages/calendar/resources/js/event-span.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { eventDaySpan } from "./event-span";
+import { eventDaySpan, shiftEventDays } from "./event-span";
 
 describe("eventDaySpan", () => {
   it("passes an all-day span through unchanged", () => {
@@ -25,5 +25,26 @@ describe("eventDaySpan", () => {
     expect(
       eventDaySpan({ start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00", allDay: false }),
     ).toEqual(["2026-08-10", "2026-08-11"]);
+  });
+});
+
+describe("shiftEventDays", () => {
+  it("moves all-day bounds as dates", () => {
+    expect(shiftEventDays({ start: "2026-08-10", end: "2026-08-13" }, 3)).toEqual({
+      start: "2026-08-13",
+      end: "2026-08-16",
+    });
+  });
+
+  it("keeps a timed event's wall-clock times across a month boundary", () => {
+    expect(shiftEventDays({ start: "2026-08-30T09:15:00", end: "2026-08-31T17:30:00" }, 7)).toEqual(
+      { start: "2026-09-06T09:15:00", end: "2026-09-07T17:30:00" },
+    );
+  });
+
+  it("shifts backwards", () => {
+    expect(
+      shiftEventDays({ start: "2026-08-10T09:00:00", end: "2026-08-10T10:00:00" }, -1),
+    ).toEqual({ start: "2026-08-09T09:00:00", end: "2026-08-09T10:00:00" });
   });
 });

--- a/packages/calendar/resources/js/event-span.ts
+++ b/packages/calendar/resources/js/event-span.ts
@@ -20,3 +20,17 @@ export function eventDaySpan(
 
   return [startDay, exclusiveEnd > startDay ? exclusiveEnd : addDays(startDay, 1)];
 }
+
+/**
+ * Shifts an event by whole days in its own representation: all-day `Y-m-d`
+ * bounds move as dates; a timed event keeps its wall-clock times and only the
+ * date parts shift.
+ */
+export function shiftEventDays(
+  event: Pick<CalendarEventData, "start" | "end">,
+  days: number,
+): { start: string; end: string } {
+  const shift = (value: string): string => addDays(value.slice(0, 10), days) + value.slice(10);
+
+  return { start: shift(event.start), end: shift(event.end) };
+}

--- a/packages/calendar/resources/js/types.ts
+++ b/packages/calendar/resources/js/types.ts
@@ -10,10 +10,14 @@ export type CalendarResourceData = ResourceGroupData["resources"][number];
 
 export type CalendarActionNode = NonNullable<Calendar["eventAction"]>;
 
-/** Day-granular, half-open `[start, end)` — the shape the PATCH endpoint expects. */
+/**
+ * Half-open `[start, end)` in the event's own representation — `Y-m-d` bounds
+ * for all-day events, wall-clock datetimes for timed ones. `resourceId` is
+ * `null` for resource-less events; adapters validate what they accept.
+ */
 export type CalendarRescheduleRequest = {
   id: string;
-  resourceId: string;
+  resourceId: string | null;
   start: string;
   end: string;
 };

--- a/packages/calendar/resources/js/use-announced-reschedule.ts
+++ b/packages/calendar/resources/js/use-announced-reschedule.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { announce } from "@lattice-php/lattice/dnd";
+import { useEffectDispatcher } from "@lattice-php/ui/effects/use-effect-dispatcher";
+import type { UseCalendarEventsReturn } from "./calendar-state";
+import type { CalendarEventData, CalendarRescheduleRequest } from "./types";
+
+type Translate = (key: string, defaultValue?: string, options?: Record<string, unknown>) => string;
+
+/**
+ * Wraps the optimistic reschedule with the feedback both views share: a
+ * screen-reader announcement on success and an announced danger toast on
+ * rejection (the rollback itself happens in the event cache).
+ */
+export function useAnnouncedReschedule(
+  events: Map<string, CalendarEventData>,
+  reschedule: UseCalendarEventsReturn["reschedule"],
+  t: Translate,
+): { submitReschedule: (request: CalendarRescheduleRequest) => Promise<void> } {
+  const dispatch = useEffectDispatcher();
+
+  const submitReschedule = useCallback(
+    async (request: CalendarRescheduleRequest): Promise<void> => {
+      const event = events.get(request.id);
+
+      if (!event) {
+        return;
+      }
+
+      const result = await reschedule(request);
+
+      if (result.accepted) {
+        announce(t("calendar.rescheduled", "Rescheduled {{label}}", { label: event.label }));
+        return;
+      }
+
+      const message =
+        result.message ??
+        t("calendar.reschedule-failed", "Could not reschedule {{label}}", {
+          label: event.label,
+        });
+      dispatch([{ type: "toast", props: { message, variant: "danger" } }]);
+      announce(message);
+    },
+    [dispatch, events, reschedule, t],
+  );
+
+  return { submitReschedule };
+}

--- a/packages/calendar/resources/js/views/month-view.tsx
+++ b/packages/calendar/resources/js/views/month-view.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
+import { announce, draggable, dropTargetForElements } from "@lattice-php/lattice/dnd";
 import { coerceColor, namedColor, toneProps } from "@lattice-php/ui/lib/color";
 import { cn } from "@lattice-php/ui/lib/utils";
 import { Icon } from "@lattice-php/ui/icons";
@@ -7,25 +8,31 @@ import { Popover, PopoverContent, PopoverTrigger } from "@lattice-php/ui/popover
 import {
   addDays,
   addMonths,
+  daysBetween,
   formatWallTime,
   startOfMonthISO,
 } from "@lattice-php/ui/format/temporal";
 import { buildMonthGrid, capLanes, eventsOnDay, weekChips } from "../month-grid";
-import type { MonthChip, MonthWeek } from "../month-grid";
+import { eventDaySpan, shiftEventDays } from "../event-span";
+import { useAnnouncedReschedule } from "../use-announced-reschedule";
+import type { MonthChip, MonthDay, MonthWeek } from "../month-grid";
+import type { UseCalendarEventsReturn } from "../calendar-state";
 import type { CalendarEventData } from "../types";
 
 export const MAX_VISIBLE_LANES = 3;
 
+const MONTH_DRAG_TYPE = "lattice-calendar-month-event";
+
 type Translate = (key: string, defaultValue?: string, options?: Record<string, unknown>) => string;
 
 export type MonthViewProps = {
-  events: Map<string, CalendarEventData>;
-  loading: boolean;
+  canReschedule: boolean;
   locale: string;
   month: string;
   onDayClick: ((date: string) => void) | null;
   onEventClick: ((event: CalendarEventData) => void) | null;
   onNavigate: (month: string) => void;
+  state: UseCalendarEventsReturn;
   t: Translate;
   today: string;
 };
@@ -35,19 +42,23 @@ function toNoonUtc(dateISO: string): Date {
 }
 
 export function MonthView({
-  events,
-  loading,
+  canReschedule,
   locale,
   month,
   onDayClick,
   onEventClick,
   onNavigate,
+  state,
   t,
   today,
 }: MonthViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const pendingFocusRef = useRef<string | null>(null);
+  const pendingChipFocusRef = useRef<string | null>(null);
   const [focusedDate, setFocusedDate] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const { events, isRescheduling, loading, reschedule } = state;
+  const { submitReschedule } = useAnnouncedReschedule(events, reschedule, t);
   const grid = useMemo(() => buildMonthGrid(month, locale, today), [month, locale, today]);
   const eventList = useMemo(() => [...events.values()], [events]);
   const title = useMemo(
@@ -94,6 +105,23 @@ export function MonthView({
     }
   });
 
+  useEffect(() => {
+    const pending = pendingChipFocusRef.current;
+
+    if (!pending) {
+      return;
+    }
+
+    const chip = containerRef.current?.querySelector<HTMLElement>(
+      `[data-test="calendar-event-${pending}"]`,
+    );
+
+    if (chip) {
+      pendingChipFocusRef.current = null;
+      chip.focus();
+    }
+  });
+
   function onCellKeyDown(keyboardEvent: KeyboardEvent<HTMLDivElement>, date: string): void {
     let next: string;
 
@@ -132,8 +160,92 @@ export function MonthView({
     moveFocus(next);
   }
 
+  function moveEventByDays(event: CalendarEventData, deltaDays: number): void {
+    if (deltaDays === 0) {
+      return;
+    }
+
+    void submitReschedule({
+      id: event.id,
+      resourceId: event.resourceId,
+      ...shiftEventDays(event, deltaDays),
+    });
+  }
+
+  function onChipKeyDown(
+    keyboardEvent: KeyboardEvent<HTMLButtonElement>,
+    event: CalendarEventData,
+  ): void {
+    if (
+      !canReschedule ||
+      isRescheduling(event.id) ||
+      !keyboardEvent.ctrlKey ||
+      !keyboardEvent.shiftKey
+    ) {
+      return;
+    }
+
+    let deltaDays: number;
+
+    switch (keyboardEvent.key) {
+      case "ArrowLeft":
+        deltaDays = -1;
+        break;
+      case "ArrowRight":
+        deltaDays = 1;
+        break;
+      case "ArrowUp":
+        deltaDays = -7;
+        break;
+      case "ArrowDown":
+        deltaDays = 7;
+        break;
+      default:
+        return;
+    }
+
+    keyboardEvent.preventDefault();
+    pendingChipFocusRef.current = event.id;
+    moveEventByDays(event, deltaDays);
+  }
+
+  const onEventDrop = useCallback(
+    (data: Record<string | symbol, unknown>, date: string): void => {
+      const id = data.id;
+      const grabOffsetDays = typeof data.grabOffsetDays === "number" ? data.grabOffsetDays : 0;
+
+      if (typeof id !== "string") {
+        return;
+      }
+
+      const event = events.get(id);
+
+      if (!event) {
+        return;
+      }
+
+      const [dayStart] = eventDaySpan(event);
+      const deltaDays = daysBetween(dayStart, addDays(date, -grabOffsetDays));
+
+      if (deltaDays === 0) {
+        return;
+      }
+
+      void submitReschedule({
+        id: event.id,
+        resourceId: event.resourceId,
+        ...shiftEventDays(event, deltaDays),
+      });
+    },
+    [events, submitReschedule],
+  );
+
   return (
-    <div className="lt-calendar-month" ref={containerRef}>
+    <div
+      className="lt-calendar-month"
+      data-dragging={dragging ? "true" : undefined}
+      ref={containerRef}
+    >
       <div className="mb-2 flex items-center gap-1">
         <button
           aria-label={t("calendar.previous", "Previous")}
@@ -164,7 +276,7 @@ export function MonthView({
       </div>
 
       <div
-        aria-busy={loading}
+        aria-busy={loading || [...events.keys()].some((id) => isRescheduling(id))}
         aria-label={title}
         className="overflow-hidden rounded-lt-sm border border-lt-border"
         role="grid"
@@ -183,14 +295,19 @@ export function MonthView({
 
         {grid.weeks.map((week, weekIndex) => (
           <MonthWeekRow
+            canReschedule={canReschedule}
             dayFormatter={dayFormatter}
             eventList={eventList}
             first={weekIndex === 0}
+            isRescheduling={isRescheduling}
             key={week.start}
             locale={locale}
             onCellKeyDown={onCellKeyDown}
+            onChipKeyDown={onChipKeyDown}
             onDayClick={onDayClick}
+            onDragStateChange={setDragging}
             onEventClick={onEventClick}
+            onEventDrop={onEventDrop}
             t={t}
             tabStopDate={tabStopDate}
             week={week}
@@ -202,24 +319,37 @@ export function MonthView({
 }
 
 function MonthWeekRow({
+  canReschedule,
   dayFormatter,
   eventList,
   first,
+  isRescheduling,
   locale,
   onCellKeyDown,
+  onChipKeyDown,
   onDayClick,
+  onDragStateChange,
   onEventClick,
+  onEventDrop,
   t,
   tabStopDate,
   week,
 }: {
+  canReschedule: boolean;
   dayFormatter: Intl.DateTimeFormat;
   eventList: CalendarEventData[];
   first: boolean;
+  isRescheduling: (id: string) => boolean;
   locale: string;
   onCellKeyDown: (keyboardEvent: KeyboardEvent<HTMLDivElement>, date: string) => void;
+  onChipKeyDown: (
+    keyboardEvent: KeyboardEvent<HTMLButtonElement>,
+    event: CalendarEventData,
+  ) => void;
   onDayClick: ((date: string) => void) | null;
+  onDragStateChange: (dragging: boolean) => void;
   onEventClick: ((event: CalendarEventData) => void) | null;
+  onEventDrop: (data: Record<string | symbol, unknown>, date: string) => void;
   t: Translate;
   tabStopDate: string;
   week: MonthWeek;
@@ -230,36 +360,17 @@ function MonthWeekRow({
   return (
     <div className={cn("lt-calendar-week", !first && "border-t border-lt-border")} role="row">
       {week.days.map((day, dayIndex) => (
-        <div
-          aria-current={day.isToday ? "date" : undefined}
-          aria-label={dayFormatter.format(toNoonUtc(day.date))}
-          className={cn(
-            "lt-calendar-day",
-            dayIndex > 0 && "border-l border-lt-border",
-            day.isWeekend && "bg-lt-muted/40",
-            !day.inMonth && "text-lt-muted-fg",
-            onDayClick && "cursor-pointer",
-          )}
-          data-date={day.date}
-          data-test={`calendar-day-${day.date}`}
+        <MonthDayCell
+          ariaLabel={dayFormatter.format(toNoonUtc(day.date))}
+          canReschedule={canReschedule}
+          day={day}
+          dayIndex={dayIndex}
           key={day.date}
-          onClick={onDayClick ? () => onDayClick(day.date) : undefined}
-          onKeyDown={(keyboardEvent) => onCellKeyDown(keyboardEvent, day.date)}
-          role="gridcell"
-          tabIndex={day.date === tabStopDate ? 0 : -1}
+          onDayClick={onDayClick}
+          onEventDrop={onEventDrop}
+          onKeyDown={onCellKeyDown}
+          tabStop={day.date === tabStopDate}
         >
-          <div className="flex justify-end px-1.5 pt-1">
-            <span
-              className={cn(
-                "flex size-6 items-center justify-center rounded-full text-xs",
-                day.isToday && "bg-lt-primary font-semibold text-lt-primary-fg",
-                !day.isToday && !day.inMonth && "text-lt-muted-fg",
-              )}
-            >
-              {day.dayOfMonth}
-            </span>
-          </div>
-          <div className="flex-1" />
           {hiddenByDay[dayIndex] > 0 ? (
             <DayOverflow
               count={hiddenByDay[dayIndex]}
@@ -271,20 +382,108 @@ function MonthWeekRow({
               t={t}
             />
           ) : null}
-        </div>
+        </MonthDayCell>
       ))}
 
-      <div aria-hidden={onEventClick ? undefined : true} className="lt-calendar-chips">
+      <div
+        aria-hidden={onEventClick || canReschedule ? undefined : true}
+        className="lt-calendar-chips"
+      >
         {visible.map((chip) => (
           <EventChip
+            canReschedule={canReschedule}
             chip={chip}
+            isRescheduling={isRescheduling(chip.id)}
             key={`${chip.id}-${chip.start}`}
             locale={locale}
+            onDragStateChange={onDragStateChange}
             onEventClick={onEventClick}
+            onMoveKeyDown={onChipKeyDown}
             t={t}
+            weekStart={week.start}
           />
         ))}
       </div>
+    </div>
+  );
+}
+
+function MonthDayCell({
+  ariaLabel,
+  canReschedule,
+  children,
+  day,
+  dayIndex,
+  onDayClick,
+  onEventDrop,
+  onKeyDown,
+  tabStop,
+}: {
+  ariaLabel: string;
+  canReschedule: boolean;
+  children: ReactNode;
+  day: MonthDay;
+  dayIndex: number;
+  onDayClick: ((date: string) => void) | null;
+  onEventDrop: (data: Record<string | symbol, unknown>, date: string) => void;
+  onKeyDown: (keyboardEvent: KeyboardEvent<HTMLDivElement>, date: string) => void;
+  tabStop: boolean;
+}) {
+  const cellRef = useRef<HTMLDivElement>(null);
+  const [dropActive, setDropActive] = useState(false);
+
+  useEffect(() => {
+    const element = cellRef.current;
+
+    if (!element || !canReschedule) {
+      return;
+    }
+
+    return dropTargetForElements({
+      canDrop: ({ source }) => source.data.type === MONTH_DRAG_TYPE,
+      element,
+      onDragEnter: () => setDropActive(true),
+      onDragLeave: () => setDropActive(false),
+      onDrop: ({ source }) => {
+        setDropActive(false);
+        onEventDrop(source.data, day.date);
+      },
+    });
+  }, [canReschedule, day.date, onEventDrop]);
+
+  return (
+    <div
+      aria-current={day.isToday ? "date" : undefined}
+      aria-label={ariaLabel}
+      className={cn(
+        "lt-calendar-day",
+        dayIndex > 0 && "border-l border-lt-border",
+        day.isWeekend && "bg-lt-muted/40",
+        !day.inMonth && "text-lt-muted-fg",
+        onDayClick && "cursor-pointer",
+        dropActive && "bg-lt-primary/10",
+      )}
+      data-date={day.date}
+      data-test={`calendar-day-${day.date}`}
+      onClick={onDayClick ? () => onDayClick(day.date) : undefined}
+      onKeyDown={(keyboardEvent) => onKeyDown(keyboardEvent, day.date)}
+      ref={cellRef}
+      role="gridcell"
+      tabIndex={tabStop ? 0 : -1}
+    >
+      <div className="flex justify-end px-1.5 pt-1">
+        <span
+          className={cn(
+            "flex size-6 items-center justify-center rounded-full text-xs",
+            day.isToday && "bg-lt-primary font-semibold text-lt-primary-fg",
+            !day.isToday && !day.inMonth && "text-lt-muted-fg",
+          )}
+        >
+          {day.dayOfMonth}
+        </span>
+      </div>
+      <div className="flex-1" />
+      {children}
     </div>
   );
 }
@@ -302,7 +501,15 @@ function chipContent(event: CalendarEventData, locale: string) {
   );
 }
 
-function chipLabel(event: CalendarEventData, t: Translate): string {
+function chipLabel(event: CalendarEventData, t: Translate, reschedulable = false): string {
+  if (reschedulable) {
+    return t(
+      "calendar.event-chip-label-reschedulable",
+      "{{label}}, {{start}} to {{end}}. Use Control Shift and arrow keys to reschedule.",
+      { end: event.end, label: event.label, start: event.start },
+    );
+  }
+
   return t("calendar.event-chip-label", "{{label}}, {{start}} to {{end}}", {
     end: event.end,
     label: event.label,
@@ -311,24 +518,84 @@ function chipLabel(event: CalendarEventData, t: Translate): string {
 }
 
 function EventChip({
+  canReschedule,
   chip,
+  isRescheduling,
   locale,
+  onDragStateChange,
   onEventClick,
+  onMoveKeyDown,
   t,
+  weekStart,
 }: {
+  canReschedule: boolean;
   chip: MonthChip;
+  isRescheduling: boolean;
   locale: string;
+  onDragStateChange: (dragging: boolean) => void;
   onEventClick: ((event: CalendarEventData) => void) | null;
+  onMoveKeyDown: (
+    keyboardEvent: KeyboardEvent<HTMLButtonElement>,
+    event: CalendarEventData,
+  ) => void;
   t: Translate;
+  weekStart: string;
 }) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const { event, span, start } = chip;
+
+  useEffect(() => {
+    const element = buttonRef.current;
+
+    if (!element || !canReschedule) {
+      return;
+    }
+
+    const [dayStart, dayEnd] = eventDaySpan(event);
+    const durationDays = daysBetween(dayStart, dayEnd);
+    const hiddenStartDays = daysBetween(dayStart, addDays(weekStart, start));
+
+    return draggable({
+      canDrag: () => !isRescheduling,
+      element,
+      getInitialData: ({ element: source, input }) => {
+        const rect = source.getBoundingClientRect();
+        const dayWidth = rect.width / span;
+
+        return {
+          grabOffsetDays: Math.max(
+            0,
+            Math.min(
+              durationDays - 1,
+              hiddenStartDays + Math.floor((input.clientX - rect.left) / dayWidth),
+            ),
+          ),
+          id: event.id,
+          type: MONTH_DRAG_TYPE,
+        };
+      },
+      onDragStart: () => {
+        onDragStateChange(true);
+        announce(
+          t("calendar.dragging-day", "Moving {{label}}. Drop on a day.", {
+            label: event.label,
+          }),
+        );
+      },
+      onDrop: () => onDragStateChange(false),
+    });
+  }, [canReschedule, event, isRescheduling, onDragStateChange, span, start, t, weekStart]);
+
   const tone = toneProps(coerceColor(chip.event.color) ?? namedColor("primary"));
   const className = cn(
     "lt-calendar-chip mx-1 mb-0.5 flex items-center gap-1 overflow-hidden px-1.5 text-left text-xs",
     tone.className,
     chip.continuesBefore ? "rounded-l-none" : "rounded-l-lt-xs",
     chip.continuesAfter ? "rounded-r-none" : "rounded-r-lt-xs",
-    onEventClick &&
-      "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-lt-primary",
+    (onEventClick || canReschedule) &&
+      "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-lt-primary",
+    onEventClick && "cursor-pointer",
+    canReschedule && !onEventClick && "cursor-grab",
   );
   const style = {
     gridColumn: `${chip.start + 1} / span ${chip.span}`,
@@ -336,9 +603,15 @@ function EventChip({
     ...tone.style,
   };
 
-  if (!onEventClick) {
+  if (!onEventClick && !canReschedule) {
     return (
-      <div className={className} data-test={`calendar-event-${chip.id}`} style={style}>
+      <div
+        className={className}
+        data-end={chip.event.end}
+        data-start={chip.event.start}
+        data-test={`calendar-event-${chip.id}`}
+        style={style}
+      >
         {chipContent(chip.event, locale)}
       </div>
     );
@@ -346,10 +619,20 @@ function EventChip({
 
   return (
     <button
-      aria-label={chipLabel(chip.event, t)}
+      aria-disabled={isRescheduling || undefined}
+      aria-keyshortcuts={
+        canReschedule
+          ? "Control+Shift+ArrowLeft Control+Shift+ArrowRight Control+Shift+ArrowUp Control+Shift+ArrowDown"
+          : undefined
+      }
+      aria-label={chipLabel(chip.event, t, canReschedule)}
       className={className}
+      data-end={chip.event.end}
+      data-start={chip.event.start}
       data-test={`calendar-event-${chip.id}`}
-      onClick={() => onEventClick(chip.event)}
+      onClick={onEventClick ? () => onEventClick(chip.event) : undefined}
+      onKeyDown={(keyboardEvent) => onMoveKeyDown(keyboardEvent, chip.event)}
+      ref={buttonRef}
       style={style}
       title={chip.event.label}
       type="button"

--- a/packages/calendar/resources/js/views/timeline-view.browser.test.tsx
+++ b/packages/calendar/resources/js/views/timeline-view.browser.test.tsx
@@ -113,7 +113,7 @@ describe("timeline rescheduling in a browser", () => {
     });
   });
 
-  it("rolls an optimistic move back and displays the translated rejection", async () => {
+  it("rolls an optimistic move back and raises the translated rejection as a danger toast", async () => {
     let rejectRequest: ((response: Response) => void) | undefined;
     const fetchMock = vi.fn<typeof fetch>().mockImplementation(
       () =>
@@ -122,6 +122,8 @@ describe("timeline rescheduling in a browser", () => {
         }),
     );
     vi.stubGlobal("fetch", fetchMock);
+    const toastListener = vi.fn<(toastEvent: Event) => void>();
+    window.addEventListener("lattice:toast", toastListener);
     await renderTimeline();
 
     await dragToTeam();
@@ -136,9 +138,13 @@ describe("timeline rescheduling in a browser", () => {
     );
 
     await expect.element(entry()).toHaveAttribute("data-resource-id", "anna");
-    await expect
-      .element(page.getByRole("alert"))
-      .toHaveTextContent("This planning resource is unavailable.");
+    await expect.poll(() => toastListener.mock.calls.length).toBe(1);
+    expect((toastListener.mock.calls[0]?.[0] as CustomEvent).detail).toMatchObject({
+      message: "This planning resource is unavailable.",
+      variant: "danger",
+    });
+
+    window.removeEventListener("lattice:toast", toastListener);
   });
 
   it("supports moving a focused assignment by keyboard", async () => {
@@ -265,7 +271,7 @@ describe("timeline rescheduling in a browser", () => {
     });
   });
 
-  it("rolls a rejected resize back and displays the translated rejection", async () => {
+  it("rolls a rejected resize back and raises the translated rejection as a danger toast", async () => {
     let rejectRequest: ((response: Response) => void) | undefined;
     const fetchMock = vi.fn<typeof fetch>().mockImplementation(
       () =>
@@ -274,6 +280,8 @@ describe("timeline rescheduling in a browser", () => {
         }),
     );
     vi.stubGlobal("fetch", fetchMock);
+    const toastListener = vi.fn<(toastEvent: Event) => void>();
+    window.addEventListener("lattice:toast", toastListener);
     await renderTimeline();
 
     await userEvent.dragAndDrop(resizeHandle("end"), resource("anna"), {
@@ -287,8 +295,12 @@ describe("timeline rescheduling in a browser", () => {
     );
 
     await expect.element(entry()).toHaveAttribute("data-end", "2026-01-04");
-    await expect
-      .element(page.getByRole("alert"))
-      .toHaveTextContent("This assignment cannot end then.");
+    await expect.poll(() => toastListener.mock.calls.length).toBe(1);
+    expect((toastListener.mock.calls[0]?.[0] as CustomEvent).detail).toMatchObject({
+      message: "This assignment cannot end then.",
+      variant: "danger",
+    });
+
+    window.removeEventListener("lattice:toast", toastListener);
   });
 });

--- a/packages/calendar/resources/js/views/timeline-view.tsx
+++ b/packages/calendar/resources/js/views/timeline-view.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@lattice-php/ui/icons";
 import { addDays, daysBetween } from "@lattice-php/ui/format/temporal";
 import { assignLanes, buildAxis } from "../date-axis";
 import { eventDaySpan } from "../event-span";
+import { useAnnouncedReschedule } from "../use-announced-reschedule";
 import type { UseCalendarEventsReturn } from "../calendar-state";
 import type {
   CalendarEventData,
@@ -124,8 +125,8 @@ export function TimelineView({
 }: TimelineViewProps) {
   const [dayWidth, setDayWidth] = useState(DEFAULT_DAY_WIDTH);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { events, eventsForResource, isRescheduling, loading, reschedule } = state;
+  const { submitReschedule } = useAnnouncedReschedule(events, reschedule, t);
   const resources = useMemo(() => groups.flatMap((group) => group.resources), [groups]);
 
   const entriesForResource = useCallback(
@@ -174,23 +175,9 @@ export function TimelineView({
         return;
       }
 
-      setErrorMessage(null);
-      const result = await reschedule(request);
-
-      if (result.accepted) {
-        announce(t("calendar.rescheduled", "Rescheduled {{label}}", { label: event.label }));
-        return;
-      }
-
-      const message =
-        result.message ??
-        t("calendar.reschedule-failed", "Could not reschedule {{label}}", {
-          label: event.label,
-        });
-      setErrorMessage(message);
-      announce(message);
+      await submitReschedule(request);
     },
-    [events, reschedule, t],
+    [events, submitReschedule],
   );
 
   const rootStyle = {
@@ -246,12 +233,6 @@ export function TimelineView({
           </button>
         </div>
       </div>
-
-      {errorMessage ? (
-        <div className="mb-2 text-sm text-lt-danger" role="alert">
-          {errorMessage}
-        </div>
-      ) : null}
 
       <div
         aria-busy={loading || [...events.keys()].some((id) => isRescheduling(id))}

--- a/tests/Feature/Calendar/CalendarEndpointTest.php
+++ b/tests/Feature/Calendar/CalendarEndpointTest.php
@@ -128,6 +128,21 @@ it('returns the adapter translated message when a reschedule is rejected', funct
         ->assertJsonPath('errors.resourceId.0', 'This planning resource is unavailable.');
 });
 
+it('rejects a resource-less month-view drag of a meeting with the translated message', function (): void {
+    $today = CarbonImmutable::today();
+    $calendar = $this->sealCalendar(fn (): Calendar => Calendar::use(ProjectPlanCalendar::class));
+
+    patchJson($calendar['props']['endpoint'], [
+        'id' => 'sprint-review',
+        'resourceId' => null,
+        'start' => $today->addDay()->format('Y-m-d\T09:00:00'),
+        'end' => $today->addDay()->format('Y-m-d\T10:00:00'),
+    ], ['X-Lattice-Ref' => $calendar['props']['ref']])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.id.0', 'This assignment is unavailable.')
+        ->assertJsonPath('errors.resourceId.0', 'This planning resource is unavailable.');
+});
+
 it('rejects a request without a ref', function (): void {
     $calendar = $this->sealCalendar(fn (): Calendar => Calendar::use(ProjectPlanCalendar::class));
 

--- a/workbench/app/Calendars/ProjectPlanCalendarAdapter.php
+++ b/workbench/app/Calendars/ProjectPlanCalendarAdapter.php
@@ -55,6 +55,7 @@ final class ProjectPlanCalendarAdapter implements CalendarAdapter, ProvidesCalen
             'end' => ['required', 'date_format:Y-m-d', 'after:start'],
         ], [
             'id.exists' => __('workbench.calendar.assignment-unavailable'),
+            'resourceId.required' => __('workbench.calendar.resource-unavailable'),
             'resourceId.in' => __('workbench.calendar.resource-unavailable'),
         ]);
 

--- a/workbench/app/Pages/CalendarPage.php
+++ b/workbench/app/Pages/CalendarPage.php
@@ -30,7 +30,7 @@ final class CalendarPage extends WorkbenchPage
                 ->gap(Gap::ExtraLarge)
                 ->schema([
                     Heading::make($this->title()),
-                    Text::make('Switch between the month grid and the resource timeline; drag an assignment in the timeline to reschedule it.'),
+                    Text::make('Switch between the month grid and the resource timeline; drag an assignment in either view to reschedule it.'),
                     Calendar::use(ProjectPlanCalendar::class)
                         ->views([CalendarView::Month, CalendarView::Timeline])
                         ->eventAction(ShowCalendarEventAction::class)


### PR DESCRIPTION
Adds drag & drop and a keyboard equivalent to the calendar month view, completing the rescheduling story from #468 (which shipped it for the timeline only).

- Drag an event chip onto another day cell to move it by whole days: duration preserved, all-day events shift their `Y-m-d` bounds, timed events keep their wall-clock times. Dragging any weekly segment of a multi-week chip moves the whole event, honoring the grab offset in days.
- Keyboard: focused chip + <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+Arrow moves ±1 day / ±7 days (documented via `aria-keyshortcuts`).
- `CalendarRescheduleRequest.resourceId` is nullable end-to-end so resource-less events reschedule too; `start`/`end` travel in the event's own representation and adapters validate what they accept.
- Rejections roll back and now surface as a **danger toast** in both views (shared `useAnnouncedReschedule` hook) instead of the inline alert; the workbench adapter's `resourceId.required` message is translated.

Before/after: month chips were click-only; now they are draggable buttons (day cells highlight as drop targets) and a rejected drag — e.g. dragging the resource-less "Company Retreat" meeting in the workbench — snaps back and shows "This assignment is unavailable." as a toast.

Covered by jsdom tests (keyboard payloads incl. wall-time preservation, no affordance when not reschedulable), browser vitest (real drags: happy path, multi-week grab offset, rejected rollback + toast), and a Pest endpoint test for the nullable-resourceId contract.