### PR TITLE
feat(form): async submit mode for inline forms + preserveScroll

### DIFF
--- a/packages/form/resources/js/action-form.tsx
+++ b/packages/form/resources/js/action-form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { apiFetch } from "@lattice-php/core/api";
 import { Button } from "@lattice-php/ui/components/button/button";
 import {
@@ -14,22 +14,15 @@ import type { Node } from "@lattice-php/core/types";
 import type { ModalWidth } from "@lattice-php/ui/types";
 import {
   collectFields,
-  FORM_DEBOUNCE_MS,
   FormProvider,
   FormValuesProvider,
-  errorKeyBelongsTo,
-  firstErrors,
   PrefillProvider,
   ResolvedNodesProvider,
   useFormResolver,
-  useFormValues,
 } from "./embed";
-import type { FieldErrors } from "./embed";
-import { useDebouncedCallback } from "@lattice-php/ui/lib/use-debounced-callback";
+import { useFetchForm } from "./hooks/use-fetch-form";
 import { useT } from "@lattice-php/ui/i18n";
-import { dispatchActionError, getActionEffects } from "@lattice-php/ui/effects/dispatch";
 import type { ActionResponse } from "@lattice-php/ui/effects/dispatch";
-import { useEffectDispatcher } from "@lattice-php/ui/effects/use-effect-dispatcher";
 
 type ActionFormProps = {
   cancelLabel: string;
@@ -123,135 +116,23 @@ function ActionFormBody({
   formNode: Node;
   precognitive: boolean;
 }) {
-  const values = useFormValues();
-  const valuesRef = useRef(values);
-  valuesRef.current = values;
-  const extraDataRef = useRef(extraData);
-  extraDataRef.current = extraData;
   const { nodes: resolvedNodes, markUserEdit } = useFormResolver(
     endpoint,
     componentRef,
     formNode.schema,
   );
 
-  const dispatch = useEffectDispatcher();
-  const [errors, setErrors] = useState<FieldErrors>({});
-  const [processing, setProcessing] = useState(false);
-  const [validating, setValidating] = useState(false);
-
-  const request = useCallback(
-    (extraHeaders?: Record<string, string>): Promise<Response> =>
-      apiFetch(endpoint, {
-        body: JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
-        method,
-        ref: componentRef,
-        headers: extraHeaders,
-        throwOnError: false,
-      }),
-    [componentRef, endpoint, method],
-  );
-
-  const clearErrors = useCallback((field: string) => {
-    setErrors((current) =>
-      current[field] === undefined ? current : { ...current, [field]: undefined },
-    );
-  }, []);
-
-  const runValidation = useDebouncedCallback((field: string) => {
-    void request({ Precognition: "true", "Precognition-Validate-Only": field })
-      .then(async (response) => {
-        if (response.status === 422) {
-          const body = (await response.json()) as { errors?: Record<string, string[]> };
-          setErrors((current) => ({ ...current, ...firstErrors(body.errors) }));
-
-          return;
-        }
-
-        clearErrors(field);
-      })
-      .catch(() => {});
-  }, FORM_DEBOUNCE_MS);
-
-  const validate = useCallback(
-    (field: string) => {
-      if (precognitive) {
-        runValidation(field);
-      }
-    },
-    [precognitive, runValidation],
-  );
-
-  const touch = useCallback(() => {}, []);
-
-  const validateFields = useCallback(
-    (fields: string[], options?: { onSuccess?: () => void; onValidationError?: () => void }) => {
-      setValidating(true);
-
-      void request({ Precognition: "true", "Precognition-Validate-Only": fields.join(",") })
-        .then(async (response) => {
-          if (response.status === 422) {
-            const body = (await response.json()) as { errors?: Record<string, string[]> };
-            setErrors((current) => ({ ...current, ...firstErrors(body.errors) }));
-            options?.onValidationError?.();
-
-            return;
-          }
-
-          if (!response.ok) {
-            options?.onValidationError?.();
-
-            return;
-          }
-
-          const cleared = fields.filter((field) => !field.includes("*"));
-          setErrors((current) =>
-            Object.fromEntries(
-              Object.entries(current).filter(
-                ([key]) => !cleared.some((name) => errorKeyBelongsTo(key, name)),
-              ),
-            ),
-          );
-          options?.onSuccess?.();
-        })
-        .catch(() => options?.onValidationError?.())
-        .finally(() => setValidating(false));
-    },
-    [request],
-  );
-
-  const submit = useCallback(() => {
-    setProcessing(true);
-    onBefore?.();
-
-    void request()
-      .then(async (response) => {
-        const body = (await response.json().catch(() => ({}))) as ActionResponse & {
-          errors?: Record<string, string[]>;
-        };
-
-        dispatch(getActionEffects(body.effects));
-
-        if (response.status === 422 && body.errors) {
-          setErrors(firstErrors(body.errors));
-          onError?.();
-
-          return;
-        }
-
-        if (!response.ok) {
-          onError?.();
-
-          return;
-        }
-
-        onSuccess(body);
-      })
-      .catch((error: unknown) => {
-        dispatchActionError(error);
-        onError?.();
-      })
-      .finally(() => setProcessing(false));
-  }, [dispatch, onBefore, onError, onSuccess, request]);
+  const { clearErrors, errors, processing, submit, touch, validate, validateFields, validating } =
+    useFetchForm({
+      componentRef,
+      endpoint,
+      extraData,
+      method,
+      onBefore,
+      onError,
+      onSuccess,
+      precognitive,
+    });
 
   const context = useMemo(
     () => ({

--- a/packages/form/resources/js/components/form/form-adapter.test.tsx
+++ b/packages/form/resources/js/components/form/form-adapter.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearRefreshedRefs } from "@lattice-php/core/component-ref";
+import { LATTICE_EVENT } from "@lattice-php/core/event-names";
 import { createRegistry, eagerComponent } from "@lattice-php/core/registry";
 import { ButtonAdapter } from "@lattice-php/ui/components/button/button-adapter";
 import { fakeNode } from "@lattice-php/core/test-support";
@@ -474,5 +475,91 @@ describe("Lattice form schema components", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toHaveAttribute("type", "button");
     expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute("type", "submit");
     expect(screen.queryByRole("button", { name: "Submit" })).not.toBeInTheDocument();
+  });
+});
+
+describe("async Lattice forms", () => {
+  afterEach(() => {
+    clearRefreshedRefs();
+    vi.unstubAllGlobals();
+  });
+
+  const nameNode = fakeNode({
+    props: { label: "Name", name: "name", value: "" },
+    type: "field.text-input",
+  });
+
+  function renderAsyncForm(response: { body: unknown; status: number }) {
+    const fetchMock = vi.fn<typeof fetch>(
+      async () =>
+        ({
+          ok: response.status < 300,
+          status: response.status,
+          json: async () => response.body,
+        }) as unknown as Response,
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formNode = fakeNode({
+      id: "answers.form",
+      props: {
+        action: "/lattice/forms/answers",
+        async: true,
+        method: "post",
+        ref: "sealed-ref",
+        submitButton: true,
+      },
+      schema: [nameNode],
+      type: "form",
+    });
+
+    render(
+      <FormAdapter node={formNode}>
+        <TextInputAdapter node={nameNode}>{null}</TextInputAdapter>
+      </FormAdapter>,
+    );
+
+    return fetchMock;
+  }
+
+  it("submits over fetch and dispatches the response effects without navigating", async () => {
+    const reloaded: string[] = [];
+    const listener = (event: Event) =>
+      reloaded.push((event as CustomEvent<{ component: string }>).detail.component);
+    window.addEventListener(LATTICE_EVENT.reloadComponent, listener);
+
+    const fetchMock = renderAsyncForm({
+      body: { effects: [{ type: "reload-component", props: { component: "projects.summary" } }] },
+      status: 200,
+    });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "Widget" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/lattice/forms/answers");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init?.body as string)).toMatchObject({ name: "Widget" });
+    expect(reloaded).toEqual(["projects.summary"]);
+
+    window.removeEventListener(LATTICE_EVENT.reloadComponent, listener);
+  });
+
+  it("maps a 422 body onto field errors instead of dispatching effects", async () => {
+    renderAsyncForm({
+      body: { errors: { name: ["The name is required."] } },
+      status: 422,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    });
+
+    expect(screen.getByText("The name is required.")).toBeInTheDocument();
   });
 });

--- a/packages/form/resources/js/components/form/form-adapter.tsx
+++ b/packages/form/resources/js/components/form/form-adapter.tsx
@@ -307,6 +307,7 @@ function FormShell({ children, node }: { children: React.ReactNode; node: Node<"
       data-test={node.id}
       errorBag={errorBag}
       method={method}
+      options={{ preserveScroll: true }}
       resetOnError={resetOnError}
       resetOnSuccess={resetOnSuccess}
       validationTimeout={precognitive ? validationTimeout : undefined}

--- a/packages/form/resources/js/components/form/form-adapter.tsx
+++ b/packages/form/resources/js/components/form/form-adapter.tsx
@@ -16,6 +16,7 @@ import { collectFields } from "../../lib/collect-fields";
 import { PrefillProvider } from "../../hooks/prefill-context";
 import { ResolvedNodesProvider } from "../../hooks/resolved-nodes";
 import { useFormResolver } from "../../hooks/use-form-resolver";
+import { useFetchForm } from "../../hooks/use-fetch-form";
 import { FormValuesProvider, useResetFormValues } from "../../hooks/values";
 
 const JUSTIFY_CLASS: Record<Justify, string> = {
@@ -139,12 +140,120 @@ export const FormAdapter: RendererComponent<"form"> = ({ children, node }) => {
     [node.schema, node.props.state],
   );
 
+  const Shell = node.props.async ? AsyncFormShell : FormShell;
+
   return (
     <FormValuesProvider initial={initialValues}>
-      <FormShell node={node}>{children}</FormShell>
+      <Shell node={node}>{children}</Shell>
     </FormValuesProvider>
   );
 };
+
+/**
+ * The fetch-based shell for `Form::async()`: submits as JSON and applies the
+ * response's effects in place — no Inertia visit, no page re-render. Error
+ * bags don't exist here; 422 bodies map straight onto field errors, and ref
+ * renewal on 403 lives inside apiFetch.
+ */
+function AsyncFormShell({ children, node }: { children: React.ReactNode; node: Node<"form"> }) {
+  const { t } = useT("lattice");
+  const props = node.props;
+  const action = props.action ?? "#";
+  const componentRef = props.ref ?? "";
+  const method = props.method ?? "post";
+  const precognitive = props.precognitive;
+  const resetOnError = props.resetOnError ?? false;
+  const resetOnSuccess = props.resetOnSuccess ?? [];
+  const fieldLabels = useMemo(() => collectFields(node.schema).labels, [node.schema]);
+  const submitButtons = (props.submitButtons as SubmitButtonNode[] | null) ?? undefined;
+  const submitLabel = props.submitLabel ?? t("form.submit", "Submit");
+
+  const resetValues = useResetFormValues();
+  const resetConfigured = (configured: string[] | boolean | null | undefined): void => {
+    const fields = configuredResetFields(configured);
+
+    if (fields !== false) {
+      resetValues(fields);
+    }
+  };
+
+  const { clearErrors, errors, processing, submit, touch, validate, validateFields, validating } =
+    useFetchForm({
+      componentRef,
+      endpoint: action,
+      method,
+      onError: () => resetConfigured(resetOnError),
+      onSuccess: () => resetConfigured(resetOnSuccess),
+      precognitive,
+      validationDebounceMs: props.validationTimeout ?? undefined,
+    });
+
+  const context = useMemo(
+    () => ({
+      action,
+      clearErrors,
+      componentId: node.id,
+      componentRef,
+      errors,
+      fieldLabels,
+      precognitive,
+      processing,
+      touch,
+      validate,
+      validateFields,
+      validating,
+    }),
+    [
+      action,
+      clearErrors,
+      componentRef,
+      errors,
+      fieldLabels,
+      node.id,
+      precognitive,
+      processing,
+      touch,
+      validate,
+      validateFields,
+      validating,
+    ],
+  );
+
+  return (
+    <form
+      data-slot="form"
+      data-test={node.id}
+      className="flex w-full flex-col gap-6"
+      onSubmit={(event) => {
+        event.preventDefault();
+        submit();
+      }}
+    >
+      <FormProvider value={context}>
+        <FormResetListener componentId={node.id} reset={() => {}} />
+
+        {props.status && (
+          <div className="text-center text-sm font-medium text-lt-success">{props.status}</div>
+        )}
+
+        <FormBody
+          action={action}
+          componentRef={componentRef}
+          nodes={node.schema}
+          shouldRenderSubmitButton={props.submitButton}
+          submitButtons={submitButtons}
+          submitEmphasis={props.submitEmphasis ?? undefined}
+          submitJustify={props.submitJustify ?? undefined}
+          submitLabel={submitLabel}
+          submitVariant={props.submitVariant ?? undefined}
+          summaryLabel={props.validationSummaryLabel}
+        >
+          {children}
+        </FormBody>
+      </FormProvider>
+    </form>
+  );
+}
 
 function FormShell({ children, node }: { children: React.ReactNode; node: Node<"form"> }) {
   const { t } = useT("lattice");

--- a/packages/form/resources/js/generated.ts
+++ b/packages/form/resources/js/generated.ts
@@ -272,6 +272,7 @@ export type FileUpload = {
 };
 export type Form = {
   action: string | null;
+  async: boolean;
   errorBag: string | null;
   method: HttpMethod | null;
   precognitive: boolean;

--- a/packages/form/resources/js/hooks/use-fetch-form.ts
+++ b/packages/form/resources/js/hooks/use-fetch-form.ts
@@ -1,0 +1,194 @@
+import { useCallback, useRef, useState } from "react";
+import { apiFetch } from "@lattice-php/core/api";
+import { dispatchActionError, getActionEffects } from "@lattice-php/ui/effects/dispatch";
+import type { ActionResponse } from "@lattice-php/ui/effects/dispatch";
+import { useEffectDispatcher } from "@lattice-php/ui/effects/use-effect-dispatcher";
+import { useDebouncedCallback } from "@lattice-php/ui/lib/use-debounced-callback";
+import { errorKeyBelongsTo, firstErrors } from "../lib/field-errors";
+import type { FieldErrors } from "../lib/field-errors";
+import { FORM_DEBOUNCE_MS } from "../lib/form-transport";
+import { useFormValues } from "./values";
+
+export type FetchFormOptions = {
+  componentRef: string;
+  endpoint: string;
+  /** Extra payload merged into every request, e.g. a bulk action's selection. */
+  extraData?: Record<string, unknown>;
+  method: string;
+  onBefore?: () => void;
+  /** Fires on every failed submit: validation (422), a non-2xx response, or a thrown error. */
+  onError?: () => void;
+  onSuccess: (response: ActionResponse) => void;
+  precognitive: boolean;
+  validationDebounceMs?: number;
+};
+
+export type FetchForm = {
+  clearErrors: (field: string) => void;
+  errors: FieldErrors;
+  processing: boolean;
+  submit: () => void;
+  touch: (fields: string[]) => void;
+  validate: (field: string) => void;
+  validateFields: (
+    fields: string[],
+    options?: { onSuccess?: () => void; onValidationError?: () => void },
+  ) => void;
+  validating: boolean;
+};
+
+/**
+ * The fetch-based form runtime: submits the current form values as JSON,
+ * dispatches the effects from the response body, and maps 422 bodies onto
+ * field errors — with the same Precognition wiring the Inertia runtime gets
+ * from the server. Shared by modal action forms and async inline forms;
+ * ref renewal on 403 is apiFetch's job.
+ */
+export function useFetchForm({
+  componentRef,
+  endpoint,
+  extraData,
+  method,
+  onBefore,
+  onError,
+  onSuccess,
+  precognitive,
+  validationDebounceMs = FORM_DEBOUNCE_MS,
+}: FetchFormOptions): FetchForm {
+  const values = useFormValues();
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+  const extraDataRef = useRef(extraData);
+  extraDataRef.current = extraData;
+
+  const dispatch = useEffectDispatcher();
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [processing, setProcessing] = useState(false);
+  const [validating, setValidating] = useState(false);
+
+  const request = useCallback(
+    (extraHeaders?: Record<string, string>): Promise<Response> =>
+      apiFetch(endpoint, {
+        body: JSON.stringify({ ...valuesRef.current, ...extraDataRef.current }),
+        method,
+        ref: componentRef,
+        headers: extraHeaders,
+        throwOnError: false,
+      }),
+    [componentRef, endpoint, method],
+  );
+
+  const clearErrors = useCallback((field: string) => {
+    setErrors((current) =>
+      current[field] === undefined ? current : { ...current, [field]: undefined },
+    );
+  }, []);
+
+  const runValidation = useDebouncedCallback((field: string) => {
+    void request({ Precognition: "true", "Precognition-Validate-Only": field })
+      .then(async (response) => {
+        if (response.status === 422) {
+          const body = (await response.json()) as { errors?: Record<string, string[]> };
+          setErrors((current) => ({ ...current, ...firstErrors(body.errors) }));
+
+          return;
+        }
+
+        clearErrors(field);
+      })
+      .catch(() => {});
+  }, validationDebounceMs);
+
+  const validate = useCallback(
+    (field: string) => {
+      if (precognitive) {
+        runValidation(field);
+      }
+    },
+    [precognitive, runValidation],
+  );
+
+  const touch = useCallback(() => {}, []);
+
+  const validateFields = useCallback(
+    (fields: string[], options?: { onSuccess?: () => void; onValidationError?: () => void }) => {
+      setValidating(true);
+
+      void request({ Precognition: "true", "Precognition-Validate-Only": fields.join(",") })
+        .then(async (response) => {
+          if (response.status === 422) {
+            const body = (await response.json()) as { errors?: Record<string, string[]> };
+            setErrors((current) => ({ ...current, ...firstErrors(body.errors) }));
+            options?.onValidationError?.();
+
+            return;
+          }
+
+          if (!response.ok) {
+            options?.onValidationError?.();
+
+            return;
+          }
+
+          const cleared = fields.filter((field) => !field.includes("*"));
+          setErrors((current) =>
+            Object.fromEntries(
+              Object.entries(current).filter(
+                ([key]) => !cleared.some((name) => errorKeyBelongsTo(key, name)),
+              ),
+            ),
+          );
+          options?.onSuccess?.();
+        })
+        .catch(() => options?.onValidationError?.())
+        .finally(() => setValidating(false));
+    },
+    [request],
+  );
+
+  const submit = useCallback(() => {
+    setProcessing(true);
+    onBefore?.();
+
+    void request()
+      .then(async (response) => {
+        const body = (await response.json().catch(() => ({}))) as ActionResponse & {
+          errors?: Record<string, string[]>;
+        };
+
+        dispatch(getActionEffects(body.effects));
+
+        if (response.status === 422 && body.errors) {
+          setErrors(firstErrors(body.errors));
+          onError?.();
+
+          return;
+        }
+
+        if (!response.ok) {
+          onError?.();
+
+          return;
+        }
+
+        setErrors({});
+        onSuccess(body);
+      })
+      .catch((error: unknown) => {
+        dispatchActionError(error);
+        onError?.();
+      })
+      .finally(() => setProcessing(false));
+  }, [dispatch, onBefore, onError, onSuccess, request]);
+
+  return {
+    clearErrors,
+    errors,
+    processing,
+    submit,
+    touch,
+    validate,
+    validateFields,
+    validating,
+  };
+}

--- a/packages/form/src/Components/Form.php
+++ b/packages/form/src/Components/Form.php
@@ -42,6 +42,8 @@ class Form extends ContainerComponent implements FormRootComponent, InteractiveC
 
     public ?int $validationTimeout = null;
 
+    public bool $async = false;
+
     public bool $submitButton = true;
 
     public ?Justify $submitJustify = null;
@@ -157,6 +159,20 @@ class Form extends ContainerComponent implements FormRootComponent, InteractiveC
         return $this;
     }
 
+    /**
+     * Submit over fetch and apply the response's effects in place — no Inertia
+     * visit, no page re-render, no scroll movement. The handler's LatticeResponse
+     * arrives as an effects JSON body; an explicit redirect becomes a redirect
+     * effect. Validation runs the same 422/Precognition path modal action forms
+     * use, so `errorBag()` has no meaning here.
+     */
+    public function async(bool $async = true): static
+    {
+        $this->async = $async;
+
+        return $this;
+    }
+
     public function precognitive(int $debounceMs = self::DEFAULT_VALIDATION_DEBOUNCE_MS): static
     {
         $this->precognitive = true;
@@ -246,6 +262,22 @@ class Form extends ContainerComponent implements FormRootComponent, InteractiveC
 
         if ($hasRootWizard) {
             $this->submitButton = false;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[SerializationHook(priority: 185)]
+    protected function guardAsyncUploads(array $data): array
+    {
+        if ($this->async && $this->fields()->contains(fn (Field $field): bool => $field instanceof FileUpload)) {
+            throw new LogicException(
+                'An async form cannot contain file uploads: the fetch submit sends JSON, not multipart form data.',
+            );
         }
 
         return $data;

--- a/packages/framework/src/Http/LatticeResponse.php
+++ b/packages/framework/src/Http/LatticeResponse.php
@@ -6,8 +6,12 @@ namespace Lattice\Http;
 use BackedEnum;
 use Closure;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Lattice\Core\Support\Wire;
 use Lattice\Facades\Effects;
+use Lattice\Ui\Effects\Builtin\Redirect;
 use Lattice\Ui\Effects\Concerns\QueuesEffects;
 use Lattice\Ui\Effects\Effect;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,6 +22,11 @@ use Symfony\Component\HttpFoundation\Response;
  * modal close, …) and a redirect. The effects survive the redirect through the
  * `latticeEffects` flash bag, giving plain controllers the same ergonomics
  * ActionResult gives actions. Defaults to redirecting back.
+ *
+ * A plain JSON request (no `X-Inertia` header — an async form submit, a raw
+ * fetch) gets the effects as a JSON body instead, in the shape the action
+ * effect dispatcher already consumes; an explicit redirect travels along as a
+ * redirect effect, so `toRoute()` navigates in both worlds.
  *
  * @phpstan-consistent-constructor
  */
@@ -66,11 +75,38 @@ readonly class LatticeResponse implements Responsable
 
     public function toResponse($request): Response
     {
+        if ($this->wantsEffectsJson($request)) {
+            return new JsonResponse(['effects' => [...$this->effects, ...$this->redirectEffect()]]);
+        }
+
         if ($this->effects !== []) {
             Effects::flash(...$this->effects);
         }
 
         return ($this->redirect ?? fn (): Response => redirect()->back())();
+    }
+
+    private function wantsEffectsJson(Request $request): bool
+    {
+        return ! $request->headers->has('X-Inertia') && $request->expectsJson();
+    }
+
+    /**
+     * The default back() is deliberately not carried over: a fetch client that
+     * asked for JSON has nowhere to go "back" to — staying on the page is the
+     * point of submitting asynchronously.
+     *
+     * @return array<int, Effect>
+     */
+    private function redirectEffect(): array
+    {
+        if (! $this->redirect instanceof Closure) {
+            return [];
+        }
+
+        $response = ($this->redirect)();
+
+        return $response instanceof RedirectResponse ? [new Redirect($response->getTargetUrl())] : [];
     }
 
     private function withRedirect(Closure $redirect): static

--- a/tests/Feature/Core/RegistryTest.php
+++ b/tests/Feature/Core/RegistryTest.php
@@ -37,6 +37,7 @@ test('lattice can discover attributed definitions from a path and namespace', fu
                 'ref' => $this->latticeRef($form),
                 'submitLabel' => null,
                 'validationSummaryLabel' => 'Fix these fields to continue:',
+                'async' => false,
                 'precognitive' => false,
                 'validationTimeout' => null,
                 'submitButton' => true,

--- a/tests/Feature/Forms/FormEndpointTest.php
+++ b/tests/Feature/Forms/FormEndpointTest.php
@@ -5,12 +5,14 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Lattice\Core\Facades\Lattice;
+use Lattice\Facades\Effects;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Components\NumberInput;
 use Lattice\Form\Components\TextInput;
 use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
+use Lattice\Http\LatticeResponse;
 use Lattice\Ui\Components\Text;
 use Lattice\Ui\Enums\HttpMethod;
 use Symfony\Component\HttpFoundation\Response;
@@ -50,6 +52,7 @@ test('registered forms serialize their configured endpoint and isolated error ba
                 'submitEmphasis' => null,
                 'submitButtons' => null,
                 'validationSummaryLabel' => 'Fix these fields to continue:',
+                'async' => false,
                 'precognitive' => false,
                 'validationTimeout' => null,
                 'resetOnSuccess' => null,
@@ -111,6 +114,22 @@ test('registered form submissions validate before handle is called', function ()
     expect(session('handled-required-profile'))->toBeNull();
 });
 
+test('an async form submit gets its effects as json instead of a redirect', function (): void {
+    Lattice::forms([WorkbenchAsyncProfileForm::class]);
+
+    $ref = $this->latticeRef(wire(Form::use(WorkbenchAsyncProfileForm::class)));
+
+    patchJson('/lattice/forms/workbench.async-profile', [
+        'name' => 'Taylor',
+    ], $this->latticeHeaders($ref))
+        ->assertOk()
+        ->assertJsonPath('effects.0.type', 'toast')
+        ->assertJsonPath('effects.1.type', 'reload-component')
+        ->assertJsonPath('effects.1.props.component', 'projects.summary');
+
+    expect(session('handled-async-form'))->toBe('Taylor');
+});
+
 test('registered forms receive the current request while serializing definitions', function (): void {
     Lattice::forms([WorkbenchRequestAwareForm::class]);
 
@@ -167,6 +186,29 @@ class WorkbenchProfileForm extends FormDefinition
         $request->session()->put('handled-form-team', $this->context('team'));
 
         return redirect('/submitted');
+    }
+}
+
+#[AsForm('workbench.async-profile')]
+class WorkbenchAsyncProfileForm extends FormDefinition
+{
+    public function definition(Form $form, Request $request): Form
+    {
+        return $form
+            ->method(HttpMethod::Patch)
+            ->async()
+            ->schema([
+                TextInput::make('name', 'Name')->required(),
+            ]);
+    }
+
+    public function handle(Request $request): LatticeResponse
+    {
+        $request->session()->put('handled-async-form', $request->string('name')->toString());
+
+        return Effects::respond()
+            ->toast('Saved.')
+            ->reloadComponent('projects.summary');
     }
 }
 

--- a/tests/Feature/Forms/FormSerializationTest.php
+++ b/tests/Feature/Forms/FormSerializationTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Lattice\Form\Components\FileUpload;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Components\PasswordInput;
 use Lattice\Form\Components\TextInput;
@@ -65,6 +66,17 @@ test('editable computed fields serialize an explicit client prefill flag', funct
         'prefillRefreshOn' => ['@customer'],
     ])->not->toHaveKey('prefill');
 });
+
+test('forms serialize the async submit mode', function (): void {
+    expect(wire(Form::make('answers'))['props']['async'])->toBeFalse()
+        ->and(wire(Form::make('answers')->async())['props']['async'])->toBeTrue();
+});
+
+test('async forms reject file uploads', function (): void {
+    wire(Form::make('attachments')->async()->schema([
+        FileUpload::make('document', 'Document'),
+    ]));
+})->throws(LogicException::class, 'An async form cannot contain file uploads');
 
 test('forms serialize submit row configuration', function (): void {
     $wire = wire(Form::make('checkout')

--- a/tests/Feature/Http/LatticeResponseTest.php
+++ b/tests/Feature/Http/LatticeResponseTest.php
@@ -60,6 +60,52 @@ test('a lattice response flashes the trait-provided effects', function (): void 
     expect(wire(app(EffectFlasher::class)->all()[1])['type'])->toBe('locale-change');
 });
 
+test('a json request gets the effects as a body instead of a redirect', function (): void {
+    $request = request();
+    $request->headers->set('Accept', 'application/json');
+
+    $response = LatticeResponse::make()
+        ->toast('Saved.', Variant::Success)
+        ->reloadComponent('projects.summary')
+        ->toResponse($request);
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->headers->get('Content-Type'))->toContain('application/json');
+
+    $effects = json_decode((string) $response->getContent(), true)['effects'];
+    expect($effects)->toHaveCount(2);
+    expect($effects[0]['type'])->toBe('toast');
+    expect($effects[1])->toBe(['type' => 'reload-component', 'props' => ['component' => 'projects.summary']]);
+    expect(app(EffectFlasher::class)->all())->toBe([]);
+});
+
+test('a json request carries an explicit redirect as a redirect effect', function (): void {
+    $request = request();
+    $request->headers->set('Accept', 'application/json');
+
+    $response = LatticeResponse::make()
+        ->toast('Saved.')
+        ->toRoute('after-save')
+        ->toResponse($request);
+
+    $effects = json_decode((string) $response->getContent(), true)['effects'];
+    expect($effects)->toHaveCount(2);
+    expect($effects[1])->toBe(['type' => 'redirect', 'props' => ['url' => route('after-save')]]);
+});
+
+test('an inertia request keeps the redirect flow even when it accepts json', function (): void {
+    $request = request();
+    $request->headers->set('Accept', 'application/json');
+    $request->headers->set('X-Inertia', 'true');
+
+    $response = LatticeResponse::make()
+        ->toast('Saved.')
+        ->toResponse($request);
+
+    expect($response->getStatusCode())->toBe(302);
+    expect(app(EffectFlasher::class)->all())->toHaveCount(1);
+});
+
 test('Effects::respond starts a fluent response', function (): void {
     $response = Effects::respond()
         ->toast('Done.')


### PR DESCRIPTION
Inline Lattice forms always submit through Inertia's `<Form>`, and `LatticeResponse` always redirects (default: back). Every save is therefore a POST plus a full non-partial page GET: the whole React tree re-renders, the progress bar runs, and `Scroll.reset()` throws the user to the top of the page. In Cert Assist this makes saving a criterion answer sheet feel like a 1-2s full page reload.

**`Form::async()`** — a non-navigating submit mode for inline forms:

- `LatticeResponse::toResponse()` returns its effects as a JSON body for plain JSON requests (no `X-Inertia` header). An explicit `toRoute()`/`to()`/`back()` travels along as a `redirect` effect, so navigation works in both worlds; the *default* back() is deliberately dropped — a fetch client stays on the page.
- The fetch runtime (submit, 422 → field errors, Precognition single-field and multi-field validation) is extracted from the modal action form into a shared `useFetchForm` hook; `ActionFormBody` and the new `AsyncFormShell` both use it. Ref renewal on 403 already lives inside `apiFetch`, so async forms get it for free.
- Async forms reject `FileUpload` fields at serialization time (JSON body, no multipart). `errorBag()` has no meaning in async mode.
- Backward compatible: `async` defaults to `false`; the JSON branch only fires for requests that could never consume the 302 anyway.

**`preserveScroll` for the Inertia path** (separate commit): inline forms now pass `options={{ preserveScroll: true }}`, so a redirect-back submit no longer scrolls the window to the top.

Typical consumer pattern:

```php
Form::use(CriterionAnswerForm::class, $context)->async();

// handler
return Effects::respond()
    ->toast('Saved.')
    ->reloadComponent('projects.overview.summary');
```

Validated with: `vendor/bin/pest tests/Feature/Forms tests/Feature/Http` (425 passing), vitest form+action packages (399 passing), phpstan (both configs, 0 errors), `npm run typecheck`, `npm run build:lib`.
