### PR TITLE
feat(form): let Choice render its options as cards

### DIFF
--- a/docs/fixtures/choice.basic.json
+++ b/docs/fixtures/choice.basic.json
@@ -12,6 +12,7 @@
             "label": "Plan",
             "labelAction": null,
             "name": "plan",
+            "optionSchema": null,
             "options": [
                 {
                     "data": null,

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -12,6 +12,7 @@
             "label": "Country",
             "labelAction": null,
             "name": "country",
+            "optionSchema": null,
             "options": [
                 {
                     "data": null,

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -12,6 +12,7 @@
             "label": "Account type",
             "labelAction": null,
             "name": "type",
+            "optionSchema": null,
             "options": [
                 {
                     "data": null,

--- a/docs/fixtures/pattern-input.basic.json
+++ b/docs/fixtures/pattern-input.basic.json
@@ -34,6 +34,7 @@
                                 "label": "Padding",
                                 "labelAction": null,
                                 "name": "padding",
+                                "optionSchema": null,
                                 "options": [
                                     {
                                         "data": null,

--- a/packages/form/resources/js/components/fields/choice.tsx
+++ b/packages/form/resources/js/components/fields/choice.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { Option, RendererComponent } from "@lattice-php/core";
+import { OptionCards } from "@lattice-php/ui/option-cards";
 import { SegmentedPills } from "@lattice-php/ui/segmented-pills";
 import { FormFieldFrame } from "@lattice-php/form/components/base/field";
 import { fieldLabelAction } from "@lattice-php/form/components/base/label-action";
@@ -15,6 +16,7 @@ export const ChoiceComponent: RendererComponent<"field.choice"> = ({ node }) => 
     () => (resolvedNode.props as { options?: Option[] }).options ?? [],
     [resolvedNode.props],
   );
+  const optionSchema = resolvedNode.props.optionSchema;
   const fallbackValue = options[0]?.value ?? "";
   const selected = value || fallbackValue;
 
@@ -37,17 +39,32 @@ export const ChoiceComponent: RendererComponent<"field.choice"> = ({ node }) => 
       {(controlProps) => (
         <>
           <input name={name} type="hidden" value={selected} />
-          <SegmentedPills
-            {...controlProps}
-            ariaLabel={node.props.label ?? undefined}
-            autoFocus={node.props.autoFocus ?? undefined}
-            disabled={readOnly || disabled}
-            name={testId ?? "segment"}
-            onSelect={commit}
-            options={options}
-            tabIndex={node.props.tabIndex ?? undefined}
-            value={selected}
-          />
+          {optionSchema?.length ? (
+            <OptionCards
+              {...controlProps}
+              ariaLabel={node.props.label ?? undefined}
+              autoFocus={node.props.autoFocus ?? undefined}
+              disabled={readOnly || disabled}
+              name={testId ?? "choice"}
+              onSelect={commit}
+              optionSchema={optionSchema}
+              options={options}
+              tabIndex={node.props.tabIndex ?? undefined}
+              value={selected}
+            />
+          ) : (
+            <SegmentedPills
+              {...controlProps}
+              ariaLabel={node.props.label ?? undefined}
+              autoFocus={node.props.autoFocus ?? undefined}
+              disabled={readOnly || disabled}
+              name={testId ?? "segment"}
+              onSelect={commit}
+              options={options}
+              tabIndex={node.props.tabIndex ?? undefined}
+              value={selected}
+            />
+          )}
         </>
       )}
     </FormFieldFrame>

--- a/packages/form/resources/js/generated.ts
+++ b/packages/form/resources/js/generated.ts
@@ -68,6 +68,7 @@ export type Choice = {
   label: string | null;
   labelAction: Node | null;
   name: string;
+  optionSchema: Node[] | null;
   options: Option[];
   prefillRefreshOn: string[] | null;
   prefillResetOn: string[] | null;

--- a/packages/form/src/Components/Choice.php
+++ b/packages/form/src/Components/Choice.php
@@ -6,6 +6,8 @@ namespace Lattice\Form\Components;
 use Illuminate\Validation\Rule;
 use Lattice\Form\Attributes\AsField;
 use Lattice\Form\Enums\FieldType;
+use Lattice\Ui\Components\Component;
+use Lattice\Ui\Concerns\FiltersRenderableComponents;
 use Lattice\Ui\Concerns\HasAutoFocus;
 use Lattice\Ui\Concerns\HasOptions;
 use Lattice\Ui\Concerns\HasTabIndex;
@@ -13,9 +15,29 @@ use Lattice\Ui\Concerns\HasTabIndex;
 #[AsField(FieldType::Choice)]
 class Choice extends Field
 {
+    use FiltersRenderableComponents;
     use HasAutoFocus;
     use HasOptions;
     use HasTabIndex;
+
+    /** @var list<Component>|null */
+    public ?array $optionSchema = null;
+
+    /**
+     * Render each option as a card built from a schema of bound components
+     * instead of a label-only pill. Components bind option fields with
+     * `->dataKey($prop, $key)`; bindings resolve against the option's `data`
+     * record plus its `label` and `value`. The schema ships once on the wire —
+     * options only carry data. Mirrors {@see Select::optionSchema()}.
+     *
+     * @param  array<int, Component>  $components
+     */
+    public function optionSchema(array $components): static
+    {
+        $this->optionSchema = $components === [] ? null : array_values($components);
+
+        return $this;
+    }
 
     /**
      * A choice is always backed by a fixed set of options, so its submitted
@@ -32,5 +54,22 @@ class Choice extends Field
         }
 
         return ['nullable', Rule::in($this->optionValues())];
+    }
+
+    /**
+     * @param  array<string, mixed>  $props
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function decorateProps(array $props): array
+    {
+        $props = parent::decorateProps($props);
+
+        if ($this->optionSchema !== null) {
+            $schema = $this->renderableComponents($this->optionSchema);
+            $props['optionSchema'] = $schema === [] ? null : $schema;
+        }
+
+        return $props;
     }
 }

--- a/packages/ui/resources/js/option-cards.test.tsx
+++ b/packages/ui/resources/js/option-cards.test.tsx
@@ -1,0 +1,118 @@
+import { configure, fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent } from "@lattice-php/core/registry";
+import { renderWithRegistry } from "@lattice-php/core/test-support";
+import type { Node, Option } from "@lattice-php/core/types";
+import { OptionCards } from "./option-cards";
+
+configure({ testIdAttribute: "data-test" });
+
+const registry = createRegistry({
+  components: {
+    text: eagerComponent(({ node }: { node: Node }) => (
+      <span>{String((node.props as { text?: unknown }).text ?? "")}</span>
+    )),
+  },
+  name: "test/option-cards",
+});
+
+const optionSchema: Node[] = [
+  { key: "name", type: "text", props: { text: "", dataBindings: { text: "label" } } },
+  { key: "hint", type: "text", props: { text: "", dataBindings: { text: "description" } } },
+];
+
+const options: Option[] = [
+  { label: "Passkey", value: "passkey", data: { description: "Face ID or Touch ID" } },
+  { label: "Authenticator", value: "totp", data: { description: "Six digit code" } },
+];
+
+function renderCards(props: Partial<Parameters<typeof OptionCards>[0]> = {}) {
+  return renderWithRegistry(
+    <OptionCards
+      name="provider"
+      onSelect={vi.fn<(value: string) => void>()}
+      optionSchema={optionSchema}
+      options={options}
+      value="passkey"
+      {...props}
+    />,
+    registry,
+  );
+}
+
+describe("OptionCards", () => {
+  it("renders each option through the bound schema", () => {
+    renderCards();
+
+    expect(screen.getByTestId("provider-passkey")).toHaveTextContent("Passkey");
+    expect(screen.getByTestId("provider-passkey")).toHaveTextContent("Face ID or Touch ID");
+    expect(screen.getByTestId("provider-totp")).toHaveTextContent("Six digit code");
+    expect(screen.getAllByRole("radio")).toHaveLength(2);
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+  });
+
+  it("marks the selected card and calls onSelect on click", () => {
+    const onSelect = vi.fn<(value: string) => void>();
+    renderCards({ onSelect });
+
+    expect(screen.getByTestId("provider-passkey")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("provider-totp")).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(screen.getByTestId("provider-totp"));
+    expect(onSelect).toHaveBeenCalledWith("totp");
+  });
+
+  it("moves the selection to the next card with the arrow keys", () => {
+    const onSelect = vi.fn<(value: string) => void>();
+    renderCards({ onSelect, value: "passkey" });
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowDown" });
+
+    expect(onSelect).toHaveBeenCalledWith("totp");
+  });
+
+  it("wraps past either end of the group", () => {
+    const onSelect = vi.fn<(value: string) => void>();
+    const { unmount } = renderCards({ onSelect, value: "passkey" });
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowUp" });
+    expect(onSelect).toHaveBeenCalledWith("totp");
+
+    unmount();
+    onSelect.mockClear();
+    renderCards({ onSelect, value: "totp" });
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowDown" });
+    expect(onSelect).toHaveBeenCalledWith("passkey");
+  });
+
+  it("keeps a single tab stop on the selected card", () => {
+    renderCards({ value: "totp" });
+
+    expect(screen.getByTestId("provider-totp")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("provider-passkey")).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("gives the first card the tab stop while nothing is selected", () => {
+    renderCards({ value: "" });
+
+    expect(screen.getByTestId("provider-passkey")).toHaveAttribute("tabindex", "0");
+  });
+
+  it("focuses the selected card when autoFocus is on", () => {
+    renderCards({ autoFocus: true, value: "totp" });
+
+    expect(screen.getByTestId("provider-totp")).toHaveFocus();
+  });
+
+  it("ignores the arrow keys and disables every card when disabled", () => {
+    const onSelect = vi.fn<(value: string) => void>();
+    renderCards({ disabled: true, onSelect });
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowDown" });
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByTestId("provider-passkey")).toBeDisabled();
+    expect(screen.getByTestId("provider-totp")).toBeDisabled();
+  });
+});

--- a/packages/ui/resources/js/option-cards.tsx
+++ b/packages/ui/resources/js/option-cards.tsx
@@ -1,0 +1,128 @@
+import { type ComponentProps, type KeyboardEvent, useEffect, useRef } from "react";
+import type { Option, Schema } from "@lattice-php/core/types";
+import { materializeSchema } from "@lattice-php/core/materialize";
+import { Renderer } from "@lattice-php/core/renderer";
+import { cn } from "./lib/utils";
+
+const PREVIOUS_KEYS = new Set(["ArrowUp", "ArrowLeft"]);
+const NEXT_KEYS = new Set(["ArrowDown", "ArrowRight"]);
+
+/**
+ * Presentational radio-card group: each option renders through a bound
+ * component schema instead of a bare label, so an option can carry an icon, a
+ * description, and badges. The sibling to {@see SegmentedPills} — same prop
+ * shape, so a control can pick either presentation from the same options.
+ */
+export function OptionCards({
+  ariaLabel,
+  autoFocus = false,
+  className,
+  disabled = false,
+  name,
+  onSelect,
+  optionSchema,
+  options,
+  tabIndex,
+  value,
+  ...props
+}: Omit<ComponentProps<"div">, "children" | "onSelect" | "ref"> & {
+  ariaLabel?: string;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  name: string;
+  onSelect: (value: string) => void;
+  optionSchema: Schema;
+  options: Option[];
+  tabIndex?: number;
+  value: string;
+}) {
+  const groupRef = useRef<HTMLDivElement>(null);
+  const hasSelection = options.some((option) => option.value === value);
+
+  useEffect(() => {
+    if (!autoFocus) {
+      return;
+    }
+
+    const group = groupRef.current;
+    const target =
+      group?.querySelector<HTMLButtonElement>('button[aria-checked="true"]') ??
+      group?.querySelector<HTMLButtonElement>("button");
+
+    target?.focus();
+  }, [autoFocus]);
+
+  // Selection follows focus inside a radiogroup, so the arrow keys both move and
+  // commit; the group keeps a single tab stop on the checked card.
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (disabled || options.length === 0) {
+      return;
+    }
+
+    const step = NEXT_KEYS.has(event.key) ? 1 : PREVIOUS_KEYS.has(event.key) ? -1 : 0;
+
+    if (step === 0) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const current = options.findIndex((option) => option.value === value);
+    const next = options[(current + step + options.length) % options.length];
+
+    if (!next) {
+      return;
+    }
+
+    onSelect(next.value);
+    groupRef.current
+      ?.querySelector<HTMLButtonElement>(`[data-test="${name}-${next.value}"]`)
+      ?.focus();
+  };
+
+  return (
+    <div
+      {...props}
+      aria-label={ariaLabel}
+      className={cn("grid w-full gap-2", className)}
+      onKeyDown={onKeyDown}
+      ref={groupRef}
+      role="radiogroup"
+    >
+      {options.map((option, index) => {
+        const isSelected = value === option.value;
+        // With nothing selected the group would have no tab stop at all, so the
+        // first card takes it until a choice is made.
+        const isTabStop = isSelected || (!hasSelection && index === 0);
+
+        return (
+          <button
+            aria-checked={isSelected}
+            className={cn(
+              "rounded-lt border p-4 text-left transition-colors",
+              isSelected
+                ? "border-lt-primary bg-lt-accent text-lt-accent-fg"
+                : "border-lt-border hover:border-lt-input",
+              disabled && "cursor-not-allowed opacity-60",
+            )}
+            data-test={`${name}-${option.value}`}
+            disabled={disabled}
+            key={option.value}
+            onClick={() => onSelect(option.value)}
+            role="radio"
+            tabIndex={isTabStop ? (tabIndex ?? 0) : -1}
+            type="button"
+          >
+            <Renderer
+              nodes={materializeSchema(optionSchema, {
+                ...option.data,
+                label: option.label,
+                value: option.value,
+              })}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/tests/Feature/Forms/Components/ChoiceTest.php
+++ b/tests/Feature/Forms/Components/ChoiceTest.php
@@ -3,6 +3,44 @@ declare(strict_types=1);
 
 use Lattice\Core\Support\Wire;
 use Lattice\Form\Components\Choice;
+use Lattice\Ui\Components\Badge;
+use Lattice\Ui\Components\Text;
+
+it('serializes the option schema only when set', function (): void {
+    $plain = Choice::make('plan', 'Plan')->options([Choice::option('Free', 'free')]);
+
+    expect(wire($plain)['props']['optionSchema'])->toBeNull();
+
+    $rich = Choice::make('provider', 'Method')->optionSchema([
+        Text::make('')->dataKey('text', 'label'),
+        Badge::make('')->dataKey('label', 'role'),
+    ]);
+
+    $schema = wire($rich)['props']['optionSchema'];
+
+    expect($schema)->toHaveCount(2)
+        ->and($schema[0]['type'])->toBe('text')
+        ->and($schema[0]['props']['dataBindings'])->toBe(['text' => 'label'])
+        ->and($schema[1]['type'])->toBe('badge')
+        ->and($schema[1]['props']['dataBindings'])->toBe(['label' => 'role']);
+});
+
+it('omits the option schema when every component is hidden', function (): void {
+    $field = Choice::make('provider', 'Method')->optionSchema([
+        Text::make('')->dataKey('text', 'label')->hidden(),
+    ]);
+
+    expect(wire($field)['props']['optionSchema'])->toBeNull();
+});
+
+it('keeps per-option data available to the schema', function (): void {
+    $field = Choice::make('provider', 'Method')->options([
+        Choice::option('Passkey', 'passkey', ['description' => 'Face ID or Touch ID']),
+    ]);
+
+    expect(wire($field)['props']['options'][0]['data'])
+        ->toBe(['description' => 'Face ID or Touch ID']);
+});
 
 describe('docs fixtures', function (): void {
     it('matches the choice example fixture', function (): void {


### PR DESCRIPTION
`Choice` rendered label-only pills, so an option's `data` record had nowhere to go — a picker that needs an icon, a description, or a badge per option could not be built from it.

`Choice` now takes an `optionSchema` exactly like `Select` already does, and a new `OptionCards` presentational component renders each option through that bound schema as a radio card. Selection follows focus inside the radiogroup with a single tab stop, matching the ARIA pattern.

```php
Choice::make('provider', 'Method')
    ->options($options)
    ->optionSchema([
        Text::make('')->dataKey('text', 'label'),
        Text::make('')->dataKey('text', 'description')->size(Size::Sm),
        Badge::make('')->dataKey('label', 'role'),
    ]);
```

Without an `optionSchema` the field renders exactly as before — additive, not breaking.

Tests: 8 Vitest for `OptionCards`, 3 Pest for the wire shape. Four docs fixtures pick up the new `optionSchema: null` prop.