### PR TITLE
feat(ui): sticky stacks and tab rails, extra-large width

### DIFF
--- a/docs/content/docs/components/layout.mdx
+++ b/docs/content/docs/components/layout.mdx
@@ -45,8 +45,14 @@ Tune the layout with enum-typed options (see the [enums reference](/advanced/enu
 
 - `->gap(Gap::ExtraSmall … ExtraLarge)` — the space between children.
 - `->align(Align::…)` and `->justify(Justify::…)` — cross-axis and main-axis alignment.
-- `->width(Width::…)` and `->height(Height::…)` — sizing.
+- `->width(Width::…)` and `->height(Height::…)` — sizing. The capped widths (`Small` … `ExtraLarge`)
+  centre the stack; add `->float(Side::Start)` or `->float(Side::End)` to pin it to one edge instead.
 - `->float(Side::…)` — float the stack to one side.
+- `->sticky()` — pin the stack below the sticky chrome above it (a sticky `Topbar`, an earlier sticky
+  stack) while the page scrolls. The stack paints the page background, keeps a small gutter once
+  stuck, and publishes its own height as the sticky offset for its siblings, so a sticky vertical
+  tab rail or another sticky stack further down lines up beneath it. A page header with the title
+  and primary actions is the typical candidate.
 
 ## Grid
 

--- a/docs/content/docs/components/tabs.mdx
+++ b/docs/content/docs/components/tabs.mdx
@@ -38,6 +38,9 @@ open.
   (tabs share the full width); `Start`, `Center`, and `End` shrink the strip to its content and pin it
   left, center, or right. Vertical tabs only read `End` — it moves the strip to the right of the
   panels; every other value keeps it on the left.
+- `->sticky()` keeps a vertical rail in view while a long panel scrolls. The rail sits a gap below
+  whatever sticky chrome the page publishes above it — a sticky `Topbar`, a sticky `Stack` header —
+  so it never slides underneath. Horizontal strips ignore the option.
 
 See the [enums reference](/advanced/enums/) for the full `Orientation` and `TabsAlignment` cases.
 

--- a/docs/content/docs/core/layouts.md
+++ b/docs/content/docs/core/layouts.md
@@ -92,7 +92,8 @@ An empty named slot disappears without affecting the `Outlet` or the page tree i
 
 `Topbar` is a horizontal bar for chrome that sits above the page — a logo, search, settings menu, or
 appearance switcher. Call `->sticky()` to keep it pinned to the top of the viewport as the page
-scrolls, and `->items([...])` to fill it:
+scrolls, and `->items([...])` to fill it. A sticky topbar also claims its height as the page's sticky
+offset (`--lt-sticky-offset`), which sticky stacks and vertical tab rails pin beneath:
 
 ```php
 use Lattice\Layouts\Components\Topbar;

--- a/docs/fixtures/components.avatar.json
+++ b/docs/fixtures/components.avatar.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.buttons.json
+++ b/docs/fixtures/components.buttons.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.card.json
+++ b/docs/fixtures/components.card.json
@@ -15,6 +15,7 @@
                     "gap": "sm",
                     "height": null,
                     "justify": null,
+                    "sticky": false,
                     "width": null
                 },
                 "schema": [

--- a/docs/fixtures/components.image.json
+++ b/docs/fixtures/components.image.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.popover.json
+++ b/docs/fixtures/components.popover.json
@@ -27,6 +27,7 @@
                     "gap": "sm",
                     "height": null,
                     "justify": null,
+                    "sticky": false,
                     "width": null
                 },
                 "schema": [

--- a/docs/fixtures/components.progress.json
+++ b/docs/fixtures/components.progress.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [
@@ -44,6 +45,7 @@
                     "gap": "md",
                     "height": null,
                     "justify": null,
+                    "sticky": false,
                     "width": null
                 },
                 "schema": [

--- a/docs/fixtures/components.separator-vertical.json
+++ b/docs/fixtures/components.separator-vertical.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.separator.json
+++ b/docs/fixtures/components.separator.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.stack.json
+++ b/docs/fixtures/components.stack.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.tabs.json
+++ b/docs/fixtures/components.tabs.json
@@ -5,7 +5,8 @@
             "alignment": "stretch",
             "defaultValue": "details",
             "orientation": "horizontal",
-            "queryKey": "tabs"
+            "queryKey": "tabs",
+            "sticky": false
         },
         "schema": [
             {

--- a/docs/fixtures/components.text.json
+++ b/docs/fixtures/components.text.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/components.tooltip.json
+++ b/docs/fixtures/components.tooltip.json
@@ -7,6 +7,7 @@
             "gap": "sm",
             "height": null,
             "justify": null,
+            "sticky": false,
             "width": null
         },
         "schema": [

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -198,6 +198,10 @@
                 "value": "full"
             },
             {
+                "name": "ExtraLarge",
+                "value": "xl"
+            },
+            {
                 "name": "Large",
                 "value": "lg"
             },
@@ -1186,6 +1190,10 @@
             {
                 "name": "Large",
                 "value": "lg"
+            },
+            {
+                "name": "ExtraLarge",
+                "value": "xl"
             },
             {
                 "name": "Fill",

--- a/docs/fixtures/packages.map.json
+++ b/docs/fixtures/packages.map.json
@@ -23,6 +23,7 @@
                                 "gap": "sm",
                                 "height": null,
                                 "justify": null,
+                                "sticky": false,
                                 "width": null
                             },
                             "schema": [

--- a/docs/fixtures/select.rich.json
+++ b/docs/fixtures/select.rich.json
@@ -24,6 +24,7 @@
                         "gap": null,
                         "height": null,
                         "justify": null,
+                        "sticky": false,
                         "width": null
                     },
                     "schema": [

--- a/packages/core/resources/js/generated.ts
+++ b/packages/core/resources/js/generated.ts
@@ -51,7 +51,7 @@ export type Op =
   | "empty"
   | "filled";
 export type PageLayout = "app" | "auth" | "none";
-export type PageWidth = "full" | "lg" | "md" | "sm";
+export type PageWidth = "full" | "xl" | "lg" | "md" | "sm";
 export type RemoteAccess = {
   readonly audience: string;
   readonly nodeId: string;

--- a/packages/core/src/Enums/PageWidth.php
+++ b/packages/core/src/Enums/PageWidth.php
@@ -14,6 +14,7 @@ use Lattice\Core\Attributes\TypeScript;
 enum PageWidth: string
 {
     case Full = 'full';
+    case ExtraLarge = 'xl';
     case Large = 'lg';
     case Medium = 'md';
     case Small = 'sm';

--- a/packages/framework/resources/js/layout/components/topbar.tsx
+++ b/packages/framework/resources/js/layout/components/topbar.tsx
@@ -8,8 +8,10 @@ const TopbarComponent: RendererComponent<"topbar"> = ({ children, node }) => {
   return (
     <header
       data-lattice-component={nodeIdentity(node)}
+      data-lattice-topbar=""
+      data-sticky={sticky || undefined}
       className={cn(
-        "flex h-14 w-full items-center gap-2 border-b border-lt-border bg-lt-bg px-4 text-lt-fg",
+        "flex h-(--lt-topbar-h) w-full items-center gap-2 border-b border-lt-border bg-lt-bg px-4 text-lt-fg",
         sticky && "sticky top-0 z-lt-sticky",
       )}
     >

--- a/packages/framework/resources/js/page.tsx
+++ b/packages/framework/resources/js/page.tsx
@@ -10,6 +10,7 @@ type Props = {
 
 const pageWidths: Record<string, string> = {
   full: "max-w-none",
+  xl: "max-w-6xl",
   lg: "max-w-4xl",
   md: "max-w-2xl",
   sm: "max-w-md",

--- a/packages/ui/resources/css/lattice.css
+++ b/packages/ui/resources/css/lattice.css
@@ -128,11 +128,19 @@
   --lt-sidebar-w: 16rem;
   --lt-sidebar-w-collapsed: 4rem;
   --lt-container-max: 80rem;
+  --lt-topbar-h: 3.5rem;
+
+  /* Viewport-top clearance for sticky content; a sticky topbar claims it below */
+  --lt-sticky-offset: 0px;
 
   /* Card / section content inset — the gutter apps can break out of */
   --lt-gutter: calc(var(--spacing) * 6);
 
   color-scheme: light;
+  }
+
+  :root:has([data-lattice-topbar][data-sticky]) {
+    --lt-sticky-offset: var(--lt-topbar-h);
   }
 }
 

--- a/packages/ui/resources/js/components/stack/stack-adapter.tsx
+++ b/packages/ui/resources/js/components/stack/stack-adapter.tsx
@@ -11,6 +11,7 @@ const StackAdapter: RendererComponent<"stack"> = ({ children, node }) => (
     gap={node.props.gap ?? undefined}
     height={node.props.height ?? undefined}
     justify={node.props.justify ?? undefined}
+    sticky={node.props.sticky}
     width={node.props.width ?? undefined}
   >
     {children}

--- a/packages/ui/resources/js/components/stack/stack.browser.test.tsx
+++ b/packages/ui/resources/js/components/stack/stack.browser.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, it } from "vitest";
+import { Stack } from "./stack";
+
+describe("Stack in a browser", () => {
+  it("pins a sticky stack below the inherited offset and publishes its height to siblings", async () => {
+    const screen = await render(
+      <div style={{ "--lt-sticky-offset": "56px" } as React.CSSProperties}>
+        <div data-test="parent">
+          <Stack sticky>
+            <div data-test="header" style={{ height: 40 }}>
+              Header
+            </div>
+          </Stack>
+          <div data-test="sibling">Sibling</div>
+        </div>
+      </div>,
+    );
+
+    const stack = screen.getByText("Header").element().parentElement;
+    const parent = screen.getByTestId("parent").element() as HTMLElement;
+    const sibling = screen.getByTestId("sibling").element();
+
+    await expect
+      .poll(() => parent.style.getPropertyValue("--lt-sticky-offset"))
+      .toBe("calc(56px + 72px)");
+    expect(stack).not.toBeNull();
+    expect(getComputedStyle(stack as HTMLElement).position).toBe("sticky");
+    expect(getComputedStyle(stack as HTMLElement).top).toBe("56px");
+    expect(getComputedStyle(sibling).getPropertyValue("--lt-sticky-offset")).toBe(
+      "calc(56px + 72px)",
+    );
+  });
+});

--- a/packages/ui/resources/js/components/stack/stack.tsx
+++ b/packages/ui/resources/js/components/stack/stack.tsx
@@ -1,4 +1,5 @@
 import type { ComponentProps } from "react";
+import { useStickyOffsetPublisher } from "../../lib/use-sticky-offset";
 import { cn } from "../../lib/utils";
 
 export type StackAlign = "center" | "left" | "start" | "stretch";
@@ -7,7 +8,7 @@ export type StackGap = "none" | "xs" | "sm" | "md" | "lg" | "xl";
 export type StackHeight = "full" | "screen";
 export type StackJustify = "start" | "center" | "end" | "between" | "around" | "evenly";
 export type StackSide = "start" | "end";
-export type StackWidth = "full" | "auto" | "sm" | "md" | "lg" | "fill";
+export type StackWidth = "full" | "auto" | "sm" | "md" | "lg" | "xl" | "fill";
 
 export type StackProps = Omit<ComponentProps<"div">, "align"> & {
   align?: StackAlign;
@@ -16,6 +17,7 @@ export type StackProps = Omit<ComponentProps<"div">, "align"> & {
   gap?: StackGap;
   height?: StackHeight;
   justify?: StackJustify;
+  sticky?: boolean;
   width?: StackWidth;
 };
 
@@ -46,6 +48,7 @@ const stackWidths: Record<StackWidth, string> = {
   sm: "mx-auto w-full max-w-md",
   md: "mx-auto w-full max-w-2xl",
   lg: "mx-auto w-full max-w-4xl",
+  xl: "mx-auto w-full max-w-6xl",
   fill: "min-w-0 flex-1",
 };
 
@@ -68,6 +71,14 @@ const floatClasses: Record<StackSide, string> = {
   end: "ml-auto",
 };
 
+/**
+ * The vertical padding only shows once the stack is stuck — the negative
+ * margin cancels it in normal flow — so the pinned content keeps a gutter
+ * between itself and the chrome above without shifting the page.
+ */
+const stickyClasses =
+  "sticky top-[var(--lt-sticky-own-top,var(--lt-sticky-offset))] z-lt-sticky -my-4 bg-lt-bg py-4";
+
 export function Stack({
   align = "stretch",
   className,
@@ -76,14 +87,18 @@ export function Stack({
   gap = "md",
   height,
   justify,
+  sticky = false,
   width = "full",
   ...props
 }: StackProps) {
   const isFlex = direction === "row" || justify !== undefined;
+  const ref = useStickyOffsetPublisher(sticky);
 
   return (
     <div
       data-slot="stack"
+      data-sticky={sticky || undefined}
+      ref={ref}
       className={cn(
         isFlex ? cn("flex", direction === "row" ? "flex-wrap" : "flex-col") : "grid content-start",
         isFlex
@@ -94,6 +109,7 @@ export function Stack({
         justify ? justifyClasses[justify] : null,
         height ? stackHeights[height] : null,
         float ? floatClasses[float] : null,
+        sticky && stickyClasses,
         className,
       )}
       {...props}

--- a/packages/ui/resources/js/components/tabs/tabs-adapter.tsx
+++ b/packages/ui/resources/js/components/tabs/tabs-adapter.tsx
@@ -45,6 +45,7 @@ export const TabsAdapter: RendererComponent<"tabs"> = ({ children, node }) => {
       items={tabs.map((tab) => ({ label: tab.label, value: tab.value }))}
       onValueChange={selectTab}
       orientation={node.props.orientation}
+      sticky={node.props.sticky}
       value={activeValue}
     >
       {children}

--- a/packages/ui/resources/js/components/tabs/tabs.test.tsx
+++ b/packages/ui/resources/js/components/tabs/tabs.test.tsx
@@ -49,6 +49,30 @@ describe("Tabs", () => {
     expect(screen.getByText("Overview panel")).toBeVisible();
   });
 
+  it("pins a sticky vertical rail below the published sticky offset", () => {
+    render(
+      <Tabs defaultValue="overview" orientation="vertical" sticky>
+        <Tab label="Overview" value="overview" />
+        <Tab label="Details" value="details" />
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tablist")).toHaveClass(
+      "sticky top-[calc(var(--lt-sticky-offset)+--spacing(6))]",
+    );
+  });
+
+  it("keeps a horizontal strip in flow even when sticky is requested", () => {
+    render(
+      <Tabs defaultValue="overview" sticky>
+        <Tab label="Overview" value="overview" />
+        <Tab label="Details" value="details" />
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tablist")).not.toHaveClass("sticky");
+  });
+
   it("roves focus with orientation-aware keyboard navigation", () => {
     render(
       <Tabs defaultValue="overview" orientation="vertical">

--- a/packages/ui/resources/js/components/tabs/tabs.tsx
+++ b/packages/ui/resources/js/components/tabs/tabs.tsx
@@ -31,6 +31,7 @@ export type TabsProps = Omit<ComponentProps<"div">, "children" | "defaultValue" 
   items?: readonly TabsItem[];
   onValueChange?: (value: string) => void;
   orientation?: TabsOrientation;
+  sticky?: boolean;
   value?: string;
 };
 
@@ -49,6 +50,8 @@ type TabsContextValue = {
 type TabElement = ReactElement<TabProps, typeof Tab>;
 
 const TabsContext = createContext<TabsContextValue | null>(null);
+/** Pins the rail a gap below whatever sticky chrome the page publishes above it. */
+const stickyRailClassName = "sticky top-[calc(var(--lt-sticky-offset)+--spacing(6))]";
 const SELECT_COLLAPSE_THRESHOLD = 3;
 
 function useTabsContext(): TabsContextValue {
@@ -64,6 +67,7 @@ export function Tabs({
   items,
   onValueChange,
   orientation = "horizontal",
+  sticky = false,
   value,
   ...props
 }: TabsProps) {
@@ -138,7 +142,7 @@ export function Tabs({
       <div
         {...props}
         className={cn(
-          "gap-6",
+          "min-w-0 gap-6",
           isVertical && !collapseToSelect
             ? cn("flex", alignment === "end" && "flex-row-reverse")
             : "grid",
@@ -165,6 +169,7 @@ export function Tabs({
             className={cn(
               "gap-1",
               isVertical ? "flex w-44 shrink-0 flex-col self-start" : "rounded-lt bg-lt-muted p-1",
+              isVertical && sticky && stickyRailClassName,
               isStretched && "flex w-full",
               !isVertical &&
                 !isStretched &&

--- a/packages/ui/resources/js/generated.ts
+++ b/packages/ui/resources/js/generated.ts
@@ -362,6 +362,7 @@ export type Stack = {
   gap: Gap | null;
   height: Height | null;
   justify: Justify | null;
+  sticky: boolean;
   width: Width | null;
 };
 export type StackDirection = "row" | "column";
@@ -380,6 +381,7 @@ export type Tabs = {
   defaultValue: string | null;
   orientation: Orientation;
   queryKey: string;
+  sticky: boolean;
 };
 export type TabsAlignment = "start" | "center" | "end" | "stretch";
 export type Text = {
@@ -450,4 +452,4 @@ export type UiNodeType =
   | "text"
   | "tooltip";
 export type Variant = "primary" | "secondary" | "success" | "info" | "warning" | "danger";
-export type Width = "full" | "auto" | "sm" | "md" | "lg" | "fill";
+export type Width = "full" | "auto" | "sm" | "md" | "lg" | "xl" | "fill";

--- a/packages/ui/resources/js/lib/use-sticky-offset.ts
+++ b/packages/ui/resources/js/lib/use-sticky-offset.ts
@@ -1,0 +1,62 @@
+import { useRef } from "react";
+import type { RefObject } from "react";
+import { useLayoutEffect } from "./use-layout-effect";
+
+/**
+ * The distance from the viewport top that sticky content must leave free for
+ * the sticky chrome above it. The stylesheet seeds it (0, or the topbar height
+ * when the topbar is sticky); a sticky stack republishes it for its siblings.
+ */
+export const STICKY_OFFSET_VAR = "--lt-sticky-offset";
+
+/**
+ * The offset a sticky stack itself pins to. It is frozen per element because
+ * the stack overrides the shared variable on its parent, which would otherwise
+ * feed back into its own `top`.
+ */
+export const STICKY_OWN_TOP_VAR = "--lt-sticky-own-top";
+
+/**
+ * Pins an element below the sticky chrome above it and publishes the element's
+ * own height, added to that chrome, as the sticky offset for its siblings.
+ */
+export function useStickyOffsetPublisher(enabled: boolean): RefObject<HTMLDivElement | null> {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    const parent = element?.parentElement;
+
+    if (!enabled || !element || !parent || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const base = inheritedOffset(parent.parentElement);
+    element.style.setProperty(STICKY_OWN_TOP_VAR, base);
+
+    const publish = (): void => {
+      parent.style.setProperty(STICKY_OFFSET_VAR, `calc(${base} + ${element.offsetHeight}px)`);
+    };
+
+    publish();
+
+    const observer = new ResizeObserver(publish);
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+      parent.style.removeProperty(STICKY_OFFSET_VAR);
+      element.style.removeProperty(STICKY_OWN_TOP_VAR);
+    };
+  }, [enabled]);
+
+  return ref;
+}
+
+function inheritedOffset(element: HTMLElement | null): string {
+  if (!element) {
+    return "0px";
+  }
+
+  return getComputedStyle(element).getPropertyValue(STICKY_OFFSET_VAR).trim() || "0px";
+}

--- a/packages/ui/src/Components/Stack.php
+++ b/packages/ui/src/Components/Stack.php
@@ -29,6 +29,8 @@ class Stack extends ContainerComponent
 
     public ?Side $float = null;
 
+    public bool $sticky = false;
+
     public static function make(?string $key = null): static
     {
         return new static($key);
@@ -79,6 +81,19 @@ class Stack extends ContainerComponent
     public function direction(StackDirection $direction): static
     {
         $this->direction = $direction;
+
+        return $this;
+    }
+
+    /**
+     * Pin the stack below the sticky chrome above it while the page scrolls.
+     * The stack publishes its own height as the sticky offset for its
+     * siblings, so sticky content further down (a vertical tab rail, another
+     * sticky stack) stacks beneath it instead of sliding underneath.
+     */
+    public function sticky(bool $sticky = true): static
+    {
+        $this->sticky = $sticky;
 
         return $this;
     }

--- a/packages/ui/src/Components/Tabs.php
+++ b/packages/ui/src/Components/Tabs.php
@@ -21,6 +21,8 @@ class Tabs extends ContainerComponent
 
     public TabsAlignment $alignment = TabsAlignment::Stretch;
 
+    public bool $sticky = false;
+
     public string $activeValue;
 
     public static function make(?string $key = null): static
@@ -52,6 +54,17 @@ class Tabs extends ContainerComponent
     public function alignment(TabsAlignment $alignment): static
     {
         $this->alignment = $alignment;
+
+        return $this;
+    }
+
+    /**
+     * Keep a vertical rail in view while its panel scrolls; horizontal
+     * strips ignore it.
+     */
+    public function sticky(bool $sticky = true): static
+    {
+        $this->sticky = $sticky;
 
         return $this;
     }

--- a/packages/ui/src/Enums/Width.php
+++ b/packages/ui/src/Enums/Width.php
@@ -13,5 +13,6 @@ enum Width: string
     case Small = 'sm';
     case Medium = 'md';
     case Large = 'lg';
+    case ExtraLarge = 'xl';
     case Fill = 'fill';
 }

--- a/tests/Feature/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Feature/Core/Components/CoreTypedPropsTest.php
@@ -40,6 +40,7 @@ it('stack serializes enums direction and key wire-identically', function (): voi
                 'justify' => null,
                 'height' => null,
                 'float' => null,
+                'sticky' => false,
             ],
             'schema' => [
                 ['type' => 'text', 'props' => ['text' => 'Body', 'align' => null, 'size' => 'md', 'color' => null, 'copyable' => false]],
@@ -145,6 +146,7 @@ it('tabs serialize defaultValue queryKey and computed activeValue', function ():
                 'queryKey' => 'tabs',
                 'orientation' => 'horizontal',
                 'alignment' => 'stretch',
+                'sticky' => false,
                 'defaultValue' => 'security',
                 'activeValue' => 'security',
             ],
@@ -172,6 +174,7 @@ it('tabs with custom queryKey and no defaultValue keep empty activeValue', funct
                 'queryKey' => 'settings-tab',
                 'orientation' => 'horizontal',
                 'alignment' => 'stretch',
+                'sticky' => false,
                 'activeValue' => '',
                 'defaultValue' => null,
             ],

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -287,6 +287,7 @@ test('links and horizontal stacks serialize as separate composable primitives', 
                 'justify' => null,
                 'height' => null,
                 'float' => null,
+                'sticky' => false,
             ],
             'schema' => [
                 [


### PR DESCRIPTION
Sticky content below a sticky topbar had no way to know how much room to leave, and a tabbed page with tables could not stay narrow.

- `--lt-sticky-offset` is seeded by the stylesheet (topbar height when the topbar is sticky, via `data-lattice-topbar[data-sticky]`).
- `Stack::sticky()` pins a stack beneath that offset, paints the page background with a gutter once stuck, and republishes `offset + own height` to its siblings (ResizeObserver, frozen own `top` to avoid feedback).
- `Tabs::sticky()` keeps a vertical rail one gap below the published offset; horizontal strips ignore it.
- Tabs root gets `min-w-0` so a wide table inside a panel scrolls instead of stretching the tabs past their container.
- `Width::ExtraLarge` / `PageWidth::ExtraLarge` (`max-w-6xl`) between `Large` and `Full`.

Checks: vitest ui + framework (incl. new browser test for the sticky offset chain), Pest unit + TypeScript snapshot, PHPStan, docs updated.