### PR TITLE
ci: stop apt hangs in playwright install-deps from stalling browser jobs

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -16,6 +16,7 @@ jobs:
   pest-browser:
     name: Browser (Pest, shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -98,10 +99,18 @@ jobs:
 
       - name: Install Playwright browser and system deps
         if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
 
+      # install-deps shells out to apt-get, which sporadically hangs on hosted
+      # runners (dpkg lock contention, mirror stalls) — without a timeout that
+      # held a shard for 48 minutes. The ubuntu-24.04 image already ships the
+      # Chromium libraries, so a timed-out install never blocks the job; a lib
+      # that is genuinely missing fails the browser launch loudly right after.
       - name: Install Playwright system deps only
         if: steps.pw-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        continue-on-error: true
         run: npx playwright install-deps chromium
 
       - name: Pest (browser coverage)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
   vitest-browser:
     name: Vitest Browser
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
@@ -106,10 +107,18 @@ jobs:
 
       - name: Install Playwright browser and system deps
         if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 10
         run: npx playwright install --with-deps chromium
 
+      # install-deps shells out to apt-get, which sporadically hangs on hosted
+      # runners (dpkg lock contention, mirror stalls). The ubuntu-24.04 image
+      # already ships the Chromium libraries, so a timed-out install never
+      # blocks the job; a lib that is genuinely missing fails the browser
+      # launch loudly right after.
       - name: Install Playwright system deps only
         if: steps.pw-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        continue-on-error: true
         run: npx playwright install-deps chromium
 
       - run: |


### PR DESCRIPTION
## What

- The cache-hit `npx playwright install-deps chromium` step (runs on **every** browser job) gets `timeout-minutes: 6` + `continue-on-error: true` in both `browser.yml` and `ci.yml`.
- The cache-miss `install --with-deps` step gets `timeout-minutes: 10`.
- `pest-browser` (25 min) and `vitest-browser` (20 min) get job-level timeouts as a backstop — neither workflow had any.

## Why

`install-deps` shells out to `sudo apt-get`, which sporadically hangs on hosted runners (dpkg lock contention, mirror stalls). Evidence: run 32224612853 — shard 1 finished in 9 minutes, shard 2 sat **48 minutes** inside `npm exec playwright install-deps chromium` (the orphan process the runner killed) until a later push's concurrency cancel ended it. Without timeouts such a hang can occupy a runner for up to 6 hours and leaves the PR check dangling.

`continue-on-error` is safe here: the ubuntu-24.04 image already ships the Chromium libraries, so a skipped/timed-out deps install still launches the browser; a genuinely missing library fails the very next step loudly instead of silently.