### PR TITLE
fix(map,pdf): drop tsconfig extends that is missing in the Composer package

### DIFF
--- a/packages/map/tsconfig.json
+++ b/packages/map/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
     "target": "ES2022",

--- a/packages/pdf/tsconfig.json
+++ b/packages/pdf/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
     "target": "ES2022",


### PR DESCRIPTION
The Composer-shipped packages do not include packages/tsconfig.base.json,
so Vite's transform failed with "Tsconfig not found" in consumer apps.
