### PR TITLE
feat(ui): let Image open a larger previewSrc in the lightbox

### DIFF
--- a/docs/content/docs/components/image.mdx
+++ b/docs/content/docs/components/image.mdx
@@ -34,6 +34,8 @@ press <kbd>Esc</kbd>, click the backdrop, or use the close button to dismiss it.
 - `->circular()` clips the image to a circle. For people, prefer the [Avatar](/components/avatar/)
   component and its initials fallback.
 - `->previewable(false)` turns the lightbox off and renders a plain image.
+- `->previewSrc($url)` gives the lightbox a larger source than the inline `src` — render a thumbnail
+  conversion inline and open the original on click.
 
 <Info>
   The [Image column](/tables/columns/image/) renders through the same lightbox, so table thumbnails

--- a/docs/fixtures/components.image.json
+++ b/docs/fixtures/components.image.json
@@ -15,6 +15,7 @@
                 "props": {
                     "alt": "Coffee brewing setup",
                     "circular": false,
+                    "previewSrc": null,
                     "previewable": true,
                     "size": 96,
                     "src": "https://picsum.photos/id/1060/600/400"
@@ -25,6 +26,7 @@
                 "props": {
                     "alt": "Strawberries",
                     "circular": true,
+                    "previewSrc": null,
                     "previewable": true,
                     "size": 96,
                     "src": "https://picsum.photos/id/1080/600/400"
@@ -35,6 +37,7 @@
                 "props": {
                     "alt": "Walrus resting",
                     "circular": false,
+                    "previewSrc": null,
                     "previewable": false,
                     "size": 96,
                     "src": "https://picsum.photos/id/1084/600/400"

--- a/packages/ui/resources/js/components/image/image-adapter.tsx
+++ b/packages/ui/resources/js/components/image/image-adapter.tsx
@@ -9,6 +9,7 @@ export const ImageAdapter: RendererComponent<"image"> = ({ node }) => (
     className={node.props.class ?? undefined}
     data-test={nodeIdentity(node)}
     previewable={node.props.previewable}
+    previewSrc={node.props.previewSrc}
     size={node.props.size}
     src={node.props.src}
     testId={nodeIdentity(node)}

--- a/packages/ui/resources/js/components/image/image.test.tsx
+++ b/packages/ui/resources/js/components/image/image.test.tsx
@@ -13,6 +13,29 @@ describe("Image", () => {
     expect(document.querySelector('[data-slot="image-lightbox"]')).not.toBeInTheDocument();
   });
 
+  it("opens the lightbox on the preview source while the thumbnail keeps its own", () => {
+    render(
+      <Image
+        alt="Product photo"
+        previewable
+        previewSrc="https://example.test/product.png"
+        src="https://example.test/product-thumb.png"
+      />,
+    );
+
+    expect(screen.getByAltText("Product photo")).toHaveAttribute(
+      "src",
+      "https://example.test/product-thumb.png",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "View image" }));
+
+    expect(document.querySelector('[data-slot="image-lightbox"]')).toHaveAttribute(
+      "src",
+      "https://example.test/product.png",
+    );
+  });
+
   it("renders a plain image when previewable is off", () => {
     render(<Image alt="Product photo" src="https://example.test/product.png" />);
 

--- a/packages/ui/resources/js/generated.ts
+++ b/packages/ui/resources/js/generated.ts
@@ -222,6 +222,7 @@ export type Icon = {
 export type Image = {
   alt: string | null;
   circular: boolean;
+  previewSrc: string | null;
   previewable: boolean;
   size: number | null;
   src: string;

--- a/packages/ui/resources/js/primitives/image-preview.tsx
+++ b/packages/ui/resources/js/primitives/image-preview.tsx
@@ -9,6 +9,7 @@ export type PreviewableImageProps = Omit<ComponentProps<"img">, "children"> & {
   onOpenChange?: (open: boolean) => void;
   open?: boolean;
   previewable: boolean;
+  previewSrc?: string | null;
   testId?: string;
 };
 
@@ -19,6 +20,7 @@ export function PreviewableImage({
   onOpenChange,
   open: controlledOpen,
   previewable,
+  previewSrc,
   width,
   height,
   className,
@@ -66,7 +68,7 @@ export function PreviewableImage({
         <DialogTitle className="sr-only">{alt || openLabel}</DialogTitle>
         <img
           alt={alt}
-          src={src}
+          src={previewSrc ?? src}
           data-slot="image-lightbox"
           className="max-h-[90vh] max-w-[90vw] rounded-lt object-contain"
         />

--- a/packages/ui/src/Components/Image.php
+++ b/packages/ui/src/Components/Image.php
@@ -21,6 +21,8 @@ class Image extends Component
 
     public bool $previewable = true;
 
+    public ?string $previewSrc = null;
+
     public static function make(string $src, ?string $key = null): static
     {
         $image = new static($key);
@@ -60,6 +62,17 @@ class Image extends Component
     public function previewable(bool $previewable = true): static
     {
         $this->previewable = $previewable;
+
+        return $this;
+    }
+
+    /**
+     * A larger source the lightbox opens instead of `src`, so a thumbnail
+     * conversion can render inline while the original stays one click away.
+     */
+    public function previewSrc(?string $previewSrc): static
+    {
+        $this->previewSrc = $previewSrc;
 
         return $this;
     }

--- a/tests/Unit/Core/ComponentSerializationTest.php
+++ b/tests/Unit/Core/ComponentSerializationTest.php
@@ -79,22 +79,25 @@ test('images serialize their source and preview configuration', function (): voi
                 'size' => null,
                 'circular' => false,
                 'previewable' => true,
+                'previewSrc' => null,
             ],
         ]);
 
-    expect(wire(Image::make('https://example.test/p.png')
+    expect(wire(Image::make('https://example.test/p-thumb.png')
         ->alt('Product photo')
         ->size(64)
         ->circular()
-        ->previewable(false)))
+        ->previewable(false)
+        ->previewSrc('https://example.test/p.png')))
         ->toMatchArray([
             'type' => 'image',
             'props' => [
-                'src' => 'https://example.test/p.png',
+                'src' => 'https://example.test/p-thumb.png',
                 'alt' => 'Product photo',
                 'size' => 64,
                 'circular' => true,
                 'previewable' => false,
+                'previewSrc' => 'https://example.test/p.png',
             ],
         ]);
 });


### PR DESCRIPTION
`Image::make($thumbUrl)->previewSrc($originalUrl)` renders the thumbnail inline and opens the larger source in the lightbox; without `previewSrc` the lightbox keeps using `src` as before.

Motivation: media thumbnails (e.g. a `thumb` conversion) in message threads should not force the browser to load full-size originals just to show a 120 px preview.

- PHP builder prop + wire type, `ImageAdapter` passes it through, `PreviewableImage` uses `previewSrc ?? src` for the lightbox image.
- Serialization test, Vitest for thumb vs. lightbox source, docs option, regenerated `generated.ts` and the docs fixture.