### PR TITLE
chore: drop the design-sync gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,3 @@ docs/superpowers
 # Vitest browser-mode failure artifacts
 __screenshots__/
 .vitest-attachments/
-.ds-sync/
-ds-bundle/
-.design-sync/.cache/
-.design-sync/learnings/
-.design-sync/node_modules


### PR DESCRIPTION
The design-sync workspace moved to the app repo (artisan-os#187); lattice ships no design system, so the ignore entries are dead.