### PR TITLE
fix(ui): let a bled description list's divider reach both edges

### DIFF
--- a/packages/ui/resources/js/components/description-list.browser.test.tsx
+++ b/packages/ui/resources/js/components/description-list.browser.test.tsx
@@ -10,6 +10,43 @@ describe("DescriptionList in a browser", () => {
     window.localStorage.clear();
   });
 
+  it("bleeds its divider flush to both edges of a padded parent", async () => {
+    // Mirrors CardContent's own px-lt-gutter: the padded box a bled list
+    // divides edge to edge in real usage.
+    const screen = await render(
+      <div className="px-lt-gutter" style={{ width: 400 }} data-testid="panel">
+        <DescriptionListComponent
+          node={fakeNode({
+            type: "description-list",
+            id: "bled",
+            props: { bleed: true, semantic: "list" },
+          })}
+        >
+          <TextEntryComponent
+            node={fakeNode({
+              type: "entry.text",
+              id: "entry-name",
+              props: { label: "Name", value: "Ada Lovelace" },
+            })}
+          >
+            {null}
+          </TextEntryComponent>
+        </DescriptionListComponent>
+      </div>,
+    );
+
+    await expect.element(screen.getByText("Ada Lovelace")).toBeVisible();
+
+    const panel = document.querySelector('[data-testid="panel"]') as HTMLElement;
+    const list = panel.querySelector('[data-slot="description-list"]') as HTMLElement;
+
+    const panelRect = panel.getBoundingClientRect();
+    const listRect = list.getBoundingClientRect();
+
+    expect(listRect.left).toBeCloseTo(panelRect.left, 0);
+    expect(listRect.right).toBeCloseTo(panelRect.right, 0);
+  });
+
   it("reveals and hides an entry's disclosure content when its row is used", async () => {
     const screen = await render(
       <DescriptionListComponent

--- a/packages/ui/resources/js/components/description-list.tsx
+++ b/packages/ui/resources/js/components/description-list.tsx
@@ -11,9 +11,12 @@ const DescriptionListComponent: RendererComponent<"description-list"> = ({ child
   const className = cn(
     "w-full",
     divided && "divide-y divide-lt-border",
-    // The rows carry the gutter padding, so pulling the list out by the same
-    // amount runs the dividers to the panel edge while the content stays put.
-    bleed && "-mx-lt-gutter",
+    // `w-full` pins the width to the containing block's content box, which
+    // stops the negative margins below from growing the box — only the left
+    // edge would shift outward, since the right edge is `left + width` with a
+    // fixed width. `w-auto` lets them expand it on both sides instead, so the
+    // divider reaches the panel edge symmetrically (see Separator's bleed).
+    bleed && "-mx-lt-gutter w-auto",
   );
 
   const body =


### PR DESCRIPTION
## Summary

`DescriptionList`'s `bleed()` mode uses a negative-margin technique (`-mx-lt-gutter`) to run its `divide-y` dividers to a padded panel's edge while row content stays aligned — the same technique `Separator` already uses for its own bleed mode. But `DescriptionList` kept its base `w-full` class active even in bleed mode.

`w-full` pins the element's width to its containing block's content-box width. With a fixed width, a negative `margin-left`/`margin-right` only *repositions* the box — the right edge is `left + width`, and `width` never grows to absorb the extra margin on that side. The divider reached the panel's left edge but stopped short of the right edge by exactly twice the gutter (confirmed via a downstream app's real render: 48px short at a 24px gutter).

Fix: switch to `w-auto` in bleed mode (matching `Separator`), so both negative margins expand the box symmetrically instead of one just shifting it.

## Test plan

- [x] Added a browser test rendering `DescriptionList` inside a padded parent (mirroring `CardContent`'s own `px-lt-gutter`), asserting the bled list's left/right edges both match the parent's — reverting the fix reproduces the exact 48px discrepancy found in the wild.
- [x] `npx vitest run --project browser packages/ui/resources/js/components/description-list.browser.test.tsx` — 2 passed
- [x] `npx vitest run --project browser packages/ui` — 11 passed
- [x] `npx vitest run --project jsdom packages/ui` — 271 passed
- [x] `npx tsc --noEmit`, `oxlint`, `oxfmt --check` on the changed files