### PR TITLE
refactor(js): type enum class maps against generated wire unions

### DIFF
--- a/packages/api-reference/resources/js/api-reference/RequestPlayground.tsx
+++ b/packages/api-reference/resources/js/api-reference/RequestPlayground.tsx
@@ -12,7 +12,7 @@ import {
 import { Badge } from "@lattice-php/ui/components/badge/badge";
 import { Button } from "@lattice-php/ui/components/button/button";
 import { Combobox } from "@lattice-php/form/primitives/combobox";
-import { CodeBlock } from "@lattice-php/ui";
+import { CodeBlock, type Breakpoint } from "@lattice-php/ui";
 import { CopyButton } from "@lattice-php/ui/primitives/copyable-text";
 import { InfoTooltip } from "@lattice-php/ui/primitives/info-tooltip";
 import { Input } from "@lattice-php/form/primitives/input";
@@ -78,7 +78,7 @@ type SecuritySchemeDefinition = {
   flows?: Record<string, OAuthFlowDefinition>;
 };
 
-export type TwoColumnBreakpoint = "default" | "sm" | "md" | "lg" | "xl" | "2xl";
+export type TwoColumnBreakpoint = Breakpoint;
 
 const TWO_COLUMN_LAYOUTS: Record<TwoColumnBreakpoint, { grid: string; reference: string }> = {
   default: {

--- a/packages/core/resources/js/index.ts
+++ b/packages/core/resources/js/index.ts
@@ -44,7 +44,7 @@ export {
   useComponentRegistry,
   useExtensionRegistry,
 } from "./registry-context";
-export { Renderer, RenderNode } from "./renderer";
+export { Renderer, RenderNode, type VisibilityBreakpoint } from "./renderer";
 export {
   leafTestIdentity,
   nodeIdentity,

--- a/packages/core/resources/js/renderer.tsx
+++ b/packages/core/resources/js/renderer.tsx
@@ -7,7 +7,9 @@ import { useComponentRegistry } from "./registry-context";
 
 const warnedMissingTypes = new Set<string>();
 
-const HIDDEN_FROM_CLASS: Record<string, string> = {
+export type VisibilityBreakpoint = "sm" | "md" | "lg" | "xl" | "2xl";
+
+const HIDDEN_FROM_CLASS: Record<VisibilityBreakpoint, string> = {
   sm: "sm:hidden",
   md: "md:hidden",
   lg: "lg:hidden",
@@ -15,7 +17,7 @@ const HIDDEN_FROM_CLASS: Record<string, string> = {
   "2xl": "2xl:hidden",
 };
 
-const VISIBLE_FROM_CLASS: Record<string, string> = {
+const VISIBLE_FROM_CLASS: Record<VisibilityBreakpoint, string> = {
   sm: "sm:contents",
   md: "md:contents",
   lg: "lg:contents",
@@ -23,14 +25,27 @@ const VISIBLE_FROM_CLASS: Record<string, string> = {
   "2xl": "2xl:contents",
 };
 
+function breakpointClass(
+  map: Record<VisibilityBreakpoint, string>,
+  value: string | undefined,
+): string | undefined {
+  return value !== undefined && value in map ? map[value as VisibilityBreakpoint] : undefined;
+}
+
 /**
  * A `display: contents` wrapper stays transparent to the parent layout, so the
  * responsive visibility classes can toggle any node without disturbing flex or
  * grid parents.
  */
 function responsiveVisibilityClass(props: Node["props"]): string | null {
-  const hiddenFrom = HIDDEN_FROM_CLASS[(props as { hiddenFrom?: string })?.hiddenFrom ?? ""];
-  const visibleFrom = VISIBLE_FROM_CLASS[(props as { visibleFrom?: string })?.visibleFrom ?? ""];
+  const hiddenFrom = breakpointClass(
+    HIDDEN_FROM_CLASS,
+    (props as { hiddenFrom?: string })?.hiddenFrom,
+  );
+  const visibleFrom = breakpointClass(
+    VISIBLE_FROM_CLASS,
+    (props as { visibleFrom?: string })?.visibleFrom,
+  );
 
   if (visibleFrom && hiddenFrom) {
     return `hidden ${visibleFrom} ${hiddenFrom}`;

--- a/packages/form/resources/js/components/form/form-adapter.tsx
+++ b/packages/form/resources/js/components/form/form-adapter.tsx
@@ -9,6 +9,7 @@ import { RenderNode } from "@lattice-php/core/renderer";
 import type { Node, RendererComponent } from "@lattice-php/core";
 import { useT } from "@lattice-php/ui/i18n";
 import type { Emphasis, Justify, Variant } from "@lattice-php/ui";
+import { justifyClasses } from "@lattice-php/ui/lib/justify";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FormSubmitButton } from "../base/submit-button";
 import { FormProvider } from "../../hooks/context";
@@ -18,15 +19,6 @@ import { ResolvedNodesProvider } from "../../hooks/resolved-nodes";
 import { useFormResolver } from "../../hooks/use-form-resolver";
 import { useFetchForm } from "../../hooks/use-fetch-form";
 import { FormValuesProvider, useResetFormValues } from "../../hooks/values";
-
-const JUSTIFY_CLASS: Record<Justify, string> = {
-  start: "justify-start",
-  center: "justify-center",
-  end: "justify-end",
-  between: "justify-between",
-  around: "justify-around",
-  evenly: "justify-evenly",
-};
 
 type SubmitButtonNode = Node & {
   props: {
@@ -93,7 +85,7 @@ function FormBody({
           {children}
 
           {shouldRenderSubmitButton && (
-            <div className={`flex gap-3 ${JUSTIFY_CLASS[submitJustify ?? "end"]}`}>
+            <div className={`flex gap-3 ${justifyClasses[submitJustify ?? "end"]}`}>
               {submitButtons?.length ? (
                 submitButtons.map((button, index) =>
                   button.props.buttonType === "submit" ? (

--- a/packages/form/resources/js/components/wizard/wizard-adapter.tsx
+++ b/packages/form/resources/js/components/wizard/wizard-adapter.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useRef, useState } from 
 import type { ReactNode } from "react";
 import type { Node, RendererComponent } from "@lattice-php/core";
 import type { WizardStep } from "../../generated";
+import type { Align } from "@lattice-php/ui";
 import { cn } from "@lattice-php/ui/lib/utils";
 import { useT } from "@lattice-php/ui/i18n";
 import { Icon } from "@lattice-php/ui/icons";
@@ -15,7 +16,7 @@ import {
   stepValidationPaths,
 } from "../../lib/wizard-steps";
 
-const RAIL_ALIGNMENTS: Record<string, string> = {
+const RAIL_ALIGNMENTS: Record<Align, string> = {
   center: "justify-center",
   left: "justify-start",
   start: "justify-start",

--- a/packages/framework/resources/js/page.tsx
+++ b/packages/framework/resources/js/page.tsx
@@ -3,12 +3,13 @@ import { Renderer } from "@lattice-php/core/renderer";
 import type { PagePayload } from "@lattice-php/lattice";
 import { cn } from "@lattice-php/ui/lib/utils";
 import { RealtimeListeners } from "./realtime/listeners";
+import type { KnownPageWidth } from "./types";
 
 type Props = {
   lattice: PagePayload;
 };
 
-const pageWidths: Record<string, string> = {
+const pageWidths: Record<KnownPageWidth, string> = {
   full: "max-w-none",
   xl: "max-w-6xl",
   lg: "max-w-4xl",
@@ -28,7 +29,7 @@ export default function Page({ lattice }: Props) {
         data-page-width={lattice.width}
         className={cn(
           "mx-auto w-full px-4 py-6 sm:px-6 lg:px-8",
-          pageWidths[lattice.width] ?? pageWidths.full,
+          pageWidths[lattice.width as KnownPageWidth] ?? pageWidths.full,
         )}
       >
         <Renderer nodes={lattice.schema} />

--- a/packages/table/resources/js/primitives/data-table.tsx
+++ b/packages/table/resources/js/primitives/data-table.tsx
@@ -11,12 +11,13 @@ import { Icon } from "@lattice-php/ui/icons";
 import { cn } from "@lattice-php/ui/lib/utils";
 import { IconButton } from "@lattice-php/ui/primitives/icon-button";
 import { Input } from "@lattice-php/form/primitives/input";
+import type { ColumnAlign, ColumnPin, SortDirection } from "../generated";
 
-export type DataTableAlign = "start" | "center" | "end";
-export type DataTablePinSide = "left" | "right";
+export type DataTableAlign = ColumnAlign;
+export type DataTablePinSide = ColumnPin;
 export type DataTablePinBoundary = "start" | "end";
 export type DataTableTrack = "column" | "expander" | "selection" | "actions" | "filler";
-export type DataTableSortDirection = "asc" | "desc";
+export type DataTableSortDirection = SortDirection;
 
 const alignText: Record<DataTableAlign, string> = {
   start: "text-start",

--- a/packages/ui/resources/js/components/avatar/avatar.tsx
+++ b/packages/ui/resources/js/components/avatar/avatar.tsx
@@ -1,8 +1,9 @@
 import type { ComponentProps } from "react";
+import type { AvatarShape, Size } from "../../generated";
 import { cn } from "../../lib/utils";
 
-export type AvatarShape = "circle" | "rounded";
-export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
+export type { AvatarShape } from "../../generated";
+export type AvatarSize = Size;
 
 export type AvatarProps = Omit<ComponentProps<"span">, "children"> & {
   name?: string | null;

--- a/packages/ui/resources/js/components/stack/stack.tsx
+++ b/packages/ui/resources/js/components/stack/stack.tsx
@@ -1,14 +1,16 @@
 import type { ComponentProps } from "react";
+import type { Align, Gap, Height, Justify, Side, StackDirection, Width } from "../../generated";
+import { justifyClasses } from "../../lib/justify";
 import { useStickyOffsetPublisher } from "../../lib/use-sticky-offset";
 import { cn } from "../../lib/utils";
 
-export type StackAlign = "center" | "left" | "start" | "stretch";
-export type StackDirection = "column" | "row";
-export type StackGap = "none" | "xs" | "sm" | "md" | "lg" | "xl";
-export type StackHeight = "full" | "screen";
-export type StackJustify = "start" | "center" | "end" | "between" | "around" | "evenly";
-export type StackSide = "start" | "end";
-export type StackWidth = "full" | "auto" | "sm" | "md" | "lg" | "xl" | "fill";
+export type StackAlign = Align;
+export type { StackDirection } from "../../generated";
+export type StackGap = Gap;
+export type StackHeight = Height;
+export type StackJustify = Justify;
+export type StackSide = Side;
+export type StackWidth = Width;
 
 export type StackProps = Omit<ComponentProps<"div">, "align"> & {
   align?: StackAlign;
@@ -50,15 +52,6 @@ const stackWidths: Record<StackWidth, string> = {
   lg: "mx-auto w-full max-w-4xl",
   xl: "mx-auto w-full max-w-6xl",
   fill: "min-w-0 flex-1",
-};
-
-const justifyClasses: Record<StackJustify, string> = {
-  start: "justify-start",
-  center: "justify-center",
-  end: "justify-end",
-  between: "justify-between",
-  around: "justify-around",
-  evenly: "justify-evenly",
 };
 
 const stackHeights: Record<StackHeight, string> = {

--- a/packages/ui/resources/js/components/tabs/tabs.tsx
+++ b/packages/ui/resources/js/components/tabs/tabs.tsx
@@ -14,9 +14,10 @@ import { cn } from "../../lib/utils";
 import { useMediaQuery } from "../../lib/use-media-query";
 import { NativeSelect } from "../../primitives/native-select";
 import { pillClassName } from "../../lib/pill";
+import type { Orientation, TabsAlignment } from "../../generated";
 
-export type TabsAlignment = "start" | "center" | "end" | "stretch";
-export type TabsOrientation = "horizontal" | "vertical";
+export type { TabsAlignment } from "../../generated";
+export type TabsOrientation = Orientation;
 
 export type TabsItem = {
   label: ReactNode;

--- a/packages/ui/resources/js/components/text/text.tsx
+++ b/packages/ui/resources/js/components/text/text.tsx
@@ -3,9 +3,10 @@ import { CopyableText } from "../../primitives/copyable-text";
 import { coerceColor, colorValue, namedColor } from "../../lib/color";
 import { cn } from "../../lib/utils";
 import type { Color } from "../../types";
+import type { Align, Size } from "../../generated";
 
-export type TextAlign = "center" | "left";
-export type TextSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
+export type TextAlign = Extract<Align, "center" | "left">;
+export type TextSize = Size;
 
 export type TextProps = Omit<ComponentProps<"p">, "children" | "color"> & {
   align?: TextAlign;

--- a/packages/ui/resources/js/lib/justify.ts
+++ b/packages/ui/resources/js/lib/justify.ts
@@ -1,0 +1,10 @@
+import type { Justify } from "../types";
+
+export const justifyClasses: Record<Justify, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+  between: "justify-between",
+  around: "justify-around",
+  evenly: "justify-evenly",
+};

--- a/packages/ui/resources/js/types.test-d.ts
+++ b/packages/ui/resources/js/types.test-d.ts
@@ -1,0 +1,8 @@
+import type { VisibilityBreakpoint } from "@lattice-php/core/renderer";
+import type { Breakpoint } from "./generated";
+
+const _toCore: VisibilityBreakpoint = {} as Exclude<Breakpoint, "default">;
+const _fromCore: Exclude<Breakpoint, "default"> = {} as VisibilityBreakpoint;
+
+void _toCore;
+void _fromCore;


### PR DESCRIPTION
Several components re-declared the generated enum unions by hand or used untyped `Record<string, string>` class maps, so a new or renamed PHP enum case silently fell through to a fallback instead of failing the build. This PR makes the generated types the single source of truth for every enum-keyed Tailwind class map.

- Hand-rolled unions in `stack`, `text`, `avatar`, `tabs`, `data-table` and `RequestPlayground` now alias the generated types (`Gap`, `Size`, `Align`, `ColumnAlign`, `Breakpoint`, …). All old exported names survive as aliases — no public API change. `TextAlign` stays deliberately narrow via `Extract<Align, "center" | "left">`.
- Untyped maps get typed keys with their runtime fallbacks intact: `page.tsx` (`KnownPageWidth`), wizard `RAIL_ALIGNMENTS` (`Align`), core renderer visibility maps (new `VisibilityBreakpoint` + lookup helper).
- The byte-identical Justify map from `stack.tsx` and form's `form-adapter.tsx` moves to a shared `ui/lib/justify.ts`.
- A new `ui/types.test-d.ts` asserts `VisibilityBreakpoint` equals `Exclude<Breakpoint, "default">`, closing the drift loop in the correct dependency direction (core cannot import ui).

No wire or runtime change. Validated with `typecheck`, oxlint, `format:check`, `type-coverage` (99.81 %), `test:changed` (846 tests) and `build:lib`.
