### PR TITLE
feat(ui): bind recordless description list entries to row data

### DIFF
--- a/docs/content/docs/components/description-list.mdx
+++ b/docs/content/docs/components/description-list.mdx
@@ -22,15 +22,19 @@ to a [form](/forms/overview/). Give it a record and each entry reads its own val
 />
 
 An entry's label defaults to its name in headline case (`joined_at` → `Joined at`); pass a second
-argument to override it. Its value is also bound to that name through Lattice's `dataBindings`, so
-the same list works inside a client-materialised schema. Use `->dataKey('value', 'profile.email')`
-when the data path differs from the entry name.
+argument to override it. The record may be an associative array, a keyed Collection, a model, or
+another object. Entry names use Laravel's `data_get()`, so dotted paths such as `profile.email` work
+across those record types.
+
+When the list has no record, it treats its entries as a row template and binds each value to the
+entry name through Lattice's `dataBindings`. This lets the same list work inside a client-materialised
+schema. Use `->dataKey('value', 'profile.email')` when the row path differs from the entry name.
 
 <Info title="Value precedence">
-  `->record()` fills the server-rendered value and keeps its data binding. `->value('…')` — which
-  also accepts a Closure resolved against the render context — is an explicit override and removes
-  the automatic value binding. Calling `->dataKey('value', '…')` afterwards deliberately enables
-  client materialisation again.
+  `->record()` is the source for record-backed lists and does not add automatic row bindings.
+  `->value('…')` — which also accepts a Closure resolved against the render context — overrides the
+  record and prevents an automatic binding. An explicit `->dataKey('value', '…')` remains an
+  intentional client-materialisation instruction.
 </Info>
 
 ## Entries

--- a/docs/content/docs/components/description-list.mdx
+++ b/docs/content/docs/components/description-list.mdx
@@ -22,9 +22,16 @@ to a [form](/forms/overview/). Give it a record and each entry reads its own val
 />
 
 An entry's label defaults to its name in headline case (`joined_at` → `Joined at`); pass a second
-argument to override it. Without `->record()`, or for any entry that should not read from it, set the
-value outright with `->value('…')` — which also accepts a Closure resolved against the render
-context.
+argument to override it. Its value is also bound to that name through Lattice's `dataBindings`, so
+the same list works inside a client-materialised schema. Use `->dataKey('value', 'profile.email')`
+when the data path differs from the entry name.
+
+<Info title="Value precedence">
+  `->record()` fills the server-rendered value and keeps its data binding. `->value('…')` — which
+  also accepts a Closure resolved against the render context — is an explicit override and removes
+  the automatic value binding. Calling `->dataKey('value', '…')` afterwards deliberately enables
+  client materialisation again.
+</Info>
 
 ## Entries
 

--- a/docs/fixtures/components.description-list.json
+++ b/docs/fixtures/components.description-list.json
@@ -18,6 +18,9 @@
                     {
                         "props": {
                             "copyable": false,
+                            "dataBindings": {
+                                "value": "name"
+                            },
                             "description": null,
                             "label": "Name",
                             "name": "name",
@@ -29,6 +32,9 @@
                     {
                         "props": {
                             "copyable": true,
+                            "dataBindings": {
+                                "value": "email"
+                            },
                             "description": null,
                             "label": "Email",
                             "name": "email",
@@ -39,6 +45,9 @@
                     },
                     {
                         "props": {
+                            "dataBindings": {
+                                "value": "joined_at"
+                            },
                             "description": null,
                             "format": {
                                 "dateStyle": "long",
@@ -55,6 +64,9 @@
                     },
                     {
                         "props": {
+                            "dataBindings": {
+                                "value": "is_active"
+                            },
                             "description": null,
                             "falseIcon": "x",
                             "label": "Active",

--- a/docs/fixtures/components.description-list.json
+++ b/docs/fixtures/components.description-list.json
@@ -18,9 +18,6 @@
                     {
                         "props": {
                             "copyable": false,
-                            "dataBindings": {
-                                "value": "name"
-                            },
                             "description": null,
                             "label": "Name",
                             "name": "name",
@@ -32,9 +29,6 @@
                     {
                         "props": {
                             "copyable": true,
-                            "dataBindings": {
-                                "value": "email"
-                            },
                             "description": null,
                             "label": "Email",
                             "name": "email",
@@ -45,9 +39,6 @@
                     },
                     {
                         "props": {
-                            "dataBindings": {
-                                "value": "joined_at"
-                            },
                             "description": null,
                             "format": {
                                 "dateStyle": "long",
@@ -64,9 +55,6 @@
                     },
                     {
                         "props": {
-                            "dataBindings": {
-                                "value": "is_active"
-                            },
                             "description": null,
                             "falseIcon": "x",
                             "label": "Active",

--- a/packages/framework/src/Layouts/Components/Sidebar.php
+++ b/packages/framework/src/Layouts/Components/Sidebar.php
@@ -62,6 +62,6 @@ class Sidebar extends ContainerComponent
     {
         $children = parent::resolvedChildren();
 
-        return ! $this->footerNode instanceof SidebarFooter ? $children : [...$children, $this->footerNode];
+        return $this->footerNode instanceof SidebarFooter ? [...$children, $this->footerNode] : $children;
     }
 }

--- a/packages/ui/src/Components/Concerns/HasDataBindings.php
+++ b/packages/ui/src/Components/Concerns/HasDataBindings.php
@@ -35,6 +35,11 @@ trait HasDataBindings
         return array_values($this->dataBindings);
     }
 
+    protected function forgetDataBinding(string $property): void
+    {
+        unset($this->dataBindings[$property]);
+    }
+
     /**
      * @param  array<string, mixed>  $props
      * @return array<string, mixed>

--- a/packages/ui/src/Components/Concerns/HasDataBindings.php
+++ b/packages/ui/src/Components/Concerns/HasDataBindings.php
@@ -35,9 +35,9 @@ trait HasDataBindings
         return array_values($this->dataBindings);
     }
 
-    protected function forgetDataBinding(string $property): void
+    protected function hasDataBinding(string $property): bool
     {
-        unset($this->dataBindings[$property]);
+        return array_key_exists($property, $this->dataBindings);
     }
 
     /**

--- a/packages/ui/src/Components/DescriptionList.php
+++ b/packages/ui/src/Components/DescriptionList.php
@@ -61,8 +61,9 @@ class DescriptionList extends ContainerComponent
     }
 
     /**
-     * The subject the entries read their values from. Entries given an explicit
-     * value keep it.
+     * The subject the entries read their values from. This may be an array, a
+     * keyed Collection, an ArrayAccess object, a model, or a DTO. Entries given
+     * an explicit value keep it.
      */
     public function record(mixed $record): static
     {
@@ -92,10 +93,6 @@ class DescriptionList extends ContainerComponent
     #[SerializationHook(priority: 250)]
     protected function distributeRecord(array $data): array
     {
-        if ($this->record === null) {
-            return $data;
-        }
-
         foreach ($this->entries() as $entry) {
             $entry->hydrateFromRecord($this->record);
         }

--- a/packages/ui/src/Components/Entries/Entry.php
+++ b/packages/ui/src/Components/Entries/Entry.php
@@ -35,6 +35,7 @@ abstract class Entry extends ContainerComponent
         $entry = new static($key);
         $entry->name = $name;
         $entry->label = $label ?? str($name)->headline()->toString();
+        $entry->dataKey('value', $name);
 
         return $entry;
     }
@@ -47,6 +48,7 @@ abstract class Entry extends ContainerComponent
     public function value(mixed $value): static
     {
         $this->hasExplicitValue = true;
+        $this->forgetDataBinding('value');
 
         if ($value instanceof Closure) {
             $this->valueResolver = $value;

--- a/packages/ui/src/Components/Entries/Entry.php
+++ b/packages/ui/src/Components/Entries/Entry.php
@@ -35,7 +35,6 @@ abstract class Entry extends ContainerComponent
         $entry = new static($key);
         $entry->name = $name;
         $entry->label = $label ?? str($name)->headline()->toString();
-        $entry->dataKey('value', $name);
 
         return $entry;
     }
@@ -48,7 +47,6 @@ abstract class Entry extends ContainerComponent
     public function value(mixed $value): static
     {
         $this->hasExplicitValue = true;
-        $this->forgetDataBinding('value');
 
         if ($value instanceof Closure) {
             $this->valueResolver = $value;
@@ -93,6 +91,14 @@ abstract class Entry extends ContainerComponent
     public function hydrateFromRecord(mixed $record): void
     {
         if ($this->hasExplicitValue) {
+            return;
+        }
+
+        if ($record === null) {
+            if (! $this->hasDataBinding('value')) {
+                $this->dataKey('value', $this->name);
+            }
+
             return;
         }
 

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Support\Collection;
 use Lattice\Chat\Components\ChatBox;
 use Lattice\Core\Attributes\SerializationHook;
 use Lattice\Core\Color;
@@ -406,34 +407,56 @@ test('column spans reject values that are neither positive integers nor full', f
     Text::make('hello')->columnSpan('wide');
 })->throws(InvalidArgumentException::class);
 
-test('a description list hands its record to entries that were not given a value', function (): void {
+test('a description list hands array-like and object records to entries without explicit values', function (mixed $record): void {
     $payload = wire(DescriptionList::make('summary')
-        ->record(['name' => 'Ada Lovelace', 'email' => 'ada@example.test'])
+        ->record($record)
         ->schema([
             TextEntry::make('name'),
+            TextEntry::make('profile.email', 'Email'),
             TextEntry::make('email')->value('override@example.test'),
         ]));
 
     expect($payload['schema'][0]['props']['value'])->toBe('Ada Lovelace')
-        ->and($payload['schema'][0]['props']['dataBindings'])->toBe(['value' => 'name'])
-        ->and($payload['schema'][1]['props']['value'])->toBe('override@example.test')
-        ->and($payload['schema'][1]['props'])->not->toHaveKey('dataBindings');
-});
+        ->and($payload['schema'][0]['props'])->not->toHaveKey('dataBindings')
+        ->and($payload['schema'][1]['props']['value'])->toBe('ada@example.test')
+        ->and($payload['schema'][1]['props'])->not->toHaveKey('dataBindings')
+        ->and($payload['schema'][2]['props']['value'])->toBe('override@example.test')
+        ->and($payload['schema'][2]['props'])->not->toHaveKey('dataBindings');
+})->with([
+    'array' => [[
+        'name' => 'Ada Lovelace',
+        'profile' => ['email' => 'ada@example.test'],
+    ]],
+    'collection' => [fn (): Collection => collect([
+        'name' => 'Ada Lovelace',
+        'profile' => collect(['email' => 'ada@example.test']),
+    ])],
+    'object' => [(object) [
+        'name' => 'Ada Lovelace',
+        'profile' => (object) ['email' => 'ada@example.test'],
+    ]],
+]);
 
-test('description entries bind their value until it is explicitly assigned', function (): void {
-    $bound = wire(TextEntry::make('email'));
-    $rebound = wire(TextEntry::make('email')
-        ->value('fallback@example.test')
-        ->dataKey('value', 'profile.email'));
-    $resolved = TextEntry::make('email')
-        ->dataKey('description', 'email_hint')
-        ->value(fn (): string => 'resolved@example.test');
-    $component = wire(ComponentEntry::make('status')->value(Text::make('Active')));
+test('a description list without a record binds entries to row data', function (): void {
+    $payload = wire(DescriptionList::make()->schema([
+        TextEntry::make('email'),
+        TextEntry::make('email')->dataKey('value', 'profile.email'),
+        TextEntry::make('email')->value('fallback@example.test'),
+        TextEntry::make('email')
+            ->value('fallback@example.test')
+            ->dataKey('value', 'profile.email'),
+        TextEntry::make('email')
+            ->dataKey('description', 'email_hint')
+            ->value('resolved@example.test'),
+        ComponentEntry::make('status')->value(Text::make('Active')),
+    ]));
 
-    expect($bound['props']['dataBindings'])->toBe(['value' => 'email'])
-        ->and($rebound['props']['dataBindings'])->toBe(['value' => 'profile.email'])
-        ->and($resolved->dataBindingKeys())->toBe(['email_hint'])
-        ->and($component['props'])->not->toHaveKey('dataBindings');
+    expect($payload['schema'][0]['props']['dataBindings'])->toBe(['value' => 'email'])
+        ->and($payload['schema'][1]['props']['dataBindings'])->toBe(['value' => 'profile.email'])
+        ->and($payload['schema'][2]['props'])->not->toHaveKey('dataBindings')
+        ->and($payload['schema'][3]['props']['dataBindings'])->toBe(['value' => 'profile.email'])
+        ->and($payload['schema'][4]['props']['dataBindings'])->toBe(['description' => 'email_hint'])
+        ->and($payload['schema'][5]['props'])->not->toHaveKey('dataBindings');
 });
 
 test('a description list drops to list semantics once an entry can disclose', function (): void {

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -11,6 +11,7 @@ use Lattice\Ui\Components\Button;
 use Lattice\Ui\Components\CodeBlock;
 use Lattice\Ui\Components\Component;
 use Lattice\Ui\Components\DescriptionList;
+use Lattice\Ui\Components\Entries\ComponentEntry;
 use Lattice\Ui\Components\Entries\TextEntry;
 use Lattice\Ui\Components\FloatingPanel;
 use Lattice\Ui\Components\Grid;
@@ -414,7 +415,25 @@ test('a description list hands its record to entries that were not given a value
         ]));
 
     expect($payload['schema'][0]['props']['value'])->toBe('Ada Lovelace')
-        ->and($payload['schema'][1]['props']['value'])->toBe('override@example.test');
+        ->and($payload['schema'][0]['props']['dataBindings'])->toBe(['value' => 'name'])
+        ->and($payload['schema'][1]['props']['value'])->toBe('override@example.test')
+        ->and($payload['schema'][1]['props'])->not->toHaveKey('dataBindings');
+});
+
+test('description entries bind their value until it is explicitly assigned', function (): void {
+    $bound = wire(TextEntry::make('email'));
+    $rebound = wire(TextEntry::make('email')
+        ->value('fallback@example.test')
+        ->dataKey('value', 'profile.email'));
+    $resolved = TextEntry::make('email')
+        ->dataKey('description', 'email_hint')
+        ->value(fn (): string => 'resolved@example.test');
+    $component = wire(ComponentEntry::make('status')->value(Text::make('Active')));
+
+    expect($bound['props']['dataBindings'])->toBe(['value' => 'email'])
+        ->and($rebound['props']['dataBindings'])->toBe(['value' => 'profile.email'])
+        ->and($resolved->dataBindingKeys())->toBe(['email_hint'])
+        ->and($component['props'])->not->toHaveKey('dataBindings');
 });
 
 test('a description list drops to list semantics once an entry can disclose', function (): void {


### PR DESCRIPTION
## Summary

- keep DescriptionList record() authoritative for associative arrays, keyed Collections, models, and DTOs, including dotted entry paths
- add automatic row-data bindings only when a DescriptionList has no record
- preserve explicit value and dataKey precedence, and align the sidebar footer condition with Rector

## Verification

- composer check
- npm run check
- npm run docs:build