### PR TITLE
fix(table): resolve duplicate resolveLink declaration from crossed merges

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,3 @@
+{
+    "projectId": "321043fb-1c9c-4df2-b5e4-4ef63f61d18c"
+}

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,3 +1,0 @@
-{
-    "projectId": "321043fb-1c9c-4df2-b5e4-4ef63f61d18c"
-}

--- a/packages/table/resources/js/lib/format.test.ts
+++ b/packages/table/resources/js/lib/format.test.ts
@@ -115,4 +115,16 @@ describe("resolveLink", () => {
   it("falls back to the cell value when no explicit href is set", () => {
     expect(resolveLink(column(null), row, "https://example.test")).toBe("https://example.test");
   });
+
+  it("prefers the row-resolved closure link over the template", () => {
+    const linked = { ...row, links: { col: "/customers/7" } };
+
+    expect(resolveLink(column("/x/{id}"), linked, "Ada")).toBe("/customers/7");
+  });
+
+  it("returns null when the closure resolved no link for the row", () => {
+    const unlinked = { ...row, links: { col: null } };
+
+    expect(resolveLink(column(null), unlinked, "https://example.test")).toBeNull();
+  });
 });

--- a/packages/table/resources/js/lib/format.ts
+++ b/packages/table/resources/js/lib/format.ts
@@ -40,10 +40,10 @@ export function resolveLink(column: TableColumn, row: TableRow, value: unknown):
     return null;
   }
 
-  const resolved = getRowLink(row, column.key);
+  const rowLink = getRowLink(row, column.key);
 
-  if (resolved !== undefined) {
-    return resolved;
+  if (rowLink !== undefined) {
+    return rowLink;
   }
 
   const href = link.href ?? String(value ?? "");

--- a/packages/table/src/TableRegistry.php
+++ b/packages/table/src/TableRegistry.php
@@ -268,12 +268,6 @@ final class TableRegistry extends DefinitionRegistry
     }
 
     /**
-     * The identity keys plus every rendering column's bound row keys. A
-     * visible(false) column stays authoritative for its own key: hidden means
-     * gone from the row payload even when a rendering sibling binds the key
-     * (e.g. a badge colour reference) — unless the key is also a rendering
-     * column's own key or an identity key.
-     *
      * @param  array<int, Column>  $columns
      * @param  callable(TextColumn): bool  $matches
      * @return array<int, TextColumn>
@@ -328,6 +322,12 @@ final class TableRegistry extends DefinitionRegistry
     }
 
     /**
+     * The identity keys plus every rendering column's bound row keys. A
+     * visible(false) column stays authoritative for its own key: hidden means
+     * gone from the row payload even when a rendering sibling binds the key
+     * (e.g. a badge colour reference) — unless the key is also a rendering
+     * column's own key or an identity key.
+     *
      * @param  array<int, Column>  $columns
      * @return array<int, string>
      */


### PR DESCRIPTION
#513 and #514 both extended `resolveLink` in `packages/table/resources/js/lib/format.ts` — the merge produced two `const resolved` declarations in one scope, a parse error that broke every JS build on main (CI, Browser, Docs, standalone-assets).

- Rename the row-resolved early return to `rowLink`; both behaviors are preserved: a server-resolved closure link wins, then the `{placeholder}` template logic with #513's unresolved-token handling.
- Move #513's `rowKeys()` prose docblock back onto `rowKeys()` — the merge had attached it to the unrelated `textColumnsWhere()` inserted by #514.

Verified: table Vitest (175, includes both PRs' `resolveLink` suites), table Pest (185), `npm run check` green.