### PR TITLE
feat(form)!: validate once and pass validated FormData to handle()

### DIFF
--- a/docs/content/docs/actions/bulk-actions.md
+++ b/docs/content/docs/actions/bulk-actions.md
@@ -12,7 +12,6 @@ Extend `BulkActionDefinition` and implement `definition()` and `handle()`. The `
 attribute registers it.
 
 ```php
-use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\BulkActionDefinition;
@@ -30,7 +29,7 @@ class ArchiveSelectedProductsAction extends BulkActionDefinition
             ->variant(Variant::Danger);
     }
 
-    public function handle(Collection $records, Request $request): ActionResult
+    public function handle(Collection $records): ActionResult
     {
         $records->each(fn (Product $product) => $product->update(['status' => 'archived']));
 
@@ -46,6 +45,10 @@ class ArchiveSelectedProductsAction extends BulkActionDefinition
 all apply — including a [`->lazyForm()`](/actions/confirmation-and-forms/#deferring-the-schema)
 one, which fetches its schema together with the selection payload once the bulk action bar opens
 it. `handle()` returns an [`ActionResult`](/actions/effects/) like any action.
+
+`$records` is a reserved parameter name — declare it to receive the selected records, and add
+`FormData $data` alongside it when the bulk action also collects a form: `handle(Collection
+$records, FormData $data): ActionResult`.
 
 ## Attaching it to a table
 

--- a/docs/content/docs/actions/confirmation-and-forms.md
+++ b/docs/content/docs/actions/confirmation-and-forms.md
@@ -58,17 +58,16 @@ The form fields are the same `Field` builders used everywhere, so [validation](/
 [conditions](/forms/conditional-fields/), and searchable selects all work. Validation is precognitive
 by default — the modal validates as the user types.
 
-In `handle()`, call `$this->validate($request)` to get the validated, cast values:
+Declare `FormData $data` on `handle()` to receive the validated, cast values — the endpoint
+validates before calling you, so there's nothing to trigger yourself:
 
 ```php
-public function handle(Request $request): ActionResult
+public function handle(FormData $data, Request $request): ActionResult
 {
-    $data = $this->validate($request);
-
     $this->product($request)->update(['status' => 'rejected']);
 
     return ActionResult::success()
-        ->toast("Rejected: {$data['reason']}")
+        ->toast("Rejected: {$data->string('reason')}")
         ->reloadComponent('app.products');
 }
 ```
@@ -113,6 +112,7 @@ extend `FormActionDefinition` instead and build it in `formSchema()`:
 ```php
 use Lattice\Actions\FormActionDefinition;
 use Lattice\Form\Components\Form;
+use Lattice\Form\FormData;
 use Illuminate\Http\Request;
 
 #[AsAction('products.edit')]
@@ -127,9 +127,8 @@ final class EditProduct extends FormActionDefinition
         ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        $data = $this->validate($request);
         // …
     }
 }

--- a/docs/content/docs/actions/overview.mdx
+++ b/docs/content/docs/actions/overview.mdx
@@ -68,7 +68,7 @@ class ArchiveProductAction extends ActionDefinition
             ->confirm('Archive product?', 'This hides it from the catalogue.');
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(): ActionResult
     {
         $product = $this->contextModel('product_id', Product::class);
         $product->update(['status' => 'archived']);

--- a/docs/content/docs/actions/toasts.md
+++ b/docs/content/docs/actions/toasts.md
@@ -28,10 +28,10 @@ is not available, use `Effects::flash()`:
 ```php
 use Lattice\Ui\Enums\Variant;
 use Lattice\Facades\Effects;
+use Lattice\Form\FormData;
 
-public function handle(Request $request): Response
+public function handle(FormData $data): Response
 {
-    $this->validate($request);
     // … persist …
 
     Effects::flash(Effects::toast('Profile saved.', Variant::Success));

--- a/docs/content/docs/core/closure-evaluation.md
+++ b/docs/content/docs/core/closure-evaluation.md
@@ -29,8 +29,17 @@ first; the type annotation documents it rather than driving the resolution.
 
 ```php
 TextInput::make('slug', 'Slug')
-    ->value(fn (FormData $state) => Str::slug($state->string('name')));
+    ->value(fn (FormData $state) => $state->string('name')->slug());
 ```
+
+:::note
+`FormData::string()` returns a `Stringable`, not a plain `string`. Field values and prefills
+normalize `Stringable` and enum instances to their scalar automatically (a backed enum becomes its
+value, a pure enum its name), so returning one from a `value()` closure just works — call
+`->toString()` only when a helper expects a real `string`. Because `Stringable` implements
+`__toString()`, it always passes truthy checks like `?:`; compare `->toString() !== ''` or use
+`->isNotEmpty()` instead when the value might be empty.
+:::
 
 ## Field utilities
 
@@ -89,12 +98,44 @@ Inside row hooks, use the named `$form` utility when you need values outside the
 
 ```php
 Repeater::make('lines')
-    ->itemLabel(fn (FormData $row, FormData $form) => $row->string('name') ?: $form->string('currency'));
+    ->itemLabel(fn (FormData $row, FormData $form) => $row->string('name')->isNotEmpty()
+        ? $row->string('name')
+        : $form->string('currency'));
 ```
+
+`Stringable` always evaluates truthy — even when it wraps an empty string — so `?:` never falls
+through to the second operand. Check `->isNotEmpty()` (or `->toString() !== ''`) explicitly instead.
 
 Named slot factories also resolve any remaining class or interface from Laravel's container. A
 context object is registered under its concrete type and can satisfy a parameter typed as that class,
 a parent class, or an implemented interface.
+
+## `handle()` parameter resolution
+
+Form, action, and bulk-action endpoints validate the submission once, then invoke `handle()` through
+the same evaluator, with a small, purpose-built context:
+
+| Utility            | Resolves to                                              |
+| ------------------ | -------------------------------------------------------- |
+| `$data`            | The validated, cast `FormData` for this submission.      |
+| `$request`         | The current `Request`.                                   |
+| `$records`         | The selected `Collection` of models — bulk actions only. |
+| `FormData $…`      | Same as `$data`, by type.                                |
+| `Request $…`       | Same as `$request`, by type.                             |
+| `Collection $…`    | Same as `$records`, by type — bulk actions only.         |
+| Any container type | A service resolved from Laravel's container.             |
+
+```php
+public function handle(FormData $data): ActionResult { /* … */ }
+public function handle(FormData $data, Request $request): ActionResult { /* … */ }
+public function handle(Collection $records, FormData $data): ActionResult { /* … */ } // bulk only
+```
+
+`$data`, `$request`, and `$records` are reserved names — declare only the ones you need, in any
+order. Outside a bulk action there is no selection to resolve, so a `Collection`-typed parameter
+falls through to the container instead, which constructs an **empty** `Collection` rather than
+raising an error — a `Collection $records` parameter on a non-bulk action silently receives nothing
+useful.
 
 ## Server-side timing
 

--- a/docs/content/docs/core/i18n.md
+++ b/docs/content/docs/core/i18n.md
@@ -250,7 +250,6 @@ the request's `Accept-Language` header.
 For server-driven screens, make locale choices normal actions that return a `locale-change` effect:
 
 ```php
-use Illuminate\Http\Request;
 use Lattice\Actions\ActionDefinition;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\Components\Action;
@@ -264,7 +263,7 @@ class SetLocaleAction extends ActionDefinition
         return $action->label(__('language.switch'));
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(): ActionResult
     {
         $locale = $this->context('locale');
         $locales = config('lattice.i18n.locales', []);

--- a/docs/content/docs/extending/custom-fields.md
+++ b/docs/content/docs/extending/custom-fields.md
@@ -167,6 +167,7 @@ use App\Forms\Fields\ColorPicker;
 use Illuminate\Http\Request;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form as FormComponent;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -182,11 +183,9 @@ final class BrandSettingsForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data): Response
     {
-        $validated = $this->validate($request);
-
-        // persist $validated['brand_color'] …
+        // persist $data->string('brand_color') …
 
         return redirect()->back();
     }

--- a/docs/content/docs/forms/fields/file-upload.mdx
+++ b/docs/content/docs/forms/fields/file-upload.mdx
@@ -85,10 +85,8 @@ A submitted file arrives as an `UploadedFile` (or an array of them for `->multip
 however you like:
 
 ```php
-public function handle(Request $request): Response
+public function handle(FormData $data): Response
 {
-    $data = $this->validate($request);
-
     if (($data['avatar'] ?? null) instanceof UploadedFile) {
         $data['avatar'] = $data['avatar']->store('avatars', 'public');
     }
@@ -109,7 +107,7 @@ closure that returns each file's destination path. It moves the object and retur
 $finalized = FileUpload::make('document')->disk('s3')->signedUpload()
     ->finalizeSignedUploads(
         (array) $data['document'],
-        fn (string $key, array $meta): string => "documents/{$request->user()->id}.{$meta['extension']}",
+        fn (string $key, array $meta): string => "documents/".auth()->id().".{$meta['extension']}",
     );
 
 foreach ($finalized as $upload) {

--- a/docs/content/docs/forms/overview.mdx
+++ b/docs/content/docs/forms/overview.mdx
@@ -20,6 +20,7 @@ use Illuminate\Http\Request;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form as FormComponent;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -34,11 +35,9 @@ class ProfileForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data, Request $request): Response
     {
-        $validated = $this->validate($request);
-
-        $request->user()->update($validated);
+        $request->user()->update($data->only('name', 'email'));
 
         return redirect('/profile');
     }
@@ -106,12 +105,30 @@ form only accepts submissions for the schema it actually rendered. `FormControll
 2. A **resolve** request (a [dependent field](/forms/conditional-fields/) recomputing) returns the
    updated field nodes and values.
 3. A **precognitive** request validates and returns `204`/`422` without running `handle()`.
-4. Otherwise the submission is validated and passed to `handle()`.
+4. Otherwise the submission is validated once, then passed straight to `handle()`.
 
-`$this->validate($request)` runs the field rules and returns the validated, cast data as an array —
-visible-only, with hidden values and locked (disabled or read-only) user input stripped; a
-server-set `->value()` on a locked field still comes through. Your `handle()` returns any Laravel
-`Response` or `Responsable`: a redirect, a JSON payload, or a [toast effect](/actions/overview/).
+The endpoint validates internally and hands `handle()` the result — you never call `validate()`
+yourself inside `handle()`. The data it receives is already validated **and** cast: visible-only,
+with hidden values and locked (disabled or read-only) user input stripped, and a server-set
+`->value()` on a locked field still comes through. Your `handle()` returns any Laravel `Response` or
+`Responsable`: a redirect, a JSON payload, or a [toast effect](/actions/overview/).
+
+## The `handle()` signature
+
+`handle()` accepts any combination of parameters, resolved in this order: by name (`$data` for the
+validated `FormData`, `$request` for the `Request`), then by type (`FormData`, `Request`), then from
+the Laravel container. Declare only what you need:
+
+```php
+public function handle(FormData $data): Response { /* … */ }
+public function handle(FormData $data, Request $request): Response { /* … */ }
+public function handle(Request $request): Response { /* … */ } // no validated data needed
+```
+
+Older `handle(Request $request)` signatures keep working, reading raw input off `$request` directly —
+but don't call `validate()` again inside `handle()`: the endpoint already validated the submission
+once before calling you, and calling it a second time just re-runs the same rules. Add `FormData
+$data` to the signature instead.
 
 ## Resetting after submit
 
@@ -129,18 +146,26 @@ everywhere else.
 
 ## Working with submitted data
 
-`validate()` returns a plain array of validated values. Where a callback needs to read the in-flight
-form state — [dynamic rules](/forms/validation/#dynamic-rules) and
-[dependent fields](/forms/conditional-fields/) — it receives a `FormData` object with typed
-accessors:
+`FormData` (`Lattice\Form\FormData`) extends Laravel's `ValidatedInput`, so the full
+`InteractsWithData` API is available — typed accessors, `only()`/`except()`, `collect()`,
+array access, and dot-notation `get()`:
 
 ```php
-$data->string('name');
+$data->string('name');   // Stringable — call ->toString() to get a plain string
 $data->boolean('subscribe');
 $data->integer('quantity');
 $data->float('price');
 $data->get('tags', []);
+$data->only('name', 'email');
+$data['name'];
 ```
+
+Returning a `Stringable` or an enum from a field's `value()` closure is fine — field values
+normalize them to their scalar on the way to the wire, so no `->toString()` is needed there.
+
+The same object shows up wherever a callback needs to read the in-flight form state —
+[dynamic rules](/forms/validation/#dynamic-rules) and [dependent fields](/forms/conditional-fields/) —
+as well as in `handle()`.
 
 ## Live validation with Precognition
 

--- a/docs/content/docs/forms/wizard.mdx
+++ b/docs/content/docs/forms/wizard.mdx
@@ -113,7 +113,7 @@ the earlier steps' input automatically.
 WizardStep::make('review')->schema([
     TextInput::make('review_name', 'Name')
         ->readOnly()
-        ->value(fn (FormData $data): string => $data->string('name')),
+        ->value(fn (FormData $data): Stringable => $data->string('name')),
     TextInput::make('review_items', 'Items')
         ->readOnly()
         ->value(fn (FormData $data): string => collect($data->get('items', []))

--- a/packages/action/src/ActionDefinition.php
+++ b/packages/action/src/ActionDefinition.php
@@ -3,17 +3,23 @@ declare(strict_types=1);
 
 namespace Lattice\Actions;
 
-use Illuminate\Http\Request;
 use Lattice\Actions\Components\Action;
 use Lattice\Actions\Concerns\InteractsWithActionForm;
 use Lattice\Core\Definition;
 use Lattice\Form\Contracts\InteractsWithForm;
 
+/**
+ * A concrete action declares a public `handle()` method with a flexible
+ * signature — parameters resolve by name (`$data` for the validated
+ * `FormData`, `$request` for the current `Request`), by type (`FormData`,
+ * `Request`), or fall back to the container. It must return an `ActionResult`,
+ * e.g.:
+ *
+ *     public function handle(FormData $data): ActionResult
+ */
 abstract class ActionDefinition extends Definition implements InteractsWithForm
 {
     use InteractsWithActionForm;
 
     abstract public function definition(Action $action): Action;
-
-    abstract public function handle(Request $request): ActionResult;
 }

--- a/packages/action/src/BulkActionDefinition.php
+++ b/packages/action/src/BulkActionDefinition.php
@@ -3,21 +3,24 @@ declare(strict_types=1);
 
 namespace Lattice\Actions;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Lattice\Actions\Components\Action;
 use Lattice\Actions\Concerns\InteractsWithActionForm;
 use Lattice\Core\Definition;
 use Lattice\Form\Contracts\InteractsWithForm;
 
+/**
+ * A concrete bulk action declares a public `handle()` method with a flexible
+ * signature — parameters resolve by name (`$records` for the selected rows,
+ * `$data` for the validated `FormData`, `$request` for the current
+ * `Request`), by type (`Collection`, `FormData`, `Request`), or fall back to
+ * the container. `$records`/`Collection` is bulk-only. It must return an
+ * `ActionResult`, e.g.:
+ *
+ *     public function handle(Collection $records, FormData $data): ActionResult
+ */
 abstract class BulkActionDefinition extends Definition implements InteractsWithForm
 {
     use InteractsWithActionForm;
 
     abstract public function definition(Action $action): Action;
-
-    /**
-     * @param  Collection<int, mixed>  $records
-     */
-    abstract public function handle(Collection $records, Request $request): ActionResult;
 }

--- a/packages/action/src/Concerns/InteractsWithActionForm.php
+++ b/packages/action/src/Concerns/InteractsWithActionForm.php
@@ -10,6 +10,7 @@ use Lattice\Form\Components\Field;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Concerns\ResolvesFormFields;
 use Lattice\Form\FieldValidator;
+use Lattice\Form\FormData;
 
 /**
  * Validation, searchable options, and computed-field resolution for an action's
@@ -22,13 +23,11 @@ trait InteractsWithActionForm
 
     /**
      * Validate the request against this action's embedded form schema and return
-     * the validated, cast input. Returns an empty array when no form is attached.
-     *
-     * @return array<string, mixed>
+     * the validated, cast input. Empty when no form is attached.
      */
-    public function validate(Request $request): array
+    public function validate(Request $request): FormData
     {
-        return app(FieldValidator::class)->validate($this->formFields($request), $request);
+        return FormData::make(app(FieldValidator::class)->validate($this->formFields($request), $request));
     }
 
     /**

--- a/packages/action/src/Http/Controllers/ActionController.php
+++ b/packages/action/src/Http/Controllers/ActionController.php
@@ -5,10 +5,14 @@ namespace Lattice\Actions\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Lattice\Actions\ActionRegistry;
+use Lattice\Actions\ActionResult;
 use Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Form\FormData;
 use Lattice\Form\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Form\Http\Controllers\Concerns\HandlesPrecognition;
+use Lattice\Form\Http\Controllers\Concerns\InvokesHandleMethod;
+use LogicException;
 use Symfony\Component\HttpFoundation\Response;
 
 final readonly class ActionController
@@ -16,6 +20,7 @@ final readonly class ActionController
     use HandlesFormSubRequests;
     use HandlesPrecognition;
     use InteractsWithComponents;
+    use InvokesHandleMethod;
 
     public function __construct(
         private ActionRegistry $actions,
@@ -33,12 +38,14 @@ final readonly class ActionController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, fn (): array => $definition->validate($request));
+            return $this->validatePrecognitive($request, fn (): FormData => $definition->validate($request));
         }
 
-        $definition->validate($request);
+        $result = $this->invokeHandle($definition, $request, $definition->validate($request));
 
-        $result = $definition->handle($request);
+        if (! $result instanceof ActionResult) {
+            throw new LogicException(sprintf('%s::handle() must return an %s.', $definition::class, ActionResult::class));
+        }
 
         return response()->json($result, $result->status());
     }

--- a/packages/form/src/Components/Field.php
+++ b/packages/form/src/Components/Field.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Form\Components;
 
+use BackedEnum;
 use Closure;
 use Illuminate\Http\Request;
 use Lattice\Core\Enums\Op;
@@ -16,6 +17,8 @@ use Lattice\Ui\Components\Component;
 use Lattice\Ui\Concerns\HasLabel;
 use Lattice\Ui\Concerns\HasTooltip;
 use Lattice\Ui\Enums\ColumnWidth;
+use Stringable;
+use UnitEnum;
 
 abstract class Field extends Component
 {
@@ -355,7 +358,7 @@ abstract class Field extends Component
             return $this;
         }
 
-        $this->value = $value;
+        $this->value = $this->normalizeValue($value);
         $this->valueWasSet = true;
 
         if ($this->resolving) {
@@ -392,7 +395,23 @@ abstract class Field extends Component
             ->named('row', $row)
             ->named('form', $form);
 
-        return Evaluate::resolve($this->prefillResolver, $context);
+        return $this->normalizeValue(Evaluate::resolve($this->prefillResolver, $context));
+    }
+
+    /**
+     * Values may be provided as Stringable or enum instances (e.g. straight from
+     * FormData::string() or a domain enum); the wire and the validator need the
+     * underlying scalar.
+     */
+    private function normalizeValue(mixed $value): mixed
+    {
+        return match (true) {
+            $value instanceof Stringable => (string) $value,
+            $value instanceof BackedEnum => $value->value,
+            $value instanceof UnitEnum => $value->name,
+            is_array($value) => array_map($this->normalizeValue(...), $value),
+            default => $value,
+        };
     }
 
     /**

--- a/packages/form/src/Contracts/InteractsWithForm.php
+++ b/packages/form/src/Contracts/InteractsWithForm.php
@@ -8,12 +8,12 @@ use Lattice\Core\Http\SubRequest;
 use Lattice\Core\Option;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Components\SignedUpload;
+use Lattice\Form\FormData;
 use Lattice\Form\ResolveResponse;
 
 interface InteractsWithForm
 {
-    /** @return array<string, mixed> */
-    public function validate(Request $request): array;
+    public function validate(Request $request): FormData;
 
     public function resolveFormSchema(Request $request): ?Form;
 

--- a/packages/form/src/FormData.php
+++ b/packages/form/src/FormData.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 namespace Lattice\Form;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
+use Illuminate\Support\ValidatedInput;
 
-final readonly class FormData
+/**
+ * A form payload container. It doubles as the raw request state during schema
+ * resolution (`fromRequest()`) and as the validated, cast input handed to
+ * `handle()` (`make()`). Extends `ValidatedInput`, so the full Laravel
+ * `InteractsWithData` API is available: `only`/`except`/`collect`/`date`/
+ * `enum`/`boolean`/ArrayAccess/property access.
+ */
+class FormData extends ValidatedInput
 {
-    /**
-     * @param  array<array-key, mixed>  $attributes
-     */
-    public function __construct(private array $attributes) {}
-
     /**
      * @param  array<array-key, mixed>  $attributes
      */
@@ -28,39 +30,6 @@ final readonly class FormData
 
     public function get(string $key, mixed $default = null): mixed
     {
-        return Arr::get($this->attributes, $key, $default);
-    }
-
-    public function has(string $key): bool
-    {
-        return Arr::has($this->attributes, $key);
-    }
-
-    public function string(string $key, string $default = ''): string
-    {
-        return (string) $this->get($key, $default);
-    }
-
-    public function boolean(string $key, bool $default = false): bool
-    {
-        return filter_var($this->get($key, $default), FILTER_VALIDATE_BOOLEAN);
-    }
-
-    public function integer(string $key, int $default = 0): int
-    {
-        return (int) $this->get($key, $default);
-    }
-
-    public function float(string $key, float $default = 0.0): float
-    {
-        return (float) $this->get($key, $default);
-    }
-
-    /**
-     * @return array<array-key, mixed>
-     */
-    public function all(): array
-    {
-        return $this->attributes;
+        return $this->input($key, $default);
     }
 }

--- a/packages/form/src/FormDefinition.php
+++ b/packages/form/src/FormDefinition.php
@@ -3,29 +3,31 @@ declare(strict_types=1);
 
 namespace Lattice\Form;
 
-use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Core\Definition;
 use Lattice\Form\Components\Field;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Concerns\ResolvesFormFields;
-use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * A concrete form declares a public `handle()` method with a flexible
+ * signature — parameters resolve by name (`$data` for the validated
+ * `FormData`, `$request` for the current `Request`), by type (`FormData`,
+ * `Request`), or fall back to the container. It must return a Symfony
+ * `Response` or a `Responsable`, e.g.:
+ *
+ *     public function handle(FormData $data): Response
+ */
 abstract class FormDefinition extends Definition
 {
     use ResolvesFormFields;
 
     abstract public function definition(Form $form, Request $request): Form;
 
-    abstract public function handle(Request $request): Response|Responsable;
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function validate(Request $request): array
+    public function validate(Request $request): FormData
     {
-        return app(FieldValidator::class)->validate($this->formFields($request), $request);
+        return FormData::make(app(FieldValidator::class)->validate($this->formFields($request), $request));
     }
 
     /**

--- a/packages/form/src/Http/Controllers/Concerns/InvokesHandleMethod.php
+++ b/packages/form/src/Http/Controllers/Concerns/InvokesHandleMethod.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Form\Http\Controllers\Concerns;
+
+use BadMethodCallException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Lattice\Core\Facades\Evaluate;
+use Lattice\Form\FormData;
+
+/**
+ * Invokes a definition's flexible handle() method. Parameters resolve by
+ * name ($data, $request, $records), by type (FormData, Request, Collection),
+ * or fall back to the container.
+ */
+trait InvokesHandleMethod
+{
+    /**
+     * @param  Collection<int, mixed>|null  $records
+     */
+    protected function invokeHandle(object $definition, Request $request, FormData $data, ?Collection $records = null): mixed
+    {
+        if (! method_exists($definition, 'handle')) {
+            throw new BadMethodCallException(sprintf(
+                '%s must declare a public handle() method — type the parameters you need, e.g. handle(FormData $data).',
+                $definition::class,
+            ));
+        }
+
+        $context = Evaluate::context()
+            ->named('data', $data)
+            ->named('request', $request)
+            ->typed(FormData::class, $data)
+            ->typed(Request::class, $request);
+
+        if ($records instanceof Collection) {
+            $context = $context->named('records', $records)->typed(Collection::class, $records);
+        }
+
+        return Evaluate::resolve($definition->handle(...), $context);
+    }
+}

--- a/packages/form/src/Http/Controllers/FormController.php
+++ b/packages/form/src/Http/Controllers/FormController.php
@@ -7,9 +7,12 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 use Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Core\Contracts\SignsComponentReferences;
+use Lattice\Form\FormData;
 use Lattice\Form\FormRegistry;
 use Lattice\Form\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Form\Http\Controllers\Concerns\HandlesPrecognition;
+use Lattice\Form\Http\Controllers\Concerns\InvokesHandleMethod;
+use LogicException;
 use Symfony\Component\HttpFoundation\Response;
 
 final readonly class FormController
@@ -17,6 +20,7 @@ final readonly class FormController
     use HandlesFormSubRequests;
     use HandlesPrecognition;
     use InteractsWithComponents;
+    use InvokesHandleMethod;
 
     public function __construct(
         private FormRegistry $forms,
@@ -34,11 +38,20 @@ final readonly class FormController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, fn (): array => $definition->validate($request));
+            return $this->validatePrecognitive($request, fn (): FormData => $definition->validate($request));
         }
 
-        $definition->validate($request);
+        $response = $this->invokeHandle($definition, $request, $definition->validate($request));
 
-        return $definition->handle($request);
+        if (! $response instanceof Response && ! $response instanceof Responsable) {
+            throw new LogicException(sprintf(
+                '%s::handle() must return a %s or %s.',
+                $definition::class,
+                Response::class,
+                Responsable::class,
+            ));
+        }
+
+        return $response;
     }
 }

--- a/packages/framework/src/Console/stubs/action.php.stub
+++ b/packages/framework/src/Console/stubs/action.php.stub
@@ -2,7 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Http\Request;
 use Lattice\Actions\ActionDefinition;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\Components\Action;
@@ -16,7 +15,7 @@ class {{ class }} extends ActionDefinition
         return $action->label('{{ class }}');
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(): ActionResult
     {
         return ActionResult::success();
     }

--- a/packages/framework/src/Console/stubs/bulk-action.php.stub
+++ b/packages/framework/src/Console/stubs/bulk-action.php.stub
@@ -2,7 +2,6 @@
 
 namespace {{ namespace }};
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\BulkActionDefinition;
@@ -20,7 +19,7 @@ class {{ class }} extends BulkActionDefinition
     /**
      * @param  Collection<int, \Illuminate\Database\Eloquent\Model>  $records
      */
-    public function handle(Collection $records, Request $request): ActionResult
+    public function handle(Collection $records): ActionResult
     {
         return ActionResult::success();
     }

--- a/packages/framework/src/Console/stubs/form.php.stub
+++ b/packages/framework/src/Console/stubs/form.php.stub
@@ -3,8 +3,10 @@
 namespace {{ namespace }};
 
 use Illuminate\Http\Request;
+use Lattice\Facades\Effects;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Http\LatticeResponse;
 
@@ -18,10 +20,8 @@ class {{ class }} extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): LatticeResponse
+    public function handle(FormData $data): LatticeResponse
     {
-        $this->validate($request);
-
-        return $this->respond()->back();
+        return Effects::respond()->back();
     }
 }

--- a/packages/framework/src/Http/Controllers/BulkActionController.php
+++ b/packages/framework/src/Http/Controllers/BulkActionController.php
@@ -5,16 +5,20 @@ namespace Lattice\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Lattice\Actions\ActionResult;
 use Lattice\Actions\BulkActionRegistry;
 use Lattice\Core\Authorization;
 use Lattice\Core\Concerns\InteractsWithComponents;
 use Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Core\Exceptions\UnknownComponent;
+use Lattice\Form\FormData;
 use Lattice\Form\Http\Controllers\Concerns\HandlesFormSubRequests;
 use Lattice\Form\Http\Controllers\Concerns\HandlesPrecognition;
+use Lattice\Form\Http\Controllers\Concerns\InvokesHandleMethod;
 use Lattice\Table\TableDefinition;
 use Lattice\Table\TableQuery;
 use Lattice\Table\TableRegistry;
+use LogicException;
 use Symfony\Component\HttpFoundation\Response;
 
 final readonly class BulkActionController
@@ -22,6 +26,7 @@ final readonly class BulkActionController
     use HandlesFormSubRequests;
     use HandlesPrecognition;
     use InteractsWithComponents;
+    use InvokesHandleMethod;
 
     public function __construct(
         private BulkActionRegistry $bulkActions,
@@ -40,7 +45,7 @@ final readonly class BulkActionController
         }
 
         if ($request->isPrecognitive()) {
-            return $this->validatePrecognitive($request, fn (): array => $definition->validate($request));
+            return $this->validatePrecognitive($request, fn (): FormData => $definition->validate($request));
         }
 
         $tableKey = $this->trustedTableKey($context);
@@ -48,9 +53,15 @@ final readonly class BulkActionController
 
         Authorization::ensure($table, $request);
 
+        $data = $definition->validate($request);
+
         $records = $this->resolveRecords($request, $table, $tableKey);
 
-        $result = $definition->handle($records, $request);
+        $result = $this->invokeHandle($definition, $request, $data, $records);
+
+        if (! $result instanceof ActionResult) {
+            throw new LogicException(sprintf('%s::handle() must return an %s.', $definition::class, ActionResult::class));
+        }
 
         return response()->json($result, $result->status());
     }

--- a/packages/media/src/Actions/UpdateMediaAction.php
+++ b/packages/media/src/Actions/UpdateMediaAction.php
@@ -11,6 +11,7 @@ use Lattice\Actions\FormActionDefinition;
 use Lattice\Core\Attributes\AsAction;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Media\Models\Media;
 use Lattice\Ui\Enums\HttpMethod;
 use Lattice\Ui\Enums\Variant;
@@ -43,10 +44,9 @@ final class UpdateMediaAction extends FormActionDefinition
         ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data, Request $request): ActionResult
     {
         $media = $this->media($request);
-        $data = $this->validate($request);
 
         $media->update(['name' => $data['name']]);
         $media->mergeMeta(['alt' => $data['alt'] ?? null]);

--- a/packages/media/src/Actions/UploadMediaAction.php
+++ b/packages/media/src/Actions/UploadMediaAction.php
@@ -15,6 +15,7 @@ use Lattice\Actions\FormActionDefinition;
 use Lattice\Core\Attributes\AsAction;
 use Lattice\Form\Components\FileUpload;
 use Lattice\Form\Components\Form;
+use Lattice\Form\FormData;
 use Lattice\Media\Jobs\GenerateMediaConversions;
 use Lattice\Media\Models\Media;
 use Lattice\Ui\Enums\HttpMethod;
@@ -47,11 +48,9 @@ final class UploadMediaAction extends FormActionDefinition
      * rule bag validates the `files` array. Signed uploads submit temporary
      * keys rather than files, so nothing is checked there — `dimensions` and
      * friends are multipart-only.
-     *
-     * @return array<string, mixed>
      */
     #[\Override]
-    public function validate(Request $request): array
+    public function validate(Request $request): FormData
     {
         $validated = parent::validate($request);
         $rules = array_values(array_filter((array) $this->context('upload_rules', []), is_string(...)));
@@ -68,9 +67,8 @@ final class UploadMediaAction extends FormActionDefinition
      * upload-only picker selects the fresh rows straight from this response
      * without a follow-up fetch.
      */
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        $data = $this->validate($request);
         $media = array_map(
             // A sync queue has already generated the conversions by now, on its
             // own instances — refresh so the descriptors see them.
@@ -81,7 +79,7 @@ final class UploadMediaAction extends FormActionDefinition
                 'preview_url' => $item->previewUrl(),
                 'mime_type' => $item->mime_type,
             ],
-            $this->storeUploads($data['files'] ?? []),
+            $this->storeUploads($data->get('files', [])),
         );
 
         return ActionResult::success(['media' => $media])

--- a/packages/table/src/Filters/DateRangeFilter.php
+++ b/packages/table/src/Filters/DateRangeFilter.php
@@ -31,8 +31,8 @@ final class DateRangeFilter extends Filter
     #[\Override]
     public function indicator(FormData $data): ?string
     {
-        $from = $data->string('from');
-        $until = $data->string('until');
+        $from = $data->string('from')->toString();
+        $until = $data->string('until')->toString();
 
         return trim($from.' - '.$until, ' -') ?: null;
     }

--- a/tests/Feature/Actions/ActionFormTest.php
+++ b/tests/Feature/Actions/ActionFormTest.php
@@ -10,6 +10,7 @@ use Lattice\Core\Attributes\AsAction;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form as FormComponent;
+use Lattice\Form\Components\NumberInput;
 use Lattice\Form\Components\Select;
 use Lattice\Form\Components\Textarea;
 use Lattice\Form\Components\TextInput;
@@ -68,9 +69,9 @@ class EditActionFixture extends FormActionDefinition
             ->fill(['title' => $this->context('current_title')]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        return ActionResult::success($this->validate($request));
+        return ActionResult::success($data->all());
     }
 }
 
@@ -159,9 +160,9 @@ class WizardActionFixture extends FormActionDefinition
         ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        return ActionResult::success($this->validate($request));
+        return ActionResult::success($data->all());
     }
 }
 
@@ -199,9 +200,9 @@ class AssignActionFixture extends ActionDefinition
             ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        return ActionResult::success($this->validate($request));
+        return ActionResult::success($data->all());
     }
 }
 
@@ -218,10 +219,8 @@ class RejectActionFixture extends ActionDefinition
             ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        $data = $this->validate($request);
-
         return ActionResult::success(['reason' => $data['reason']]);
     }
 }
@@ -289,5 +288,60 @@ class ActionWithDeniedEmbeddedFormFixture extends ActionDefinition
     public function handle(Request $request): ActionResult
     {
         return ActionResult::success();
+    }
+}
+
+test('an action handle(FormData $data) echoes the validated and cast embedded form data', function (): void {
+    Lattice::actions([EchoCastActionFixture::class]);
+
+    $this->callAction(EchoCastActionFixture::class, ['qty' => '4'])
+        ->assertOk()
+        ->assertJsonPath('data.qty', 4);
+});
+
+#[AsAction('test.echo-cast')]
+class EchoCastActionFixture extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Echo')->method(HttpMethod::Post)->form([
+            NumberInput::make('qty', 'Qty')->rules(['required', 'integer']),
+        ]);
+    }
+
+    public function handle(FormData $data): ActionResult
+    {
+        return ActionResult::success(['qty' => $data->integer('qty')]);
+    }
+}
+
+test('an embedded action form validates exactly once per call', function (): void {
+    Lattice::actions([RuleCounterActionFixture::class]);
+    RuleCounterActionFixture::$calls = 0;
+
+    $this->callAction(RuleCounterActionFixture::class, ['name' => 'Ada'])->assertOk();
+
+    expect(RuleCounterActionFixture::$calls)->toBe(1);
+});
+
+#[AsAction('test.rule-counter')]
+class RuleCounterActionFixture extends ActionDefinition
+{
+    public static int $calls = 0;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Counter')->method(HttpMethod::Post)->form([
+            TextInput::make('name', 'Name')->rules(function (): array {
+                self::$calls++;
+
+                return ['required', 'string'];
+            }),
+        ]);
+    }
+
+    public function handle(FormData $data): ActionResult
+    {
+        return ActionResult::success($data->all());
     }
 }

--- a/tests/Feature/Actions/BulkActionFormTest.php
+++ b/tests/Feature/Actions/BulkActionFormTest.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\BulkActionDefinition;
+use Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Core\Attributes\AsBulkAction;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\CallbackTableSource;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Contracts\TableSource;
+use Lattice\Table\TableDefinition;
+use Lattice\Table\TableQuery;
+use Lattice\Table\TableResult;
+use Lattice\Ui\Enums\HttpMethod;
+
+test('a bulk action validates its embedded form before resolving records or running handle', function (): void {
+    Lattice::tables([BulkFormTable::class]);
+    Lattice::bulkActions([RequiredReasonBulkAction::class]);
+    RequiredReasonBulkAction::$handled = false;
+
+    $this->callBulkAction(RequiredReasonBulkAction::class, [
+        'reason' => '',
+        'selected' => [1, 2],
+    ], ['table' => 'test.bulk-form'])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('reason');
+
+    expect(RequiredReasonBulkAction::wasHandled())->toBeFalse();
+});
+
+test('bulk action handle(Collection $records, FormData $data) receives both the resolved rows and the validated data', function (): void {
+    Lattice::tables([BulkFormTable::class]);
+    Lattice::bulkActions([RequiredReasonBulkAction::class]);
+
+    $this->callBulkAction(RequiredReasonBulkAction::class, [
+        'reason' => 'Cleanup',
+        'selected' => [1, 2],
+    ], ['table' => 'test.bulk-form'])
+        ->assertOk()
+        ->assertJsonPath('data.count', 2)
+        ->assertJsonPath('data.reason', 'Cleanup');
+});
+
+#[AsBulkAction('test.bulk-form.required-reason')]
+class RequiredReasonBulkAction extends BulkActionDefinition
+{
+    public static bool $handled = false;
+
+    public static function wasHandled(): bool
+    {
+        return self::$handled;
+    }
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Archive')->method(HttpMethod::Patch)->form([
+            TextInput::make('reason', 'Reason')->required(),
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, mixed>  $records
+     */
+    public function handle(Collection $records, FormData $data): ActionResult
+    {
+        self::$handled = true;
+
+        return ActionResult::success([
+            'count' => $records->count(),
+            'reason' => $data->get('reason'),
+        ]);
+    }
+}
+
+#[AsTable('test.bulk-form')]
+class BulkFormTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [TextColumn::make('name')->label('Name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(
+            query: fn (TableQuery $query): TableResult => TableResult::make([
+                ['id' => 1, 'name' => 'Ada'],
+                ['id' => 2, 'name' => 'Grace'],
+            ]),
+            selection: fn (array $keys): Collection => collect($keys),
+        );
+    }
+}

--- a/tests/Feature/Forms/ColorPickerFieldTest.php
+++ b/tests/Feature/Forms/ColorPickerFieldTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Lattice\Form\Components\ColorPicker;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 
 function colorPickerDefinition(): FormDefinition
@@ -20,6 +21,6 @@ it('accepts a valid hex color through the hex_color rule', function (): void {
 });
 
 it('rejects an invalid color through the hex_color rule', function (): void {
-    expect(fn (): array => colorPickerDefinition()->validate(Request::create('/', 'POST', ['color' => 'not-a-color'])))
+    expect(fn (): FormData => colorPickerDefinition()->validate(Request::create('/', 'POST', ['color' => 'not-a-color'])))
         ->toThrow(ValidationException::class);
 });

--- a/tests/Feature/Forms/FieldClosureInjectionTest.php
+++ b/tests/Feature/Forms/FieldClosureInjectionTest.php
@@ -21,7 +21,7 @@ it('injects the field component and its own value into rule closures', function 
 });
 
 it('keeps supporting typed FormData and Request rule closures', function (): void {
-    $field = TextInput::make('age')->rules(fn (FormData $state, Request $request): array => [$state->string('extra')]);
+    $field = TextInput::make('age')->rules(fn (FormData $state, Request $request): array => [$state->string('extra')->toString()]);
 
     expect($field->resolveRules(FormData::make(['extra' => 'min:3']), Request::create('/')))->toBe(['min:3']);
 });
@@ -56,7 +56,7 @@ it('injects row and form scopes into prefill resolvers by name', function (): vo
 
 it('resolves a typed FormData prefill parameter to the row scope', function (): void {
     $field = TextInput::make('label')
-        ->value(fn (FormData $data): string => $data->string('first'), editable: true);
+        ->value(fn (FormData $data): string => $data->string('first')->toString(), editable: true);
 
     $row = FormData::make(['first' => 'ada']);
     $form = FormData::make(['first' => 'grace']);

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -7,7 +7,9 @@ use Illuminate\Support\Facades\URL;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form;
+use Lattice\Form\Components\NumberInput;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Ui\Components\Text;
 use Lattice\Ui\Enums\HttpMethod;
@@ -241,3 +243,215 @@ class WorkbenchConditionHiddenForm extends FormDefinition
         return response()->json(['handled' => true]);
     }
 }
+
+test('a rules closure resolves exactly once per submission', function (): void {
+    Lattice::forms([RuleCounterForm::class]);
+    RuleCounterForm::$calls = 0;
+
+    $this->submitForm(RuleCounterForm::class, ['name' => 'Taylor'])->assertNoContent();
+
+    expect(RuleCounterForm::$calls)->toBe(1);
+});
+
+#[AsForm('test.rule-counter')]
+class RuleCounterForm extends FormDefinition
+{
+    public static int $calls = 0;
+
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([
+            TextInput::make('name', 'Name')->rules(function (): array {
+                self::$calls++;
+
+                return ['required', 'string'];
+            }),
+        ]);
+    }
+
+    public function handle(FormData $data): Response
+    {
+        return response()->noContent();
+    }
+}
+
+test('handle receives cast, hidden-stripped, and server-injected form data', function (): void {
+    Lattice::forms([ProcessedDataForm::class]);
+
+    $this->submitForm(ProcessedDataForm::class, [
+        'qty' => '5',
+        'secret' => 'client-supplied',
+    ])->assertOk();
+
+    expect(session('processed-form-qty'))->toBe(5)
+        ->and(session('processed-form-data'))->not->toHaveKey('secret')
+        ->and(session('processed-form-data'))->toHaveKey('owner', 'server');
+});
+
+#[AsForm('test.processed-data')]
+class ProcessedDataForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([
+            NumberInput::make('qty', 'Qty')->rules(['required', 'integer']),
+            TextInput::make('secret', 'Secret')->hidden()->required(),
+            TextInput::make('owner', 'Owner')->readOnly()->value('server'),
+        ]);
+    }
+
+    public function handle(FormData $data): Response
+    {
+        session()->put('processed-form-qty', $data->integer('qty'));
+        session()->put('processed-form-data', $data->all());
+
+        return response()->json(['handled' => true]);
+    }
+}
+
+test('handle(FormData $data) receives the validated input', function (): void {
+    Lattice::forms([FormDataOnlyHandlerForm::class]);
+
+    $this->submitForm(FormDataOnlyHandlerForm::class, ['name' => 'Ada'])
+        ->assertOk()
+        ->assertJsonPath('name', 'Ada');
+});
+
+#[AsForm('test.handler.form-data')]
+class FormDataOnlyHandlerForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([TextInput::make('name', 'Name')->required()]);
+    }
+
+    public function handle(FormData $data): Response
+    {
+        return response()->json(['name' => $data->get('name')]);
+    }
+}
+
+test('handle(Request $request, FormData $data) resolves both parameters regardless of declared order', function (): void {
+    Lattice::forms([SwappedOrderHandlerForm::class]);
+
+    $this->submitForm(SwappedOrderHandlerForm::class, ['name' => 'Grace'])
+        ->assertOk()
+        ->assertJsonPath('name', 'Grace')
+        ->assertJsonPath('method', 'POST');
+});
+
+#[AsForm('test.handler.swapped-order')]
+class SwappedOrderHandlerForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([TextInput::make('name', 'Name')->required()]);
+    }
+
+    public function handle(Request $request, FormData $data): Response
+    {
+        return response()->json(['name' => $data->get('name'), 'method' => $request->method()]);
+    }
+}
+
+final class GreetingService
+{
+    public function greet(string $name): string
+    {
+        return "Hello, {$name}!";
+    }
+}
+
+test('handle(GreetingService $service, FormData $data) resolves a container service alongside the validated data', function (): void {
+    Lattice::forms([ServiceHandlerForm::class]);
+
+    $this->submitForm(ServiceHandlerForm::class, ['name' => 'Ada'])
+        ->assertOk()
+        ->assertJsonPath('greeting', 'Hello, Ada!');
+});
+
+#[AsForm('test.handler.service')]
+class ServiceHandlerForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([TextInput::make('name', 'Name')->required()]);
+    }
+
+    public function handle(GreetingService $service, FormData $data): Response
+    {
+        return response()->json(['greeting' => $service->greet($data->get('name'))]);
+    }
+}
+
+test('handle() with no parameters still runs', function (): void {
+    Lattice::forms([NoParamHandlerForm::class]);
+
+    $this->submitForm(NoParamHandlerForm::class, ['name' => 'Taylor'])->assertNoContent();
+
+    expect(session('no-param-handler-ran'))->toBeTrue();
+});
+
+#[AsForm('test.handler.no-params')]
+class NoParamHandlerForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([TextInput::make('name', 'Name')]);
+    }
+
+    public function handle(): Response
+    {
+        session()->put('no-param-handler-ran', true);
+
+        return response()->noContent();
+    }
+}
+
+test('a handle() return value that is not a Response or Responsable throws a LogicException', function (): void {
+    Lattice::forms([BadReturnHandlerForm::class]);
+    $this->withoutExceptionHandling();
+
+    expect(fn () => $this->submitForm(BadReturnHandlerForm::class, ['name' => 'Ada']))
+        ->toThrow(LogicException::class, 'must return a');
+});
+
+#[AsForm('test.handler.bad-return')]
+class BadReturnHandlerForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([TextInput::make('name', 'Name')]);
+    }
+
+    public function handle(FormData $data): string
+    {
+        return 'not a response';
+    }
+}
+
+test('a definition missing handle() throws a BadMethodCallException', function (): void {
+    Lattice::forms([NoHandlerForm::class]);
+    $this->withoutExceptionHandling();
+
+    expect(fn () => $this->submitForm(NoHandlerForm::class, ['name' => 'Ada']))
+        ->toThrow(BadMethodCallException::class, 'must declare a public handle()');
+});
+
+#[AsForm('test.handler.missing')]
+class NoHandlerForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form->schema([TextInput::make('name', 'Name')]);
+    }
+}
+
+test('the legacy handle(Request $request) signature still works', function (): void {
+    Lattice::forms([WorkbenchProfileForm::class]);
+
+    $this->submitForm(WorkbenchProfileForm::class, ['name' => 'Taylor'])
+        ->assertRedirect('/submitted');
+
+    expect(session('handled-form'))->toBe('Taylor');
+});

--- a/tests/Feature/Forms/FormResolveTest.php
+++ b/tests/Feature/Forms/FormResolveTest.php
@@ -34,7 +34,7 @@ function pricingDefinition(): FormDefinition
             RowTemplate::make('product')->label('Product')->schema([
                 TextInput::make('product', 'Product'),
                 TextInput::make('price', 'Price')->value(
-                    fn (FormData $row, FormData $form): float => $row->float('product') * ($form->string('customer') === 'vip' ? 0.5 : 1.0),
+                    fn (FormData $row, FormData $form): float => $row->float('product') * ($form->string('customer')->toString() === 'vip' ? 0.5 : 1.0),
                     editable: true,
                     resetOn: ['product'],
                     refreshOn: ['@customer'],
@@ -98,7 +98,7 @@ it('resolves nested repeater prefill values keyed by recursive full path', funct
             Repeater::make('lines', 'Lines')->schema([
                 TextInput::make('base', 'Base'),
                 TextInput::make('price', 'Price')->value(
-                    fn (FormData $row, FormData $form): float => $row->float('base') + ($form->string('customer') === 'vip' ? 10 : 0),
+                    fn (FormData $row, FormData $form): float => $row->float('base') + ($form->string('customer')->toString() === 'vip' ? 10 : 0),
                     editable: true,
                     resetOn: ['base'],
                     refreshOn: ['@customer'],

--- a/tests/Feature/Forms/Validation/FieldRulesValidationTest.php
+++ b/tests/Feature/Forms/Validation/FieldRulesValidationTest.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Lattice\Form\Components\Choice;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 
 function stubDefinition(): FormDefinition
@@ -39,7 +40,7 @@ function conditionalDefinition(): FormDefinition
 it('derives validation rules from fields and fails an empty payload', function (): void {
     $definition = stubDefinition();
 
-    expect(fn (): array => $definition->validate(Request::create('/', 'POST', [])))
+    expect(fn (): FormData => $definition->validate(Request::create('/', 'POST', [])))
         ->toThrow(ValidationException::class);
 });
 
@@ -55,7 +56,7 @@ it('passes validation with a valid payload', function (): void {
 });
 
 it('rejects a non-fully-qualified email when email() is used', function (): void {
-    expect(fn (): array => emailDefinition()->validate(Request::create('/', 'POST', ['email' => 'a@a'])))
+    expect(fn (): FormData => emailDefinition()->validate(Request::create('/', 'POST', ['email' => 'a@a'])))
         ->toThrow(ValidationException::class);
 });
 
@@ -72,7 +73,7 @@ it('skips hidden field rules', function (): void {
 });
 
 it('requires the field when its condition matches', function (): void {
-    expect(fn (): array => conditionalDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
+    expect(fn (): FormData => conditionalDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
         ->toThrow(ValidationException::class);
 });
 
@@ -89,7 +90,7 @@ function choiceDefinition(bool $required = false): FormDefinition
 }
 
 it('rejects a choice value outside its options', function (): void {
-    expect(fn (): array => choiceDefinition()->validate(Request::create('/', 'POST', ['role' => 'owner'])))
+    expect(fn (): FormData => choiceDefinition()->validate(Request::create('/', 'POST', ['role' => 'owner'])))
         ->toThrow(ValidationException::class);
 });
 
@@ -100,11 +101,11 @@ it('accepts a choice value within its options', function (): void {
 });
 
 it('allows an optional choice to be omitted', function (): void {
-    expect(fn (): array => choiceDefinition()->validate(Request::create('/', 'POST', [])))
+    expect(fn (): FormData => choiceDefinition()->validate(Request::create('/', 'POST', [])))
         ->not->toThrow(ValidationException::class);
 });
 
 it('still requires a choice marked required', function (): void {
-    expect(fn (): array => choiceDefinition(required: true)->validate(Request::create('/', 'POST', [])))
+    expect(fn (): FormData => choiceDefinition(required: true)->validate(Request::create('/', 'POST', [])))
         ->toThrow(ValidationException::class);
 });

--- a/tests/Feature/Forms/Validation/ImperativeRulesTest.php
+++ b/tests/Feature/Forms/Validation/ImperativeRulesTest.php
@@ -25,7 +25,7 @@ it('skips the rule when the closure returns it optional', function (): void {
 });
 
 it('enforces the rule when the closure makes it required', function (): void {
-    expect(fn (): array => imperativeRulesDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
+    expect(fn (): FormData => imperativeRulesDefinition()->validate(Request::create('/', 'POST', ['type' => 'business'])))
         ->toThrow(ValidationException::class);
 });
 

--- a/tests/Feature/Forms/Validation/ResolvedValidationTest.php
+++ b/tests/Feature/Forms/Validation/ResolvedValidationTest.php
@@ -29,7 +29,7 @@ it('skips validation for a field hidden by a closure', function (): void {
 });
 
 it('applies rules set inside a dependsOn closure', function (): void {
-    expect(fn (): array => resolvedDefinition()->validate(Request::create('/', 'POST', ['mode' => 'reveal'])))
+    expect(fn (): FormData => resolvedDefinition()->validate(Request::create('/', 'POST', ['mode' => 'reveal'])))
         ->toThrow(ValidationException::class);
 });
 

--- a/tests/Feature/Forms/Validation/ValueNormalizationTest.php
+++ b/tests/Feature/Forms/Validation/ValueNormalizationTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Stringable;
+use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
+
+enum NormalizedStatus: string
+{
+    case Active = 'active';
+}
+
+enum NormalizedTier
+{
+    case Gold;
+}
+
+it('normalizes a Stringable server value to a plain string', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('name', 'Name')->rules(['required', 'string']),
+        TextInput::make('slug', 'Slug')
+            ->rules(['string'])
+            ->value(fn (FormData $d): Stringable => $d->string('name')->slug()),
+    ]);
+
+    $validated = $definition->validate(Request::create('/', 'POST', ['name' => 'Neu Kunde', 'slug' => 'tampered']));
+
+    expect($validated['slug'])->toBe('neu-kunde');
+});
+
+it('normalizes enum field values to their scalar representation', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('status', 'Status')->readOnly()->value(NormalizedStatus::Active)->rules(['string']),
+        TextInput::make('tier', 'Tier')->readOnly()->value(NormalizedTier::Gold)->rules(['string']),
+    ]);
+
+    $validated = $definition->validate(Request::create('/', 'POST', []));
+
+    expect($validated['status'])->toBe('active')
+        ->and($validated['tier'])->toBe('Gold');
+});
+
+it('normalizes Stringable prefill values', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('name', 'Name'),
+        TextInput::make('slug', 'Slug')
+            ->value(fn (FormData $form): Stringable => $form->string('name')->slug(), editable: true),
+    ]);
+
+    $result = $definition->resolveFields(Request::create('/', 'POST', ['name' => 'Neu Kunde']));
+
+    expect($result->prefill)->toBe(['slug' => 'neu-kunde']);
+});

--- a/tests/Support/TestFixtures.php
+++ b/tests/Support/TestFixtures.php
@@ -124,6 +124,11 @@ function testFormDefinition(Closure $schema): FormDefinition
             return $form->schema(($this->schema)());
         }
 
+        /**
+         * Deliberately kept on the legacy Request-only signature — living
+         * proof that handle() still resolves without a typed FormData
+         * parameter.
+         */
         public function handle(Request $request): Response
         {
             return new Response('ok');

--- a/workbench/app/Actions/EditProductAction.php
+++ b/workbench/app/Actions/EditProductAction.php
@@ -12,6 +12,7 @@ use Lattice\Core\Attributes\AsAction;
 use Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Form\Components\FileUpload;
 use Lattice\Form\Components\Form;
+use Lattice\Form\FormData;
 use Lattice\Ui\Effects\Builtin\Toast;
 use Lattice\Ui\Enums\HttpMethod;
 use Lattice\Ui\Enums\Variant;
@@ -46,20 +47,19 @@ class EditProductAction extends FormActionDefinition
         ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data, Request $request): ActionResult
     {
-        $data = $this->validate($request);
         $product = $this->product();
 
-        $relatedIds = $data['related_products'] ?? [];
-        $priceRows = $data['sales_prices'] ?? [];
+        $relatedIds = $data->get('related_products', []);
+        $priceRows = $data->get('sales_prices', []);
         $productForm = app(ProductForm::class);
-        $imageKeys = $productForm->uploadedImageKeys($data['images'] ?? []);
+        $imageKeys = $productForm->uploadedImageKeys($data->get('images', []));
         $removedImagePaths = FileUpload::removed($request, 'images');
-        unset($data['related_products'], $data['sales_prices'], $data['images']);
+        $attributes = $data->except(['related_products', 'sales_prices', 'images']);
 
-        DB::transaction(function () use ($product, $data, $relatedIds, $priceRows, $productForm, $imageKeys, $removedImagePaths): void {
-            $product->update($data);
+        DB::transaction(function () use ($product, $attributes, $relatedIds, $priceRows, $productForm, $imageKeys, $removedImagePaths): void {
+            $product->update($attributes);
             $product->relatedProducts()->sync(
                 Product::query()->whereIn('id', $relatedIds)->pluck('id')->all(),
             );

--- a/workbench/app/Actions/RejectProductAction.php
+++ b/workbench/app/Actions/RejectProductAction.php
@@ -12,6 +12,7 @@ use Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Core\Option;
 use Lattice\Form\Components\Select;
 use Lattice\Form\Components\Textarea;
+use Lattice\Form\FormData;
 use Lattice\Ui\Enums\HttpMethod;
 use Lattice\Ui\Enums\Variant;
 use Workbench\App\Models\Product;
@@ -49,10 +50,8 @@ class RejectProductAction extends ActionDefinition
         return $this->product()->status !== 'archived';
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(FormData $data): ActionResult
     {
-        $data = $this->validate($request);
-
         $product = $this->product();
         $product->update(['status' => 'archived']);
 

--- a/workbench/app/Actions/RejectSelectedProductsAction.php
+++ b/workbench/app/Actions/RejectSelectedProductsAction.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Workbench\App\Actions;
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\BulkActionDefinition;
 use Lattice\Actions\Components\Action;
 use Lattice\Core\Attributes\AsBulkAction;
 use Lattice\Form\Components\Textarea;
+use Lattice\Form\FormData;
 use Lattice\Ui\Enums\HttpMethod;
 use Lattice\Ui\Enums\Variant;
 use Workbench\App\Models\Product;
@@ -32,10 +32,8 @@ class RejectSelectedProductsAction extends BulkActionDefinition
     /**
      * @param  Collection<int, mixed>  $records
      */
-    public function handle(Collection $records, Request $request): ActionResult
+    public function handle(Collection $records, FormData $data): ActionResult
     {
-        $data = $this->validate($request);
-
         $records->each(function (mixed $product): void {
             if ($product instanceof Product) {
                 $product->update(['status' => 'archived']);

--- a/workbench/app/Actions/SubmitFeedbackAction.php
+++ b/workbench/app/Actions/SubmitFeedbackAction.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Workbench\App\Actions;
 
-use Illuminate\Http\Request;
 use Lattice\Actions\ActionDefinition;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\Components\Action as ActionComponent;
@@ -28,10 +27,8 @@ class SubmitFeedbackAction extends ActionDefinition
             ]);
     }
 
-    public function handle(Request $request): ActionResult
+    public function handle(): ActionResult
     {
-        $this->validate($request);
-
         return ActionResult::success()
             ->toast(__('workbench.pages.components.modals.feedback.toast'), Variant::Success);
     }

--- a/workbench/app/Forms/BusinessPartnerForm.php
+++ b/workbench/app/Forms/BusinessPartnerForm.php
@@ -13,6 +13,7 @@ use Lattice\Form\Components\HiddenInput;
 use Lattice\Form\Components\Repeater;
 use Lattice\Form\Components\Select;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Ui\Components\Card;
 use Lattice\Ui\Components\Text;
@@ -99,19 +100,18 @@ class BusinessPartnerForm extends FormDefinition
         return $form->schema($schema);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data): Response
     {
         $partner = $this->partner();
-        $validated = $this->validate($request);
 
-        $groupIds = $validated['groups'] ?? [];
-        $addressRows = $validated['addresses'] ?? [];
-        $defaultShippingId = $validated['default_shipping_address_id'] ?? null;
-        $defaultBillingId = $validated['default_billing_address_id'] ?? null;
+        $groupIds = $data->get('groups', []);
+        $addressRows = $data->get('addresses', []);
+        $defaultShippingId = $data->get('default_shipping_address_id');
+        $defaultBillingId = $data->get('default_billing_address_id');
 
         $partnerData = [
-            'name' => $validated['name'],
-            'email' => $validated['email'] ?? null,
+            'name' => $data->get('name'),
+            'email' => $data->get('email'),
         ];
 
         if (! $partner instanceof BusinessPartner) {

--- a/workbench/app/Forms/CheckoutWizardForm.php
+++ b/workbench/app/Forms/CheckoutWizardForm.php
@@ -16,6 +16,7 @@ use Lattice\Form\FormDefinition;
 use Lattice\Http\LatticeResponse;
 use Lattice\Ui\Components\Grid;
 use Lattice\Ui\Components\Text;
+use Stringable;
 
 #[AsForm('workbench.checkout-wizard')]
 class CheckoutWizardForm extends FormDefinition
@@ -47,10 +48,10 @@ class CheckoutWizardForm extends FormDefinition
                         Grid::make()->columns(2)->schema([
                             TextInput::make('review_name', __('workbench.pages.wizard.fields.name'))
                                 ->readOnly()
-                                ->value(fn (FormData $data): string => $data->string('name')),
+                                ->value(fn (FormData $data): Stringable => $data->string('name')),
                             TextInput::make('review_email', __('workbench.pages.wizard.fields.email'))
                                 ->readOnly()
-                                ->value(fn (FormData $data): string => $data->string('email')),
+                                ->value(fn (FormData $data): Stringable => $data->string('email')),
                         ]),
                         TextInput::make('review_items', __('workbench.pages.wizard.fields.items'))
                             ->readOnly()
@@ -70,10 +71,8 @@ class CheckoutWizardForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): LatticeResponse
+    public function handle(): LatticeResponse
     {
-        $this->validate($request);
-
         return Effects::respond()->toast(__('workbench.pages.wizard.submitted'))->back();
     }
 }

--- a/workbench/app/Forms/DependentFieldsForm.php
+++ b/workbench/app/Forms/DependentFieldsForm.php
@@ -53,10 +53,8 @@ class DependentFieldsForm extends FormDefinition
             ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/dependent');
     }
 }

--- a/workbench/app/Forms/Fields/BooleanFieldsForm.php
+++ b/workbench/app/Forms/Fields/BooleanFieldsForm.php
@@ -37,10 +37,8 @@ class BooleanFieldsForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/boolean');
     }
 }

--- a/workbench/app/Forms/Fields/BuilderFieldForm.php
+++ b/workbench/app/Forms/Fields/BuilderFieldForm.php
@@ -62,10 +62,8 @@ class BuilderFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/builder');
     }
 }

--- a/workbench/app/Forms/Fields/ChoiceFieldForm.php
+++ b/workbench/app/Forms/Fields/ChoiceFieldForm.php
@@ -27,10 +27,8 @@ class ChoiceFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/choice');
     }
 }

--- a/workbench/app/Forms/Fields/ColorPickerFieldForm.php
+++ b/workbench/app/Forms/Fields/ColorPickerFieldForm.php
@@ -25,10 +25,8 @@ class ColorPickerFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/color-picker');
     }
 }

--- a/workbench/app/Forms/Fields/DateTimeFieldsForm.php
+++ b/workbench/app/Forms/Fields/DateTimeFieldsForm.php
@@ -46,10 +46,8 @@ class DateTimeFieldsForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/date-time');
     }
 }

--- a/workbench/app/Forms/Fields/FileUploadFieldForm.php
+++ b/workbench/app/Forms/Fields/FileUploadFieldForm.php
@@ -10,6 +10,7 @@ use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\FileUpload;
 use Lattice\Form\Components\Form as FormComponent;
 use Lattice\Form\Components\Repeater;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Ui\Components\Tab;
 use Lattice\Ui\Components\Tabs;
@@ -42,19 +43,19 @@ class FileUploadFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data, Request $request): Response
     {
-        $data = $this->validate($request);
-
         foreach (FileUpload::removed($request, 'avatar') as $path) {
             Storage::disk('public')->delete($path);
         }
 
-        if (($data['avatar'] ?? null) instanceof UploadedFile) {
-            $data['avatar'] = $data['avatar']->store('uploads', 'public');
+        $attributes = $data->all();
+
+        if (($attributes['avatar'] ?? null) instanceof UploadedFile) {
+            $attributes['avatar'] = $attributes['avatar']->store('uploads', 'public');
         }
 
-        session()->flash('upload', $data);
+        session()->flash('upload', $attributes);
 
         return redirect('/form/fields/file-upload');
     }

--- a/workbench/app/Forms/Fields/NumberInputFieldForm.php
+++ b/workbench/app/Forms/Fields/NumberInputFieldForm.php
@@ -47,10 +47,8 @@ class NumberInputFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/number');
     }
 }

--- a/workbench/app/Forms/Fields/OtpFieldForm.php
+++ b/workbench/app/Forms/Fields/OtpFieldForm.php
@@ -22,10 +22,8 @@ class OtpFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/otp');
     }
 }

--- a/workbench/app/Forms/Fields/PasswordFieldForm.php
+++ b/workbench/app/Forms/Fields/PasswordFieldForm.php
@@ -37,10 +37,8 @@ class PasswordFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/password');
     }
 }

--- a/workbench/app/Forms/Fields/PatternInputFieldForm.php
+++ b/workbench/app/Forms/Fields/PatternInputFieldForm.php
@@ -37,10 +37,8 @@ class PatternInputFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/pattern-input');
     }
 }

--- a/workbench/app/Forms/Fields/RepeaterFieldForm.php
+++ b/workbench/app/Forms/Fields/RepeaterFieldForm.php
@@ -55,10 +55,8 @@ class RepeaterFieldForm extends FormDefinition
             ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/repeater');
     }
 }

--- a/workbench/app/Forms/Fields/RichEditorFieldForm.php
+++ b/workbench/app/Forms/Fields/RichEditorFieldForm.php
@@ -43,10 +43,8 @@ class RichEditorFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/rich-editor');
     }
 }

--- a/workbench/app/Forms/Fields/SelectFieldForm.php
+++ b/workbench/app/Forms/Fields/SelectFieldForm.php
@@ -109,10 +109,8 @@ class SelectFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/select');
     }
 

--- a/workbench/app/Forms/Fields/TextInputFieldForm.php
+++ b/workbench/app/Forms/Fields/TextInputFieldForm.php
@@ -56,10 +56,8 @@ class TextInputFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/text');
     }
 }

--- a/workbench/app/Forms/Fields/TextareaFieldForm.php
+++ b/workbench/app/Forms/Fields/TextareaFieldForm.php
@@ -23,10 +23,8 @@ class TextareaFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/textarea');
     }
 }

--- a/workbench/app/Forms/Fields/TreeFieldForm.php
+++ b/workbench/app/Forms/Fields/TreeFieldForm.php
@@ -38,10 +38,8 @@ class TreeFieldForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(): Response
     {
-        $this->validate($request);
-
         return redirect('/form/fields/tree');
     }
 }

--- a/workbench/app/Forms/GroupForm.php
+++ b/workbench/app/Forms/GroupForm.php
@@ -8,6 +8,7 @@ use Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form as FormComponent;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Ui\Components\Card;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,15 +29,14 @@ class GroupForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data): Response
     {
         $group = $this->group();
-        $validated = $this->validate($request);
 
         if (! $group instanceof Group) {
-            Group::query()->create($validated);
+            Group::query()->create($data->all());
         } else {
-            $group->update($validated);
+            $group->update($data->all());
         }
 
         return redirect('/groups');

--- a/workbench/app/Forms/ProductForm.php
+++ b/workbench/app/Forms/ProductForm.php
@@ -19,6 +19,7 @@ use Lattice\Form\Components\Form as FormComponent;
 use Lattice\Form\Components\Repeater;
 use Lattice\Form\Components\Select;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Ui\Components\Card;
 use Symfony\Component\HttpFoundation\Response;
@@ -79,22 +80,21 @@ class ProductForm extends FormDefinition
             ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data, Request $request): Response
     {
         $product = $this->product();
-        $validated = $this->validate($request);
 
-        $relatedIds = $validated['related_products'] ?? [];
-        $priceRows = $validated['sales_prices'] ?? [];
-        $imageKeys = $this->uploadedImageKeys($validated['images'] ?? []);
+        $relatedIds = $data->get('related_products', []);
+        $priceRows = $data->get('sales_prices', []);
+        $imageKeys = $this->uploadedImageKeys($data->get('images', []));
         $removedImagePaths = FileUpload::removed($request, 'images');
-        unset($validated['related_products'], $validated['sales_prices'], $validated['images']);
+        $attributes = $data->except(['related_products', 'sales_prices', 'images']);
 
-        DB::transaction(function () use ($product, $validated, $relatedIds, $priceRows, $imageKeys, $removedImagePaths): void {
+        DB::transaction(function () use ($product, $attributes, $relatedIds, $priceRows, $imageKeys, $removedImagePaths): void {
             if (! $product instanceof Product) {
-                $product = Product::query()->create($validated);
+                $product = Product::query()->create($attributes);
             } else {
-                $product->update($validated);
+                $product->update($attributes);
             }
 
             $product->relatedProducts()->sync(

--- a/workbench/app/Forms/ProductMediaForm.php
+++ b/workbench/app/Forms/ProductMediaForm.php
@@ -8,6 +8,7 @@ use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form as FormComponent;
 use Lattice\Form\Components\RichEditor;
 use Lattice\Form\Components\TextInput;
+use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
 use Lattice\Media\Forms\Components\MediaPicker;
 use Lattice\Media\Forms\RichEditor\MediaImage;
@@ -31,13 +32,11 @@ class ProductMediaForm extends FormDefinition
         ]);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data): Response
     {
-        $validated = $this->validate($request);
-
-        $this->product()->syncMedia($validated['gallery'] ?? [], 'gallery');
-        $this->product()->update(['body' => $validated['body'] ?? null]);
-        $this->product()->syncMedia(MediaImage::idsIn($validated['body'] ?? null), 'content');
+        $this->product()->syncMedia($data->get('gallery', []), 'gallery');
+        $this->product()->update(['body' => $data->get('body')]);
+        $this->product()->syncMedia(MediaImage::idsIn($data->get('body')), 'content');
 
         return redirect('/media-picker');
     }

--- a/workbench/app/Forms/SalesOrderForm.php
+++ b/workbench/app/Forms/SalesOrderForm.php
@@ -94,27 +94,26 @@ class SalesOrderForm extends FormDefinition
         return $form->schema($schema);
     }
 
-    public function handle(Request $request): Response
+    public function handle(FormData $data): Response
     {
         $order = $this->order();
-        $validated = $this->validate($request);
 
-        $lineRows = $validated['lines'] ?? [];
+        $lineRows = $data->get('lines', []);
 
-        $partner = BusinessPartner::query()->findOrFail((int) $validated['business_partner_id']);
+        $partner = BusinessPartner::query()->findOrFail((int) $data->get('business_partner_id'));
 
-        DB::transaction(function () use ($order, $validated, $lineRows, $partner): void {
-            $shippingAddressId = array_key_exists('shipping_address_id', $validated)
-                ? $this->resolveAddressId($partner, $validated['shipping_address_id'] ?? null)
+        DB::transaction(function () use ($order, $data, $lineRows, $partner): void {
+            $shippingAddressId = $data->has('shipping_address_id')
+                ? $this->resolveAddressId($partner, $data->get('shipping_address_id'))
                 : $partner->default_shipping_address_id;
 
-            $billingAddressId = array_key_exists('billing_address_id', $validated)
-                ? $this->resolveAddressId($partner, $validated['billing_address_id'] ?? null)
+            $billingAddressId = $data->has('billing_address_id')
+                ? $this->resolveAddressId($partner, $data->get('billing_address_id'))
                 : $partner->default_billing_address_id;
 
             $orderData = [
                 'business_partner_id' => $partner->getKey(),
-                'status' => $validated['status'],
+                'status' => $data->get('status'),
                 'shipping_address_id' => $shippingAddressId,
                 'billing_address_id' => $billingAddressId,
             ];


### PR DESCRIPTION
Form/action/bulk submits validated twice: the controller validated as a gate, discarded the result, and every `handle()` re-derived it via `$this->validate($request)` — re-running schema building, closures, and DB-hitting rules on each submit.

## What changed

- Endpoints validate **once** and invoke `handle()` through the closure evaluator. Parameters resolve by name (`$data`, `$request`, `$records`), by type (`FormData`, `Request`, `Collection`), or from the container:
  ```php
  public function handle(FormData $data): Response { ... }
  public function handle(Collection $records, FormData $data): ActionResult { ... } // bulk
  ```
  Old `handle(Request $request)` signatures keep working via typed resolution.
- `FormData` extends Laravel's `ValidatedInput` — `handle()` receives the validated, **cast** payload (server values injected, hidden/locked stripped) with the full `InteractsWithData` API.
- Field values and prefills normalize `Stringable`/enum returns to their scalar, so `->value(fn (FormData $d) => $d->string('name'))` works without `->toString()`.
- `BulkActionController` now pre-validates the embedded form (previously it never did): invalid input 422s before `handle()`.
- Fixes the stale `$this->respond()` in `form.php.stub` and two latent `Stringable`-truthiness bugs in docs/tests.

## Breaking

- Abstract `handle(Request)` declarations removed; missing/mistyped `handle()` fails at submit time with a clear exception.
- `validate()` returns `FormData` instead of `array`.
- `FormData::string()` returns `Stringable` (Laravel semantics).

## Validation

Full Pest suite: 1838 passed (6334 assertions). PHPStan clean on both configs. New coverage: validate-once regression counter, cast/stripped/injected `FormData` in `handle()`, flexible-signature matrix, return-type/missing-method guards, bulk 422-before-handle, value normalization.
