### PR TITLE
feat: expose notification API route profiles

### DIFF
--- a/packages/framework/config/lattice.php
+++ b/packages/framework/config/lattice.php
@@ -82,6 +82,10 @@ return [
     'notifications' => [
         'endpoint' => 'lattice/notifications',
         'middleware' => ['web', 'auth'],
+        // Named profiles expose the same inbox through different authentication stacks.
+        // When empty, the endpoint and middleware above register the original route group.
+        'routes' => [],
+        'component_route' => 'web',
         'per_page' => 15,
         'polling_interval' => null,
         'prune_after_days' => 30,

--- a/packages/framework/routes/web.php
+++ b/packages/framework/routes/web.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Route;
 use Lattice\Http\Controllers\BulkActionController;
 use Lattice\Http\Controllers\FragmentController;
-use Lattice\Http\Controllers\NotificationController;
 use Lattice\Http\Controllers\RemoteSourceTokenController;
+use Lattice\Notifications\NotificationRoutes;
 
 Route::middleware(config('lattice.bulk-actions.middleware'))
     ->match(['post', 'put', 'patch', 'delete'], 'lattice/bulk-actions/{bulkAction}', BulkActionController::class)
@@ -22,13 +22,4 @@ Route::middleware(config('lattice.remote-sources.middleware'))
     ->where('source', '.*')
     ->name('lattice.remote-sources.token');
 
-Route::middleware(config('lattice.notifications.middleware', ['web', 'auth']))
-    ->prefix(config('lattice.notifications.endpoint', 'lattice/notifications'))
-    ->name('lattice.notifications.')
-    ->group(function (): void {
-        Route::get('/', [NotificationController::class, 'index'])->name('index');
-        Route::post('read-all', [NotificationController::class, 'readAll'])->name('read-all');
-        Route::patch('{id}/read', [NotificationController::class, 'read'])->name('read');
-        Route::delete('{id}', [NotificationController::class, 'destroy'])->name('destroy');
-        Route::delete('/', [NotificationController::class, 'clear'])->name('clear');
-    });
+NotificationRoutes::register();

--- a/packages/framework/src/Http/Controllers/NotificationController.php
+++ b/packages/framework/src/Http/Controllers/NotificationController.php
@@ -3,18 +3,21 @@ declare(strict_types=1);
 
 namespace Lattice\Http\Controllers;
 
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\DatabaseNotification;
 use Lattice\Notifications\NotificationItem;
 use Lattice\Notifications\NotificationList;
-use Lattice\Notifications\Support\ActionDescriptor;
+use Lattice\Notifications\NotificationPresenter;
+use Lattice\Notifications\NotificationRoutes;
+use Lattice\Notifications\NotificationTranslationMode;
 use Lattice\Notifications\UnreadCount;
-use Lattice\Ui\Enums\Variant;
-use Lattice\Ui\I18n\Values\Translatable;
 
-final class NotificationController
+final readonly class NotificationController
 {
+    public function __construct(private NotificationPresenter $presenter) {}
+
     public function index(Request $request): JsonResponse
     {
         $notifiable = $request->user();
@@ -26,12 +29,45 @@ final class NotificationController
         $perPage = (int) config('lattice.notifications.per_page', 15);
 
         $notifications = $notifiable->notifications()->paginate($perPage);
+        $translationMode = $this->translationMode($request);
+        $locale = $this->locale($notifiable);
 
         return response()->json(new NotificationList(
-            notifications: array_values(array_map($this->present(...), $notifications->items())),
+            notifications: array_values(array_map(
+                fn (DatabaseNotification $notification): NotificationItem => $this->presenter->present($notification, $translationMode, $locale),
+                $notifications->items(),
+            )),
             unreadCount: $notifiable->unreadNotifications()->count(),
             hasMore: $notifications->hasMorePages(),
         ));
+    }
+
+    public function show(Request $request, string $id): JsonResponse
+    {
+        $notifiable = $request->user();
+
+        if ($notifiable === null) {
+            abort(401);
+        }
+
+        $notification = $notifiable->notifications()->findOrFail($id);
+
+        return response()->json($this->presenter->present(
+            $notification,
+            $this->translationMode($request),
+            $this->locale($notifiable),
+        ));
+    }
+
+    public function unreadCount(Request $request): JsonResponse
+    {
+        $notifiable = $request->user();
+
+        if ($notifiable === null) {
+            abort(401);
+        }
+
+        return $this->count($notifiable);
     }
 
     public function read(Request $request, string $id): JsonResponse
@@ -91,29 +127,23 @@ final class NotificationController
         return response()->json(new UnreadCount($notifiable->unreadNotifications()->count()));
     }
 
-    private function present(DatabaseNotification $notification): NotificationItem
+    private function translationMode(Request $request): NotificationTranslationMode
     {
-        $data = $notification->getAttribute('data');
-        $variant = $data['variant'] ?? null;
+        $translationMode = $request->route(NotificationRoutes::TranslationModeParameter);
 
-        return new NotificationItem(
-            id: $notification->getAttribute('id'),
-            title: $this->text($data['title'] ?? $data['message'] ?? $data['subject'] ?? null),
-            body: $this->text($data['body'] ?? (($data['title'] ?? null) ? ($data['message'] ?? null) : null)),
-            icon: $data['icon'] ?? null,
-            variant: is_string($variant) ? Variant::tryFrom($variant) : null,
-            href: $data['href'] ?? null,
-            isRead: $notification->getAttribute('read_at') !== null,
-            createdAt: $notification->getAttribute('created_at')?->toIso8601String(),
-            actions: array_values(array_filter(array_map(
-                ActionDescriptor::materialize(...),
-                $data['actions'] ?? [],
-            ))),
-        );
+        return is_string($translationMode)
+            ? NotificationTranslationMode::tryFrom($translationMode) ?? NotificationTranslationMode::Wire
+            : NotificationTranslationMode::Wire;
     }
 
-    private function text(mixed $value): string|Translatable|null
+    private function locale(mixed $notifiable): ?string
     {
-        return Translatable::tryFromWire($value) ?? (is_string($value) ? $value : null);
+        if (! $notifiable instanceof HasLocalePreference) {
+            return null;
+        }
+
+        $locale = $notifiable->preferredLocale();
+
+        return is_string($locale) && $locale !== '' ? $locale : null;
     }
 }

--- a/packages/framework/src/Layouts/Components/Sidebar.php
+++ b/packages/framework/src/Layouts/Components/Sidebar.php
@@ -62,6 +62,6 @@ class Sidebar extends ContainerComponent
     {
         $children = parent::resolvedChildren();
 
-        return ! $this->footerNode instanceof SidebarFooter ? $children : [...$children, $this->footerNode];
+        return $this->footerNode instanceof SidebarFooter ? [...$children, $this->footerNode] : $children;
     }
 }

--- a/packages/framework/src/Notifications/Components/Notifications.php
+++ b/packages/framework/src/Notifications/Components/Notifications.php
@@ -5,6 +5,7 @@ namespace Lattice\Notifications\Components;
 
 use Lattice\Core\Attributes\AsComponent;
 use Lattice\Notifications\NotificationChannel;
+use Lattice\Notifications\NotificationRoutes;
 use Lattice\Ui\Components\Component;
 
 #[AsComponent('notifications')]
@@ -21,7 +22,7 @@ class Notifications extends Component
     public static function make(?string $key = null): static
     {
         $component = new static($key);
-        $component->endpoint = '/'.ltrim((string) config('lattice.notifications.endpoint', 'lattice/notifications'), '/');
+        $component->endpoint = '/'.ltrim(NotificationRoutes::componentEndpoint(), '/');
         $component->pollingInterval = config('lattice.notifications.polling_interval');
 
         $user = auth()->user();

--- a/packages/framework/src/Notifications/NotificationPresenter.php
+++ b/packages/framework/src/Notifications/NotificationPresenter.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Notifications;
+
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Lattice\Notifications\Support\ActionDescriptor;
+use Lattice\Ui\Enums\Variant;
+use Lattice\Ui\I18n\Values\Translatable;
+
+final readonly class NotificationPresenter
+{
+    public function __construct(private Translator $translator) {}
+
+    public function present(
+        DatabaseNotification $notification,
+        NotificationTranslationMode $translationMode,
+        ?string $locale = null,
+    ): NotificationItem {
+        $data = $notification->getAttribute('data');
+        $data = is_array($data) ? $data : [];
+        $variant = $data['variant'] ?? null;
+
+        return new NotificationItem(
+            id: $notification->getAttribute('id'),
+            title: $this->text($data['title'] ?? $data['message'] ?? $data['subject'] ?? null, $data, $translationMode, $locale),
+            body: $this->text($data['body'] ?? (($data['title'] ?? null) ? ($data['message'] ?? null) : null), $data, $translationMode, $locale),
+            icon: $data['icon'] ?? null,
+            variant: is_string($variant) ? Variant::tryFrom($variant) : null,
+            href: $data['href'] ?? null,
+            isRead: $notification->getAttribute('read_at') !== null,
+            createdAt: $notification->getAttribute('created_at')?->toIso8601String(),
+            actions: array_values(array_filter(array_map(
+                ActionDescriptor::materialize(...),
+                $data['actions'] ?? [],
+            ))),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function text(
+        mixed $value,
+        array $data,
+        NotificationTranslationMode $translationMode,
+        ?string $locale,
+    ): string|Translatable|null {
+        $translatable = Translatable::tryFromWire($value);
+
+        if (! $translatable instanceof Translatable) {
+            return is_string($value) ? $value : null;
+        }
+
+        if ($translationMode === NotificationTranslationMode::Wire) {
+            return $translatable;
+        }
+
+        $translation = $this->translator->get(
+            Str::replaceFirst(':', '.', $translatable->key),
+            $this->replacements($translatable, $data),
+            $locale,
+        );
+
+        return is_string($translation) ? $translation : $translatable->key;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, string|int|float|bool>
+     */
+    private function replacements(Translatable $translatable, array $data): array
+    {
+        $replacements = $translatable->replacements;
+
+        foreach ($translatable->payload as $name => $path) {
+            $value = Arr::get($data, $path);
+
+            if (is_string($value) || is_int($value) || is_float($value) || is_bool($value)) {
+                $replacements[$name] = $value;
+            }
+        }
+
+        return $replacements;
+    }
+}

--- a/packages/framework/src/Notifications/NotificationRoutes.php
+++ b/packages/framework/src/Notifications/NotificationRoutes.php
@@ -1,0 +1,161 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Notifications;
+
+use Illuminate\Routing\Route as LaravelRoute;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Lattice\Http\Controllers\NotificationController;
+
+final class NotificationRoutes
+{
+    public const string TranslationModeParameter = '_lattice_notification_translation_mode';
+
+    public static function register(): void
+    {
+        foreach (self::profiles() as $name => $profile) {
+            self::registerProfile($name, $profile);
+        }
+    }
+
+    public static function componentEndpoint(): string
+    {
+        $profileName = config('lattice.notifications.component_route') ?? 'web';
+        $profiles = config('lattice.notifications.routes');
+
+        if (is_string($profileName) && is_array($profiles)) {
+            $profile = $profiles[$profileName] ?? null;
+            $endpoint = is_array($profile) ? ($profile['endpoint'] ?? null) : null;
+
+            if (is_string($endpoint) && $endpoint !== '') {
+                return $endpoint;
+            }
+        }
+
+        return (string) config('lattice.notifications.endpoint', 'lattice/notifications');
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function profiles(): array
+    {
+        $configured = config('lattice.notifications.routes');
+
+        if (! is_array($configured) || $configured === []) {
+            return [
+                'web' => [
+                    'endpoint' => config('lattice.notifications.endpoint', 'lattice/notifications'),
+                    'middleware' => config('lattice.notifications.middleware', ['web', 'auth']),
+                    'name' => 'lattice.notifications.',
+                    'translations' => NotificationTranslationMode::Wire->value,
+                ],
+            ];
+        }
+
+        $profiles = [];
+
+        foreach ($configured as $name => $profile) {
+            if (! is_string($name) || ! is_array($profile)) {
+                throw new InvalidArgumentException('Lattice notification route profiles must be named configuration arrays.');
+            }
+
+            $profiles[$name] = $profile;
+        }
+
+        return $profiles;
+    }
+
+    /**
+     * @param  array<string, mixed>  $profile
+     */
+    private static function registerProfile(string $name, array $profile): void
+    {
+        $endpoint = self::requiredString($profile['endpoint'] ?? null, "notifications.routes.{$name}.endpoint");
+        $middleware = self::middleware($profile['middleware'] ?? ['web', 'auth']);
+        $routeName = Str::finish(self::requiredString(
+            $profile['name'] ?? "lattice.notifications.{$name}",
+            "notifications.routes.{$name}.name",
+        ), '.');
+        $translationMode = self::translationMode($profile['translations'] ?? NotificationTranslationMode::Wire->value, $name);
+
+        Route::middleware($middleware)
+            ->prefix($endpoint)
+            ->name($routeName)
+            ->group(function () use ($translationMode): void {
+                self::withTranslationMode(
+                    Route::get('/', [NotificationController::class, 'index'])->name('index'),
+                    $translationMode,
+                );
+                self::withTranslationMode(
+                    Route::get('unread-count', [NotificationController::class, 'unreadCount'])->name('unread-count'),
+                    $translationMode,
+                );
+                self::withTranslationMode(
+                    Route::post('read-all', [NotificationController::class, 'readAll'])->name('read-all'),
+                    $translationMode,
+                );
+                self::withTranslationMode(
+                    Route::get('{id}', [NotificationController::class, 'show'])->name('show'),
+                    $translationMode,
+                );
+                self::withTranslationMode(
+                    Route::patch('{id}/read', [NotificationController::class, 'read'])->name('read'),
+                    $translationMode,
+                );
+                self::withTranslationMode(
+                    Route::delete('{id}', [NotificationController::class, 'destroy'])->name('destroy'),
+                    $translationMode,
+                );
+                self::withTranslationMode(
+                    Route::delete('/', [NotificationController::class, 'clear'])->name('clear'),
+                    $translationMode,
+                );
+            });
+    }
+
+    private static function withTranslationMode(LaravelRoute $route, NotificationTranslationMode $translationMode): void
+    {
+        $route->defaults(self::TranslationModeParameter, $translationMode->value);
+    }
+
+    private static function requiredString(mixed $value, string $key): string
+    {
+        if (! is_string($value) || $value === '') {
+            throw new InvalidArgumentException("Lattice [{$key}] must be a non-empty string.");
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function middleware(mixed $middleware): array
+    {
+        if (! is_array($middleware)) {
+            throw new InvalidArgumentException('Lattice notification route middleware must be an array.');
+        }
+
+        foreach ($middleware as $value) {
+            if (! is_string($value)) {
+                throw new InvalidArgumentException('Lattice notification route middleware entries must be strings.');
+            }
+        }
+
+        return array_values($middleware);
+    }
+
+    private static function translationMode(mixed $value, string $name): NotificationTranslationMode
+    {
+        $translationMode = is_string($value) ? NotificationTranslationMode::tryFrom($value) : null;
+
+        if ($translationMode === null) {
+            throw new InvalidArgumentException("Lattice notification route profile [{$name}] has an invalid translation mode.");
+        }
+
+        return $translationMode;
+    }
+}

--- a/packages/framework/src/Notifications/NotificationTranslationMode.php
+++ b/packages/framework/src/Notifications/NotificationTranslationMode.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Notifications;
+
+enum NotificationTranslationMode: string
+{
+    case Wire = 'wire';
+    case Resolved = 'resolved';
+}

--- a/tests/Feature/Notifications/NotificationIndexTest.php
+++ b/tests/Feature/Notifications/NotificationIndexTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Str;
 use Lattice\Actions\ActionDefinition;
 use Lattice\Actions\ActionResult;
@@ -44,6 +45,50 @@ test('index returns translatable titles and bodies as their wire shape', functio
         ->assertJsonPath('notifications.0.title.key', 'orders.shipped.title')
         ->assertJsonPath('notifications.0.body.key', 'orders.shipped.body')
         ->assertJsonPath('notifications.0.body.replacements.order', 1234);
+});
+
+test('show returns one of the users notifications', function (): void {
+    $user = workbenchTestUser();
+    Notification::make()->title('Order shipped')->send($user);
+    $notification = $user->notifications()->first();
+    expect($notification)->toBeInstanceOf(DatabaseNotification::class);
+    assert($notification instanceof DatabaseNotification);
+
+    actingAs($user);
+
+    getJson("/lattice/notifications/{$notification->id}")
+        ->assertOk()
+        ->assertJsonPath('id', $notification->id)
+        ->assertJsonPath('title', 'Order shipped');
+});
+
+test('show never leaks another users notification', function (): void {
+    $me = workbenchTestUser();
+    $other = workbenchTestUser();
+    Notification::make()->title('Theirs')->send($other);
+    $notification = $other->notifications()->first();
+    expect($notification)->toBeInstanceOf(DatabaseNotification::class);
+    assert($notification instanceof DatabaseNotification);
+
+    actingAs($me);
+
+    getJson("/lattice/notifications/{$notification->id}")->assertNotFound();
+});
+
+test('unread count returns only the users unread notifications', function (): void {
+    $user = workbenchTestUser();
+    Notification::make()->title('Read')->send($user);
+    Notification::make()->title('Unread')->send($user);
+    $notification = $user->notifications()->latest()->first();
+    expect($notification)->toBeInstanceOf(DatabaseNotification::class);
+    assert($notification instanceof DatabaseNotification);
+    $notification->markAsRead();
+
+    actingAs($user);
+
+    getJson('/lattice/notifications/unread-count')
+        ->assertOk()
+        ->assertJsonPath('unreadCount', 1);
 });
 
 test('index never leaks another users notifications', function (): void {

--- a/tests/Feature/Notifications/NotificationRouteProfilesTest.php
+++ b/tests/Feature/Notifications/NotificationRouteProfilesTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Route;
+use Lattice\Notifications\Notification;
+use Lattice\Notifications\NotificationRoutes;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+test('configured route profiles expose the same notification API with their own presentation mode', function (): void {
+    config()->set('lattice.notifications.routes', [
+        'browser' => [
+            'endpoint' => 'browser/notifications',
+            'middleware' => ['web', 'auth'],
+            'name' => 'browser.notifications',
+        ],
+        'mobile' => [
+            'endpoint' => 'api/mobile-notifications',
+            'middleware' => ['api', 'auth'],
+            'name' => 'mobile.notifications',
+            'translations' => 'resolved',
+        ],
+    ]);
+
+    NotificationRoutes::register();
+    Route::getRoutes()->refreshNameLookups();
+
+    $indexRoute = Route::getRoutes()->getByName('mobile.notifications.index');
+    expect($indexRoute)->not->toBeNull()
+        ->and($indexRoute?->uri())->toBe('api/mobile-notifications')
+        ->and($indexRoute?->gatherMiddleware())->toContain('api', 'auth')
+        ->and(Route::getRoutes()->getByName('browser.notifications.index'))->not->toBeNull()
+        ->and(Route::getRoutes()->getByName('mobile.notifications.show'))->not->toBeNull()
+        ->and(Route::getRoutes()->getByName('mobile.notifications.unread-count'))->not->toBeNull();
+
+    Lang::addLines([
+        'orders.shipped.title' => 'Bestellung :order versandt',
+        'orders.shipped.body' => 'Die Bestellung ist unterwegs.',
+    ], 'de');
+
+    $user = workbenchTestUser();
+    $user->update(['locale' => 'de']);
+    Notification::make()
+        ->title(rt('orders:shipped.title')->with(['order' => 1234]))
+        ->body(rt('orders:shipped.body'))
+        ->send($user);
+
+    actingAs($user);
+
+    getJson('/api/mobile-notifications')
+        ->assertOk()
+        ->assertJsonPath('notifications.0.title', 'Bestellung 1234 versandt')
+        ->assertJsonPath('notifications.0.body', 'Die Bestellung ist unterwegs.');
+});

--- a/tests/Feature/Notifications/NotificationsComponentTest.php
+++ b/tests/Feature/Notifications/NotificationsComponentTest.php
@@ -23,6 +23,19 @@ test('the bell serializes its endpoint, channel and mode', function (): void {
     ]);
 });
 
+test('the bell uses the configured browser route profile endpoint', function (): void {
+    config()->set('lattice.notifications.component_route', 'browser');
+    config()->set('lattice.notifications.routes', [
+        'browser' => [
+            'endpoint' => 'inbox/notifications',
+        ],
+    ]);
+
+    $payload = wire(Notifications::make());
+
+    expect($payload)->toHaveKey('props.endpoint', '/inbox/notifications');
+});
+
 describe('docs fixtures', function (): void {
     test('matches the bell example fixture', function (): void {
         assertFixtureMatches('notifications.bell', Wire::toWire([


### PR DESCRIPTION
## Summary

- expose one notification inbox through multiple route profiles with independent endpoints, middleware, route names, and translation modes
- preserve deferred wire translations for browser clients while allowing locale-resolved strings for native/API clients
- add notification detail and lightweight unread-count endpoints without duplicating inbox behavior in consuming apps
- include the Rector normalization required for the repository gate

## Checks

- `composer check`
- `npm run check`
