### PR TITLE
fix: register page routes most-specific first

### DIFF
--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -34,6 +34,7 @@ use Lattice\Core\Discovery\DiscoveryKinds;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Core\LatticeRegistry;
+use Lattice\Core\PageMetadata;
 use Lattice\Core\Wire\WireSourceCatalog;
 use Lattice\Form\FormServiceProvider;
 use Lattice\Fragments\FragmentDefinition;
@@ -190,6 +191,11 @@ final class LatticeServiceProvider extends PackageServiceProvider
      * A page with no route is a valid embedded page (rendered by returning it
      * from a developer-owned controller, never dispatched by Lattice itself),
      * so it is skipped here rather than passed to `Route::get()`.
+     *
+     * Routes register most-specific first because the router matches in
+     * registration order: discovery order would let `/orders/{order}` swallow
+     * `/orders/create`. `route:cache` compiles this same order, so the fix
+     * carries into the cached route table.
      */
     public function bootPages(): void
     {
@@ -197,7 +203,11 @@ final class LatticeServiceProvider extends PackageServiceProvider
             return;
         }
 
-        foreach (Lattice::pageRegistry()->all() as $page) {
+        $pages = Lattice::pageRegistry()->all();
+
+        usort($pages, $this->compareRouteSpecificity(...));
+
+        foreach ($pages as $page) {
             if ($page->route === null) {
                 continue;
             }
@@ -212,6 +222,23 @@ final class LatticeServiceProvider extends PackageServiceProvider
         }
 
         Route::getRoutes()->refreshNameLookups();
+    }
+
+    /**
+     * Lexicographic comparison of per-segment flags (static = 0, parameter = 1),
+     * so `/orders/create` outranks `/orders/{order}` at the segment where they
+     * diverge. PHP's array comparison ranks a smaller segment count first, which
+     * is safe because routes of different lengths cannot shadow each other, and
+     * `usort` being stable keeps discovery order between equally specific routes.
+     */
+    private function compareRouteSpecificity(PageMetadata $a, PageMetadata $b): int
+    {
+        $flags = static fn (PageMetadata $page): array => array_map(
+            static fn (string $segment): int => (int) str_starts_with($segment, '{'),
+            explode('/', trim((string) $page->route, '/')),
+        );
+
+        return $flags($a) <=> $flags($b);
     }
 
     /**

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Route as RoutingRoute;
 use Illuminate\Support\Facades\Route;
 use Lattice\Core\Attributes\AsPage;
@@ -78,6 +79,42 @@ final class RegGuardedBarePage extends RegBasePage
     public function render(PageSchema $schema): PageSchema
     {
         return $schema->component(Text::make('Guarded bare'));
+    }
+}
+
+#[AsPage(route: '/orders/{order}', name: 'orders.show')]
+final class RegOrdersShowPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Order'));
+    }
+}
+
+#[AsPage(route: '/orders/create', name: 'orders.create')]
+final class RegOrdersCreatePage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Create order'));
+    }
+}
+
+#[AsPage(route: '/orders/{order}/edit', name: 'orders.edit')]
+final class RegOrdersEditPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Edit order'));
+    }
+}
+
+#[AsPage(route: '/orders/bulk/{action}', name: 'orders.bulk')]
+final class RegOrdersBulkPage extends RegBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Bulk orders'));
     }
 }
 
@@ -208,6 +245,26 @@ test('an imperatively registered route-less page registers no route, while a rou
     expect(collect(Lattice::pageRegistry()->all())->pluck('class'))->toContain(RegEmbeddedPage::class)
         ->and($actions)->not->toContain(RegEmbeddedPage::class.'@render')
         ->and(Route::getRoutes()->getByName('widgets.index'))->not->toBeNull();
+});
+
+test('a static route wins over a parameterised sibling registered before it', function (): void {
+    Lattice::pages([RegOrdersShowPage::class, RegOrdersCreatePage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    $matched = Route::getRoutes()->match(Request::create('/orders/create'));
+
+    expect($matched->getActionName())->toBe(RegOrdersCreatePage::class.'@render');
+});
+
+test('a route with an earlier static segment wins over one whose parameter would swallow it', function (): void {
+    Lattice::pages([RegOrdersEditPage::class, RegOrdersBulkPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    $matched = Route::getRoutes()->match(Request::create('/orders/bulk/edit'));
+
+    expect($matched->getActionName())->toBe(RegOrdersBulkPage::class.'@render');
 });
 
 test('the service provider skips building routes when the route cache is active', function (): void {


### PR DESCRIPTION
Discovered `#[AsPage]` routes registered in discovery order, so a parameterised route like `/orders/{order}` could shadow a static sibling like `/orders/create` when it happened to register first.

`bootPages()` now sorts routable pages before registration: segments compare lexicographically with static segments outranking parameters, and the stable sort keeps discovery order between equally specific routes. `route:cache` compiles this same registration order, so the fix carries into the cached route table.

Covered by two new tests: `/orders/create` wins over an earlier-registered `/orders/{order}`, and `/orders/bulk/{action}` wins over `/orders/{order}/edit` for `/orders/bulk/edit`.