### PR TITLE
refactor!: dedicated TextAlign enum, align exported type names with generated enums

### DIFF
--- a/docs/content/docs/advanced/enums.mdx
+++ b/docs/content/docs/advanced/enums.mdx
@@ -51,7 +51,7 @@ layout primitives.
 Sizing lives in `Lattice\Ui\Enums`; the color vocabulary lives in
 `Lattice\Core\Enums` and backs the `Color` value object.
 
-<EnumTable enums={["Size", "ColorName", "ColorKind"]} showNamespace />
+<EnumTable enums={["Size", "TextAlign", "ColorName", "ColorKind"]} showNamespace />
 
 The icon names a `Lattice\Ui\Enums\Icon` accepts are the enum's own cases — one per bundled
 SVG. The [Icons](/core/icons/) page covers where they come from and how to add your own.

--- a/docs/content/docs/components/text.mdx
+++ b/docs/content/docs/components/text.mdx
@@ -37,11 +37,11 @@ Heading::make('sk-live-4242', 3)->copyable();
 - `->size(Size::…)` — text size (`Md` by default).
 - `->color()` — a colour name (`Color::success()`, `'success'`) or any CSS colour; text renders in
   the `muted` colour when unset.
-- `->align(Align::Center)` — alignment.
+- `->align(TextAlign::Center)` — alignment.
 - `->copyable()` — render a copy-to-clipboard affordance.
 
 ```php
-Text::make('Invoices are sent on the first of each month.')->align(Align::Center);
+Text::make('Invoices are sent on the first of each month.')->align(TextAlign::Center);
 ```
 
 ## Badge

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -502,10 +502,6 @@
                 "value": "center"
             },
             {
-                "name": "Left",
-                "value": "left"
-            },
-            {
                 "name": "Start",
                 "value": "start"
             },
@@ -1183,6 +1179,20 @@
             }
         ],
         "name": "TabsAlignment",
+        "namespace": "Lattice\\Ui\\Enums"
+    },
+    "Lattice\\Ui\\Enums\\TextAlign": {
+        "cases": [
+            {
+                "name": "Left",
+                "value": "left"
+            },
+            {
+                "name": "Center",
+                "value": "center"
+            }
+        ],
+        "name": "TextAlign",
         "namespace": "Lattice\\Ui\\Enums"
     },
     "Lattice\\Ui\\Enums\\Variant": {

--- a/packages/api-reference/resources/js/api-reference/ApiReference.tsx
+++ b/packages/api-reference/resources/js/api-reference/ApiReference.tsx
@@ -9,7 +9,7 @@ import { operationToMarkdown } from "./operation-markdown";
 import { OperationView } from "./OperationView";
 import { buildNavigation, filterNavigationByTags, parseOperation } from "./parse";
 import { operationUrl } from "./request-builder";
-import type { TwoColumnBreakpoint } from "./RequestPlayground";
+import type { Breakpoint } from "@lattice-php/ui";
 import { ServerPicker } from "./ServerPicker";
 import type { ApiInfo, Navigation } from "./types";
 
@@ -29,7 +29,7 @@ export type ApiReferenceProps = {
   /** Overrides the spec's info.title in the header. */
   title?: string | null;
   expandDepth?: number;
-  twoColumnBreakpoint?: TwoColumnBreakpoint;
+  twoColumnBreakpoint?: Breakpoint;
   /** Pre-fills the playground's bearer token. */
   token?: string | null;
   /** Sealed per-scope-set token accesses; execute fetches a scoped token lazily. Wins over token. */

--- a/packages/api-reference/resources/js/api-reference/OperationView.tsx
+++ b/packages/api-reference/resources/js/api-reference/OperationView.tsx
@@ -2,7 +2,8 @@ import { useMemo } from "react";
 import type { RemoteAccess } from "@lattice-php/core/api";
 import type { ResolveAccessToken } from "./access-token";
 import { parseOperation } from "./parse";
-import { RequestPlayground, type TwoColumnBreakpoint } from "./RequestPlayground";
+import type { Breakpoint } from "@lattice-php/ui";
+import { RequestPlayground } from "./RequestPlayground";
 
 type OperationViewProps = {
   spec: unknown;
@@ -12,7 +13,7 @@ type OperationViewProps = {
   remoteTokens?: RemoteAccess[] | null;
   resolveAccessToken?: ResolveAccessToken | null;
   expandDepth?: number;
-  twoColumnBreakpoint?: TwoColumnBreakpoint;
+  twoColumnBreakpoint?: Breakpoint;
   hideHeaderIdentity?: boolean;
 };
 

--- a/packages/api-reference/resources/js/api-reference/RequestPlayground.tsx
+++ b/packages/api-reference/resources/js/api-reference/RequestPlayground.tsx
@@ -78,9 +78,7 @@ type SecuritySchemeDefinition = {
   flows?: Record<string, OAuthFlowDefinition>;
 };
 
-export type TwoColumnBreakpoint = Breakpoint;
-
-const TWO_COLUMN_LAYOUTS: Record<TwoColumnBreakpoint, { grid: string; reference: string }> = {
+const TWO_COLUMN_LAYOUTS: Record<Breakpoint, { grid: string; reference: string }> = {
   default: {
     grid: "grid-cols-[minmax(0,1fr)_minmax(22rem,32rem)]",
     reference: "sticky top-0 border-l border-t-0",
@@ -779,7 +777,7 @@ type RequestPlaygroundProps = {
   resolveAccessToken?: ResolveAccessToken | null;
   components: unknown;
   expandDepth?: number;
-  twoColumnBreakpoint?: TwoColumnBreakpoint;
+  twoColumnBreakpoint?: Breakpoint;
   hideHeaderIdentity?: boolean;
 };
 

--- a/packages/form/resources/js/components/wizard/wizard-adapter.tsx
+++ b/packages/form/resources/js/components/wizard/wizard-adapter.tsx
@@ -18,7 +18,6 @@ import {
 
 const RAIL_ALIGNMENTS: Record<Align, string> = {
   center: "justify-center",
-  left: "justify-start",
   start: "justify-start",
   stretch: "justify-stretch",
 };

--- a/packages/table/resources/js/primitives/data-table.tsx
+++ b/packages/table/resources/js/primitives/data-table.tsx
@@ -13,25 +13,22 @@ import { IconButton } from "@lattice-php/ui/primitives/icon-button";
 import { Input } from "@lattice-php/form/primitives/input";
 import type { ColumnAlign, ColumnPin, SortDirection } from "../generated";
 
-export type DataTableAlign = ColumnAlign;
-export type DataTablePinSide = ColumnPin;
 export type DataTablePinBoundary = "start" | "end";
 export type DataTableTrack = "column" | "expander" | "selection" | "actions" | "filler";
-export type DataTableSortDirection = SortDirection;
 
-const alignText: Record<DataTableAlign, string> = {
+const alignText: Record<ColumnAlign, string> = {
   start: "text-start",
   center: "text-center",
   end: "text-end",
 };
 
-const alignJustify: Record<DataTableAlign, string> = {
+const alignJustify: Record<ColumnAlign, string> = {
   start: "justify-start",
   center: "justify-center",
   end: "justify-end",
 };
 
-const alignJustifyItems: Record<DataTableAlign, string> = {
+const alignJustifyItems: Record<ColumnAlign, string> = {
   start: "justify-items-start",
   center: "justify-items-center",
   end: "justify-items-end",
@@ -80,7 +77,7 @@ export function pinBoundaryClassName(
 type PinProps = {
   pinBoundary?: DataTablePinBoundary;
   pinIndex?: number;
-  pinned?: DataTablePinSide;
+  pinned?: ColumnPin;
 };
 
 function pinOffsetStyle(
@@ -337,7 +334,7 @@ const headerCellClassName: Record<DataTableTrack, string> = {
 };
 
 function ariaSort(
-  direction: DataTableSortDirection | null | undefined,
+  direction: SortDirection | null | undefined,
 ): "ascending" | "descending" | undefined {
   if (direction === "asc") {
     return "ascending";
@@ -352,10 +349,10 @@ function ariaSort(
 
 export type DataTableHeaderCellProps = ComponentProps<"div"> &
   PinProps & {
-    align?: DataTableAlign;
+    align?: ColumnAlign;
     bottomBordered?: boolean;
     kind?: DataTableTrack;
-    sortDirection?: DataTableSortDirection | null;
+    sortDirection?: SortDirection | null;
   };
 
 export function DataTableHeaderCell({
@@ -394,7 +391,7 @@ export function DataTableHeaderCell({
   );
 }
 
-function SortIndicator({ direction }: { direction: DataTableSortDirection | null | undefined }) {
+function SortIndicator({ direction }: { direction: SortDirection | null | undefined }) {
   if (direction === "asc") {
     return <Icon name="arrow-up" aria-hidden="true" className="size-lt-icon-sm shrink-0" />;
   }
@@ -413,8 +410,8 @@ function SortIndicator({ direction }: { direction: DataTableSortDirection | null
 }
 
 export type DataTableSortButtonProps = ComponentProps<"button"> & {
-  align?: DataTableAlign;
-  direction?: DataTableSortDirection | null;
+  align?: ColumnAlign;
+  direction?: SortDirection | null;
 };
 
 export function DataTableSortButton({
@@ -441,7 +438,7 @@ export function DataTableSortButton({
 }
 
 export type DataTableHeaderLabelProps = ComponentProps<"span"> & {
-  align?: DataTableAlign;
+  align?: ColumnAlign;
 };
 
 export function DataTableHeaderLabel({
@@ -545,7 +542,7 @@ const bodyCellClassName: Record<DataTableTrack, string> = {
 
 export type DataTableCellProps = ComponentProps<"div"> &
   PinProps & {
-    align?: DataTableAlign;
+    align?: ColumnAlign;
     kind?: DataTableTrack;
     label?: ReactNode;
   };

--- a/packages/table/resources/js/types.ts
+++ b/packages/table/resources/js/types.ts
@@ -25,6 +25,7 @@ import type {
   TableResult,
   TableSort,
 } from "./generated";
+export type { ColumnAlign, ColumnPin, SortDirection } from "./generated";
 
 declare module "@lattice-php/core" {
   interface ComponentProps extends ComponentPropsMap {}

--- a/packages/ui/resources/js/components/accordion/accordion.tsx
+++ b/packages/ui/resources/js/components/accordion/accordion.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useMemo, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 import { cn } from "../../lib/utils";
-import { stackGaps, type StackGap } from "../stack/stack";
+import type { Gap } from "../../generated";
+import { stackGaps } from "../stack/stack";
 
 type AccordionContextValue = {
   items: readonly string[];
@@ -14,7 +15,7 @@ const AccordionContext = createContext<AccordionContextValue | null>(null);
 export type AccordionProps = Omit<ComponentProps<"div">, "children"> & {
   children?: ReactNode;
   defaultOpen?: string | null;
-  gap?: StackGap;
+  gap?: Gap;
   items: readonly string[];
 };
 

--- a/packages/ui/resources/js/components/avatar/avatar.tsx
+++ b/packages/ui/resources/js/components/avatar/avatar.tsx
@@ -2,17 +2,14 @@ import type { ComponentProps } from "react";
 import type { AvatarShape, Size } from "../../generated";
 import { cn } from "../../lib/utils";
 
-export type { AvatarShape } from "../../generated";
-export type AvatarSize = Size;
-
 export type AvatarProps = Omit<ComponentProps<"span">, "children"> & {
   name?: string | null;
   shape?: AvatarShape;
-  size?: AvatarSize;
+  size?: Size;
   src?: string | null;
 };
 
-const sizeClasses: Record<AvatarSize, string> = {
+const sizeClasses: Record<Size, string> = {
   xs: "size-6 text-[0.5rem]",
   sm: "size-8 text-xs",
   md: "size-10 text-sm",

--- a/packages/ui/resources/js/components/progress/progress.tsx
+++ b/packages/ui/resources/js/components/progress/progress.tsx
@@ -3,9 +3,7 @@ import { useLocale } from "../../i18n";
 import { coerceColor, colorValue, namedColor } from "../../lib/color";
 import { cn } from "../../lib/utils";
 import type { Color } from "../../types";
-
-export type ProgressShape = "bar" | "circle";
-export type ProgressSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
+import type { ProgressShape, Size } from "../../generated";
 
 export type ProgressProps = Omit<ComponentProps<"div">, "children" | "color"> & {
   color?: Color | string | null;
@@ -13,11 +11,11 @@ export type ProgressProps = Omit<ComponentProps<"div">, "children" | "color"> & 
   max?: number;
   shape?: ProgressShape;
   showValue?: boolean;
-  size?: ProgressSize;
+  size?: Size;
   value: number;
 };
 
-const barHeights: Record<ProgressSize, string> = {
+const barHeights: Record<Size, string> = {
   xs: "h-1",
   sm: "h-1.5",
   md: "h-2.5",
@@ -28,7 +26,7 @@ const barHeights: Record<ProgressSize, string> = {
   "4xl": "h-8",
 };
 
-const circleDiameters: Record<ProgressSize, number> = {
+const circleDiameters: Record<Size, number> = {
   xs: 24,
   sm: 32,
   md: 40,
@@ -39,7 +37,7 @@ const circleDiameters: Record<ProgressSize, number> = {
   "4xl": 128,
 };
 
-const circleReadouts: Record<ProgressSize, string> = {
+const circleReadouts: Record<Size, string> = {
   xs: "text-[0.5rem]",
   sm: "text-[0.625rem]",
   md: "text-xs",

--- a/packages/ui/resources/js/components/stack/stack.tsx
+++ b/packages/ui/resources/js/components/stack/stack.tsx
@@ -4,38 +4,30 @@ import { justifyClasses } from "../../lib/justify";
 import { useStickyOffsetPublisher } from "../../lib/use-sticky-offset";
 import { cn } from "../../lib/utils";
 
-export type StackAlign = Align;
-export type { StackDirection } from "../../generated";
-export type StackGap = Gap;
-export type StackHeight = Height;
-export type StackJustify = Justify;
-export type StackSide = Side;
-export type StackWidth = Width;
-
 export type StackProps = Omit<ComponentProps<"div">, "align"> & {
-  align?: StackAlign;
+  align?: Align;
   direction?: StackDirection;
-  float?: StackSide;
-  gap?: StackGap;
-  height?: StackHeight;
-  justify?: StackJustify;
+  float?: Side;
+  gap?: Gap;
+  height?: Height;
+  justify?: Justify;
   sticky?: boolean;
-  width?: StackWidth;
+  width?: Width;
 };
 
-const gridAlignments: Partial<Record<StackAlign, string>> = {
+const gridAlignments: Record<Align, string> = {
   center: "justify-items-center text-center",
   start: "justify-items-start text-left",
   stretch: "justify-items-stretch",
 };
 
-const flexAlignments: Partial<Record<StackAlign, string>> = {
+const flexAlignments: Record<Align, string> = {
   center: "items-center text-center",
   start: "items-center text-left",
   stretch: "items-stretch justify-stretch",
 };
 
-export const stackGaps: Record<StackGap, string> = {
+export const stackGaps: Record<Gap, string> = {
   none: "gap-0",
   xs: "gap-1",
   sm: "gap-2",
@@ -44,7 +36,7 @@ export const stackGaps: Record<StackGap, string> = {
   xl: "gap-8",
 };
 
-const stackWidths: Record<StackWidth, string> = {
+const stackWidths: Record<Width, string> = {
   full: "w-full",
   auto: "w-auto",
   sm: "mx-auto w-full max-w-md",
@@ -54,12 +46,12 @@ const stackWidths: Record<StackWidth, string> = {
   fill: "min-w-0 flex-1",
 };
 
-const stackHeights: Record<StackHeight, string> = {
+const stackHeights: Record<Height, string> = {
   full: "h-full",
   screen: "min-h-screen",
 };
 
-const floatClasses: Record<StackSide, string> = {
+const floatClasses: Record<Side, string> = {
   start: "mr-auto",
   end: "ml-auto",
 };
@@ -94,9 +86,7 @@ export function Stack({
       ref={ref}
       className={cn(
         isFlex ? cn("flex", direction === "row" ? "flex-wrap" : "flex-col") : "grid content-start",
-        isFlex
-          ? (flexAlignments[align] ?? flexAlignments.stretch)
-          : (gridAlignments[align] ?? gridAlignments.stretch),
+        isFlex ? flexAlignments[align] : gridAlignments[align],
         stackGaps[gap],
         stackWidths[width],
         justify ? justifyClasses[justify] : null,

--- a/packages/ui/resources/js/components/tabs/tabs.tsx
+++ b/packages/ui/resources/js/components/tabs/tabs.tsx
@@ -16,9 +16,6 @@ import { NativeSelect } from "../../primitives/native-select";
 import { pillClassName } from "../../lib/pill";
 import type { Orientation, TabsAlignment } from "../../generated";
 
-export type { TabsAlignment } from "../../generated";
-export type TabsOrientation = Orientation;
-
 export type TabsItem = {
   label: ReactNode;
   selectLabel?: string;
@@ -31,7 +28,7 @@ export type TabsProps = Omit<ComponentProps<"div">, "children" | "defaultValue" 
   defaultValue?: string;
   items?: readonly TabsItem[];
   onValueChange?: (value: string) => void;
-  orientation?: TabsOrientation;
+  orientation?: Orientation;
   sticky?: boolean;
   value?: string;
 };

--- a/packages/ui/resources/js/components/text/text-adapter.tsx
+++ b/packages/ui/resources/js/components/text/text-adapter.tsx
@@ -4,7 +4,7 @@ import { Text } from "./text";
 
 export const TextAdapter: RendererComponent<"text"> = ({ node }) => (
   <Text
-    align={node.props.align === "center" ? "center" : "left"}
+    align={node.props.align ?? undefined}
     className={node.props.class ?? undefined}
     color={node.props.color}
     copyable={node.props.copyable}

--- a/packages/ui/resources/js/components/text/text.tsx
+++ b/packages/ui/resources/js/components/text/text.tsx
@@ -3,10 +3,7 @@ import { CopyableText } from "../../primitives/copyable-text";
 import { coerceColor, colorValue, namedColor } from "../../lib/color";
 import { cn } from "../../lib/utils";
 import type { Color } from "../../types";
-import type { Align, Size } from "../../generated";
-
-export type TextAlign = Extract<Align, "center" | "left">;
-export type TextSize = Size;
+import type { Size, TextAlign } from "../../generated";
 
 export type TextProps = Omit<ComponentProps<"p">, "children" | "color"> & {
   align?: TextAlign;
@@ -15,7 +12,7 @@ export type TextProps = Omit<ComponentProps<"p">, "children" | "color"> & {
   copyable?: boolean;
   copyLabel?: string;
   copyValue?: string;
-  size?: TextSize;
+  size?: Size;
 };
 
 const textAlignments: Record<TextAlign, string> = {
@@ -23,7 +20,7 @@ const textAlignments: Record<TextAlign, string> = {
   left: "text-left",
 };
 
-const textSizes: Record<TextSize, string> = {
+const textSizes: Record<Size, string> = {
   xs: "text-xs leading-5",
   sm: "text-sm leading-6",
   md: "text-base leading-7",

--- a/packages/ui/resources/js/generated.ts
+++ b/packages/ui/resources/js/generated.ts
@@ -5,7 +5,7 @@ export type Accordion = {
   defaultOpen: string | null;
   gap: Gap | null;
 };
-export type Align = "center" | "left" | "start" | "stretch";
+export type Align = "center" | "start" | "stretch";
 export type Avatar = {
   name: string | null;
   shape: AvatarShape;
@@ -444,12 +444,13 @@ export type Tabs = {
 };
 export type TabsAlignment = "start" | "center" | "end" | "stretch";
 export type Text = {
-  align: Align | null;
+  align: TextAlign | null;
   color: Color | null;
   copyable: boolean;
   size: Size;
   text: string;
 };
+export type TextAlign = "left" | "center";
 export type TextEntry = {
   copyable: boolean;
   description: string | null;

--- a/packages/ui/resources/js/types.ts
+++ b/packages/ui/resources/js/types.ts
@@ -8,12 +8,15 @@ declare module "@lattice-php/core" {
 export type { Affix, Color, ColorKind, ColorName } from "@lattice-php/core";
 export type {
   Align,
+  AvatarShape,
   Breakpoint,
   Callout,
   ColumnWidth,
   ComponentPropsMap,
   DateFormat,
   DateTimeStyle,
+  Gap,
+  Height,
   HttpMethod,
   Justify,
   ModalHeight,
@@ -22,12 +25,17 @@ export type {
   NumberFormatUnit,
   Orientation,
   Placement,
+  ProgressShape,
   RetractCallout,
   Side,
   Size,
+  StackDirection,
+  TabsAlignment,
+  TextAlign,
   Toast,
   Translatable,
   UiNodeType,
+  Width,
 } from "./generated";
 
 export type UiNode = NodeUnionOf<UiNodeType>;

--- a/packages/ui/src/Components/Text.php
+++ b/packages/ui/src/Components/Text.php
@@ -8,7 +8,7 @@ use Lattice\Ui\Components\Concerns\HasPrimaryBinding;
 use Lattice\Ui\Concerns\HasColor;
 use Lattice\Ui\Concerns\HasCopyable;
 use Lattice\Ui\Concerns\HasSize;
-use Lattice\Ui\Enums\Align;
+use Lattice\Ui\Enums\TextAlign;
 
 #[AsComponent('text')]
 class Text extends Component
@@ -20,7 +20,7 @@ class Text extends Component
 
     public string $text = '';
 
-    public ?Align $align = null;
+    public ?TextAlign $align = null;
 
     public static function make(string $text, ?string $key = null): static
     {
@@ -30,7 +30,7 @@ class Text extends Component
         return $component;
     }
 
-    public function align(Align $align): static
+    public function align(TextAlign $align): static
     {
         $this->align = $align;
 

--- a/packages/ui/src/Enums/TextAlign.php
+++ b/packages/ui/src/Enums/TextAlign.php
@@ -6,9 +6,8 @@ namespace Lattice\Ui\Enums;
 use Lattice\Core\Attributes\TypeScript;
 
 #[TypeScript]
-enum Align: string
+enum TextAlign: string
 {
+    case Left = 'left';
     case Center = 'center';
-    case Start = 'start';
-    case Stretch = 'stretch';
 }

--- a/tests/Feature/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Feature/Core/Components/CoreTypedPropsTest.php
@@ -20,6 +20,7 @@ use Lattice\Ui\Enums\Side;
 use Lattice\Ui\Enums\Size;
 use Lattice\Ui\Enums\StackDirection;
 use Lattice\Ui\Enums\TabsAlignment;
+use Lattice\Ui\Enums\TextAlign;
 use Lattice\Ui\Enums\Width;
 
 it('stack serializes enums direction and key wire-identically', function (): void {
@@ -248,7 +249,7 @@ it('serializes the justify prop', function (): void {
 it('serializes text size and color styling', function (): void {
     $data = wire(
         Text::make('Manuel Christlieb')
-            ->align(Align::Center)
+            ->align(TextAlign::Center)
             ->size(Size::Sm)
             ->color(Color::default()),
     );


### PR DESCRIPTION
Follow-up to #560: instead of aliasing generated enum types under per-component names, the generated names are now the public vocabulary everywhere.

- **New `TextAlign` PHP enum** (`left`, `center`): `Text::align()` no longer accepts the full `Align` enum, so an unsupported alignment (`start`, `stretch`) is a PHP type error instead of the adapter silently clamping to `left`. The clamp is removed.
- **`Align::Left` removed** — it was unreachable (Stack's alignment maps never had a `left` entry and fell back to `stretch`; no call site used it). `Align` is now a coherent `start`/`center`/`stretch` vocabulary for Stack and Wizard, and Stack's alignment maps become full `Record`s without runtime fallback.
- **Type aliases dropped (breaking)**: `StackGap`/`StackAlign`/`StackJustify`/`StackWidth`/`StackHeight`/`StackSide`, `AvatarSize`, `TextSize`, `TabsOrientation`, `ProgressSize`, `DataTableAlign`/`DataTablePinSide`/`DataTableSortDirection`, `TwoColumnBreakpoint`. The barrels now export the generated names instead: `Gap`, `Align`, `Justify`, `Width`, `Height`, `Side`, `Size`, `Orientation`, `TabsAlignment`, `AvatarShape`, `ProgressShape`, `StackDirection`, `TextAlign` from `@lattice-php/ui`; `ColumnAlign`, `ColumnPin`, `SortDirection` from `@lattice-php/table`.
- Docs: `text.mdx` example updated, `TextAlign` added to the enums reference, enum fixture regenerated.

Wire values are unchanged except that `text.align` can no longer carry `start`/`stretch` (which rendered as `left` anyway).

Validated with Pest (Core, Docs, TypeScript suites), `typecheck`, docs typecheck, oxlint, `format:check`, `type-coverage` (99.81 %), `test:changed` (446 tests) and `build:lib`.
