### PR TITLE
feat(core): opt-in context inheritance for child components

### DIFF
--- a/packages/core/src/Concerns/InteractsWithComponents.php
+++ b/packages/core/src/Concerns/InteractsWithComponents.php
@@ -9,6 +9,7 @@ use Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Core\Definition;
 use Lattice\Core\DefinitionRegistry;
 use Lattice\Core\Exceptions\UnknownComponent;
+use Lattice\Core\Services\ContextScope;
 
 trait InteractsWithComponents
 {
@@ -34,6 +35,8 @@ trait InteractsWithComponents
         }
 
         Authorization::ensure($definition, $request);
+
+        app(ContextScope::class)->activate($context);
 
         return [$request, $definition, $context];
     }

--- a/packages/core/src/Contracts/InteractiveComponent.php
+++ b/packages/core/src/Contracts/InteractiveComponent.php
@@ -15,4 +15,13 @@ interface InteractiveComponent
      * @param  array<string, mixed>  $context
      */
     public function context(array $context): static;
+
+    /**
+     * Merge $context beneath the existing context — explicit keys set at
+     * build time win — while $override forces its keys over both.
+     *
+     * @param  array<string, mixed>  $context
+     * @param  array<string, mixed>  $override
+     */
+    public function mergeContext(array $context, array $override = []): static;
 }

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -8,6 +8,7 @@ use Lattice\Core\Contracts\ResolvesReferenceIdentity;
 use Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Core\Services\ComponentReferenceSigner;
+use Lattice\Core\Services\ContextScope;
 use Lattice\Core\Services\RequestReferenceIdentity;
 use Lattice\Core\Support\Evaluation\Evaluator;
 
@@ -21,6 +22,7 @@ final class CoreServiceProvider extends ServiceProvider
         $this->app->singleton(ResolvesReferenceIdentity::class, RequestReferenceIdentity::class);
         $this->app->singleton(ComponentReferenceSigner::class);
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);
+        $this->app->scoped(ContextScope::class);
         $this->app->singleton(DiscoveryManifest::class);
         $this->app->singleton(PageMetadataResolver::class);
     }

--- a/packages/core/src/DefinitionRegistry.php
+++ b/packages/core/src/DefinitionRegistry.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Lattice\Core\Attributes\DefinitionAttribute;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Core\Exceptions\UnknownComponent;
+use Lattice\Core\Services\ContextScope;
 use Spatie\Attributes\Attributes;
 
 /**
@@ -32,6 +33,11 @@ abstract class DefinitionRegistry
      * configured and then sealed. Registries supply only the construction
      * closures so this sequence cannot drift between them.
      *
+     * Whitelisted context keys (`lattice.context.inherited_keys`) cascade:
+     * they merge beneath the explicit context — so the gate and the sealed
+     * ref see the same merged array — and the configure step runs inside a
+     * ContextScope frame, so children built within it inherit them too.
+     *
      * @template TComponent of Contracts\CanBeHidden&Contracts\InteractiveComponent
      *
      * @param  class-string<TDefinition>  $definitionClass
@@ -42,6 +48,9 @@ abstract class DefinitionRegistry
      */
     protected function gatedComponent(string $definitionClass, callable $component, callable $configure, array $context = [])
     {
+        $scope = $this->container->make(ContextScope::class);
+        $context = [...$scope->inheritable(), ...$context];
+
         $key = $this->registeredKeyFor($definitionClass);
         $definition = $this->make($definitionClass)->withContext($context);
 
@@ -49,7 +58,7 @@ abstract class DefinitionRegistry
             return $component($key)->hidden();
         }
 
-        return $configure($definition, $component($key), $key)
+        return $scope->wrap($context, fn () => $configure($definition, $component($key), $key))
             ->signedAs($key)
             ->context($context);
     }

--- a/packages/core/src/Services/ContextScope.php
+++ b/packages/core/src/Services/ContextScope.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\Services;
+
+use Closure;
+
+/**
+ * Request-scoped stack of inheritable component context. The definition
+ * registries wrap every authorized component build in a frame so components
+ * built inside a definition (row actions, modal forms, nested actions)
+ * inherit the whitelisted keys of their parent's context without manual
+ * re-threading; endpoints activate a frame so the response paths that
+ * rebuild children (table rows, form schemas, fragments) behave identically.
+ *
+ * Only keys listed in `lattice.context.inherited_keys` cascade — context can
+ * carry routing and policy values (the bulk-action table key, media upload
+ * rules) that must never leak into a child's sealed ref.
+ */
+final class ContextScope
+{
+    /** Framework-routing keys that never cascade, whitelisted or not. */
+    private const array RESERVED = ['table'];
+
+    /** @var list<array<string, mixed>> */
+    private array $frames = [];
+
+    /**
+     * @template TReturn
+     *
+     * @param  array<string, mixed>  $context
+     * @param  Closure(): TReturn  $fn
+     * @return TReturn
+     */
+    public function wrap(array $context, Closure $fn): mixed
+    {
+        $this->frames[] = $this->inheritableSubset($context);
+
+        try {
+            return $fn();
+        } finally {
+            array_pop($this->frames);
+        }
+    }
+
+    /**
+     * Push without pop: an endpoint activates its trusted context once for
+     * the lifetime of this request-scoped instance.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function activate(array $context): void
+    {
+        $this->frames[] = $this->inheritableSubset($context);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function inheritable(): array
+    {
+        return $this->frames === [] ? [] : end($this->frames);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function inheritableSubset(array $context): array
+    {
+        $keys = config('lattice.context.inherited_keys', []);
+
+        if (! is_array($keys) || $keys === []) {
+            return [];
+        }
+
+        return array_diff_key(
+            array_intersect_key($context, array_flip($keys)),
+            array_flip(self::RESERVED),
+        );
+    }
+}

--- a/packages/framework/config/lattice.php
+++ b/packages/framework/config/lattice.php
@@ -15,6 +15,13 @@ return [
         'ref_lifetime' => 30,
     ],
 
+    'context' => [
+        // Context keys child components inherit from the definition they are
+        // built inside (row actions, modal forms, nested actions). Empty means
+        // no inheritance; explicit context always wins over inherited keys.
+        'inherited_keys' => [],
+    ],
+
     'refs' => [
         'middleware' => ['web'],
     ],

--- a/packages/table/src/TableRegistry.php
+++ b/packages/table/src/TableRegistry.php
@@ -172,7 +172,7 @@ final class TableRegistry extends DefinitionRegistry
     private function bulkActions(TableDefinition $definition, string $key, array $context): array
     {
         return array_map(
-            fn (Component&InteractiveComponent $action): Component => $action->context([...$context, 'table' => $key]),
+            fn (Component&InteractiveComponent $action): Component => $action->mergeContext($context, ['table' => $key]),
             $this->renderableComponents($definition->bulkActions()),
         );
     }
@@ -185,7 +185,7 @@ final class TableRegistry extends DefinitionRegistry
     {
         return array_map(
             fn (Component $component): Component => $component instanceof InteractiveComponent
-                ? $component->context([...$context, 'table' => $key])
+                ? $component->mergeContext($context, ['table' => $key])
                 : $component,
             $this->renderableComponents($definition->toolbar()),
         );

--- a/packages/ui/src/Components/IsInteractive.php
+++ b/packages/ui/src/Components/IsInteractive.php
@@ -46,6 +46,20 @@ trait IsInteractive
     }
 
     /**
+     * Merge $context beneath the component's existing context — explicit
+     * keys set at build time win — while $override forces its keys over both.
+     *
+     * @param  array<string, mixed>  $context
+     * @param  array<string, mixed>  $override
+     */
+    public function mergeContext(array $context, array $override = []): static
+    {
+        $this->context = [...$context, ...$this->context, ...$override];
+
+        return $this;
+    }
+
+    /**
      * @param  array<string, mixed>  $props
      * @return array<string, mixed>
      */

--- a/tests/Feature/Core/ContextInheritanceTest.php
+++ b/tests/Feature/Core/ContextInheritanceTest.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Core\Services\ContextScope;
+use Lattice\Form\Attributes\AsForm;
+use Lattice\Form\Components\Form as FormComponent;
+use Lattice\Form\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+use function Pest\Laravel\postJson;
+
+beforeEach(function (): void {
+    config()->set('lattice.context.inherited_keys', ['tenant']);
+    ContextInheritanceChildAction::$seen = [];
+    ContextInheritanceExplicitChildAction::$seenTenant = null;
+
+    Lattice::forms([ContextInheritanceParentForm::class]);
+    Lattice::actions([ContextInheritanceChildAction::class, ContextInheritanceExplicitChildAction::class]);
+});
+
+test('wrap frames nest cumulatively, filter to the whitelist, and pop even when the callback throws', function (): void {
+    $scope = app(ContextScope::class);
+
+    $scope->wrap(['tenant' => 'acme', 'secret' => 'hidden'], function () use ($scope): void {
+        expect($scope->inheritable())->toBe(['tenant' => 'acme']);
+
+        $scope->wrap([...$scope->inheritable(), 'tenant' => 'inner'], function () use ($scope): void {
+            expect($scope->inheritable())->toBe(['tenant' => 'inner']);
+        });
+
+        expect($scope->inheritable())->toBe(['tenant' => 'acme']);
+    });
+
+    expect($scope->inheritable())->toBe([]);
+
+    try {
+        $scope->wrap(['tenant' => 'acme'], fn () => throw new RuntimeException('boom'));
+    } catch (RuntimeException) {
+    }
+
+    expect($scope->inheritable())->toBe([]);
+});
+
+test('a child action built inside a form schema inherits whitelisted context through gate and definition', function (): void {
+    $form = wire(FormComponent::use(ContextInheritanceParentForm::class, ['tenant' => 'acme', 'secret' => 'hidden']));
+
+    expect(wireNode($form, 'ctx-inherit.child'))->not->toBeNull()
+        ->and(ContextInheritanceChildAction::$seen['definition_tenant'])->toBe('acme')
+        ->and(ContextInheritanceChildAction::$seen['definition_secret'])->toBeNull();
+});
+
+test('nothing is inherited when the whitelist is empty', function (): void {
+    config()->set('lattice.context.inherited_keys', []);
+
+    $form = wire(FormComponent::use(ContextInheritanceParentForm::class, ['tenant' => 'acme']));
+
+    expect(wireNode($form, 'ctx-inherit.child'))->toBeNull();
+});
+
+test('explicit child context wins over the inherited value', function (): void {
+    wire(FormComponent::use(ContextInheritanceParentForm::class, ['tenant' => 'acme']));
+
+    expect(ContextInheritanceExplicitChildAction::$seenTenant)->toBe('other');
+});
+
+test('the reserved table key is never inherited, even when whitelisted', function (): void {
+    config()->set('lattice.context.inherited_keys', ['tenant', 'table']);
+
+    wire(FormComponent::use(ContextInheritanceParentForm::class, ['tenant' => 'acme', 'table' => 'evil']));
+
+    expect(ContextInheritanceChildAction::$seen['definition_tenant'])->toBe('acme')
+        ->and(ContextInheritanceChildAction::$seen['definition_table'])->toBeNull();
+});
+
+test('the sealed child ref carries inherited keys to the endpoint but never unlisted ones', function (): void {
+    $form = wire(FormComponent::use(ContextInheritanceParentForm::class, ['tenant' => 'acme', 'secret' => 'hidden']));
+
+    $child = wireNode($form, 'ctx-inherit.child');
+    assert($child !== null);
+
+    postJson('/lattice/actions/ctx-inherit.child', [], ['X-Lattice-Ref' => $child['props']['ref']])
+        ->assertOk();
+
+    expect(ContextInheritanceChildAction::$seen['handle_tenant'])->toBe('acme')
+        ->and(ContextInheritanceChildAction::$seen['handle_secret'])->toBeNull();
+});
+
+#[AsForm('ctx-inherit.parent-form')]
+final class ContextInheritanceParentForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form->schema([
+            ActionComponent::use(ContextInheritanceChildAction::class),
+            ActionComponent::use(ContextInheritanceExplicitChildAction::class, ['tenant' => 'other']),
+        ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        return new Response('ok');
+    }
+}
+
+#[AsAction('ctx-inherit.child')]
+final class ContextInheritanceChildAction extends ActionDefinition
+{
+    /** @var array<string, mixed> */
+    public static array $seen = [];
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        self::$seen['definition_tenant'] = $this->context('tenant');
+        self::$seen['definition_secret'] = $this->context('secret');
+        self::$seen['definition_table'] = $this->context('table');
+
+        return $action->label('Child');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        self::$seen['handle_tenant'] = $this->context('tenant');
+        self::$seen['handle_secret'] = $this->context('secret');
+
+        return ActionResult::success();
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return $this->context('tenant') === 'acme';
+    }
+}
+
+#[AsAction('ctx-inherit.child-explicit')]
+final class ContextInheritanceExplicitChildAction extends ActionDefinition
+{
+    public static ?string $seenTenant = null;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        $tenant = $this->context('tenant');
+        self::$seenTenant = is_string($tenant) ? $tenant : null;
+
+        return $action->label('Explicit child');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+}

--- a/tests/Feature/Tables/RowActionContextInheritanceTest.php
+++ b/tests/Feature/Tables/RowActionContextInheritanceTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\CallbackTableSource;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\Table;
+use Lattice\Table\Contracts\TableSource;
+use Lattice\Table\TableDefinition;
+use Lattice\Table\TableQuery;
+use Lattice\Table\TableResult;
+
+use function Pest\Laravel\postJson;
+
+beforeEach(function (): void {
+    config()->set('lattice.context.inherited_keys', ['tenant']);
+    RowCtxInheritanceAction::$seen = [];
+    RowCtxToolbarAction::$seen = [];
+
+    Lattice::tables([RowCtxInheritanceTable::class]);
+    Lattice::actions([RowCtxInheritanceAction::class, RowCtxToolbarAction::class]);
+});
+
+test('row actions inherit the table context on the build path', function (): void {
+    $table = wire(Table::use(RowCtxInheritanceTable::class, ['tenant' => 'acme']));
+
+    expect($table['props']['data'][0]['actions'][0]['id'])->toBe('ctx-inherit.row-action')
+        ->and(RowCtxInheritanceAction::$seen['definition_tenant'])->toBe('acme')
+        ->and(RowCtxInheritanceAction::$seen['definition_user'])->toBe(1)
+        ->and(RowCtxInheritanceAction::$seen['definition_table'])->toBeNull();
+});
+
+test('row actions are filtered without inheritance when the whitelist is empty', function (): void {
+    config()->set('lattice.context.inherited_keys', []);
+
+    $table = wire(Table::use(RowCtxInheritanceTable::class, ['tenant' => 'acme']));
+
+    expect($table['props']['data'][0]['actions'] ?? [])->toBeEmpty();
+});
+
+test('row actions inherit the trusted table context on the endpoint response path', function (): void {
+    $this->loadTable(RowCtxInheritanceTable::class, [], ['tenant' => 'acme'])
+        ->assertOk()
+        ->assertJsonPath('data.0.actions.0.id', 'ctx-inherit.row-action');
+
+    expect(RowCtxInheritanceAction::$seen['definition_tenant'])->toBe('acme');
+});
+
+test('toolbar actions keep their explicit context, inherit the table context, and get the table key sealed', function (): void {
+    $table = wire(Table::use(RowCtxInheritanceTable::class, ['tenant' => 'acme']));
+
+    $toolbarAction = wireNode($table, 'ctx-inherit.toolbar-action');
+    assert($toolbarAction !== null);
+
+    postJson('/lattice/actions/ctx-inherit.toolbar-action', [], ['X-Lattice-Ref' => $toolbarAction['props']['ref']])
+        ->assertOk();
+
+    expect(RowCtxToolbarAction::$seen['handle_flavor'])->toBe('spicy')
+        ->and(RowCtxToolbarAction::$seen['handle_tenant'])->toBe('acme')
+        ->and(RowCtxToolbarAction::$seen['handle_table'])->toBe('ctx-inherit.table');
+});
+
+#[AsTable('ctx-inherit.table')]
+final class RowCtxInheritanceTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([
+            ['id' => 1, 'name' => 'Taylor'],
+        ]));
+    }
+
+    #[Override]
+    public function actions(array $row): array
+    {
+        return [ActionComponent::use(RowCtxInheritanceAction::class, ['user' => $row['id']])];
+    }
+
+    #[Override]
+    public function toolbar(): array
+    {
+        return [ActionComponent::use(RowCtxToolbarAction::class, ['flavor' => 'spicy'])];
+    }
+}
+
+#[AsAction('ctx-inherit.row-action')]
+final class RowCtxInheritanceAction extends ActionDefinition
+{
+    /** @var array<string, mixed> */
+    public static array $seen = [];
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        self::$seen['definition_tenant'] = $this->context('tenant');
+        self::$seen['definition_user'] = $this->context('user');
+        self::$seen['definition_table'] = $this->context('table');
+
+        return $action->label('Row action');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return $this->context('tenant') === 'acme';
+    }
+}
+
+#[AsAction('ctx-inherit.toolbar-action')]
+final class RowCtxToolbarAction extends ActionDefinition
+{
+    /** @var array<string, mixed> */
+    public static array $seen = [];
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Toolbar action');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        self::$seen['handle_flavor'] = $this->context('flavor');
+        self::$seen['handle_tenant'] = $this->context('tenant');
+        self::$seen['handle_table'] = $this->context('table');
+
+        return ActionResult::success();
+    }
+}

--- a/tests/Support/TestFixtures.php
+++ b/tests/Support/TestFixtures.php
@@ -57,6 +57,27 @@ function wireJson(mixed $value): string
 }
 
 /**
+ * Depth-first search of a wire payload for the component node with the id.
+ *
+ * @param  array<array-key, mixed>  $node
+ * @return array<array-key, mixed>|null
+ */
+function wireNode(array $node, string $id): ?array
+{
+    if (($node['id'] ?? null) === $id) {
+        return $node;
+    }
+
+    foreach ($node as $value) {
+        if (is_array($value) && ($found = wireNode($value, $id)) !== null) {
+            return $found;
+        }
+    }
+
+    return null;
+}
+
+/**
  * @param  array<int|string, string>  $people
  */
 function inMemoryOptionSource(array $people): OptionSource


### PR DESCRIPTION
Components built inside a definition (row actions, modal forms, nested actions in form schemas) start with an empty context today — every consumer has to re-thread shared keys like a tenant slug into each nested `Form::use`/`Action::use`, and a forgotten key silently hides the component at the render gate (artisan-os/artisan-os#141: empty row-action menus).

**Opt-in context inheritance:**
- New request-scoped `ContextScope` (core): `gatedComponent` merges the ambient frame *beneath* the explicit context — gate and sealed ref see the same merged array — and wraps the configure step in a frame, so children built inside inherit it. Cumulative over nesting depths, inner frame wins, `finally`-popped.
- `authorizeComponent` activates the trusted context at endpoints, so response paths (table reloads rebuilding row actions, form schema rebuilds, fragments) see exactly what the render path saw.
- Inheritance is **whitelist-only** via `lattice.context.inherited_keys` (default `[]`): context can carry routing/policy values (bulk-action `table` key, media upload rules) that must never cascade — `table` is additionally hard-reserved.

**Toolbar/bulk context fix** (prerequisite): the post-gating injection replaced a toolbar/bulk component's context wholesale, dropping explicit context passed to `Action::use` in a toolbar. New `InteractiveComponent::mergeContext` keeps explicit keys, fills gaps from the table context, and still forces the `table` key.

Tests: gate/seal identity, nesting + explicit-wins, whitelist filtering incl. reserved `table`, sealed-ref roundtrips to the endpoint, row-action inheritance on build **and** response path (the latter red without the endpoint activation), toolbar merge roundtrip. Full suite + phpstan + rector green.
