### PR TITLE
fix(table): bind cell-referenced sibling row keys into the row projection

### DIFF
--- a/packages/table/resources/js/lib/format.test.ts
+++ b/packages/table/resources/js/lib/format.test.ts
@@ -104,8 +104,12 @@ describe("resolveLink", () => {
     );
   });
 
-  it("coerces missing row tokens to an empty string", () => {
-    expect(resolveLink(column("/x/{missing}"), row, "v")).toBe("/x/");
+  it("drops the link when a row token has no value", () => {
+    expect(resolveLink(column("/x/{missing}"), row, "v")).toBeNull();
+  });
+
+  it("drops the link when the value token is empty", () => {
+    expect(resolveLink(column("/x/{value}"), row, null)).toBeNull();
   });
 
   it("falls back to the cell value when no explicit href is set", () => {

--- a/packages/table/resources/js/lib/format.ts
+++ b/packages/table/resources/js/lib/format.ts
@@ -45,11 +45,18 @@ export function resolveLink(column: TableColumn, row: TableRow, value: unknown):
     return null;
   }
 
-  return href.replace(/\{([^}]+)\}/g, (_, key: string) => {
-    if (key === "value") {
-      return encodeURIComponent(String(value ?? ""));
+  let unresolved = false;
+
+  const resolved = href.replace(/\{([^}]+)\}/g, (_, key: string) => {
+    const raw = key === "value" ? value : row[key];
+
+    if (raw === null || raw === undefined || raw === "") {
+      unresolved = true;
+      return "";
     }
 
-    return encodeURIComponent(String(row[key] ?? ""));
+    return encodeURIComponent(String(raw));
   });
+
+  return unresolved ? null : resolved;
 }

--- a/packages/table/src/Columns/MoneyColumn.php
+++ b/packages/table/src/Columns/MoneyColumn.php
@@ -32,4 +32,15 @@ final class MoneyColumn extends NumericColumn
 
         return $this;
     }
+
+    /**
+     * @return array<int, string>
+     */
+    #[\Override]
+    public function boundRowKeys(): array
+    {
+        return $this->currencyField === null
+            ? parent::boundRowKeys()
+            : [...parent::boundRowKeys(), $this->currencyField];
+    }
 }

--- a/packages/table/src/Columns/TextColumn.php
+++ b/packages/table/src/Columns/TextColumn.php
@@ -118,4 +118,31 @@ final class TextColumn extends Column implements Filterable, Searchable, Sortabl
 
         return parent::relationBinding();
     }
+
+    /**
+     * Binds the sibling row keys the cell reads besides the value: the badge's
+     * colour key (scalar columns only — multiple() carries colours per chip) and
+     * every `{placeholder}` in the link href except the literal `{value}`.
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    public function boundRowKeys(): array
+    {
+        $keys = parent::boundRowKeys();
+
+        if ($this->badge !== null && $this->multiple === null) {
+            $keys[] = $this->badge['colorKey'];
+        }
+
+        preg_match_all('/\{([^}]+)\}/', $this->link['href'] ?? '', $matches);
+
+        foreach ($matches[1] as $placeholder) {
+            if ($placeholder !== 'value') {
+                $keys[] = $placeholder;
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
 }

--- a/packages/table/src/TableRegistry.php
+++ b/packages/table/src/TableRegistry.php
@@ -255,21 +255,32 @@ final class TableRegistry extends DefinitionRegistry
     }
 
     /**
+     * The identity keys plus every rendering column's bound row keys. A
+     * visible(false) column stays authoritative for its own key: hidden means
+     * gone from the row payload even when a rendering sibling binds the key
+     * (e.g. a badge colour reference) — unless the key is also a rendering
+     * column's own key or an identity key.
+     *
      * @param  array<int, Column>  $columns
      * @return array<int, string>
      */
     private function rowKeys(array $columns): array
     {
         $keys = self::ROW_IDENTITY_KEYS;
+        $rendered = [];
+        $suppressed = [];
 
         foreach ($columns as $column) {
-            if (! $column->shouldRender()) {
-                continue;
+            if ($column->shouldRender()) {
+                $rendered[] = $column->key();
+                array_push($keys, ...$column->boundRowKeys());
+            } else {
+                $suppressed[] = $column->key();
             }
-
-            array_push($keys, ...$column->boundRowKeys());
         }
 
-        return array_values(array_unique($keys));
+        $suppressed = array_diff($suppressed, self::ROW_IDENTITY_KEYS, $rendered);
+
+        return array_values(array_unique(array_diff($keys, $suppressed)));
     }
 }

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -419,6 +419,21 @@ test('registered table responses prune hidden columns from the row payload', fun
         ->and($row)->not->toHaveKey('secret');
 });
 
+test('a badge colour key without a hidden column claiming it ships in the row payload', function (): void {
+    Lattice::tables([WorkbenchBadgeHelperUsersTable::class]);
+
+    $ref = $this->latticeRef(wire(Table::use(WorkbenchBadgeHelperUsersTable::class)));
+    $row = $this->latticeGet('/lattice/tables/workbench.badge-helper-users', $ref)
+        ->assertOk()
+        ->json('data.0');
+
+    expect($row)->toBeArray();
+    assert(is_array($row));
+
+    expect(array_keys($row))->toBe(['status', 'helper'])
+        ->and($row['helper'])->toBe('green');
+});
+
 test('a hidden column referenced by a visible badge column is still pruned from the row payload', function (): void {
     Lattice::tables([WorkbenchHiddenBadgeHelperUsersTable::class]);
 
@@ -615,6 +630,27 @@ class WorkbenchHiddenColumnUsersTable extends TableDefinition
             [
                 'name' => 'Taylor',
                 'secret' => 'top-secret',
+            ],
+        ]));
+    }
+}
+
+#[AsTable('workbench.badge-helper-users')]
+class WorkbenchBadgeHelperUsersTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('status')->badge('helper'),
+        ];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([
+            [
+                'status' => 'Active',
+                'helper' => 'green',
             ],
         ]));
     }

--- a/tests/Unit/Tables/Columns/MoneyColumnTest.php
+++ b/tests/Unit/Tables/Columns/MoneyColumnTest.php
@@ -20,3 +20,12 @@ it('serializes a per-row currency reference', function (): void {
         ->and($props['currency'])->toBeNull()
         ->and($props['minimumFractionDigits'])->toBe(0);
 });
+
+it('binds the currency field into the row keys so projection keeps it', function (): void {
+    expect(MoneyColumn::make('total')->currencyField('currency')->boundRowKeys())
+        ->toBe(['total', 'currency']);
+});
+
+it('binds only its own key without a currency field', function (): void {
+    expect(MoneyColumn::make('total')->currency('EUR')->boundRowKeys())->toBe(['total']);
+});

--- a/tests/Unit/Tables/Columns/TextColumnTest.php
+++ b/tests/Unit/Tables/Columns/TextColumnTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Table\Columns\TextColumn;
+
+it('binds link placeholder keys into the row keys so projection keeps them', function (): void {
+    expect(TextColumn::make('account.display_name')->link('/accounts/{account_id}?from={value}')->boundRowKeys())
+        ->toBe(['account.display_name', 'account_id']);
+});
+
+it('binds the badge colour key for a scalar badge column', function (): void {
+    expect(TextColumn::make('status')->badge('status_color')->boundRowKeys())
+        ->toBe(['status', 'status_color']);
+});
+
+it('binds only its own key for a multiple badge column', function (): void {
+    expect(TextColumn::make('tags')->multiple('slug')->badge()->boundRowKeys())->toBe(['tags']);
+});
+
+it('binds only its own key for a value-only link', function (): void {
+    expect(TextColumn::make('url')->link()->boundRowKeys())->toBe(['url']);
+});


### PR DESCRIPTION
The table registry whitelists each column's boundRowKeys() into the decorated row, so sibling row keys that cells read besides their own value were stripped from the wire payload:

- MoneyColumn's currencyField() — the money cell always fell back to plain number formatting without a currency symbol
- TextColumn link href {placeholder} keys — resolveLink() substituted empty strings
- TextColumn badge colour key on scalar columns — badges always fell back to gray

Each column now binds those keys through boundRowKeys() so the projection keeps them.

Validated with the table unit + feature suites, PHPStan, and Pint.
