### PR TITLE
fix(form): collect row template fields through layout containers

### DIFF
--- a/packages/form/src/Components/RowTemplate.php
+++ b/packages/form/src/Components/RowTemplate.php
@@ -6,6 +6,7 @@ namespace Lattice\Form\Components;
 use Illuminate\Support\Str;
 use Lattice\Ui\Components\Component;
 use Lattice\Ui\Components\Concerns\HasChildSchema;
+use Lattice\Ui\Components\ContainerComponent;
 
 /**
  * A typed row template for a TypedRowsField: the schema of child Fields a row
@@ -35,14 +36,42 @@ final class RowTemplate
     }
 
     /**
+     * The template's Fields, collected through layout containers (Grid,
+     * Stack) so a template can shape its row. Fields themselves stay atomic —
+     * a nested rows field owns its children via ProvidesRowFields.
+     *
      * @return array<int, Field>
      */
     public function fields(): array
     {
-        return array_values(array_filter(
-            $this->resolvedChildren(),
-            static fn (Component $child): bool => $child instanceof Field,
-        ));
+        return $this->collectFields($this->resolvedChildren());
+    }
+
+    /**
+     * @param  array<int, Component>  $children
+     * @return array<int, Field>
+     */
+    private function collectFields(array $children): array
+    {
+        $fields = [];
+
+        foreach ($children as $child) {
+            if ($child instanceof Field) {
+                $fields[] = $child;
+
+                continue;
+            }
+
+            if ($child instanceof ContainerComponent) {
+                foreach ($child->descendants() as $descendant) {
+                    if ($descendant instanceof Field) {
+                        $fields[] = $descendant;
+                    }
+                }
+            }
+        }
+
+        return $fields;
     }
 
     public function data(): RowTemplateData

--- a/tests/Feature/Forms/RowTemplateLayoutTest.php
+++ b/tests/Feature/Forms/RowTemplateLayoutTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Lattice\Form\Components\Builder;
+use Lattice\Form\Components\RowTemplate;
+use Lattice\Form\Components\TextInput;
+use Lattice\Form\FieldValidator;
+use Lattice\Ui\Components\Grid;
+
+it('validates and casts fields nested inside a template layout container', function (): void {
+    $field = Builder::make('items')->templates([
+        RowTemplate::make('product')->schema([
+            Grid::make('row-grid')->columns(3)->schema([
+                TextInput::make('name')->required(),
+                TextInput::make('qty')->rules(['numeric']),
+            ]),
+            TextInput::make('note'),
+        ]),
+    ]);
+    $request = Request::create('/', 'POST', ['items' => [
+        ['type' => 'product', 'name' => 'Widget', 'qty' => '2', 'note' => 'n'],
+    ]]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'][0]['name'])->toBe('Widget')
+        ->and($validated['items'][0]['qty'])->toBe('2')
+        ->and($validated['items'][0]['note'])->toBe('n');
+});
+
+it('rejects missing required fields nested inside a template layout container', function (): void {
+    $field = Builder::make('items')->templates([
+        RowTemplate::make('product')->schema([
+            Grid::make('row-grid')->columns(2)->schema([
+                TextInput::make('name')->required(),
+            ]),
+        ]),
+    ]);
+    $request = Request::create('/', 'POST', ['items' => [['type' => 'product']]]);
+
+    (new FieldValidator)->validate([$field], $request);
+})->throws(ValidationException::class);


### PR DESCRIPTION
A RowTemplate only saw its direct Field children, so a template shaping its row with a Grid or Stack silently dropped the nested fields from validation, casting, and prefills. `fields()` now walks layout containers via `descendants()`, stopping at Fields — a nested rows field keeps owning its children via ProvidesRowFields. Lets consumers lay out tree/builder row templates with Grids (quote line items: image | product | name / qty | price | net).