### PR TITLE
fix(form): collect repeater row fields through layout containers

### DIFF
--- a/packages/form/src/Components/Concerns/CollectsSchemaFields.php
+++ b/packages/form/src/Components/Concerns/CollectsSchemaFields.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Form\Components\Concerns;
+
+use Lattice\Form\Components\Field;
+use Lattice\Form\Contracts\ProvidesAffixFields;
+use Lattice\Ui\Components\Component;
+use Lattice\Ui\Components\ContainerComponent;
+
+/**
+ * Collects the Fields of a schema through layout containers (Grid, Stack),
+ * including each field's affix fields. Fields themselves stay atomic — a
+ * nested rows field owns its children via ProvidesRowFields.
+ */
+trait CollectsSchemaFields
+{
+    /**
+     * @param  array<int, Component>  $children
+     * @return array<int, Field>
+     */
+    protected function collectFields(array $children): array
+    {
+        $fields = [];
+
+        foreach ($children as $child) {
+            if ($child instanceof Field) {
+                $fields = [...$fields, $child, ...$this->affixFieldsOf($child)];
+
+                continue;
+            }
+
+            if ($child instanceof ContainerComponent) {
+                foreach ($child->descendants() as $descendant) {
+                    if ($descendant instanceof Field) {
+                        $fields = [...$fields, $descendant, ...$this->affixFieldsOf($descendant)];
+                    }
+                }
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @return list<Field>
+     */
+    private function affixFieldsOf(Field $field): array
+    {
+        return $field instanceof ProvidesAffixFields ? $field->affixFields() : [];
+    }
+}

--- a/packages/form/src/Components/Repeater.php
+++ b/packages/form/src/Components/Repeater.php
@@ -8,17 +8,18 @@ use Illuminate\Http\Request;
 use Lattice\Core\Contracts\ContainerComponent;
 use Lattice\Core\Facades\Evaluate;
 use Lattice\Form\Attributes\AsField;
+use Lattice\Form\Components\Concerns\CollectsSchemaFields;
 use Lattice\Form\Components\Concerns\HasRowActions;
 use Lattice\Form\Components\Concerns\HasRowLayout;
 use Lattice\Form\Enums\FieldType;
 use Lattice\Form\FormData;
-use Lattice\Ui\Components\Component;
 use Lattice\Ui\Components\Concerns\HasChildSchema;
 use Stringable;
 
 #[AsField(FieldType::Repeater)]
 class Repeater extends RowsField implements ContainerComponent
 {
+    use CollectsSchemaFields;
     use HasChildSchema;
     use HasRowActions;
     use HasRowLayout;
@@ -52,10 +53,7 @@ class Repeater extends RowsField implements ContainerComponent
      */
     public function childFields(): array
     {
-        return array_values(array_filter(
-            $this->resolvedChildren(),
-            static fn (Component $child): bool => $child instanceof Field,
-        ));
+        return $this->collectFields($this->resolvedChildren());
     }
 
     /**

--- a/packages/form/src/Components/RowTemplate.php
+++ b/packages/form/src/Components/RowTemplate.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 namespace Lattice\Form\Components;
 
 use Illuminate\Support\Str;
-use Lattice\Form\Contracts\ProvidesAffixFields;
-use Lattice\Ui\Components\Component;
+use Lattice\Form\Components\Concerns\CollectsSchemaFields;
 use Lattice\Ui\Components\Concerns\HasChildSchema;
-use Lattice\Ui\Components\ContainerComponent;
 
 /**
  * A typed row template for a TypedRowsField: the schema of child Fields a row
@@ -18,6 +16,7 @@ use Lattice\Ui\Components\ContainerComponent;
  */
 final class RowTemplate
 {
+    use CollectsSchemaFields;
     use HasChildSchema;
 
     private ?string $label = null;
@@ -46,41 +45,6 @@ final class RowTemplate
     public function fields(): array
     {
         return $this->collectFields($this->resolvedChildren());
-    }
-
-    /**
-     * @param  array<int, Component>  $children
-     * @return array<int, Field>
-     */
-    private function collectFields(array $children): array
-    {
-        $fields = [];
-
-        foreach ($children as $child) {
-            if ($child instanceof Field) {
-                $fields = [...$fields, $child, ...$this->affixFieldsOf($child)];
-
-                continue;
-            }
-
-            if ($child instanceof ContainerComponent) {
-                foreach ($child->descendants() as $descendant) {
-                    if ($descendant instanceof Field) {
-                        $fields = [...$fields, $descendant, ...$this->affixFieldsOf($descendant)];
-                    }
-                }
-            }
-        }
-
-        return $fields;
-    }
-
-    /**
-     * @return list<Field>
-     */
-    private function affixFieldsOf(Field $field): array
-    {
-        return $field instanceof ProvidesAffixFields ? $field->affixFields() : [];
     }
 
     public function data(): RowTemplateData

--- a/tests/Feature/Actions/ProductActionsTest.php
+++ b/tests/Feature/Actions/ProductActionsTest.php
@@ -153,7 +153,7 @@ test('bulk form actions validate the submitted reason before archiving', functio
         ->assertJsonPath('data.archived', 1)
         ->assertJsonPath('data.reason', 'Counterfeit');
 
-    expect($product->fresh()?->status)->toBe('archived');
+    expect($product->refresh()->status)->toBe('archived');
 });
 
 test('bulk form actions validate precognitively without archiving', function (): void {

--- a/tests/Feature/Forms/RepeaterLayoutTest.php
+++ b/tests/Feature/Forms/RepeaterLayoutTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Lattice\Form\Components\Repeater;
+use Lattice\Form\Components\Select;
+use Lattice\Form\Components\TextInput;
+use Lattice\Form\FieldValidator;
+use Lattice\Ui\Components\Grid;
+
+it('validates and casts fields nested inside a row layout container', function (): void {
+    $field = Repeater::make('items')->schema([
+        Grid::make('row-grid')->columns(3)->schema([
+            TextInput::make('name')->required(),
+            TextInput::make('qty')->rules(['numeric']),
+        ]),
+        TextInput::make('note'),
+    ]);
+    $request = Request::create('/', 'POST', ['items' => [
+        ['name' => 'Widget', 'qty' => '2', 'note' => 'n'],
+    ]]);
+
+    $validated = (new FieldValidator)->validate([$field], $request);
+
+    expect($validated['items'][0]['name'])->toBe('Widget')
+        ->and($validated['items'][0]['qty'])->toBe('2')
+        ->and($validated['items'][0]['note'])->toBe('n');
+});
+
+it('rejects missing required fields nested inside a row layout container', function (): void {
+    $field = Repeater::make('items')->schema([
+        Grid::make('row-grid')->columns(2)->schema([
+            TextInput::make('name')->required(),
+        ]),
+    ]);
+    $request = Request::create('/', 'POST', ['items' => [['name' => '']]]);
+
+    (new FieldValidator)->validate([$field], $request);
+})->throws(ValidationException::class);
+
+it('validates and casts affix selects of row fields', function (): void {
+    $field = Repeater::make('items')->schema([
+        TextInput::make('amount')->suffixField(
+            Select::make('currency')
+                ->options([Select::option('EUR', 'eur'), Select::option('USD', 'usd')])
+                ->rules(['required', 'in:eur,usd']),
+        ),
+    ]);
+
+    expect(fn (): array => (new FieldValidator)->validate([$field], Request::create('/', 'POST', [
+        'items' => [['amount' => '10', 'currency' => 'gbp']],
+    ])))->toThrow(ValidationException::class);
+
+    $validated = (new FieldValidator)->validate([$field], Request::create('/', 'POST', [
+        'items' => [['amount' => '10', 'currency' => 'eur']],
+    ]));
+
+    expect($validated['items'][0]['amount'])->toBe('10')
+        ->and($validated['items'][0]['currency'])->toBe('eur');
+});


### PR DESCRIPTION
## What

`Repeater::childFields()` only kept direct `Field` children. A `Grid`/`Stack` inside a row schema rendered fine on the client, but the server silently ignored every field inside it: no validation rules, and row casting dropped the values before `handle()`. Affix selects (`prefixField()`/`suffixField()`) of row fields were lost the same way.

## Fix

Extract `RowTemplate`'s container-aware field collection (recurse through layout containers, include affix fields, keep nested rows fields atomic) into a shared `CollectsSchemaFields` concern and use it in `Repeater::childFields()`. The builder already behaved this way; the repeater was the outlier.

Also fixes a pre-existing PHPStan `nullsafe.neverNull` error in `ProductActionsTest` that blocked the commit gate.

## Validation

- New `RepeaterLayoutTest` (mirrors `RowTemplateLayoutTest`): grid-nested fields validate and cast, missing required nested fields reject, affix selects validate and cast. All three failed before the fix.
- Full forms suites green (502 tests), Pint, PHPStan (both configs).
