### PR TITLE
feat!: dialog-stack modal host and unified action overlays

### DIFF
--- a/docs/content/docs/actions/bulk-actions.md
+++ b/docs/content/docs/actions/bulk-actions.md
@@ -43,7 +43,9 @@ class ArchiveSelectedProductsAction extends BulkActionDefinition
 
 `definition()` returns the same `Action` component as a single action, so labels, variants,
 [confirmation](/actions/confirmation-and-forms/), and [forms](/actions/confirmation-and-forms/#collecting-input-with-a-form)
-all apply. `handle()` returns an [`ActionResult`](/actions/effects/) like any action.
+all apply — including a [`->lazyForm()`](/actions/confirmation-and-forms/#deferring-the-schema)
+one, which fetches its schema together with the selection payload once the bulk action bar opens
+it. `handle()` returns an [`ActionResult`](/actions/effects/) like any action.
 
 ## Attaching it to a table
 

--- a/docs/content/docs/actions/confirmation-and-forms.md
+++ b/docs/content/docs/actions/confirmation-and-forms.md
@@ -6,6 +6,11 @@ description: Confirm an action before it runs, or collect validated input in a m
 An action can interrupt the click with a modal — either a simple confirmation, or a full form whose
 values are passed to `handle()`.
 
+Both dialogs render through the app's shared [modal host](/components/modals/#stacking): they
+survive the popover or kebab menu that triggered them closing, and they open above whatever modal
+is already open — a row action's confirmation above the modal that contains its table, for
+instance.
+
 ## Confirmation modals
 
 `->confirm()` shows a confirmation dialog before the action runs. The user must accept; cancelling

--- a/docs/content/docs/components/modals.mdx
+++ b/docs/content/docs/components/modals.mdx
@@ -9,8 +9,11 @@ import Info from "@components/Info.astro";
 its own — a single host renders it, reached one of two ways.
 
 <Info>
-  Only one modal can be open at a time. Opening a second one — from another trigger, or another
-  `open-modal` effect — replaces whatever is currently open rather than stacking.
+  The host is a stack, not a single slot: opening a modal from inside another one pushes it above
+  the current modal instead of replacing it, and an action's confirmation or form dialog (see
+  [Confirmation & forms](/actions/confirmation-and-forms/)) opens the same way. Opening the *same*
+  `Modal::make($id)` again — the same instance re-triggered, or a re-dispatched `open-modal` effect
+  — replaces that entry in place rather than pushing a duplicate.
 </Info>
 
 ## Trigger-embedded
@@ -124,6 +127,14 @@ Modal::make('saved-filters')
 
 Sheets and centered dialogs share the same width scale: `->width()` caps a centered dialog and sets
 a sheet's panel width.
+
+## Stacking
+
+Opening a modal while another is already open — a button's `->modal()` inside a modal's schema, or
+a row action's confirmation dialog above a modal that contains its table — pushes a new entry onto
+the host rather than replacing the current one. Closing the top entry (Escape, its close button, or
+`->closeModal()` with no id) reveals whatever was open underneath; the rest of the stack is
+untouched.
 
 ## Lazy content
 

--- a/packages/action/resources/js/components/action-confirm-overlay.tsx
+++ b/packages/action/resources/js/components/action-confirm-overlay.tsx
@@ -1,0 +1,86 @@
+import { router } from "@inertiajs/react";
+import type { Method } from "@inertiajs/core";
+import { useState } from "react";
+import { apiFetch } from "@lattice-php/core/api";
+import { withHeaders } from "@lattice-php/core/headers";
+import type { Node } from "@lattice-php/core/types";
+import { ConfirmDialog } from "@lattice-php/ui/confirm-dialog";
+import { useEffectDispatcher } from "@lattice-php/ui/effects/use-effect-dispatcher";
+import { MODAL_HOST_MISSING_ERROR, useEmbeddedModal } from "@lattice-php/ui/modal-host";
+import { runAction } from "@lattice-php/action/lib/run-action";
+import { confirmationLabels } from "@lattice-php/action/lib/confirmation";
+
+export function ActionConfirmOverlay({
+  node,
+  extraData,
+  onSuccess,
+}: {
+  node: Node<"action" | "action.bulk">;
+  extraData?: Record<string, unknown>;
+  onSuccess?: () => void;
+}) {
+  const context = useEmbeddedModal();
+
+  if (!context) {
+    throw new Error(MODAL_HOST_MISSING_ERROR);
+  }
+
+  const endpoint = node.props.endpoint ?? "";
+  const componentRef = node.props.ref ?? "";
+  const method: Method = node.props.method ?? "post";
+  const { variant, emphasis } = node.props;
+  const labels = confirmationLabels(node);
+
+  const [processing, setProcessing] = useState(false);
+  const dispatch = useEffectDispatcher();
+
+  const submit = async (): Promise<void> => {
+    if (!endpoint) {
+      return;
+    }
+
+    if (method === "get") {
+      router.visit(endpoint, { headers: withHeaders(componentRef) });
+      context.onOpenChange(false);
+
+      return;
+    }
+
+    setProcessing(true);
+
+    const ok = await runAction(
+      () =>
+        apiFetch(endpoint, {
+          method,
+          ref: componentRef,
+          body: extraData ? JSON.stringify(extraData) : undefined,
+          throwOnError: false,
+        }),
+      dispatch,
+    );
+
+    setProcessing(false);
+
+    if (ok) {
+      context.onOpenChange(false);
+      onSuccess?.();
+    }
+  };
+
+  return (
+    <ConfirmDialog
+      open={context.open}
+      onExited={context.onExited}
+      title={labels.title}
+      description={labels.description}
+      confirmLabel={labels.confirmLabel}
+      cancelLabel={labels.cancelLabel}
+      confirmVariant={variant}
+      confirmEmphasis={emphasis}
+      processing={processing}
+      confirmDisabled={!endpoint}
+      onConfirm={() => void submit()}
+      onCancel={() => context.onOpenChange(false)}
+    />
+  );
+}

--- a/packages/action/resources/js/components/action-form-overlay.tsx
+++ b/packages/action/resources/js/components/action-form-overlay.tsx
@@ -1,0 +1,51 @@
+import type { Node } from "@lattice-php/core/types";
+import { ActionForm, useLazyActionForm } from "@lattice-php/action/components/action-form";
+import { MODAL_HOST_MISSING_ERROR, useEmbeddedModal } from "@lattice-php/ui/modal-host";
+import { confirmationLabels } from "@lattice-php/action/lib/confirmation";
+
+export function ActionFormOverlay({
+  node,
+  extraData,
+  onSuccess,
+}: {
+  node: Node<"action" | "action.bulk">;
+  extraData?: Record<string, unknown>;
+  onSuccess?: () => void;
+}) {
+  const context = useEmbeddedModal();
+
+  if (!context) {
+    throw new Error(MODAL_HOST_MISSING_ERROR);
+  }
+
+  const endpoint = node.props.endpoint ?? "";
+  const componentRef = node.props.ref ?? "";
+  const method = node.props.method ?? "post";
+  const lazyForm = node.props.lazyForm === true;
+  const lazyNode = useLazyActionForm(endpoint, componentRef, lazyForm, extraData);
+  const formNode = lazyForm ? lazyNode : node.props.form;
+  const labels = confirmationLabels(node);
+
+  return (
+    <ActionForm
+      open={context.open}
+      onExited={context.onExited}
+      cancelLabel={labels.cancelLabel}
+      componentRef={componentRef}
+      description={labels.description}
+      endpoint={endpoint}
+      extraData={extraData}
+      formNode={formNode}
+      method={method}
+      onClose={() => context.onOpenChange(false)}
+      onSuccess={() => {
+        context.onOpenChange(false);
+        onSuccess?.();
+      }}
+      placement={node.props.modalSide ?? "center"}
+      submitLabel={labels.confirmLabel}
+      title={labels.title}
+      width={node.props.modalWidth ?? undefined}
+    />
+  );
+}

--- a/packages/action/resources/js/components/action-form.browser.test.tsx
+++ b/packages/action/resources/js/components/action-form.browser.test.tsx
@@ -6,6 +6,7 @@ import type { Node } from "@lattice-php/lattice";
 import { RegistryContext } from "@lattice-php/core";
 import { formComponents } from "@lattice-php/form";
 import { fakeNode } from "@lattice-php/core/test-support";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
 import { actionComponents } from "@lattice-php/action/plugin";
 
 vi.mock("@inertiajs/react", async () =>
@@ -45,7 +46,9 @@ describe("action form modal in a browser", () => {
 
     const screen = await render(<Renderer nodes={[rejectAction()]} />, {
       wrapper: ({ children }) => (
-        <RegistryContext.Provider value={registry}>{children}</RegistryContext.Provider>
+        <RegistryContext.Provider value={registry}>
+          <ModalHostProvider>{children}</ModalHostProvider>
+        </RegistryContext.Provider>
       ),
     });
 

--- a/packages/action/resources/js/components/action-form.test.tsx
+++ b/packages/action/resources/js/components/action-form.test.tsx
@@ -5,6 +5,7 @@ import type { Node, Plugin } from "@lattice-php/lattice";
 import { formComponents } from "@lattice-php/form";
 import { useFormContext } from "@lattice-php/form/toolkit";
 import { fakeNode, jsonResponse, renderWithRegistry } from "@lattice-php/core/test-support";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
 import { actionComponents } from "@lattice-php/action/plugin";
 
 type ValidateFieldsOptions = { onSuccess?: () => void; onValidationError?: () => void };
@@ -183,7 +184,9 @@ function editProductActionWithExistingImage(): Node {
 
 function renderAction(node: Node, ...extraPlugins: Plugin[]) {
   return renderWithRegistry(
-    <Renderer nodes={[node]} />,
+    <ModalHostProvider>
+      <Renderer nodes={[node]} />
+    </ModalHostProvider>,
     createRegistry(actionComponents, formComponents, ...extraPlugins),
   );
 }

--- a/packages/action/resources/js/components/action-group.test.tsx
+++ b/packages/action/resources/js/components/action-group.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { fakeNode } from "@lattice-php/core/test-support";
+import { renderWithModalHost } from "@lattice-php/action/test-support";
+import ActionComponent from "./action";
 import ActionGroupComponent from "./action-group";
 
 describe("Lattice action group component", () => {
@@ -70,5 +72,52 @@ describe("Lattice action group component", () => {
     );
 
     expect(screen.getByRole("button", { name: "Actions" })).toBeVisible();
+  });
+
+  it("keeps a confirm dialog usable after the kebab menu that opened it has closed", () => {
+    const groupNode = fakeNode({
+      id: "row.actions",
+      props: { label: "Manage row" },
+      type: "action.group",
+    });
+    const deleteAction = fakeNode({
+      id: "row.delete",
+      type: "action",
+      props: {
+        confirmation: {
+          cancelLabel: "Cancel",
+          confirmLabel: "Confirm delete",
+          description: null,
+          title: "Delete row?",
+        },
+        endpoint: "/lattice/actions/row.delete",
+        label: "Delete",
+        method: "delete",
+      },
+    });
+
+    renderWithModalHost(
+      <ActionGroupComponent node={groupNode}>
+        <ActionComponent node={deleteAction}>{null}</ActionComponent>
+      </ActionGroupComponent>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage row" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Delete row?" });
+    expect(dialog).toBeVisible();
+
+    // Opening the confirm dialog dismisses the popover it was clicked from,
+    // unmounting its own opener button — the host's isConnected guard covers
+    // exactly this case when the dialog later exits.
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Delete row?" })).toBeVisible();
+
+    expect(() =>
+      fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" })),
+    ).not.toThrow();
+
+    expect(screen.queryByRole("dialog", { name: "Delete row?" })).not.toBeInTheDocument();
   });
 });

--- a/packages/action/resources/js/components/action-trigger-provider.tsx
+++ b/packages/action/resources/js/components/action-trigger-provider.tsx
@@ -1,29 +1,34 @@
 import type { ReactNode } from "react";
 import type { Node } from "@lattice-php/core/types";
-import { ActionTriggerProvider, type TriggerState } from "@lattice-php/ui/click-behavior";
+import {
+  ActionTriggerProvider,
+  type ActionSubmitOptions,
+  type TriggerState,
+} from "@lattice-php/ui/click-behavior";
 import { useAction } from "@lattice-php/action/hooks/use-action";
 
 export function ActionTrigger({
   action,
   children,
+  options,
 }: {
   action: Node<"action" | "action.bulk">;
   children: (trigger: TriggerState) => ReactNode;
+  options?: ActionSubmitOptions;
 }) {
-  const { processing, requestSubmit, overlays } = useAction(action);
+  const { processing, requestSubmit } = useAction(action, options);
 
-  return (
-    <>
-      {children({ onClick: requestSubmit, processing })}
-      {overlays}
-    </>
-  );
+  return children({ onClick: requestSubmit, processing });
 }
 
 export function ActionInteractionProvider({ children }: { children: ReactNode }) {
   return (
     <ActionTriggerProvider
-      render={(props) => <ActionTrigger action={props.action}>{props.children}</ActionTrigger>}
+      render={(props) => (
+        <ActionTrigger action={props.action} options={props.options}>
+          {props.children}
+        </ActionTrigger>
+      )}
     >
       {children}
     </ActionTriggerProvider>

--- a/packages/action/resources/js/components/action.test.tsx
+++ b/packages/action/resources/js/components/action.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { router } from "@inertiajs/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
 import { IconRendererProvider } from "@lattice-php/ui/icons";
 import type { IconRendererFunction } from "@lattice-php/ui/icons";
 import { ActionMenuProvider } from "@lattice-php/ui/action-menu-context";
+import { renderWithModalHost } from "@lattice-php/action/test-support";
 import ActionComponent from "./action";
 
 const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
@@ -33,7 +34,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Send test email" }));
 
@@ -57,7 +58,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
 
@@ -78,7 +79,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Sync" }));
 
@@ -102,7 +103,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Teams" }));
 
@@ -126,7 +127,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(
+    renderWithModalHost(
       <IconRendererProvider renderer={iconRenderer}>
         <ActionComponent node={node}>{null}</ActionComponent>
       </IconRendererProvider>,
@@ -147,7 +148,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(
+    renderWithModalHost(
       <ActionMenuProvider>
         <ActionComponent node={node}>{null}</ActionComponent>
       </ActionMenuProvider>,
@@ -177,7 +178,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
 
@@ -247,7 +248,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -310,7 +311,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
 
@@ -348,7 +349,7 @@ describe("Lattice action component", () => {
       type: "action",
     });
 
-    render(<ActionComponent node={node}>{null}</ActionComponent>);
+    renderWithModalHost(<ActionComponent node={node}>{null}</ActionComponent>);
 
     fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
 

--- a/packages/action/resources/js/components/action.tsx
+++ b/packages/action/resources/js/components/action.tsx
@@ -13,36 +13,32 @@ const ActionComponent: RendererComponent<"action"> = ({ node }) => {
   const label = actionLabel(node);
   const isMenuItem = useActionMenu();
   const { variant, emphasis } = node.props;
-  const { processing, requestSubmit, overlays } = useAction(node);
+  const { processing, requestSubmit } = useAction(node);
   const testId = node.key ?? prefixedTestId("action", node.id);
 
   return (
-    <>
-      <Button
-        className={isMenuItem ? actionMenuItemClassName : undefined}
-        data-lattice-component={node.id}
-        data-test={testId}
-        disabled={processing || !endpoint}
-        onClick={requestSubmit}
-        type="button"
-        emphasis={isMenuItem ? "ghost" : emphasis}
-        variant={isMenuItem ? null : variant}
-      >
-        {processing ? (
-          <Spinner className={isMenuItem ? "size-lt-icon-sm" : undefined} />
-        ) : (
-          icon && (
-            <IconRenderer
-              className={isMenuItem ? "size-lt-icon-sm" : "size-lt-icon-md"}
-              icon={icon}
-            />
-          )
-        )}
-        {label}
-      </Button>
-
-      {overlays}
-    </>
+    <Button
+      className={isMenuItem ? actionMenuItemClassName : undefined}
+      data-lattice-component={node.id}
+      data-test={testId}
+      disabled={processing || !endpoint}
+      onClick={requestSubmit}
+      type="button"
+      emphasis={isMenuItem ? "ghost" : emphasis}
+      variant={isMenuItem ? null : variant}
+    >
+      {processing ? (
+        <Spinner className={isMenuItem ? "size-lt-icon-sm" : undefined} />
+      ) : (
+        icon && (
+          <IconRenderer
+            className={isMenuItem ? "size-lt-icon-sm" : "size-lt-icon-md"}
+            icon={icon}
+          />
+        )
+      )}
+      {label}
+    </Button>
   );
 };
 

--- a/packages/action/resources/js/hooks/use-action.tsx
+++ b/packages/action/resources/js/hooks/use-action.tsx
@@ -96,6 +96,7 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
     <>
       {isConfirming && confirmation && (
         <ConfirmDialog
+          open={isConfirming}
           title={confirmationTitle}
           description={confirmation.description ?? undefined}
           confirmLabel={confirmationConfirmLabel}

--- a/packages/action/resources/js/hooks/use-action.tsx
+++ b/packages/action/resources/js/hooks/use-action.tsx
@@ -1,38 +1,39 @@
 import { router } from "@inertiajs/react";
 import type { Method } from "@inertiajs/core";
-import { useState } from "react";
-import type { ReactNode } from "react";
-import { ConfirmDialog } from "@lattice-php/ui/confirm-dialog";
+import { useContext, useState } from "react";
 import { apiFetch } from "@lattice-php/core/api";
 import { withHeaders } from "@lattice-php/core/headers";
 import type { Node } from "@lattice-php/core/types";
-import { translate } from "@lattice-php/ui/i18n";
 import { useEffectDispatcher } from "@lattice-php/ui/effects/use-effect-dispatcher";
+import { MODAL_HOST_MISSING_ERROR, ModalHostContext } from "@lattice-php/ui/modal-host";
+import type { ActionSubmitOptions } from "@lattice-php/ui/click-behavior";
 import { runAction } from "@lattice-php/action/lib/run-action";
-import { ActionForm, useLazyActionForm } from "@lattice-php/action/components/action-form";
-import { actionLabel } from "@lattice-php/action/lib/action-label";
+import { ActionConfirmOverlay } from "@lattice-php/action/components/action-confirm-overlay";
+import { ActionFormOverlay } from "@lattice-php/action/components/action-form-overlay";
+
+export type { ActionSubmitOptions } from "@lattice-php/ui/click-behavior";
 
 type UseAction = {
-  /** Whether the action request is in flight. */
+  /** Whether the direct-submit request is in flight (form/confirm overlays track their own). */
   processing: boolean;
   /** Gate then run the action: open the form, confirm, or dispatch directly. */
   requestSubmit: () => void;
-  /** The confirm dialog and action form rendered next to the trigger. */
-  overlays: ReactNode;
 };
 
 /**
  * The shared action machinery behind the Action button, action menu items, and
  * action links: it gates submission (form → modal, confirmation → confirm,
- * otherwise dispatch) and renders the matching overlays. The host owns the
- * trigger element so each surface keeps its own styling.
+ * otherwise dispatch) and pushes the matching overlay onto the modal host. The
+ * host is read lazily so a direct-submit action never needs a
+ * ModalHostProvider in scope.
  */
-export function useAction(node: Node<"action" | "action.bulk">): UseAction {
+export function useAction(
+  node: Node<"action" | "action.bulk">,
+  options?: ActionSubmitOptions,
+): UseAction {
   const endpoint = node.props.endpoint ?? "";
   const componentRef = node.props.ref ?? "";
   const method: Method = node.props.method ?? "post";
-  const label = actionLabel(node);
-  const { variant, emphasis } = node.props;
   const confirmation = node.props.confirmation;
   const inlineForm = node.props.form;
   const lazyForm = node.props.lazyForm === true;
@@ -40,19 +41,17 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
 
   const [processing, setProcessing] = useState(false);
   const dispatch = useEffectDispatcher();
-  const [isConfirming, setIsConfirming] = useState(false);
-  const [isFilling, setIsFilling] = useState(false);
-  const lazyNode = useLazyActionForm(endpoint, componentRef, isFilling && lazyForm);
-  const formNode = lazyForm ? lazyNode : inlineForm;
+  const host = useContext(ModalHostContext);
 
   const submit = async (): Promise<void> => {
     if (!endpoint) {
       return;
     }
 
+    const extraData = options?.extraData?.();
+
     if (method === "get") {
       router.visit(endpoint, { headers: withHeaders(componentRef) });
-      setIsConfirming(false);
 
       return;
     }
@@ -60,26 +59,52 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
     setProcessing(true);
 
     const ok = await runAction(
-      () => apiFetch(endpoint, { method, ref: componentRef, throwOnError: false }),
+      () =>
+        apiFetch(endpoint, {
+          method,
+          ref: componentRef,
+          body: extraData ? JSON.stringify(extraData) : undefined,
+          throwOnError: false,
+        }),
       dispatch,
     );
 
     setProcessing(false);
 
     if (ok) {
-      setIsConfirming(false);
+      options?.onSuccess?.();
     }
   };
 
   const requestSubmit = (): void => {
     if (hasForm) {
-      setIsFilling(true);
+      if (!host) {
+        throw new Error(MODAL_HOST_MISSING_ERROR);
+      }
+
+      host.open(
+        <ActionFormOverlay
+          node={node}
+          extraData={options?.extraData?.()}
+          onSuccess={options?.onSuccess}
+        />,
+      );
 
       return;
     }
 
     if (confirmation) {
-      setIsConfirming(true);
+      if (!host) {
+        throw new Error(MODAL_HOST_MISSING_ERROR);
+      }
+
+      host.open(
+        <ActionConfirmOverlay
+          node={node}
+          extraData={options?.extraData?.()}
+          onSuccess={options?.onSuccess}
+        />,
+      );
 
       return;
     }
@@ -87,49 +112,5 @@ export function useAction(node: Node<"action" | "action.bulk">): UseAction {
     void submit();
   };
 
-  const confirmationTitle = confirmation?.title ?? label;
-  const confirmationConfirmLabel = confirmation?.confirmLabel ?? label;
-  const confirmationCancelLabel =
-    confirmation?.cancelLabel ?? translate("lattice", "common.cancel", "Cancel");
-
-  const overlays = (
-    <>
-      {isConfirming && confirmation && (
-        <ConfirmDialog
-          open={isConfirming}
-          title={confirmationTitle}
-          description={confirmation.description ?? undefined}
-          confirmLabel={confirmationConfirmLabel}
-          cancelLabel={confirmationCancelLabel}
-          confirmVariant={variant}
-          confirmEmphasis={emphasis}
-          processing={processing}
-          confirmDisabled={!endpoint}
-          onConfirm={() => void submit()}
-          onCancel={() => setIsConfirming(false)}
-        />
-      )}
-
-      {isFilling && hasForm && (
-        <ActionForm
-          cancelLabel={confirmationCancelLabel}
-          componentRef={componentRef}
-          description={confirmation?.description ?? undefined}
-          endpoint={endpoint}
-          formNode={formNode}
-          method={method}
-          onClose={() => setIsFilling(false)}
-          onSuccess={() => {
-            setIsFilling(false);
-          }}
-          placement={node.props.modalSide ?? "center"}
-          submitLabel={confirmationConfirmLabel}
-          title={confirmationTitle}
-          width={node.props.modalWidth ?? undefined}
-        />
-      )}
-    </>
-  );
-
-  return { processing, requestSubmit, overlays };
+  return { processing, requestSubmit };
 }

--- a/packages/action/resources/js/index.ts
+++ b/packages/action/resources/js/index.ts
@@ -8,6 +8,7 @@ export {
   useActionMenu,
 } from "@lattice-php/ui/action-menu-context";
 export { useAction } from "./hooks/use-action";
+export type { ActionSubmitOptions } from "./hooks/use-action";
 export { runAction } from "./lib/run-action";
 export { actionComponents } from "./plugin";
 export type * from "./types";

--- a/packages/action/resources/js/lib/confirmation.ts
+++ b/packages/action/resources/js/lib/confirmation.ts
@@ -1,0 +1,22 @@
+import type { Node } from "@lattice-php/core/types";
+import { translate } from "@lattice-php/ui/i18n";
+import { actionLabel } from "./action-label";
+
+export type ConfirmationLabels = {
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+};
+
+export function confirmationLabels(node: Node<"action" | "action.bulk">): ConfirmationLabels {
+  const label = actionLabel(node);
+  const confirmation = node.props.confirmation;
+
+  return {
+    title: confirmation?.title ?? label,
+    description: confirmation?.description ?? undefined,
+    confirmLabel: confirmation?.confirmLabel ?? label,
+    cancelLabel: confirmation?.cancelLabel ?? translate("lattice", "common.cancel", "Cancel"),
+  };
+}

--- a/packages/action/resources/js/test-support.ts
+++ b/packages/action/resources/js/test-support.ts
@@ -1,0 +1,12 @@
+import { createElement, type ReactElement, type ReactNode } from "react";
+import { render, type RenderResult } from "@testing-library/react";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
+
+/** Wraps `ui` in the host every action confirm/form overlay opens against. */
+export function withModalHost(ui: ReactNode): ReactElement {
+  return createElement(ModalHostProvider, null, ui);
+}
+
+export function renderWithModalHost(ui: ReactNode): RenderResult {
+  return render(withModalHost(ui));
+}

--- a/packages/form/resources/js/action-form.tsx
+++ b/packages/form/resources/js/action-form.tsx
@@ -37,7 +37,10 @@ type ActionFormProps = {
   formNode: Node | null;
   method: string;
   onClose: () => void;
+  /** Called by the host stack once the dialog's exit animation finishes. */
+  onExited?: (event: Event) => void;
   onSuccess: (response: ActionResponse) => void;
+  open: boolean;
   /** Dialog placement for the form modal; sheets dock to a viewport edge. */
   placement?: DialogPlacement;
   submitLabel: string;
@@ -53,6 +56,7 @@ export function useLazyActionForm(
   endpoint: string,
   componentRef: string,
   enabled: boolean,
+  extraData?: Record<string, unknown>,
 ): Node | null {
   const [node, setNode] = useState<Node | null>(null);
 
@@ -66,7 +70,7 @@ export function useLazyActionForm(
     const controller = new AbortController();
 
     void apiFetch(endpoint, {
-      body: JSON.stringify({ _sub: "schema" }),
+      body: JSON.stringify({ _sub: "schema", ...extraData }),
       ref: componentRef,
       method: "POST",
       signal: controller.signal,
@@ -77,6 +81,7 @@ export function useLazyActionForm(
       .catch(() => {});
 
     return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, endpoint, componentRef]);
 
   return node;
@@ -104,7 +109,7 @@ function ActionFormBody({
   onSuccess,
   precognitive,
   submitLabel,
-}: Omit<ActionFormProps, "description" | "title"> & {
+}: Omit<ActionFormProps, "description" | "onExited" | "open" | "placement" | "title" | "width"> & {
   fieldLabels: Record<string, string>;
   formNode: Node;
   precognitive: boolean;
@@ -302,7 +307,9 @@ function ActionFormBody({
 function ActionFormContent({
   formNode,
   ...rest
-}: Omit<ActionFormProps, "description" | "title"> & { formNode: Node }) {
+}: Omit<ActionFormProps, "description" | "onExited" | "open" | "placement" | "title" | "width"> & {
+  formNode: Node;
+}) {
   const precognitive = Boolean(formNode.props?.precognitive);
   const { labels: fieldLabels, values: initialValues } = useMemo(() => {
     const { labels, values } = collectFields(formNode.schema);
@@ -329,6 +336,8 @@ export function ActionForm({
   description,
   formNode,
   onClose,
+  onExited,
+  open,
   placement,
   title,
   width,
@@ -338,15 +347,16 @@ export function ActionForm({
 
   return (
     <Dialog
-      open
-      onOpenChange={(open) => {
-        if (!open) {
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
           onClose();
         }
       }}
     >
       <DialogContent
         {...(description ? {} : { "aria-describedby": undefined })}
+        onCloseAutoFocus={onExited}
         placement={placement}
         width={width}
       >

--- a/packages/framework/resources/js/layout/components/menu-item-action.test.tsx
+++ b/packages/framework/resources/js/layout/components/menu-item-action.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionInteractionProvider } from "@lattice-php/action";
 import { fakeNode } from "@lattice-php/core/test-support";
 import type { Node, ComponentPropsOf } from "@lattice-php/core/types";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
 import MenuItemComponent from "./menu-item";
 
 const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
@@ -38,9 +39,11 @@ function actionMenuItem(props: Partial<ComponentPropsOf<"action">> = {}): Node<"
 
 function renderActionMenuItem(node: Node<"menu-item">) {
   return render(
-    <ActionInteractionProvider>
-      <MenuItemComponent node={node}>{null}</MenuItemComponent>
-    </ActionInteractionProvider>,
+    <ModalHostProvider>
+      <ActionInteractionProvider>
+        <MenuItemComponent node={node}>{null}</MenuItemComponent>
+      </ActionInteractionProvider>
+    </ModalHostProvider>,
   );
 }
 

--- a/packages/media/resources/js/components/detail-panel.tsx
+++ b/packages/media/resources/js/components/detail-panel.tsx
@@ -177,22 +177,21 @@ export function DetailPanel({
           </Button>
         </div>
 
-        {confirming && (
-          <ConfirmDialog
-            cancelLabel={translate("lattice", "common.cancel", "Cancel")}
-            confirmLabel={deleteLabel}
-            confirmVariant="danger"
-            description={t(
-              "media.actions.delete.confirm-description",
-              "This file is attached to {{count}} record(s). Deleting removes it everywhere.",
-              { count: row.attachments_count },
-            )}
-            onCancel={() => setConfirming(false)}
-            onConfirm={() => void run(remove)}
-            processing={processing}
-            title={t("media.actions.delete.confirm-title", "Delete this file?")}
-          />
-        )}
+        <ConfirmDialog
+          cancelLabel={translate("lattice", "common.cancel", "Cancel")}
+          confirmLabel={deleteLabel}
+          confirmVariant="danger"
+          description={t(
+            "media.actions.delete.confirm-description",
+            "This file is attached to {{count}} record(s). Deleting removes it everywhere.",
+            { count: row.attachments_count },
+          )}
+          onCancel={() => setConfirming(false)}
+          onConfirm={() => void run(remove)}
+          open={confirming}
+          processing={processing}
+          title={t("media.actions.delete.confirm-title", "Delete this file?")}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/table/resources/js/components/bulk-bar.test.tsx
+++ b/packages/table/resources/js/components/bulk-bar.test.tsx
@@ -5,8 +5,8 @@ import type { EffectHandler } from "@lattice-php/ui/effects/registry";
 import { createRegistry } from "@lattice-php/core/registry";
 import { Provider } from "@lattice-php/lattice/provider";
 import { fakeNode } from "@lattice-php/core/test-support";
+import type { Node } from "@lattice-php/core/types";
 import { BulkBar } from "./bulk-bar";
-import type { BulkAction } from "@lattice-php/table/lib/bulk";
 
 const apiFetch = vi.hoisted(() =>
   vi.fn<(url: string, init?: Record<string, unknown>) => Promise<Response>>(),
@@ -33,45 +33,74 @@ type ActionFormProps = {
   submitLabel: string;
   title: string;
   onClose: () => void;
+  onExited?: (event: Event) => void;
   onSuccess: (response: ActionResponse) => void;
 };
 
-vi.mock("@lattice-php/form/action-form", () => ({
-  ActionForm: (props: ActionFormProps) => (
-    <div data-test="action-form">
-      <span data-test="form-title">{props.title}</span>
-      <span data-test="form-description">{props.description ?? "(none)"}</span>
-      <span data-test="form-cancel-label">{props.cancelLabel}</span>
-      <span data-test="form-submit-label">{props.submitLabel}</span>
-      <span data-test="form-extra">{JSON.stringify(props.extraData)}</span>
-      <button
-        type="button"
-        data-test="form-success"
-        onClick={() => props.onSuccess({ effects: [{ type: "test.bulk-success", props: {} }] })}
-      >
-        success
-      </button>
-      <button type="button" data-test="form-close" onClick={props.onClose}>
-        close
-      </button>
-    </div>
-  ),
-}));
+vi.mock("@lattice-php/form/action-form", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lattice-php/form/action-form")>();
 
-function action(partial: Partial<BulkAction> & Pick<BulkAction, "id">): BulkAction {
   return {
-    label: "Run",
-    method: "post",
-    endpoint: "/bulk/run",
-    ref: "",
-    variant: null,
-    emphasis: "solid",
-    confirmation: null,
-    form: null,
-    modalSide: null,
-    modalWidth: null,
-    ...partial,
+    ...actual,
+    // Stands in for the real Dialog/DialogContent: the host only removes the
+    // entry once `onExited` fires (Radix's onCloseAutoFocus), so this mock
+    // fires it itself right after closing/succeeding to mimic an instant
+    // (no-animation) exit, matching what jsdom would otherwise never trigger.
+    ActionForm: (props: ActionFormProps) => (
+      <div data-test="action-form">
+        <span data-test="form-title">{props.title}</span>
+        <span data-test="form-description">{props.description ?? "(none)"}</span>
+        <span data-test="form-cancel-label">{props.cancelLabel}</span>
+        <span data-test="form-submit-label">{props.submitLabel}</span>
+        <span data-test="form-extra">{JSON.stringify(props.extraData)}</span>
+        <button
+          type="button"
+          data-test="form-success"
+          onClick={() => {
+            props.onSuccess({ effects: [{ type: "test.bulk-success", props: {} }] });
+            props.onExited?.(new Event("mock-exit"));
+          }}
+        >
+          success
+        </button>
+        <button
+          type="button"
+          data-test="form-close"
+          onClick={() => {
+            props.onClose();
+            props.onExited?.(new Event("mock-exit"));
+          }}
+        >
+          close
+        </button>
+      </div>
+    ),
   };
+});
+
+function action(
+  partial: Partial<Record<string, unknown>> & { id: string },
+): Node<"action" | "action.bulk"> {
+  const { id, ...props } = partial;
+
+  return fakeNode({
+    id,
+    type: "action.bulk",
+    props: {
+      label: "Run",
+      method: "post",
+      endpoint: "/bulk/run",
+      ref: "",
+      variant: null,
+      emphasis: "solid",
+      confirmation: null,
+      form: null,
+      lazyForm: false,
+      modalSide: null,
+      modalWidth: null,
+      ...props,
+    },
+  });
 }
 
 const effectHandler = vi.fn<EffectHandler>();
@@ -165,8 +194,8 @@ describe("BulkBar", () => {
           id: "archive",
           method: "patch",
           endpoint: "/bulk/archive",
-          // "" is the real normalized "no ref" value: getBulkActions always
-          // defaults `props.ref ?? ""`, so this is an in-contract fixture.
+          // "" is the real normalized "no ref" value: getBulkActionNodes never
+          // rewrites the raw node, so this is an in-contract fixture.
           ref: "",
         }),
       ],
@@ -210,15 +239,18 @@ describe("BulkBar", () => {
     expect(onCompleted).not.toHaveBeenCalled();
   });
 
-  it("disables the action buttons and shows a spinner while processing", async () => {
+  it("tracks processing per trigger, leaving other actions clickable", async () => {
     apiFetch.mockReturnValue(new Promise<Response>(() => {}));
-    renderBar({ actions: [action({ id: "archive" })] });
+    renderBar({
+      actions: [action({ id: "archive" }), action({ id: "restore", label: "Restore" })],
+    });
 
     fireEvent.click(screen.getByTestId("bulk-action-archive"));
 
     await waitFor(() => {
       expect(screen.getByTestId("bulk-action-archive")).toBeDisabled();
     });
+    expect(screen.getByTestId("bulk-action-restore")).not.toBeDisabled();
   });
 
   describe("confirmation flow", () => {
@@ -432,6 +464,29 @@ describe("BulkBar", () => {
       expect(screen.getByTestId("form-extra")).toHaveTextContent(
         JSON.stringify({ allMatching: true, filter: "status:eq:active" }),
       );
+    });
+
+    it("opens a lazy bulk action form and posts the selection payload with the schema request", async () => {
+      renderBar({
+        selectedKeys: ["9"],
+        actions: [
+          action({ id: "tag", label: "Tag", lazyForm: true, form: null, confirmation: null }),
+        ],
+      });
+
+      fireEvent.click(screen.getByTestId("bulk-action-tag"));
+
+      await waitFor(() => expect(screen.getByTestId("action-form")).toBeInTheDocument());
+
+      const schemaCall = apiFetch.mock.calls.find(([, options]) => {
+        const body = JSON.parse((options as { body: string }).body) as Record<string, unknown>;
+
+        return body._sub === "schema";
+      });
+
+      expect(schemaCall).toBeDefined();
+      const [, options] = schemaCall as [string, { body: string }];
+      expect(JSON.parse(options.body)).toEqual({ _sub: "schema", selected: ["9"] });
     });
   });
 });

--- a/packages/table/resources/js/components/bulk-bar.tsx
+++ b/packages/table/resources/js/components/bulk-bar.tsx
@@ -114,6 +114,7 @@ export function BulkBar({
 
       {confirming?.confirmation && (
         <ConfirmDialog
+          open={confirming !== null}
           title={confirming.confirmation.title ?? confirming.label}
           description={confirming.confirmation.description ?? undefined}
           confirmLabel={confirming.confirmation.confirmLabel ?? confirming.label}

--- a/packages/table/resources/js/components/bulk-bar.tsx
+++ b/packages/table/resources/js/components/bulk-bar.tsx
@@ -1,14 +1,9 @@
-import { useState } from "react";
-import { apiFetch } from "@lattice-php/core/api";
-import { ActionForm } from "@lattice-php/form/action-form";
 import { Button } from "@lattice-php/ui/button";
-import { ConfirmDialog } from "@lattice-php/ui/confirm-dialog";
-import { runAction } from "@lattice-php/ui/effects/run-action";
-import { useEffectDispatcher } from "@lattice-php/ui/effects/use-effect-dispatcher";
+import { ActionTrigger } from "@lattice-php/ui/click-behavior";
 import { Spinner } from "@lattice-php/ui/spinner";
 import { prefixedTestId } from "@lattice-php/core/test-id";
 import { useT } from "@lattice-php/ui/i18n";
-import type { BulkAction } from "@lattice-php/table/lib/bulk";
+import type { Node } from "@lattice-php/core/types";
 
 export function BulkBar({
   actions,
@@ -20,7 +15,7 @@ export function BulkBar({
   onSelectAllMatching,
   onCompleted,
 }: {
-  actions: BulkAction[];
+  actions: Node<"action" | "action.bulk">[];
   selectedKeys: string[];
   allMatching: boolean;
   total?: number;
@@ -30,51 +25,9 @@ export function BulkBar({
   onCompleted: () => void;
 }) {
   const { t } = useT("lattice");
-  const [processing, setProcessing] = useState(false);
-  const dispatch = useEffectDispatcher();
-  const [confirming, setConfirming] = useState<BulkAction | null>(null);
-  const [filling, setFilling] = useState<BulkAction | null>(null);
 
   const selectionPayload = (): Record<string, unknown> =>
     allMatching ? { allMatching: true, ...query } : { selected: selectedKeys };
-
-  async function submit(action: BulkAction): Promise<void> {
-    setProcessing(true);
-
-    const ok = await runAction(
-      () =>
-        apiFetch(action.endpoint, {
-          method: action.method,
-          ref: action.ref,
-          body: JSON.stringify(selectionPayload()),
-          throwOnError: false,
-        }),
-      dispatch,
-    );
-
-    setProcessing(false);
-
-    if (ok) {
-      setConfirming(null);
-      onCompleted();
-    }
-  }
-
-  function run(action: BulkAction): void {
-    if (action.form) {
-      setFilling(action);
-
-      return;
-    }
-
-    if (action.confirmation) {
-      setConfirming(action);
-
-      return;
-    }
-
-    void submit(action);
-  }
 
   const count = allMatching ? (total ?? selectedKeys.length) : selectedKeys.length;
 
@@ -96,58 +49,28 @@ export function BulkBar({
         </button>
       )}
       <div className="flex flex-wrap items-center gap-2">
-        {actions.map((action) => (
-          <Button
-            key={action.id}
-            type="button"
-            data-test={prefixedTestId("bulk-action", action.id)}
-            variant={action.variant}
-            emphasis={action.emphasis}
-            disabled={processing}
-            onClick={() => run(action)}
+        {actions.map((action, index) => (
+          <ActionTrigger
+            key={action.key ?? action.id ?? index}
+            action={action}
+            options={{ extraData: selectionPayload, onSuccess: onCompleted }}
           >
-            {processing && <Spinner />}
-            {action.label}
-          </Button>
+            {({ onClick, processing }) => (
+              <Button
+                type="button"
+                data-test={prefixedTestId("bulk-action", action.id)}
+                variant={action.props.variant}
+                emphasis={action.props.emphasis}
+                disabled={processing}
+                onClick={onClick}
+              >
+                {processing && <Spinner />}
+                {action.props.label}
+              </Button>
+            )}
+          </ActionTrigger>
         ))}
       </div>
-
-      {confirming?.confirmation && (
-        <ConfirmDialog
-          open={confirming !== null}
-          title={confirming.confirmation.title ?? confirming.label}
-          description={confirming.confirmation.description ?? undefined}
-          confirmLabel={confirming.confirmation.confirmLabel ?? confirming.label}
-          cancelLabel={confirming.confirmation.cancelLabel ?? t("common.cancel", "Cancel")}
-          confirmVariant={confirming.variant}
-          confirmEmphasis={confirming.emphasis}
-          processing={processing}
-          onConfirm={() => void submit(confirming)}
-          onCancel={() => setConfirming(null)}
-        />
-      )}
-
-      {filling?.form && (
-        <ActionForm
-          open={filling !== null}
-          cancelLabel={filling.confirmation?.cancelLabel ?? t("common.cancel", "Cancel")}
-          componentRef={filling.ref}
-          description={filling.confirmation?.description ?? undefined}
-          endpoint={filling.endpoint}
-          extraData={selectionPayload()}
-          formNode={filling.form}
-          method={filling.method}
-          onClose={() => setFilling(null)}
-          onSuccess={() => {
-            setFilling(null);
-            onCompleted();
-          }}
-          placement={filling.modalSide ?? "center"}
-          submitLabel={filling.confirmation?.confirmLabel ?? filling.label}
-          title={filling.confirmation?.title ?? filling.label}
-          width={filling.modalWidth ?? undefined}
-        />
-      )}
     </div>
   );
 }

--- a/packages/table/resources/js/components/bulk-bar.tsx
+++ b/packages/table/resources/js/components/bulk-bar.tsx
@@ -129,6 +129,7 @@ export function BulkBar({
 
       {filling?.form && (
         <ActionForm
+          open={filling !== null}
           cancelLabel={filling.confirmation?.cancelLabel ?? t("common.cancel", "Cancel")}
           componentRef={filling.ref}
           description={filling.confirmation?.description ?? undefined}

--- a/packages/table/resources/js/components/table-bulk.test.tsx
+++ b/packages/table/resources/js/components/table-bulk.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
 import type { TableNode } from "@lattice-php/table/types";
 import { fakeNode } from "@lattice-php/core/test-support";
+import { ActionInteractionProvider } from "@lattice-php/action";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
 import { col, tableNode, tableQuery } from "../test-support";
 
 const apiFetch = vi.hoisted(() =>
@@ -17,6 +20,14 @@ vi.mock("@inertiajs/react", async () =>
 );
 
 const { default: TableComponent } = await import("./table");
+
+function renderTable(ui: ReactElement) {
+  return render(
+    <ModalHostProvider>
+      <ActionInteractionProvider>{ui}</ActionInteractionProvider>
+    </ModalHostProvider>,
+  );
+}
 
 const node = tableNode({
   columns: [col({ key: "name", label: "Name" })],
@@ -45,7 +56,7 @@ describe("table bulk actions", () => {
   });
 
   it("dispatches the selected rows when a bulk action runs", async () => {
-    render(<TableComponent node={node}>{null}</TableComponent>);
+    renderTable(<TableComponent node={node}>{null}</TableComponent>);
 
     expect(screen.queryByText("1 selected")).toBeNull();
 
@@ -66,7 +77,7 @@ describe("table bulk actions", () => {
   });
 
   it("selects every row from the header checkbox", () => {
-    render(<TableComponent node={node}>{null}</TableComponent>);
+    renderTable(<TableComponent node={node}>{null}</TableComponent>);
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Select all rows" }));
 
@@ -103,7 +114,7 @@ describe("table bulk actions", () => {
       },
     } satisfies TableNode;
 
-    render(<TableComponent node={matchingNode}>{null}</TableComponent>);
+    renderTable(<TableComponent node={matchingNode}>{null}</TableComponent>);
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Select all rows" }));
     fireEvent.click(screen.getByRole("button", { name: "Select all 50 matching" }));
@@ -147,7 +158,7 @@ describe("table bulk actions", () => {
       },
     } satisfies TableNode;
 
-    render(<TableComponent node={sheetNode}>{null}</TableComponent>);
+    renderTable(<TableComponent node={sheetNode}>{null}</TableComponent>);
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Select row 1" }));
     fireEvent.click(screen.getByRole("button", { name: "Tag selected" }));

--- a/packages/table/resources/js/components/table.tsx
+++ b/packages/table/resources/js/components/table.tsx
@@ -10,7 +10,7 @@ import { Checkbox } from "@lattice-php/ui/checkbox";
 import { Icon } from "@lattice-php/ui/icons";
 import { alignJustifyItems, alignText } from "@lattice-php/table/lib/align";
 import type { TableNode } from "@lattice-php/table/types";
-import { getBulkActions } from "@lattice-php/table/lib/bulk";
+import { getBulkActionNodes } from "@lattice-php/table/lib/bulk";
 import {
   getPerPageOptions,
   getRowActions,
@@ -64,7 +64,7 @@ const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => 
   } = useTable(node);
 
   const bulkActions = useMemo(
-    () => getBulkActions(node.props?.bulkActions),
+    () => getBulkActionNodes(node.props?.bulkActions),
     [node.props?.bulkActions],
   );
   const hasBulkActions = bulkActions.length > 0;

--- a/packages/table/resources/js/lib/bulk.ts
+++ b/packages/table/resources/js/lib/bulk.ts
@@ -38,6 +38,26 @@ export type BulkAction = {
   modalWidth: ModalWidth | null;
 };
 
+export function getBulkActionNodes(bulkActions: unknown): Node<"action" | "action.bulk">[] {
+  if (!Array.isArray(bulkActions)) {
+    return [];
+  }
+
+  return (bulkActions as Node[]).flatMap((node): Node<"action" | "action.bulk">[] => {
+    if (node.type !== "action" && node.type !== "action.bulk") {
+      return [];
+    }
+
+    const props = node.props as BulkActionProps | undefined;
+
+    if (!props?.endpoint) {
+      return [];
+    }
+
+    return [node as Node<"action" | "action.bulk">];
+  });
+}
+
 export function getBulkActions(actions: Node[] | undefined): BulkAction[] {
   return (actions ?? []).flatMap((node): BulkAction[] => {
     if (node.type !== "action" && node.type !== "action.bulk") {

--- a/packages/ui/resources/js/click-behavior.tsx
+++ b/packages/ui/resources/js/click-behavior.tsx
@@ -17,9 +17,16 @@ export type ClickBehavior =
 
 export type TriggerState = { onClick: () => void; processing: boolean };
 
+export type ActionSubmitOptions = {
+  /** Evaluated fresh at submit time, e.g. a bulk action's current selection. */
+  extraData?: () => Record<string, unknown>;
+  onSuccess?: () => void;
+};
+
 export type ActionTriggerRenderer = (props: {
   action: ActionNode;
   children: (trigger: TriggerState) => ReactNode;
+  options?: ActionSubmitOptions;
 }) => ReactNode;
 
 const ActionTriggerContext = createContext<ActionTriggerRenderer | null>(null);
@@ -45,9 +52,11 @@ export function useActionTrigger(): ActionTriggerRenderer | null {
 export function ActionTrigger({
   action,
   children,
+  options,
 }: {
   action: ActionNode;
   children: (trigger: TriggerState) => ReactNode;
+  options?: ActionSubmitOptions;
 }) {
   const render = useActionTrigger();
 
@@ -55,7 +64,7 @@ export function ActionTrigger({
     throw new Error("Action triggers require an ActionTriggerProvider.");
   }
 
-  return <>{render({ action, children })}</>;
+  return <>{render({ action, children, options })}</>;
 }
 
 export function useClickBehavior(props: {

--- a/packages/ui/resources/js/components/button-action.test.tsx
+++ b/packages/ui/resources/js/components/button-action.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionInteractionProvider } from "@lattice-php/action";
 import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
 import type { Node, ComponentPropsOf } from "@lattice-php/core/types";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
 import ButtonComponent from "./button";
 
 const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
@@ -37,9 +38,11 @@ function actionButton(props: Partial<ComponentPropsOf<"action">> = {}): Node<"bu
 
 function renderActionButton(node: Node<"button">) {
   return render(
-    <ActionInteractionProvider>
-      <ButtonComponent node={node}>{null}</ButtonComponent>
-    </ActionInteractionProvider>,
+    <ModalHostProvider>
+      <ActionInteractionProvider>
+        <ButtonComponent node={node}>{null}</ButtonComponent>
+      </ActionInteractionProvider>
+    </ModalHostProvider>,
   );
 }
 

--- a/packages/ui/resources/js/components/link-action.test.tsx
+++ b/packages/ui/resources/js/components/link-action.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionInteractionProvider } from "@lattice-php/action";
 import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
 import type { Node, ComponentPropsOf } from "@lattice-php/core/types";
+import { ModalHostProvider } from "@lattice-php/ui/modal-host";
 import LinkComponent from "./link";
 
 const apiFetch = vi.hoisted(() => vi.fn<() => Promise<Response>>());
@@ -36,9 +37,11 @@ function actionLink(props: Partial<ComponentPropsOf<"action">> = {}): Node<"link
 
 function renderActionLink(node: Node<"link">) {
   return render(
-    <ActionInteractionProvider>
-      <LinkComponent node={node}>{null}</LinkComponent>
-    </ActionInteractionProvider>,
+    <ModalHostProvider>
+      <ActionInteractionProvider>
+        <LinkComponent node={node}>{null}</LinkComponent>
+      </ActionInteractionProvider>
+    </ModalHostProvider>,
   );
 }
 

--- a/packages/ui/resources/js/components/modal.browser.test.tsx
+++ b/packages/ui/resources/js/components/modal.browser.test.tsx
@@ -15,7 +15,9 @@ function OpenButton() {
 
   return (
     <button
-      onClick={() => host.open(fakeNode({ type: "modal", id: "info", props: { title: "Info" } }))}
+      onClick={() =>
+        host.open(fakeNode<"modal">({ type: "modal", id: "info", props: { title: "Info" } }))
+      }
       type="button"
     >
       Open

--- a/packages/ui/resources/js/components/modal.test.tsx
+++ b/packages/ui/resources/js/components/modal.test.tsx
@@ -5,9 +5,9 @@ import type { Node } from "@lattice-php/core/types";
 import { EmbeddedModalContext } from "../modal-host";
 import ModalComponent from "./modal";
 
-function renderModal(node: Node<"modal">, open = true, onOpenChange = vi.fn()) {
+function renderModal(node: Node<"modal">, open = true, onOpenChange = vi.fn(), onExited = vi.fn()) {
   render(
-    <EmbeddedModalContext.Provider value={{ open, onOpenChange }}>
+    <EmbeddedModalContext.Provider value={{ open, onOpenChange, onExited }}>
       <ModalComponent node={node}>
         <p>Body content</p>
       </ModalComponent>

--- a/packages/ui/resources/js/components/modal.tsx
+++ b/packages/ui/resources/js/components/modal.tsx
@@ -34,6 +34,7 @@ const ModalComponent: RendererComponent<"modal"> = ({ children, node }) => {
     <Dialog open={context.open} onOpenChange={context.onOpenChange}>
       <DialogContent
         {...(description ? {} : { "aria-describedby": undefined })}
+        onCloseAutoFocus={context.onExited}
         placement={node.props.side ?? "center"}
         width={node.props.width}
         height={node.props.height}

--- a/packages/ui/resources/js/confirm-dialog.test.tsx
+++ b/packages/ui/resources/js/confirm-dialog.test.tsx
@@ -7,6 +7,7 @@ describe("ConfirmDialog", () => {
     const onConfirm = vi.fn<() => void>();
     render(
       <ConfirmDialog
+        open
         title="Delete account?"
         description="This cannot be undone."
         confirmLabel="Delete"
@@ -27,6 +28,7 @@ describe("ConfirmDialog", () => {
     const onCancel = vi.fn<() => void>();
     render(
       <ConfirmDialog
+        open
         title="Delete?"
         confirmLabel="Delete"
         onConfirm={() => {}}
@@ -43,6 +45,7 @@ describe("ConfirmDialog", () => {
     const onCancel = vi.fn<() => void>();
     render(
       <ConfirmDialog
+        open
         title="Delete?"
         confirmLabel="Delete"
         processing

--- a/packages/ui/resources/js/confirm-dialog.tsx
+++ b/packages/ui/resources/js/confirm-dialog.tsx
@@ -4,6 +4,7 @@ import type { Emphasis, Variant } from "./generated";
 import { Spinner } from "./spinner";
 
 export function ConfirmDialog({
+  open,
   title,
   description,
   confirmLabel,
@@ -14,7 +15,9 @@ export function ConfirmDialog({
   confirmDisabled = false,
   onConfirm,
   onCancel,
+  onExited,
 }: {
+  open: boolean;
   title: string;
   description?: string;
   confirmLabel: string;
@@ -25,6 +28,7 @@ export function ConfirmDialog({
   confirmDisabled?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  onExited?: (event: Event) => void;
 }) {
   const blockWhileProcessing = (event: Event): void => {
     if (processing) {
@@ -34,9 +38,9 @@ export function ConfirmDialog({
 
   return (
     <Dialog
-      open
-      onOpenChange={(open) => {
-        if (!open) {
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
           onCancel();
         }
       }}
@@ -44,6 +48,7 @@ export function ConfirmDialog({
       <DialogContent
         {...(description ? {} : { "aria-describedby": undefined })}
         width="md"
+        onCloseAutoFocus={onExited}
         onEscapeKeyDown={blockWhileProcessing}
         onInteractOutside={blockWhileProcessing}
       >

--- a/packages/ui/resources/js/index.ts
+++ b/packages/ui/resources/js/index.ts
@@ -14,7 +14,12 @@ export {
   useActionTrigger,
   useClickBehavior,
 } from "./click-behavior";
-export type { ActionTriggerRenderer, ClickBehavior, TriggerState } from "./click-behavior";
+export type {
+  ActionSubmitOptions,
+  ActionTriggerRenderer,
+  ClickBehavior,
+  TriggerState,
+} from "./click-behavior";
 export {
   Card,
   CardContent,

--- a/packages/ui/resources/js/modal-host.browser.test.tsx
+++ b/packages/ui/resources/js/modal-host.browser.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { Dialog, DialogContent, DialogHeader } from "./dialog";
+import { ConfirmDialog } from "./confirm-dialog";
+import { ModalHostProvider, useEmbeddedModal, useModalHost } from "./modal-host";
+
+function ConfirmB() {
+  const context = useEmbeddedModal();
+
+  if (!context) {
+    return null;
+  }
+
+  return (
+    <ConfirmDialog
+      open={context.open}
+      onExited={context.onExited}
+      title="Confirm B"
+      confirmLabel="Confirm"
+      onCancel={() => context.onOpenChange(false)}
+      onConfirm={() => context.onOpenChange(false)}
+    />
+  );
+}
+
+function DialogA() {
+  const context = useEmbeddedModal();
+  const host = useModalHost();
+
+  if (!context) {
+    return null;
+  }
+
+  return (
+    <Dialog open={context.open} onOpenChange={context.onOpenChange}>
+      <DialogContent onCloseAutoFocus={context.onExited}>
+        <DialogHeader title="Dialog A" />
+        <button onClick={() => host.open(<ConfirmB />)} type="button">
+          Open B
+        </button>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PageTrigger() {
+  const host = useModalHost();
+
+  return (
+    <button onClick={() => host.open(<DialogA />)} type="button">
+      Open A
+    </button>
+  );
+}
+
+describe("nested modal focus restore in a browser", () => {
+  it("restores focus down the stack as each nested dialog closes", async () => {
+    const screen = await render(
+      <ModalHostProvider>
+        <PageTrigger />
+      </ModalHostProvider>,
+    );
+
+    const pageOpener = screen.getByRole("button", { name: "Open A" });
+    await pageOpener.click();
+
+    await expect.element(screen.getByRole("dialog", { name: "Dialog A" })).toBeVisible();
+
+    const openB = screen.getByRole("button", { name: "Open B" });
+    await openB.click();
+
+    await expect.element(screen.getByRole("dialog", { name: "Confirm B" })).toBeVisible();
+
+    await screen.getByTestId("confirm-cancel").click();
+
+    await expect.element(screen.getByRole("dialog", { name: "Confirm B" })).not.toBeInTheDocument();
+    await expect.element(openB).toHaveFocus();
+
+    await screen.getByTestId("dialog-close").click();
+
+    await expect.element(screen.getByRole("dialog", { name: "Dialog A" })).not.toBeInTheDocument();
+    await expect.element(pageOpener).toHaveFocus();
+  });
+});

--- a/packages/ui/resources/js/modal-host.test.tsx
+++ b/packages/ui/resources/js/modal-host.test.tsx
@@ -203,6 +203,31 @@ describe("ModalHostProvider", () => {
     expect(screen.queryByRole("dialog", { name: "Element dialog" })).not.toBeInTheDocument();
   });
 
+  it("stacks an element overlay above an open node modal; closing the overlay leaves the modal open", () => {
+    renderWithRegistry(
+      <ModalHostProvider>
+        <OpenButton label="Open modal" node={modalNode("welcome", "Welcome")} />
+        <OpenElementButton label="Open overlay" title="Overlay dialog" />
+      </ModalHostProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open modal" }));
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open overlay", hidden: true }));
+    expect(
+      screen.getByRole("dialog", { name: "Overlay dialog", hidden: true }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close Overlay dialog", hidden: true }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Overlay dialog", hidden: true }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+  });
+
   it("removes an entry from the DOM after it closes, and a subsequent open still works", () => {
     renderWithRegistry(
       <ModalHostProvider>

--- a/packages/ui/resources/js/modal-host.test.tsx
+++ b/packages/ui/resources/js/modal-host.test.tsx
@@ -5,7 +5,7 @@ import { renderWithRegistry, fakeNode } from "@lattice-php/core/test-support";
 import { LATTICE_EVENT } from "@lattice-php/core/event-names";
 import type { Node } from "@lattice-php/core/types";
 import ModalComponent from "./components/modal";
-import { ModalHostProvider, useModalHost } from "./modal-host";
+import { ModalHostProvider, useEmbeddedModal, useModalHost } from "./modal-host";
 
 const registry = createRegistry({
   components: { modal: eagerComponent(ModalComponent) },
@@ -23,6 +23,33 @@ function OpenButton({ label, node }: { label: string; node: Node<"modal"> }) {
     <button onClick={() => host.open(node)} type="button">
       {label}
     </button>
+  );
+}
+
+function OpenElementButton({ label, title }: { label: string; title: string }) {
+  const host = useModalHost();
+
+  return (
+    <button onClick={() => host.open(<ElementDialog title={title} />)} type="button">
+      {label}
+    </button>
+  );
+}
+
+function ElementDialog({ title }: { title: string }) {
+  const context = useEmbeddedModal();
+
+  if (context && !context.open) {
+    return null;
+  }
+
+  return (
+    <div role="dialog" aria-label={title}>
+      <span>{title}</span>
+      <button onClick={() => context?.onOpenChange(false)} type="button">
+        Close {title}
+      </button>
+    </div>
   );
 }
 
@@ -56,7 +83,7 @@ describe("ModalHostProvider", () => {
     expect(screen.getByText("Welcome")).toBeInTheDocument();
   });
 
-  it("closes on Escape and replaces the node on the next open()", () => {
+  it("stacks a second node modal above the first, which stays mounted", () => {
     renderWithRegistry(
       <ModalHostProvider>
         <OpenButton label="Open first" node={modalNode("first", "First")} />
@@ -66,47 +93,132 @@ describe("ModalHostProvider", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Open first" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open second", hidden: true }));
+
     expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.getByText("Second")).toBeInTheDocument();
+  });
+
+  it("closes only the topmost entry on Escape, leaving the lower one open", () => {
+    renderWithRegistry(
+      <ModalHostProvider>
+        <OpenButton label="Open first" node={modalNode("first", "First")} />
+        <OpenButton label="Open second" node={modalNode("second", "Second")} />
+      </ModalHostProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open first" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open second", hidden: true }));
 
     fireEvent.keyDown(document.body, { key: "Escape" });
-    expect(screen.queryByText("First")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open second" }));
-    expect(screen.getByText("Second")).toBeInTheDocument();
-    expect(screen.queryByText("First")).not.toBeInTheDocument();
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    expect(screen.getByText("First")).toBeInTheDocument();
   });
 
-  it("closes on a matching lattice:close-modal id and ignores a non-matching one", () => {
+  it("closes only the matching mid-stack entry on a targeted lattice:close-modal", () => {
     renderWithRegistry(
       <ModalHostProvider>
-        <OpenButton label="Open" node={modalNode("welcome", "Welcome")} />
+        <OpenButton label="Open first" node={modalNode("first", "First")} />
+        <OpenButton label="Open second" node={modalNode("second", "Second")} />
+        <OpenButton label="Open third" node={modalNode("third", "Third")} />
       </ModalHostProvider>,
       registry,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open" }));
-    expect(screen.getByText("Welcome")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open first" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open second", hidden: true }));
+    fireEvent.click(screen.getByRole("button", { name: "Open third", hidden: true }));
 
-    fireModalEvent(LATTICE_EVENT.closeModal, { modal: "other" });
-    expect(screen.getByText("Welcome")).toBeInTheDocument();
+    fireModalEvent(LATTICE_EVENT.closeModal, { modal: "second" });
 
-    fireModalEvent(LATTICE_EVENT.closeModal, { modal: "welcome" });
-    expect(screen.queryByText("Welcome")).not.toBeInTheDocument();
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    expect(screen.getByText("Third")).toBeInTheDocument();
   });
 
-  it("closes on a lattice:close-modal event with no target modal", () => {
+  it("closes the topmost open entry on a lattice:close-modal event with no target", () => {
     renderWithRegistry(
       <ModalHostProvider>
-        <OpenButton label="Open" node={modalNode("welcome", "Welcome")} />
+        <OpenButton label="Open first" node={modalNode("first", "First")} />
+        <OpenButton label="Open second" node={modalNode("second", "Second")} />
       </ModalHostProvider>,
       registry,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open" }));
-    expect(screen.getByText("Welcome")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open first" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open second", hidden: true }));
 
     fireModalEvent(LATTICE_EVENT.closeModal, { modal: null });
+
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    expect(screen.getByText("First")).toBeInTheDocument();
+  });
+
+  it("ignores a lattice:close-modal id that doesn't match any entry", () => {
+    renderWithRegistry(
+      <ModalHostProvider>
+        <OpenButton label="Open" node={modalNode("welcome", "Welcome")} />
+      </ModalHostProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    fireModalEvent(LATTICE_EVENT.closeModal, { modal: "other" });
+
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+  });
+
+  it("replaces an already-open entry with the same node id instead of stacking a duplicate", () => {
+    renderWithRegistry(
+      <ModalHostProvider>
+        <OpenButton label="Open v1" node={modalNode("welcome", "Welcome v1")} />
+        <OpenButton label="Open v2" node={modalNode("welcome", "Welcome v2")} />
+      </ModalHostProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open v1" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open v2", hidden: true }));
+
+    expect(screen.getAllByRole("dialog", { name: "Welcome v2" })).toHaveLength(1);
+    expect(screen.queryByText("Welcome v1")).not.toBeInTheDocument();
+  });
+
+  it("renders an element entry under the embedded modal context and lets it close itself", () => {
+    renderWithRegistry(
+      <ModalHostProvider>
+        <OpenElementButton label="Open element" title="Element dialog" />
+      </ModalHostProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open element" }));
+    expect(screen.getByRole("dialog", { name: "Element dialog" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close Element dialog" }));
+
+    expect(screen.queryByRole("dialog", { name: "Element dialog" })).not.toBeInTheDocument();
+  });
+
+  it("removes an entry from the DOM after it closes, and a subsequent open still works", () => {
+    renderWithRegistry(
+      <ModalHostProvider>
+        <OpenButton label="Open" node={modalNode("welcome", "Welcome")} />
+      </ModalHostProvider>,
+      registry,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
     expect(screen.queryByText("Welcome")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
   });
 
   it("renders nothing and warns once when a modal node has no ModalHostProvider", () => {

--- a/packages/ui/resources/js/modal-host.tsx
+++ b/packages/ui/resources/js/modal-host.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  isValidElement,
   useCallback,
   useContext,
   useEffect,
@@ -7,16 +8,28 @@ import {
   useRef,
   useState,
 } from "react";
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 import type { Node } from "@lattice-php/core/types";
 import { RenderNode } from "@lattice-php/core/renderer";
 import { LATTICE_EVENT } from "@lattice-php/core/event-names";
 
 export const MODAL_HOST_MISSING_ERROR = "Embedded modals require a ModalHostProvider.";
 
+/**
+ * Contract: any dialog shell consuming this context (`modal.tsx`, a
+ * controlled `ConfirmDialog`, ...) MUST wire `onExited` to its Radix
+ * `DialogContent`'s `onCloseAutoFocus`. `onOpenChange(false)` only starts
+ * the close — Radix plays the exit animation while the entry stays mounted
+ * with `open: false` — and the host removes the entry (and restores focus)
+ * only once `onExited` fires. A shell that never wires `onExited` leaves its
+ * entry mounted-but-closed forever; this is the same silent leak the old
+ * single-slot host had if a caller skipped `onOpenChange`, so there is
+ * deliberately no backstop timer here.
+ */
 export type EmbeddedModalState = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onExited: (event: Event) => void;
 };
 
 export const EmbeddedModalContext = createContext<EmbeddedModalState | null>(null);
@@ -26,7 +39,7 @@ export function useEmbeddedModal(): EmbeddedModalState | null {
 }
 
 export type ModalHost = {
-  open: (node: Node<"modal">) => void;
+  open: (content: Node<"modal"> | ReactElement) => void;
 };
 
 export const ModalHostContext = createContext<ModalHost | null>(null);
@@ -41,41 +54,56 @@ export function useModalHost(): ModalHost {
   return host;
 }
 
+type ModalHostEntry = {
+  key: number;
+  content: Node<"modal"> | ReactElement;
+  nodeId: string | null;
+  open: boolean;
+  opener: HTMLElement | null;
+};
+
+type ModalHostClosures = {
+  onOpenChange: (open: boolean) => void;
+  onExited: (event: Event) => void;
+};
+
 type OpenModalEvent = CustomEvent<{ node?: Node<"modal"> }>;
 type CloseModalEvent = CustomEvent<{ modal?: string | null }>;
 
-export function ModalHostProvider({ children }: { children: ReactNode }) {
-  const [node, setNode] = useState<Node<"modal"> | null>(null);
-  const [isOpen, setIsOpen] = useState(false);
-  const openerRef = useRef<HTMLElement | null>(null);
-  const wasOpenRef = useRef(isOpen);
-
-  const open = useCallback((next: Node<"modal">) => {
-    openerRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    setNode(next);
-    setIsOpen(true);
-  }, []);
-
-  const onOpenChange = useCallback((next: boolean) => {
-    setIsOpen(next);
-  }, []);
-
-  // Radix only restores focus to a `DialogTrigger`-registered element, and these
-  // modals are opened imperatively rather than through one. Own the restore
-  // ourselves instead: whatever had focus when the modal opened gets it back
-  // once the closing dialog has finished unmounting.
-  useEffect(() => {
-    if (wasOpenRef.current && !isOpen) {
-      const opener = openerRef.current;
-
-      if (opener) {
-        requestAnimationFrame(() => opener.focus());
-      }
+function topmostOpenIndex(stack: ModalHostEntry[]): number {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    if (stack[index].open) {
+      return index;
     }
+  }
 
-    wasOpenRef.current = isOpen;
-  }, [isOpen]);
+  return -1;
+}
+
+export function ModalHostProvider({ children }: { children: ReactNode }) {
+  const [stack, setStack] = useState<ModalHostEntry[]>([]);
+  const nextKeyRef = useRef(0);
+  const closuresRef = useRef(new Map<number, ModalHostClosures>());
+
+  const open = useCallback((content: Node<"modal"> | ReactElement) => {
+    const nodeId = isValidElement(content) ? null : (content.id ?? null);
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    setStack((current) => {
+      if (nodeId !== null) {
+        const index = current.findIndex((entry) => entry.nodeId === nodeId && entry.open);
+
+        if (index !== -1) {
+          const next = [...current];
+          next[index] = { ...next[index], content };
+
+          return next;
+        }
+      }
+
+      return [...current, { key: nextKeyRef.current++, content, nodeId, open: true, opener }];
+    });
+  }, []);
 
   useEffect(() => {
     function handleOpen(event: Event): void {
@@ -89,9 +117,21 @@ export function ModalHostProvider({ children }: { children: ReactNode }) {
     function handleClose(event: Event): void {
       const target = (event as CloseModalEvent).detail?.modal;
 
-      if (target == null || target === node?.id) {
-        setIsOpen(false);
-      }
+      setStack((current) => {
+        const index =
+          target == null
+            ? topmostOpenIndex(current)
+            : current.findIndex((entry) => entry.nodeId === target);
+
+        if (index === -1) {
+          return current;
+        }
+
+        const next = [...current];
+        next[index] = { ...next[index], open: false };
+
+        return next;
+      });
     }
 
     window.addEventListener(LATTICE_EVENT.openModal, handleOpen);
@@ -101,19 +141,67 @@ export function ModalHostProvider({ children }: { children: ReactNode }) {
       window.removeEventListener(LATTICE_EVENT.openModal, handleOpen);
       window.removeEventListener(LATTICE_EVENT.closeModal, handleClose);
     };
-  }, [open, node?.id]);
+  }, [open]);
+
+  const closuresFor = useCallback((key: number): ModalHostClosures => {
+    let closures = closuresRef.current.get(key);
+
+    if (closures) {
+      return closures;
+    }
+
+    closures = {
+      onOpenChange: (nextOpen) => {
+        if (nextOpen) {
+          return;
+        }
+
+        setStack((current) =>
+          current.map((entry) => (entry.key === key ? { ...entry, open: false } : entry)),
+        );
+      },
+      // Radix only restores focus to a `DialogTrigger`-registered element, and
+      // these modals are opened imperatively rather than through one. Own the
+      // restore ourselves instead: whatever had focus when the entry opened
+      // gets it back once the closing dialog has finished its exit animation.
+      // The opener can itself have unmounted in the meantime (e.g. a popover
+      // menu item that also closed) — fall back to Radix's default in that case.
+      onExited: (event) => {
+        setStack((current) => {
+          const entry = current.find((candidate) => candidate.key === key);
+          const opener = entry?.opener ?? null;
+
+          if (opener?.isConnected) {
+            event.preventDefault();
+            requestAnimationFrame(() => opener.focus());
+          }
+
+          return current.filter((candidate) => candidate.key !== key);
+        });
+
+        closuresRef.current.delete(key);
+      },
+    };
+
+    closuresRef.current.set(key, closures);
+
+    return closures;
+  }, []);
 
   const host = useMemo(() => ({ open }), [open]);
-  const embedded = useMemo(() => ({ open: isOpen, onOpenChange }), [isOpen, onOpenChange]);
 
   return (
     <ModalHostContext.Provider value={host}>
       {children}
-      {node !== null ? (
-        <EmbeddedModalContext.Provider value={embedded}>
-          <RenderNode node={node} />
-        </EmbeddedModalContext.Provider>
-      ) : null}
+      {stack.map((entry) => {
+        const value: EmbeddedModalState = { open: entry.open, ...closuresFor(entry.key) };
+
+        return (
+          <EmbeddedModalContext.Provider key={entry.key} value={value}>
+            {isValidElement(entry.content) ? entry.content : <RenderNode node={entry.content} />}
+          </EmbeddedModalContext.Provider>
+        );
+      })}
     </ModalHostContext.Provider>
   );
 }


### PR DESCRIPTION
Follow-up to #488: retires the second, parallel dialog system. Action confirmation and form dialogs used to mount next to their trigger with hardcoded-open dialogs — inside the ActionGroup dropdown that meant living in a Radix popover portal, and the bulk bar carried a full duplicate of the same state machine (which could never open lazy forms).

**The modal host is now a dialog stack.** Every dialog opened through it — embedded/effect-shipped modals and action overlays — pushes an entry that owns its opener-focus restore and is removed after the Radix exit animation (`onExited` wired to `onCloseAutoFocus`). A modal can open another modal; an action confirm opens above the current modal instead of replacing it. Same-id node opens replace in place so flash replays stay idempotent.

**Action overlays are self-contained host entries.** `ActionConfirmOverlay`/`ActionFormOverlay` own their submit lifecycle (processing, keep-open-on-422, GET visits) and close themselves through the host context. `useAction` slims to `{processing, requestSubmit}` plus `{extraData, onSuccess}` options; `ConfirmDialog` and `ActionForm` are explicitly controlled (`open`/`onExited`).

**The bulk bar drives the shared hook.** Its duplicate confirm/form machine is deleted; bulk actions flow through the same `ActionTrigger` inversion with the selection payload as `extraData` — which also fixes the real bug that lazy bulk forms never opened (the schema fetch now carries the selection for future request-aware bulk definitions).

PHP and the wire format are untouched. Breaking client changes: `EmbeddedModalState` requires `onExited`; `ConfirmDialog`/`ActionForm` require `open`; `useAction` no longer returns `overlays`.

Known tradeoff: when a confirm is opened from a dropdown, the dropdown now closes (the overlay no longer holds it open); if the opener unmounts, focus restore falls back to Radix's default.

**Verification:** full jsdom suite, browser tests incl. new nested-focus-restore and popover-survival coverage, `ActionRejectionTest`/`ModalsTest`/`ProductsTableTest` as unchanged behavior contracts, Pest feature suite, docs build.

Not in scope (planned follow-ups): migrating the media picker/detail sheet, editor image dialog, and lightbox onto the stack; relocating `getBulkActions` into media.
