### PR TITLE
fix: stabilize the flaky CI browser tests

### DIFF
--- a/packages/core/resources/js/registry.test.ts
+++ b/packages/core/resources/js/registry.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
-import { createRegistry, eagerComponent, loadPluginModules } from "./registry";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRegistry, eagerComponent, lazyComponent, loadPluginModules } from "./registry";
 import type { Plugin } from "./registry";
-import type { RendererComponent } from "./index";
+import type { RendererComponent, RendererComponentModule } from "./index";
 
 const EagerComponent: RendererComponent<"test.eager"> = () => null;
 
@@ -81,6 +81,44 @@ describe("lattice registry", () => {
       );
     },
   );
+
+  describe("lazy chunk retry", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("recovers a transient chunk-fetch failure on a later retry", async () => {
+      const module: RendererComponentModule<"test.eager"> = { default: EagerComponent };
+      const load = vi
+        .fn<() => Promise<RendererComponentModule<"test.eager">>>()
+        .mockRejectedValueOnce(new Error("first failure"))
+        .mockRejectedValueOnce(new Error("second failure"))
+        .mockResolvedValue(module);
+
+      const pending = expect(lazyComponent(load).load()).resolves.toBe(module);
+      await vi.runAllTimersAsync();
+
+      await pending;
+      expect(load).toHaveBeenCalledTimes(3);
+    });
+
+    it("surfaces the original error once every retry fails", async () => {
+      const load = vi
+        .fn<() => Promise<RendererComponentModule<"test.eager">>>()
+        .mockRejectedValueOnce(new Error("original failure"))
+        .mockRejectedValue(new Error("later failure"));
+
+      const pending = expect(lazyComponent(load).load()).rejects.toThrow("original failure");
+      await vi.runAllTimersAsync();
+
+      await pending;
+      expect(load).toHaveBeenCalledTimes(4);
+    });
+  });
 
   it.each([
     { name: "invalid", components: [] },

--- a/packages/core/resources/js/registry.ts
+++ b/packages/core/resources/js/registry.ts
@@ -53,13 +53,14 @@ export function eagerComponent<TType extends string>(
   };
 }
 
-const CHUNK_RETRY_DELAY_MS = 250;
+const CHUNK_RETRY_DELAYS_MS = [250, 1000, 4000];
 
 /**
  * React.lazy caches a rejected loader forever, so one transient chunk-fetch
- * failure (a flaky network, a briefly overloaded server) would leave the
- * subtree permanently broken. One delayed retry recovers those; a persistent
- * failure still surfaces the original error.
+ * failure (a flaky network, a briefly overloaded or stalled server) would
+ * leave the subtree permanently broken. Escalating retries recover outages
+ * that outlast a single short delay; a persistent failure still surfaces the
+ * original error.
  */
 function withChunkRetry(
   load: () => Promise<RendererComponentModule>,
@@ -68,13 +69,17 @@ function withChunkRetry(
     try {
       return await load();
     } catch (error) {
-      await new Promise((resolve) => setTimeout(resolve, CHUNK_RETRY_DELAY_MS));
+      for (const delayMs of CHUNK_RETRY_DELAYS_MS) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
 
-      try {
-        return await load();
-      } catch {
-        throw error;
+        try {
+          return await load();
+        } catch {
+          continue;
+        }
       }
+
+      throw error;
     }
   };
 }

--- a/tests/BrowserTestCase.php
+++ b/tests/BrowserTestCase.php
@@ -23,6 +23,8 @@ class BrowserTestCase extends TestCase
 
         $this->assertWorkbenchManifestExists();
 
+        \startBrowserHttpServerWithLongKeepAlive();
+
         // CI runners are slower than Playwright's tight 5s default, which
         // intermittently trips browser actions/assertions under load.
         Playwright::setTimeout(15_000);

--- a/tests/Support/Browser.php
+++ b/tests/Support/Browser.php
@@ -2,16 +2,84 @@
 
 declare(strict_types=1);
 
+use Amp\Http\Server\DefaultErrorHandler;
+use Amp\Http\Server\Driver\DefaultHttpDriverFactory;
+use Amp\Http\Server\Request as ServerRequest;
+use Amp\Http\Server\RequestHandler\ClosureRequestHandler;
+use Amp\Http\Server\Response as ServerResponse;
+use Amp\Http\Server\SocketHttpServer;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\Factories\UserFactory;
 use Pest\Browser\Api\AwaitableWebpage;
 use Pest\Browser\Api\PendingAwaitablePage;
 use Pest\Browser\Api\Webpage;
+use Pest\Browser\Drivers\LaravelHttpServer;
+use Pest\Browser\ServerManager;
+use Psr\Log\NullLogger;
 use Workbench\App\Models\Product;
 use Workbench\App\Models\User;
 
 use function Amp\delay;
+
+/**
+ * Starts the Pest browser HTTP server with an hour-long keep-alive timeout
+ * before the plugin can start it with amphp's 15-second default.
+ *
+ * Chrome pools connections for minutes and ignores the server's
+ * `Keep-Alive: timeout` hint, so with the default it regularly sends a
+ * request on a connection the server is concurrently closing. The request
+ * then dies at the network level: dynamic imports fail with "Failed to fetch
+ * dynamically imported module" and Inertia POST submits vanish without any
+ * error — the recurring flaky browser failures in CI, where DOM-polling
+ * assertions routinely leave connections idle past 15 seconds. The plugin
+ * exposes no server configuration, so this pre-starts the identical server
+ * with a longer timeout; LaravelHttpServer::start() then finds the socket
+ * already present and leaves it in place.
+ */
+function startBrowserHttpServerWithLongKeepAlive(): void
+{
+    $http = ServerManager::instance()->http();
+
+    if (! $http instanceof LaravelHttpServer) {
+        return;
+    }
+
+    $socketProperty = new ReflectionProperty(LaravelHttpServer::class, 'socket');
+
+    if ($socketProperty->getValue($http) !== null) {
+        return;
+    }
+
+    $logger = new NullLogger;
+    $keepAliveSeconds = 3600;
+
+    $server = SocketHttpServer::createForDirectAccess(
+        $logger,
+        httpDriverFactory: new DefaultHttpDriverFactory(
+            $logger,
+            streamTimeout: $keepAliveSeconds,
+            connectionTimeout: $keepAliveSeconds,
+        ),
+    );
+
+    $server->expose("{$http->host}:{$http->port}");
+
+    $handleRequest = new ReflectionMethod(LaravelHttpServer::class, 'handleRequest');
+
+    $server->start(
+        new ClosureRequestHandler(function (ServerRequest $request) use ($handleRequest, $http): ServerResponse {
+            $response = $handleRequest->invoke($http, $request);
+
+            assert($response instanceof ServerResponse);
+
+            return $response;
+        }),
+        new DefaultErrorHandler,
+    );
+
+    $socketProperty->setValue($http, $server);
+}
 
 /**
  * Retries browser assertions while asynchronous UI work settles.


### PR DESCRIPTION
## Root cause

The recurring Browser-workflow flakes (`ProductFormTest`, `WizardTest`, `RepeaterTest`) share one root cause: the pest browser plugin's amphp server closes idle keep-alive connections after 15 seconds (`Http1Driver` default), while Chrome pools connections for minutes and ignores the `Keep-Alive: timeout` hint. A request sent on a connection the server is concurrently closing dies at the network level:

- module GETs fail with `Failed to fetch dynamically imported module: …/text-*.js` and blank the page (ProductFormTest screenshots show an empty viewport),
- Inertia POST submits vanish without any error — Chrome never retries POSTs — so the wizard's "Order placed." toast and the repeater's reset never happen (screenshots show the form still filled, no toast).

The DOM-polling `retryUntil` loops leave connections idle well past 15s, which is why CI (slow runners, long polls) hits the race and local runs rarely do.

## Fix

- `tests/Support/Browser.php`: pre-start the identical amphp server with an hour-long keep-alive from `BrowserTestCase::setUp()` — the plugin exposes no server configuration, so the shim reflects into `LaravelHttpServer` and its `start()` then finds the socket already present. Pest proxies run inside the test closure, i.e. after `setUp()`, so the shim always wins the race.
- `packages/core/resources/js/registry.ts`: `withChunkRetry` now retries a failed lazy chunk load at 250ms/1s/4s instead of once after 250ms, so a transient fetch failure (test server or real-world flaky network) no longer permanently breaks the subtree via `React.lazy`'s rejection cache.

Full browser suite passes locally (133 tests, 784 assertions). Upstream follow-up: a configurable `connectionTimeout` in pest-plugin-browser would make the shim unnecessary.