### PR TITLE
feat(map): reset the view to the default zoom with a map control

### DIFF
--- a/docs/content/docs/packages/map.mdx
+++ b/docs/content/docs/packages/map.mdx
@@ -85,6 +85,10 @@ scrolling — holding Cmd/Ctrl while scrolling (or a trackpad pinch) still zooms
 `->scrollZoom()` makes the plain wheel zoom too. Zoom values must fit both the general `0–24`
 range and the active provider's range.
 
+When a default zoom is set with `->zoom()`, the map shows a reset control below the zoom buttons
+that returns the viewport to its initial center and zoom after panning or zooming away.
+`->navigationControls(false)` hides it together with the zoom buttons.
+
 ## OpenStreetMap Tiles
 
 The built-in provider uses the public OpenStreetMap tile service and includes the required

--- a/packages/map/lang/de/map.php
+++ b/packages/map/lang/de/map.php
@@ -7,5 +7,6 @@ return [
     'loading' => 'Karte wird geladen…',
     'error' => 'Die Karte konnte nicht geladen werden.',
     'close-popup' => 'Popup schließen',
+    'reset-view' => 'Ansicht zurücksetzen',
     'provider-missing' => 'Der Kartenanbieter „{{provider}}“ ist nicht verfügbar.',
 ];

--- a/packages/map/lang/en/map.php
+++ b/packages/map/lang/en/map.php
@@ -7,5 +7,6 @@ return [
     'loading' => 'Loading map…',
     'error' => 'The map could not be loaded.',
     'close-popup' => 'Close popup',
+    'reset-view' => 'Reset view',
     'provider-missing' => 'Map provider “{{provider}}” is not available.',
 ];

--- a/packages/map/resources/css/map.css
+++ b/packages/map/resources/css/map.css
@@ -193,6 +193,29 @@
   color: var(--lt-accent-fg);
 }
 
+.lt-map__reset-button {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--lt-popover-fg);
+  cursor: pointer;
+}
+
+.lt-map__reset-button:hover,
+.lt-map__reset-button:focus-visible {
+  background: var(--lt-accent);
+  color: var(--lt-accent-fg);
+}
+
+.lt-map__reset-button > * {
+  width: 1rem;
+  height: 1rem;
+}
+
 .leaflet-control-attribution {
   margin: 0 !important;
   padding: 0.125rem 0.375rem;

--- a/packages/map/resources/js/map.browser.test.tsx
+++ b/packages/map/resources/js/map.browser.test.tsx
@@ -155,6 +155,51 @@ it("automatically centers a single marker for interaction", async () => {
   await expect.element(page.getByText("Munich office content")).toBeVisible();
 });
 
+it("returns to the server-defined zoom when the reset control is clicked after zooming away", async () => {
+  await renderMap({
+    center: { latitude: 48.1372, longitude: 11.5756 },
+    features: [
+      marker("munich", "Munich office", 48.1372, 11.5756),
+      marker("freising", "Freising office", 48.15, 11.6),
+    ],
+    zoom: 14,
+  });
+
+  // The distance between two markers depends only on the zoom level, so it is
+  // immune to the container resizes the test viewport goes through.
+  const markerDistance = () => {
+    const pins = document.querySelectorAll(".leaflet-marker-icon");
+
+    if (pins.length < 2) {
+      return null;
+    }
+
+    const first = pins[0].getBoundingClientRect();
+    const second = pins[1].getBoundingClientRect();
+
+    return Math.hypot(second.left - first.left, second.top - first.top);
+  };
+
+  await expect.poll(markerDistance).toBeTruthy();
+  const initialDistance = markerDistance()!;
+
+  await userEvent.click(page.getByRole("button", { name: "Zoom out" }));
+
+  await expect
+    .poll(() => markerDistance() ?? Number.POSITIVE_INFINITY)
+    .toBeLessThan(initialDistance * 0.75);
+
+  // Leaflet silently drops setView while a zoom animation is still running,
+  // so wait for the zoom-out animation to finish before resetting.
+  await expect.poll(() => document.querySelector(".leaflet-zoom-anim")).toBeNull();
+
+  await userEvent.click(page.getByRole("button", { name: "Reset view" }));
+
+  await expect
+    .poll(() => Math.abs((markerDistance() ?? Number.POSITIVE_INFINITY) - initialDistance))
+    .toBeLessThanOrEqual(1);
+});
+
 it("uses the server-provided center and zoom for an interactive marker", async () => {
   await renderMap({
     center: { latitude: 48.1372, longitude: 11.5756 },

--- a/packages/map/resources/js/openstreetmap.tsx
+++ b/packages/map/resources/js/openstreetmap.tsx
@@ -85,6 +85,39 @@ function setInitialView(
   map.setView([0, 0], node.props.zoom ?? 2);
 }
 
+function addResetControl(
+  leaflet: typeof import("leaflet"),
+  map: LeafletMap,
+  label: string,
+  setHost: (host: HTMLElement) => void,
+): void {
+  const initialCenter = map.getCenter();
+  const initialZoom = map.getZoom();
+  const control = new leaflet.Control({ position: "topleft" });
+
+  control.onAdd = () => {
+    const container = leaflet.DomUtil.create("div", "lt-map__reset");
+    const button = document.createElement("button");
+
+    button.type = "button";
+    button.className = "lt-map__reset-button";
+    button.title = label;
+    button.setAttribute("aria-label", label);
+    container.append(button);
+    leaflet.DomEvent.disableClickPropagation(container);
+    // animate: false keeps Leaflet from scheduling its 250ms zoom-animation
+    // fallback timer, which would throw if the map unmounts before it fires.
+    leaflet.DomEvent.on(button, "click", () =>
+      map.setView(initialCenter, initialZoom, { animate: false }),
+    );
+    setHost(button);
+
+    return container;
+  };
+
+  control.addTo(map);
+}
+
 function styleMarkerPin(element: HTMLElement | undefined, feature: MarkerData): HTMLElement | null {
   const pin = element?.querySelector<HTMLElement>(".lt-map-marker__pin") ?? null;
   const color = coerceColor(feature.color);
@@ -174,6 +207,7 @@ export default function OpenStreetMap({ node }: MapProviderProps) {
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [popup, setPopup] = useState<PopupPortal | null>(null);
   const [markerIcons, setMarkerIcons] = useState<MarkerIcon[]>([]);
+  const [resetHost, setResetHost] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     const element = container.current;
@@ -194,6 +228,7 @@ export default function OpenStreetMap({ node }: MapProviderProps) {
     setStatus("loading");
     setPopup(null);
     setMarkerIcons([]);
+    setResetHost(null);
 
     void import("leaflet")
       .then((leaflet) => {
@@ -235,6 +270,10 @@ export default function OpenStreetMap({ node }: MapProviderProps) {
         // Layers only initialize their DOM elements once the map has a view,
         // so the view must be set before markers are added and styled.
         setInitialView(leaflet, map, node);
+
+        if (node.props.zoom !== null && node.props.navigationControls) {
+          addResetControl(leaflet, map, t("map.reset-view", "Reset view"), setResetHost);
+        }
 
         const icons: MarkerIcon[] = [];
 
@@ -319,6 +358,7 @@ export default function OpenStreetMap({ node }: MapProviderProps) {
         </div>
       )}
       {popup && createPortal(<PopupSchema portal={popup} />, popup.host, popup.id)}
+      {resetHost && createPortal(<IconRenderer icon="rotate-ccw" />, resetHost, "reset-view")}
       {markerIcons.map((markerIcon) =>
         createPortal(
           <IconRenderer icon={markerIcon.icon} />,

--- a/workbench/app/Pages/Components/MapPage.php
+++ b/workbench/app/Pages/Components/MapPage.php
@@ -34,6 +34,8 @@ final class MapPage extends WorkbenchPage
                     Heading::make(__('workbench.pages.map.heading')),
                     Text::make(__('workbench.pages.map.description')),
                     Map::make('offices')
+                        ->center(52.47, 13.24)
+                        ->zoom(10)
                         ->height(600)
                         ->markers([
                             Marker::make('berlin')


### PR DESCRIPTION
When a map defines a default zoom via `->zoom()`, the OpenStreetMap renderer now shows a reset control below the zoom buttons that returns the viewport to its initial center and zoom after panning or zooming away. `->navigationControls(false)` hides it together with the zoom buttons.

- Icon (`rotate-ccw`) rendered through the shared `IconRenderer` portal, translated `aria-label`/`title` (en/de)
- Control styled like the existing Leaflet controls via the map stylesheet
- Browser test asserts the zoom restore through the distance between two markers (zoom-dependent, immune to test-viewport resizes) and waits out Leaflet's zoom animation, since `setView` is silently dropped while one is running
- Docs note the behavior; the workbench map page now sets `->center()->zoom(10)` so the control is visible there

Before: after zooming/panning away there was no way back to the server-defined viewport short of reloading. After: one click on the reset control below the zoom buttons restores it.