### PR TITLE
fix(form): seed the choice default and align the wizard rail

### DIFF
--- a/docs/fixtures/wizard.basic.json
+++ b/docs/fixtures/wizard.basic.json
@@ -1,6 +1,7 @@
 [
     {
         "props": {
+            "align": "start",
             "orientation": "vertical"
         },
         "schema": [

--- a/packages/form/resources/js/components/fields/choice.test.tsx
+++ b/packages/form/resources/js/components/fields/choice.test.tsx
@@ -1,8 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { fakeNode } from "@lattice-php/core/test-support";
-import { FormValuesProvider } from "@lattice-php/form/hooks/values";
+import { FormValuesProvider, useFormValue } from "@lattice-php/form/hooks/values";
 import { ChoiceComponent } from "./choice";
+
+function StoredValue({ name }: { name: string }) {
+  return <span data-test="stored">{String(useFormValue(name))}</span>;
+}
 
 describe("Lattice form choice component", () => {
   it("renders choices and selects on click", () => {
@@ -31,5 +35,33 @@ describe("Lattice form choice component", () => {
     fireEvent.click(screen.getByRole("radio", { name: "Pro" }));
 
     expect(screen.getByRole("radio", { name: "Pro" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  // A field the server left empty arrives as `null`, not as a missing key, so the
+  // seeded default has to overwrite it — otherwise the store disagrees with the
+  // option the user sees checked, and a field depending on it resolves against
+  // nothing.
+  it("seeds the preselected option over a null stored value", () => {
+    const node = fakeNode({
+      props: {
+        label: "Plan",
+        name: "plan",
+        options: [
+          { label: "Free", value: "free", data: null },
+          { label: "Pro", value: "pro", data: null },
+        ],
+        value: null,
+      },
+      type: "field.choice",
+    });
+
+    render(
+      <FormValuesProvider initial={{ plan: null }}>
+        <ChoiceComponent node={node}>{null}</ChoiceComponent>
+        <StoredValue name="plan" />
+      </FormValuesProvider>,
+    );
+
+    expect(screen.getByTestId("stored")).toHaveTextContent("free");
   });
 });

--- a/packages/form/resources/js/components/wizard.test.tsx
+++ b/packages/form/resources/js/components/wizard.test.tsx
@@ -102,4 +102,16 @@ describe("WizardComponent", () => {
     expect(screen.getByTestId("content-review").closest("section")).toHaveAttribute("hidden");
     expect(screen.getByTestId("wizard-rail-customer")).toHaveAttribute("data-error");
   });
+
+  it("centers the rail when the wizard asks for it", () => {
+    const centered = fakeNode({
+      type: "wizard",
+      props: { orientation: "horizontal", align: "center" },
+      schema: [emptyStep],
+    });
+
+    renderWithForm(<WizardComponent node={centered}>{null}</WizardComponent>);
+
+    expect(screen.getByTestId("wizard-rail-review").closest("ol")).toHaveClass("justify-center");
+  });
 });

--- a/packages/form/resources/js/components/wizard.tsx
+++ b/packages/form/resources/js/components/wizard.tsx
@@ -15,6 +15,13 @@ import {
   stepValidationPaths,
 } from "@lattice-php/form/lib/wizard-steps";
 
+const RAIL_ALIGNMENTS: Record<string, string> = {
+  center: "justify-center",
+  left: "justify-start",
+  start: "justify-start",
+  stretch: "justify-stretch",
+};
+
 type WizardContextValue = { activeName: string };
 
 const WizardContext = createContext<WizardContextValue>({ activeName: "" });
@@ -89,7 +96,11 @@ export const WizardComponent: RendererComponent<"wizard"> = ({ children, node })
       <div className={cn("gap-6", isVertical ? "flex" : "grid")} data-slot="wizard">
         <ol
           aria-label={t("form.wizard.steps", "Steps")}
-          className={cn("gap-1", isVertical ? "flex w-56 shrink-0 flex-col" : "flex flex-wrap")}
+          className={cn(
+            "gap-1",
+            isVertical ? "flex w-56 shrink-0 flex-col" : "flex flex-wrap",
+            !isVertical && RAIL_ALIGNMENTS[node.props.align ?? "start"],
+          )}
         >
           {items.map((step, index) => {
             const isActive = index === activeIndex;

--- a/packages/form/resources/js/generated.ts
+++ b/packages/form/resources/js/generated.ts
@@ -1,5 +1,6 @@
 import type { Affix, Node, Op, Option } from "@lattice-php/core";
 import type {
+  Align,
   ColumnWidth,
   Emphasis,
   HttpMethod,
@@ -667,6 +668,7 @@ export type Toggle = {
   value: unknown;
 };
 export type Wizard = {
+  align: Align;
   orientation: Orientation;
 };
 export type WizardStep = {

--- a/packages/form/resources/js/hooks/use-seed-default.ts
+++ b/packages/form/resources/js/hooks/use-seed-default.ts
@@ -5,6 +5,11 @@ import { useFormValue, useSetFormValue } from "./values";
 /**
  * Seed a field's default into the store so dependent fields and the submitted
  * payload reflect it before the user interacts. Pass undefined to skip.
+ *
+ * A field with no server-side value serializes as `null`, not as a missing key,
+ * so the store already holds `null` by the time this runs. Both count as unset:
+ * seeding only on `undefined` would leave the store disagreeing with the control
+ * the user is looking at, and a dependent field would resolve against nothing.
  */
 export function useSeedDefault(name: string, value: unknown): void {
   const scope = useFieldScope();
@@ -13,7 +18,7 @@ export function useSeedDefault(name: string, value: unknown): void {
   const setValue = useSetFormValue();
 
   useEffect(() => {
-    if (stored === undefined && value !== undefined) {
+    if ((stored === undefined || stored === null) && value !== undefined) {
       if (scope) {
         scope.setValue(name, value);
       } else {

--- a/packages/form/src/Components/Wizard.php
+++ b/packages/form/src/Components/Wizard.php
@@ -6,6 +6,7 @@ namespace Lattice\Form\Components;
 use Lattice\Core\Attributes\AsComponent;
 use Lattice\Core\Attributes\SerializationHook;
 use Lattice\Ui\Components\ContainerComponent;
+use Lattice\Ui\Enums\Align;
 use Lattice\Ui\Enums\Orientation;
 use LogicException;
 
@@ -13,6 +14,8 @@ use LogicException;
 class Wizard extends ContainerComponent
 {
     public Orientation $orientation = Orientation::Horizontal;
+
+    public Align $align = Align::Start;
 
     /**
      * @param  array<int, WizardStep>  $steps
@@ -32,6 +35,17 @@ class Wizard extends ContainerComponent
     public function vertical(): static
     {
         return $this->orientation(Orientation::Vertical);
+    }
+
+    /**
+     * Where the step rail sits above the panel. Only a horizontal wizard has a
+     * choice — a vertical one keeps its rail in a fixed column beside the panel.
+     */
+    public function align(Align $align): static
+    {
+        $this->align = $align;
+
+        return $this;
     }
 
     /**

--- a/packages/ui/resources/js/types.ts
+++ b/packages/ui/resources/js/types.ts
@@ -7,6 +7,7 @@ declare module "@lattice-php/core" {
 
 export type { Affix, Color, ColorKind, ColorName } from "@lattice-php/core";
 export type {
+  Align,
   Breakpoint,
   Callout,
   ColumnWidth,


### PR DESCRIPTION
Two fixes that surfaced while building a two-step setup wizard on top of `Choice`.

**A Choice never told the server which option it had preselected.** A field the server left empty arrives as `null`, not as a missing key, so `useSeedDefault` — which seeded only on `undefined` — left the store holding `null` while the picker rendered its first option checked. A field computed on that choice then resolved against nothing, and came back empty until the user clicked the card that was already selected: accepting the offered default was the one path that did not work. `Checkbox` and `Toggle` seed through the same hook and were wrong the same way.

**The horizontal step rail was pinned left.** `Wizard::align()` decides where it sits. The default is unchanged, and a vertical wizard ignores it because its rail lives in a fixed column beside the panel.

```
before                              after

┌──────────────────────────┐        ┌──────────────────────────┐
│ ① Method   ② Set up      │        │     ① Method  ② Set up   │
│                          │        │                          │
│   How would you like …   │        │   How would you like …   │
│   ┌────────────────────┐ │        │   ┌────────────────────┐ │
│   │ Passkey            │ │        │   │ Passkey            │ │
└──────────────────────────┘        └──────────────────────────┘
```