### PR TITLE
feat(table): content-appropriate column width defaults, tighter cell padding

### DIFF
--- a/docs/fixtures/table.badge.json
+++ b/docs/fixtures/table.badge.json
@@ -70,7 +70,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.badge"
                 }

--- a/docs/fixtures/table.boolean.json
+++ b/docs/fixtures/table.boolean.json
@@ -49,7 +49,7 @@
                         "pinned": null,
                         "sortable": true,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.boolean"
                 },
@@ -64,7 +64,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.boolean"
                 }

--- a/docs/fixtures/table.column-types.json
+++ b/docs/fixtures/table.column-types.json
@@ -19,7 +19,7 @@
                         "size": 32,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.image"
                 },
@@ -71,7 +71,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.badge"
                 },
@@ -103,7 +103,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.icon"
                 }

--- a/docs/fixtures/table.icon.json
+++ b/docs/fixtures/table.icon.json
@@ -53,7 +53,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.icon"
                 }

--- a/docs/fixtures/table.image.json
+++ b/docs/fixtures/table.image.json
@@ -19,7 +19,7 @@
                         "size": 32,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.image"
                 },

--- a/docs/fixtures/table.money.json
+++ b/docs/fixtures/table.money.json
@@ -41,7 +41,7 @@
                         "pinned": null,
                         "sortable": true,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.money"
                 },
@@ -61,7 +61,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.money"
                 }

--- a/docs/fixtures/table.number.json
+++ b/docs/fixtures/table.number.json
@@ -41,7 +41,7 @@
                         "sortable": true,
                         "toggleable": false,
                         "unit": null,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.number"
                 },
@@ -61,7 +61,7 @@
                         "sortable": false,
                         "toggleable": false,
                         "unit": "percent",
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.number"
                 }

--- a/docs/fixtures/table.overview.json
+++ b/docs/fixtures/table.overview.json
@@ -76,7 +76,7 @@
                         "sortable": true,
                         "toggleable": false,
                         "unit": null,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.number"
                 },
@@ -104,7 +104,7 @@
                         "pinned": null,
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "xs"
                     },
                     "type": "column.boolean"
                 },

--- a/docs/fixtures/table.pinned.json
+++ b/docs/fixtures/table.pinned.json
@@ -61,7 +61,7 @@
                         "sortable": false,
                         "toggleable": false,
                         "unit": null,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.number"
                 },
@@ -88,7 +88,7 @@
                         "pinned": "right",
                         "sortable": false,
                         "toggleable": false,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.badge"
                 }

--- a/docs/fixtures/table.toggleable.json
+++ b/docs/fixtures/table.toggleable.json
@@ -61,7 +61,7 @@
                         "sortable": false,
                         "toggleable": true,
                         "unit": null,
-                        "width": "md"
+                        "width": "sm"
                     },
                     "type": "column.number"
                 },

--- a/packages/table/resources/js/primitives/data-table.tsx
+++ b/packages/table/resources/js/primitives/data-table.tsx
@@ -327,10 +327,11 @@ export function DataTableHeaderRow({ className, ...props }: DataTableHeaderRowPr
 }
 
 const headerCellClassName: Record<DataTableTrack, string> = {
-  column: "relative min-w-0 px-4 py-3 pr-5 align-middle font-semibold text-lt-fg",
-  expander: "px-2 py-3",
-  selection: "flex items-center px-4 py-3",
-  actions: "flex items-center justify-end gap-2 px-4 py-2 align-middle font-semibold text-lt-fg",
+  column: "relative min-w-0 px-lt-cell-x py-lt-cell-y pr-5 align-middle font-semibold text-lt-fg",
+  expander: "px-2 py-lt-cell-y",
+  selection: "flex items-center px-lt-cell-x py-lt-cell-y",
+  actions:
+    "flex items-center justify-end gap-2 px-lt-cell-x py-2 align-middle font-semibold text-lt-fg",
   filler: "",
 };
 
@@ -453,8 +454,8 @@ export function DataTableHeaderLabel({
 const filterCellClassName: Record<DataTableTrack, string> = {
   column: "min-w-0 border-t border-b border-lt-border px-2 py-2",
   expander: "border-t border-b border-lt-border px-2 py-2",
-  selection: "border-t border-b border-lt-border px-4 py-2",
-  actions: "border-t border-b border-lt-border px-4 py-2",
+  selection: "border-t border-b border-lt-border px-lt-cell-x py-2",
+  actions: "border-t border-b border-lt-border px-lt-cell-x py-2",
   filler: "border-t border-b border-lt-border",
 };
 

--- a/packages/table/src/Columns/BadgeColumn.php
+++ b/packages/table/src/Columns/BadgeColumn.php
@@ -12,12 +12,15 @@ use Lattice\Table\Columns\Concerns\IsSortable;
 use Lattice\Table\Contracts\Filterable;
 use Lattice\Table\Contracts\Sortable;
 use Lattice\Table\Enums\ColumnType;
+use Lattice\Ui\Enums\ColumnWidth;
 
 #[AsColumn(ColumnType::Badge)]
 final class BadgeColumn extends Column implements Filterable, Sortable
 {
     use IsFilterable;
     use IsSortable;
+
+    public ColumnWidth $width = ColumnWidth::Sm;
 
     /**
      * @var array<array-key, Color>|null

--- a/packages/table/src/Columns/BooleanColumn.php
+++ b/packages/table/src/Columns/BooleanColumn.php
@@ -10,12 +10,15 @@ use Lattice\Table\Contracts\Filterable;
 use Lattice\Table\Contracts\Sortable;
 use Lattice\Table\Enums\ColumnType;
 use Lattice\Table\Enums\FilterType;
+use Lattice\Ui\Enums\ColumnWidth;
 
 #[AsColumn(ColumnType::Boolean)]
 final class BooleanColumn extends Column implements Filterable, Sortable
 {
     use IsFilterable;
     use IsSortable;
+
+    public ColumnWidth $width = ColumnWidth::Xs;
 
     public function filterType(): FilterType
     {

--- a/packages/table/src/Columns/IconColumn.php
+++ b/packages/table/src/Columns/IconColumn.php
@@ -11,11 +11,14 @@ use Lattice\Core\Support\Wire;
 use Lattice\Table\Attributes\AsColumn;
 use Lattice\Table\Enums\ColumnType;
 use Lattice\Ui\Concerns\HasIcon;
+use Lattice\Ui\Enums\ColumnWidth;
 
 #[AsColumn(ColumnType::Icon)]
 final class IconColumn extends Column
 {
     use HasIcon;
+
+    public ColumnWidth $width = ColumnWidth::Xs;
 
     /**
      * @var array<array-key, string>|null

--- a/packages/table/src/Columns/ImageColumn.php
+++ b/packages/table/src/Columns/ImageColumn.php
@@ -5,10 +5,13 @@ namespace Lattice\Table\Columns;
 
 use Lattice\Table\Attributes\AsColumn;
 use Lattice\Table\Enums\ColumnType;
+use Lattice\Ui\Enums\ColumnWidth;
 
 #[AsColumn(ColumnType::Image)]
 final class ImageColumn extends Column
 {
+    public ColumnWidth $width = ColumnWidth::Xs;
+
     public bool $circular = false;
 
     public ?int $size = null;

--- a/packages/table/src/Columns/NumericColumn.php
+++ b/packages/table/src/Columns/NumericColumn.php
@@ -10,6 +10,7 @@ use Lattice\Table\Contracts\Sortable;
 use Lattice\Table\Enums\ColumnAlign;
 use Lattice\Table\Enums\FilterType;
 use Lattice\Ui\Concerns\HasCopyable;
+use Lattice\Ui\Enums\ColumnWidth;
 
 abstract class NumericColumn extends Column implements Filterable, Sortable
 {
@@ -18,6 +19,8 @@ abstract class NumericColumn extends Column implements Filterable, Sortable
     use IsSortable;
 
     public ColumnAlign $align = ColumnAlign::End;
+
+    public ColumnWidth $width = ColumnWidth::Sm;
 
     public ?int $minimumFractionDigits = null;
 

--- a/packages/ui/resources/css/lattice.css
+++ b/packages/ui/resources/css/lattice.css
@@ -99,8 +99,8 @@
   --lt-input-font-size-mobile: 1rem;
 
   /* Table cell padding — table density lever */
-  --lt-table-cell-x: calc(var(--spacing) * 4);
-  --lt-table-cell-y: calc(var(--spacing) * 4);
+  --lt-table-cell-x: calc(var(--spacing) * 3);
+  --lt-table-cell-y: calc(var(--spacing) * 3);
 
   --lt-font-weight-normal: 400;
   --lt-font-weight-medium: 500;

--- a/tests/Feature/Tables/Components/TableWireShapeTest.php
+++ b/tests/Feature/Tables/Components/TableWireShapeTest.php
@@ -37,7 +37,7 @@ it('serializes the table component wire shape', function (): void {
         'width' => 'lg',
         'sortable' => true,
     ]);
-    expect($payload['props']['columns'][1]['props']['width'])->toBe('md');
+    expect($payload['props']['columns'][1]['props']['width'])->toBe('sm');
     expect($payload['props']['columns'][0]['props'])->toHaveKey('filter');
     expect($payload['props']['data'])->toBe([['name' => 'A'], ['name' => 'B']]);
     expect($payload['props']['query'])->toBe([

--- a/tests/Unit/Tables/Columns/ColumnPropsTest.php
+++ b/tests/Unit/Tables/Columns/ColumnPropsTest.php
@@ -62,7 +62,7 @@ it('reflects only the common concerns for columns that expose no public properti
     expect($props)->toHaveCount(9)
         ->and($props)->toMatchArray([
             'label' => 'Active',
-            'width' => 'md',
+            'width' => 'xs',
             'align' => 'start',
             'sortable' => false,
             'toggleable' => false,


### PR DESCRIPTION
Columns often rendered far wider than their content because every column defaulted to `ColumnWidth::Md` (`minmax(8rem, 1fr)`), so all columns split the full container width evenly regardless of content.

- Content-appropriate width defaults per column type: boolean/icon/image → `Xs`, number/money/badge → `Sm`; text stays `Md`, stack stays `Xl`. `->width()` still overrides.
- Cell padding tokens (`--lt-table-cell-x/y`) reduced from 16px to 12px; header and filter cells now use the tokens instead of hardcoded `px-4` classes.
- Docs fixtures regenerated; two tests pinning the old defaults updated.

Validated with Pest table suites, PHPStan (both configs), and the table Vitest jsdom suite.
