### PR TITLE
fix(tests): satisfy phpstan under laravel 13.29

### DIFF
--- a/packages/ui/src/Concerns/GatesRendering.php
+++ b/packages/ui/src/Concerns/GatesRendering.php
@@ -67,9 +67,7 @@ trait GatesRendering
 
     public function shouldRender(): bool
     {
-        if ($this->resolvedVisibility === null) {
-            $this->resolvedVisibility = $this->passesAuthorization() && $this->passesVisibleCondition();
-        }
+        $this->resolvedVisibility ??= $this->passesAuthorization() && $this->passesVisibleCondition();
 
         return $this->resolvedVisibility;
     }

--- a/tests/Feature/Actions/ProductActionsTest.php
+++ b/tests/Feature/Actions/ProductActionsTest.php
@@ -153,7 +153,7 @@ test('bulk form actions validate the submitted reason before archiving', functio
         ->assertJsonPath('data.archived', 1)
         ->assertJsonPath('data.reason', 'Counterfeit');
 
-    expect($product->fresh()->status)->toBe('archived');
+    expect($product->fresh()?->status)->toBe('archived');
 });
 
 test('bulk form actions validate precognitively without archiving', function (): void {

--- a/tests/Feature/Console/AboutCommandTest.php
+++ b/tests/Feature/Console/AboutCommandTest.php
@@ -17,8 +17,9 @@ it('surfaces discovery state in the lattice section of php artisan about', funct
     $discoverRoot = realpath($signaturePath.'/src');
     $pluginPath = realpath($signaturePath.'/resources/js/plugin.ts');
 
-    expect($discoverRoot)->not->toBeFalse()
-        ->and($pluginPath)->not->toBeFalse();
+    if (! is_string($discoverRoot) || ! is_string($pluginPath)) {
+        throw new RuntimeException('The signature-example package paths could not be resolved.');
+    }
 
     Artisan::call('about', ['--json' => true]);
     $data = json_decode((string) Artisan::output(), true);

--- a/tests/Feature/Console/TypeScriptCommandTest.php
+++ b/tests/Feature/Console/TypeScriptCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\File;
 use Lattice\Support\TypeScript\AugmentProfile;
 use Lattice\Support\TypeScript\TypeScriptProfile;
 
@@ -21,10 +22,9 @@ it('writes an augmentation file for app components, not built-ins', function ():
 
         artisan('lattice:typescript')->assertSuccessful();
 
-        $contents = file_get_contents($output);
+        $contents = File::get($output);
 
         expect($contents)
-            ->toBeString()
             ->toContain('declare module "@lattice-php/core"')
             ->toContain('interface ComponentProps')
             ->toContain('"field.sample"')
@@ -43,7 +43,7 @@ it('writes an augmentation file for app components, not built-ins', function ():
 
         // Quote style depends on whether oxfmt is available (absent on the CI
         // PHP jobs), so the built-in-descendant union asserts on a normalized form.
-        expect(str_replace("'", '"', (string) $contents))
+        expect(str_replace("'", '"', $contents))
             ->toContain('Node<"action"> | Node<"action.bulk">');
     });
 });
@@ -58,7 +58,7 @@ it('resolves built-in enum and value-object references instead of emitting undef
 
         artisan('lattice:typescript')->assertSuccessful();
 
-        $contents = (string) file_get_contents($output);
+        $contents = File::get($output);
 
         expect($contents)
             ->toContain('columnWidth: ColumnWidth;')

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -120,9 +120,7 @@ test('Lattice::pageRegistry()->all() resolves route metadata for registered page
     Lattice::pages([RegWidgetsPage::class]);
 
     $widgets = collect(Lattice::pageRegistry()->all())
-        ->firstWhere('class', RegWidgetsPage::class);
-
-    expect($widgets)->not->toBeNull();
+        ->firstOrFail('class', RegWidgetsPage::class);
 
     expect($widgets->route)->toBe('/widgets')
         ->and($widgets->name)->toBe('widgets.index')
@@ -142,9 +140,7 @@ test('the service provider builds a named GET route for each page', function ():
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $route = Route::getRoutes()->getByName('widgets.index');
-
-    expect($route)->not->toBeNull();
+    $route = namedRoute('widgets.index');
 
     expect($route->uri())->toBe('widgets')
         ->and($route->getActionName())->toBe(RegWidgetsPage::class.'@render')
@@ -156,8 +152,7 @@ test('a page without attribute middleware registers with the configured default'
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $route = Route::getRoutes()->getByName('gadgets.index');
-    expect($route)->not->toBeNull();
+    $route = namedRoute('gadgets.index');
 
     expect($route->gatherMiddleware())->toBe(['web']);
 });
@@ -168,8 +163,7 @@ test('the page middleware default is configurable', function (): void {
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $route = Route::getRoutes()->getByName('gadgets.index');
-    expect($route)->not->toBeNull();
+    $route = namedRoute('gadgets.index');
 
     expect($route->gatherMiddleware())->toBe(['web', 'auth']);
 });
@@ -180,10 +174,8 @@ test('attribute middleware merges after the configured default without duplicate
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $authRoute = Route::getRoutes()->getByName('auth.index');
-    $widgetsRoute = Route::getRoutes()->getByName('widgets.index');
-    expect($authRoute)->not->toBeNull()
-        ->and($widgetsRoute)->not->toBeNull();
+    $authRoute = namedRoute('auth.index');
+    $widgetsRoute = namedRoute('widgets.index');
 
     expect($authRoute->gatherMiddleware())->toBe(['web', 'auth'])
         ->and($widgetsRoute->gatherMiddleware())->toBe(['web']);
@@ -194,8 +186,7 @@ test('an empty middleware attribute keeps the configured default', function (): 
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $route = Route::getRoutes()->getByName('bare.index');
-    expect($route)->not->toBeNull();
+    $route = namedRoute('bare.index');
 
     expect($route->gatherMiddleware())->toBe(['web']);
 });
@@ -205,8 +196,7 @@ test('a declared ability registers as can middleware after the page middleware',
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $route = Route::getRoutes()->getByName('guarded.index');
-    expect($route)->not->toBeNull();
+    $route = namedRoute('guarded.index');
 
     expect($route->gatherMiddleware())
         ->toBe(['web', 'can:manage-widgets', 'can:inspect-widgets']);
@@ -217,8 +207,7 @@ test('a page with empty attribute middleware still registers its declared abilit
 
     new LatticeServiceProvider(app())->bootPages();
 
-    $route = Route::getRoutes()->getByName('guarded-bare.index');
-    expect($route)->not->toBeNull();
+    $route = namedRoute('guarded-bare.index');
 
     expect($route->gatherMiddleware())
         ->toBe(['web', 'can:manage-widgets']);

--- a/tests/Feature/Notifications/NotificationMutationTest.php
+++ b/tests/Feature/Notifications/NotificationMutationTest.php
@@ -11,9 +11,7 @@ use function Pest\Laravel\postJson;
 test('a user can mark a single notification read', function (): void {
     $user = workbenchTestUser();
     Notification::make()->title('One')->send($user);
-    $notification = $user->notifications()->first();
-    expect($notification)->not->toBeNull();
-    $id = $notification->id;
+    $id = $user->notifications()->firstOrFail()->id;
 
     actingAs($user);
 
@@ -21,8 +19,7 @@ test('a user can mark a single notification read', function (): void {
         ->assertOk()
         ->assertJsonPath('unreadCount', 0);
 
-    $updated = $user->notifications()->first();
-    expect($updated)->not->toBeNull();
+    $updated = $user->notifications()->firstOrFail();
     expect($updated->getAttribute('read_at'))->not->toBeNull();
 });
 
@@ -44,9 +41,7 @@ test('a user can dismiss and clear notifications', function (): void {
     $user = workbenchTestUser();
     Notification::make()->title('One')->send($user);
     Notification::make()->title('Two')->send($user);
-    $notification = $user->notifications()->first();
-    expect($notification)->not->toBeNull();
-    $id = $notification->id;
+    $id = $user->notifications()->firstOrFail()->id;
 
     actingAs($user);
 
@@ -61,16 +56,13 @@ test('a user cannot mutate another users notification', function (): void {
     $me = workbenchTestUser();
     $other = workbenchTestUser();
     Notification::make()->title('Theirs')->send($other);
-    $notification = $other->notifications()->first();
-    expect($notification)->not->toBeNull();
-    $id = $notification->id;
+    $id = $other->notifications()->firstOrFail()->id;
 
     actingAs($me);
 
     patchJson("/lattice/notifications/{$id}/read")->assertNotFound();
     deleteJson("/lattice/notifications/{$id}")->assertNotFound();
 
-    $stillUnread = $other->notifications()->first();
-    expect($stillUnread)->not->toBeNull();
+    $stillUnread = $other->notifications()->firstOrFail();
     expect($stillUnread->getAttribute('read_at'))->toBeNull();
 });

--- a/tests/Feature/Notifications/SendNotificationTest.php
+++ b/tests/Feature/Notifications/SendNotificationTest.php
@@ -11,8 +11,7 @@ test('send persists a lattice payload to the native notifications table', functi
 
     expect($user->notifications()->count())->toBe(1);
 
-    $row = $user->notifications()->first();
-    expect($row)->not->toBeNull();
+    $row = $user->notifications()->firstOrFail();
 
     expect($row->getAttribute('data'))->toMatchArray([
         'format' => 'lattice',
@@ -29,8 +28,7 @@ test('send persists a translatable title and body as their wire shape', function
         ->body(rt('orders.shipped.body')->with(['order' => 1234]))
         ->send($user);
 
-    $row = $user->notifications()->first();
-    expect($row)->not->toBeNull();
+    $row = $user->notifications()->firstOrFail();
     $data = $row->getAttribute('data');
 
     expect($data['title'])->toBe(['key' => 'orders.shipped.title', 'payload' => [], 'replacements' => []])

--- a/tests/Support/TestFixtures.php
+++ b/tests/Support/TestFixtures.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Route as Router;
 use Illuminate\Validation\ValidationException;
 use Lattice\Core\Contracts\OptionSource;
 use Lattice\Core\Discovery\DiscoveryManifest;
@@ -32,6 +34,17 @@ function subRequest(Request $request): array
     }
 
     return [$request, $sub];
+}
+
+function namedRoute(string $name): Route
+{
+    $route = Router::getRoutes()->getByName($name);
+
+    if (! $route instanceof Route) {
+        throw new RuntimeException("Route [{$name}] is not registered.");
+    }
+
+    return $route;
 }
 
 function discoverFixtures(): void


### PR DESCRIPTION
CI resolves dependencies fresh (no committed lock); laravel/framework 13.29 tightened nullable return types (`first()`, `RouteCollection::getByName()`, `realpath()`/`file_get_contents()` call sites) and broke the phpstan-tests gate with 25 errors on every branch.

Real narrowing only, per repo policy: `firstOrFail()` over `first()` + null expectations, `File::get()` over `file_get_contents()`, a `namedRoute()` fixture helper mirroring `subRequest()`'s style, and an `is_string()` guard for `realpath()`.

Verified: both phpstan configs at zero errors, all six affected Pest files green (37 passed).