### PR TITLE
feat: root-export standalone clients and add buildLatticeSprite()

### DIFF
--- a/docs/content/docs/core/icons.md
+++ b/docs/content/docs/core/icons.md
@@ -203,6 +203,22 @@ MenuItem::make('Home')->icon(Icon::House);
 
 Re-run the build (or dev server) after adding icons to refresh the generated files.
 
+## The sprite outside Vite
+
+Storybook stories, a design-system export, prerender scripts, and tests render the same components
+without a dev server or an emitted asset. `buildLatticeSprite()` builds the sprite the plugin would
+serve — Lattice's icons, every installed component package's icons, and your `icons.dirs` — and
+returns an inline `SpriteValue` for `SpriteProvider`:
+
+```ts
+import { buildLatticeSprite } from "@lattice-php/lattice/vite";
+
+const sprite = buildLatticeSprite({ icons: { dirs: ["resources/icons"] } });
+// { href: "", ids: ["check", "spark", …], source: "<svg …>…</svg>" }
+```
+
+It takes the same options as `lattice()`, so the sprite stays identical to the one your app ships.
+
 ## Custom rendering
 
 Server-driven icons resolve through a stack of renderer functions, so you can override how a name

--- a/packages/chat/resources/js/index.ts
+++ b/packages/chat/resources/js/index.ts
@@ -1,4 +1,7 @@
 export { default as chatPlugin } from "./plugin";
+export { Message } from "./components/message";
+export { MessageList } from "./components/message-list";
+export { PromptInput } from "./components/prompt-input";
 export { useChat } from "./hooks/use-chat";
 export type { UseChatOptions } from "./hooks/use-chat";
 export type * from "./types";

--- a/packages/form/resources/js/index.ts
+++ b/packages/form/resources/js/index.ts
@@ -1,11 +1,17 @@
 export { ActionForm, useLazyActionForm } from "./action-form";
 export { FormFieldFrame, type FormFieldControlProps } from "./components/base/field";
 export { Checkbox } from "./components/checkbox/checkbox";
+export { FileUpload } from "./components/file-upload/file-upload";
+export type { FileUploadItem, FileUploadProps } from "./components/file-upload/file-upload";
 export * from "./components/color-picker/color-picker";
 export * from "./components/index";
 export * from "./components/otp/otp";
 export { default as PasswordInput } from "./components/password-input/password-input";
+export { MultiSelect } from "./components/select/select";
+export type { MultiSelectItem, MultiSelectProps } from "./components/select/select";
 export { Textarea } from "./components/textarea/textarea";
+export { Toggle } from "./components/toggle/toggle";
+export type { ToggleProps } from "./components/toggle/toggle";
 export { FormValuesProvider } from "./hooks/values";
 export { formComponents } from "./plugin";
 export * from "./primitives/affix-group";

--- a/packages/framework/resources/js/vite.test.ts
+++ b/packages/framework/resources/js/vite.test.ts
@@ -3,6 +3,7 @@ import { searchForWorkspaceRoot } from "vite";
 import type { Logger, Plugin } from "vite";
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildLatticeSprite,
   collectComponentPackages,
   collectRootComponentPackage,
   componentPackagesPlugin,
@@ -390,5 +391,20 @@ describe("lattice Vite helper", () => {
       "/app/vendor/acme/signature/resources/icons",
       "/app/icons",
     ]);
+  });
+
+  it("builds an inline sprite from the same icon dirs the plugin serves", () => {
+    const appRoot = path.resolve(import.meta.dirname, "../../../..");
+    const root = path.resolve(appRoot, "packages/framework");
+
+    const sprite = buildLatticeSprite({ appRoot, root, icons: { dts: false } });
+
+    expect(sprite.href).toBe("");
+    expect(sprite.ids).toContain("chevron-down");
+    expect(sprite.source).toContain('<symbol id="chevron-down"');
+  });
+
+  it("builds an empty sprite when icons are disabled", () => {
+    expect(buildLatticeSprite({ icons: false })).toEqual({ href: "", ids: [], source: "" });
   });
 });

--- a/packages/framework/resources/js/vite.ts
+++ b/packages/framework/resources/js/vite.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { svgSprite } from "@lattice-php/vite-svg-sprite";
-import type { IconTypesOptions, SvgSpriteOptions } from "@lattice-php/vite-svg-sprite";
+import { buildSprite, svgSprite } from "@lattice-php/vite-svg-sprite";
+import type { IconTypesOptions, Sprite, SvgSpriteOptions } from "@lattice-php/vite-svg-sprite";
 import { searchForWorkspaceRoot } from "vite";
 import type { Plugin, PluginOption, UserConfig } from "vite";
 import { refreshTypeScriptTypes } from "./vite-typescript-refresh.ts";
@@ -390,6 +390,27 @@ export function resolveIconOptions(
     ],
     ...(dts === false ? {} : { dts: { ...defaultTypes, ...dts } }),
   };
+}
+
+/**
+ * Builds the same icon sprite the `lattice()` Vite plugin serves, outside of
+ * Vite: ui's icon set, every discovered component package's icons, and the
+ * app's own `icons.dirs`. The result is a `SpriteValue` for `SpriteProvider`
+ * (`href: ""` inlines the markup), which is what a Storybook, a design-system
+ * export, a prerender script, or a test needs to render `Icon` without a
+ * dev server or an emitted asset.
+ */
+export function buildLatticeSprite(options: LatticeViteOptions = {}): Sprite & { href: "" } {
+  const { appRoot } = resolveRoots(options);
+  const iconOptions = resolveIconOptions(options, discoverComponentPackages(appRoot));
+
+  if (!iconOptions) {
+    return { href: "", ids: [], source: "" };
+  }
+
+  const { iconDirs = [], symbolId, svgoConfig } = iconOptions;
+
+  return { href: "", ...buildSprite(iconDirs, { symbolId, svgoConfig }) };
 }
 
 function resolveRoots(options: LatticeViteOptions): Roots {


### PR DESCRIPTION
Apps that compose their own design system on top of Lattice need the standalone clients and the icon sprite without reaching into package internals.

- `@lattice-php/form` root-exports `Toggle`, `FileUpload`, `MultiSelect`; `@lattice-php/chat` root-exports `Message`, `MessageList`, `PromptInput`. All are props-based clients with no wire knowledge that were only reachable via deep imports.
- `@lattice-php/lattice/vite` gains `buildLatticeSprite(options)`: builds the sprite the `lattice()` plugin serves (ui icons + discovered package icons + `icons.dirs`) outside Vite and returns an inline `SpriteValue` for `SpriteProvider` — for Storybooks, design-system exports, prerender scripts and tests. Documented in the icons guide.

Checks: vitest (`vite.test.ts`, 18 passed incl. two new cases), `tsc` for framework/form/chat, oxlint/oxfmt, pre-push gate.
