### PR TITLE
feat(dnd): drop gap in board columns, straight tree drop indicators

### DIFF
--- a/packages/board/resources/css/board.css
+++ b/packages/board/resources/css/board.css
@@ -43,11 +43,6 @@
   overflow-y: auto;
 }
 
-.lt-board-column-list-drop-target {
-  background-color: var(--lt-muted);
-  border-radius: var(--lt-radius-sm);
-}
-
 .lt-board-card-actions {
   position: absolute;
   top: 0.375rem;

--- a/packages/board/resources/js/components/board/board-card.tsx
+++ b/packages/board/resources/js/components/board/board-card.tsx
@@ -10,11 +10,9 @@ import {
   combine,
   draggable,
   dropTargetForElements,
-  extractClosestEdge,
-  pointerOutsideOfPreview,
+  preserveOffsetOnSource,
   setCustomNativeDragPreview,
 } from "@lattice-php/lattice/dnd";
-import type { Edge } from "@lattice-php/lattice/dnd";
 import { boardCardDragData, boardCardDropTargetData, boardDragSource } from "../../board-dnd";
 import { BOARD_FOCUS_KEYS, type BoardFocusDirection } from "../../board-keyboard";
 import { getCardActions, getCardUrl, type BoardCard } from "../../board-store";
@@ -27,17 +25,6 @@ const CARD_INTERACTIVE_SELECTOR =
 
 function isCardInteractiveTarget(target: EventTarget | null): boolean {
   return target instanceof Element && target.closest(CARD_INTERACTIVE_SELECTOR) !== null;
-}
-
-function dropIndicatorClass(edge: Edge | null): string | null {
-  switch (edge) {
-    case "top":
-      return "border-t-lt-primary";
-    case "bottom":
-      return "border-b-lt-primary";
-    default:
-      return null;
-  }
 }
 
 export type BoardCardItemProps = {
@@ -76,7 +63,6 @@ export const BoardCardItem = forwardRef<HTMLLIElement, BoardCardItemProps>(funct
 ) {
   const elementRef = useRef<HTMLLIElement>(null);
   const [dragging, setDragging] = useState(false);
-  const [edge, setEdge] = useState<Edge | null>(null);
   const { visit } = useNavigation();
   const runAction = useCallAction();
   const url = getCardUrl(card);
@@ -173,9 +159,9 @@ export const BoardCardItem = forwardRef<HTMLLIElement, BoardCardItemProps>(funct
         getInitialData: () => boardCardDragData({ columnKey, id: cardId }),
         onDragStart: () => setDragging(true),
         onDrop: () => setDragging(false),
-        onGenerateDragPreview: ({ nativeSetDragImage }) => {
+        onGenerateDragPreview: ({ location, nativeSetDragImage }) => {
           setCustomNativeDragPreview({
-            getOffset: pointerOutsideOfPreview({ x: "16px", y: "8px" }),
+            getOffset: preserveOffsetOnSource({ element, input: location.current.input }),
             nativeSetDragImage,
             render: ({ container }) => {
               const clone = element.cloneNode(true) as HTMLElement;
@@ -197,10 +183,7 @@ export const BoardCardItem = forwardRef<HTMLLIElement, BoardCardItemProps>(funct
         element,
         getData: ({ element: target, input }) =>
           boardCardDropTargetData({ cardId, columnKey }, { element: target, input }),
-        onDrag: ({ self }) => setEdge(extractClosestEdge(self.data)),
-        onDragEnter: ({ self }) => setEdge(extractClosestEdge(self.data)),
-        onDragLeave: () => setEdge(null),
-        onDrop: () => setEdge(null),
+        getIsSticky: () => true,
       }),
     );
   }, [canMove, cardId, columnKey, moving]);
@@ -213,9 +196,7 @@ export const BoardCardItem = forwardRef<HTMLLIElement, BoardCardItemProps>(funct
         canMove && "cursor-grab",
         (url || cardAction) && "cursor-pointer",
         dragging && "opacity-50",
-        dropIndicatorClass(edge),
       )}
-      data-drop-instruction={edge ?? undefined}
       data-test={testId}
       onAuxClick={handleAuxClick}
       onClick={handleClick}

--- a/packages/board/resources/js/components/board/board-column.tsx
+++ b/packages/board/resources/js/components/board/board-column.tsx
@@ -6,13 +6,59 @@ import { Badge } from "@lattice-php/ui/components/badge/badge";
 import { coerceColor, namedColor, toneProps } from "@lattice-php/ui/lib/color";
 import { cn } from "@lattice-php/ui/lib/utils";
 import { autoScrollForElements, combine, dropTargetForElements } from "@lattice-php/lattice/dnd";
-import { boardColumnDropTargetData, boardDragSource } from "../../board-dnd";
+import {
+  boardColumnDropTargetData,
+  boardDragSource,
+  boardDropTarget,
+  type BoardDropTarget,
+} from "../../board-dnd";
 import type { BoardFocusDirection } from "../../board-keyboard";
 import type { BoardCardRemoval, BoardColumnView } from "../../use-board-state";
 import type { Board as BoardWireProps, BoardColumnData } from "../../generated";
 import { cardKey } from "../../board-store";
 import { BoardCardItem } from "./board-card";
 import { QuickAdd } from "./quick-add";
+
+type CardPlaceholder = { height: number; index: number };
+
+function dropPlaceholder(placeholder: CardPlaceholder) {
+  return (
+    <li
+      aria-hidden
+      className="shrink-0 rounded-lt border-2 border-dashed border-lt-primary/40 bg-lt-primary/5"
+      key="drop-placeholder"
+      style={{ height: placeholder.height }}
+    />
+  );
+}
+
+/**
+ * Where the drop gap opens in this column's card list, mirroring the drop
+ * intent the same hover would produce: above/below the hovered card, or at
+ * the end for the column's empty space. Null when the hover targets another
+ * column.
+ */
+function placeholderIndexFor(
+  target: BoardDropTarget,
+  cardIds: string[],
+  columnKey: string,
+): number | null {
+  if (target.type === "column") {
+    return target.columnKey === columnKey ? cardIds.length : null;
+  }
+
+  if (target.columnKey !== columnKey) {
+    return null;
+  }
+
+  const index = cardIds.indexOf(target.cardId);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return target.edge === "bottom" ? index + 1 : index;
+}
 
 export type BoardColumnProps = {
   canMove: boolean;
@@ -53,7 +99,9 @@ export function BoardColumn({
   const headingId = useId();
   const tone = toneProps(coerceColor(column.color ?? undefined) ?? namedColor("gray"));
   const listRef = useRef<HTMLUListElement>(null);
-  const [draggedOver, setDraggedOver] = useState(false);
+  const [placeholder, setPlaceholder] = useState<CardPlaceholder | null>(null);
+  const cardIdsRef = useRef<string[]>([]);
+  cardIdsRef.current = view.cards.map((card) => cardKey(card));
 
   useEffect(() => {
     const element = listRef.current;
@@ -62,14 +110,39 @@ export function BoardColumn({
       return;
     }
 
+    const updatePlaceholder = ({
+      location,
+      source,
+    }: {
+      location: { current: { dropTargets: readonly { data: Record<string | symbol, unknown> }[] } };
+      source: { element: HTMLElement };
+    }) => {
+      const target = boardDropTarget(location.current.dropTargets);
+      const index = target ? placeholderIndexFor(target, cardIdsRef.current, column.key) : null;
+
+      if (index === null) {
+        setPlaceholder(null);
+        return;
+      }
+
+      const height = source.element.getBoundingClientRect().height;
+
+      setPlaceholder((current) =>
+        current !== null && current.index === index && current.height === height
+          ? current
+          : { height, index },
+      );
+    };
+
     return combine(
       dropTargetForElements({
         canDrop: ({ source }) => boardDragSource(source.data) !== null,
         element,
         getData: () => boardColumnDropTargetData(column.key),
-        onDragEnter: () => setDraggedOver(true),
-        onDragLeave: () => setDraggedOver(false),
-        onDrop: () => setDraggedOver(false),
+        onDrag: updatePlaceholder,
+        onDragEnter: updatePlaceholder,
+        onDragLeave: () => setPlaceholder(null),
+        onDrop: () => setPlaceholder(null),
       }),
       autoScrollForElements({ element }),
     );
@@ -95,16 +168,10 @@ export function BoardColumn({
           {view.total}
         </Badge>
       </header>
-      <ul
-        aria-labelledby={headingId}
-        className={cn("lt-board-column-list", draggedOver && "lt-board-column-list-drop-target")}
-        ref={listRef}
-        role="list"
-      >
-        {view.cards.map((card) => {
+      <ul aria-labelledby={headingId} className="lt-board-column-list" ref={listRef} role="list">
+        {view.cards.flatMap((card, index) => {
           const id = cardKey(card);
-
-          return (
+          const item = (
             <BoardCardItem
               canMove={canMove}
               card={card}
@@ -123,8 +190,13 @@ export function BoardColumn({
               tabIndex={focusedCardId === id ? 0 : -1}
             />
           );
+
+          return placeholder?.index === index ? [dropPlaceholder(placeholder), item] : [item];
         })}
-        {view.cards.length === 0 && !view.loading ? (
+        {placeholder !== null && placeholder.index >= view.cards.length
+          ? dropPlaceholder(placeholder)
+          : null}
+        {view.cards.length === 0 && !view.loading && placeholder === null ? (
           <li className="px-1 py-2 text-sm text-lt-muted-fg">
             {t("board.empty-column", "No cards")}
           </li>

--- a/packages/form/src/Components/RowsField.php
+++ b/packages/form/src/Components/RowsField.php
@@ -159,7 +159,7 @@ abstract class RowsField extends Field implements ProvidesRowFields
         $originals = array_values($value);
 
         return array_map(
-            fn (array $castRow, mixed $original): array => $this->castRow($castRow, $original),
+            $this->castRow(...),
             $this->castRows($originals),
             $originals,
         );

--- a/packages/tree/resources/js/tree-item-drop.ts
+++ b/packages/tree/resources/js/tree-item-drop.ts
@@ -97,14 +97,14 @@ export function treeItemDropTarget(options: {
 export function dropIndicatorClass(instruction: TreeItemInstruction["type"] | null): string | null {
   switch (instruction) {
     case "reorder-above":
-      return "border-t-lt-primary";
+      return "relative before:absolute before:inset-x-0 before:-top-px before:h-0.5 before:bg-lt-primary";
     case "reorder-below":
-      return "border-b-lt-primary";
+      return "relative after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-lt-primary";
     case "make-child":
     case "reparent":
-      return "ring-1 ring-lt-primary";
+      return "bg-lt-primary/10";
     case "instruction-blocked":
-      return "ring-1 ring-lt-danger/50";
+      return "bg-lt-danger/10";
     default:
       return null;
   }

--- a/packages/tree/resources/js/tree.tsx
+++ b/packages/tree/resources/js/tree.tsx
@@ -440,7 +440,7 @@ function TreeItem({
     >
       <div
         className={cn(
-          "flex items-center gap-2 rounded-lt-sm border-y border-transparent px-2 py-1.5 text-sm text-lt-fg",
+          "flex items-center gap-2 rounded-lt-sm px-2 py-1.5 text-sm text-lt-fg",
           isActive && "bg-lt-muted font-medium",
           isDisabled && "pointer-events-none opacity-50",
           canMove && !isDisabled && "cursor-grab",


### PR DESCRIPTION
## What

- **Board**: while dragging, a dashed placeholder gap opens at the drop position (height of the dragged card) instead of tinting a card border and the rounded column list. Sticky card hitboxes keep the gap stable when the cursor is over the gap itself, so the drop lands where the gap shows.
- **Board**: the drag preview preserves the grab offset (`preserveOffsetOnSource`) instead of snapping the card to the pointer's top-left.
- **Tree** (display tree + tree field): reorder-above/below indicators are straight full-width 2px lines instead of tinted borders that bent around the row radius; make-child/reparent and blocked drops highlight the row background.

## Why

The rounded drop-target tint looked off (border curving around card corners), and the preview offset made grabbed cards jump to the cursor's top-left.

## Verification

- tsc, Vitest board+tree 191/191 (incl. real-drag browser tests), Pest browser Board/Tree 13/13 against a fresh build.