### PR TITLE
feat(form): grid layout for repeater rows

### DIFF
--- a/docs/content/docs/forms/fields/repeater.mdx
+++ b/docs/content/docs/forms/fields/repeater.mdx
@@ -98,6 +98,21 @@ Repeater::make('items', 'Line items')
     ->resizableColumns(showIndicator: true);
 ```
 
+## Grid layout
+
+`->grid()` lays whole rows out side by side in a grid instead of stacking them — for rows that are
+columns of the final output, like the boxes of a document footer. Pass the column count (defaults
+to 2); rows wrap into the next line once a grid row is full:
+
+```php
+Repeater::make('footer_boxes', 'Footer boxes')
+    ->schema([
+        Textarea::make('content', 'Content'),
+    ])
+    ->grid(2)
+    ->maxItems(4);
+```
+
 ## Row actions
 
 Every row carries an action menu. By default it holds just **Remove** (hidden while the row is at

--- a/docs/fixtures/builder.basic.json
+++ b/docs/fixtures/builder.basic.json
@@ -9,6 +9,7 @@
             "dependsOnKeys": null,
             "disabled": false,
             "editablePrefill": false,
+            "gridColumns": null,
             "helperText": null,
             "label": "Line items",
             "labelAction": null,

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -322,6 +322,10 @@
             {
                 "name": "Table",
                 "value": "table"
+            },
+            {
+                "name": "Grid",
+                "value": "grid"
             }
         ],
         "name": "RowLayout",

--- a/docs/fixtures/repeater.basic.json
+++ b/docs/fixtures/repeater.basic.json
@@ -9,6 +9,7 @@
             "dependsOnKeys": null,
             "disabled": false,
             "editablePrefill": false,
+            "gridColumns": null,
             "helperText": null,
             "itemLabel": null,
             "itemLabels": null,

--- a/docs/fixtures/repeater.row-actions.json
+++ b/docs/fixtures/repeater.row-actions.json
@@ -9,6 +9,7 @@
             "dependsOnKeys": null,
             "disabled": false,
             "editablePrefill": false,
+            "gridColumns": null,
             "helperText": null,
             "itemLabel": null,
             "itemLabels": null,

--- a/packages/form/resources/js/components/repeater/repeater-adapter.test.tsx
+++ b/packages/form/resources/js/components/repeater/repeater-adapter.test.tsx
@@ -83,6 +83,31 @@ it("renders declared row actions in a kebab and duplicates a row", () => {
   expect(screen.getAllByTestId("child")).toHaveLength(2);
 });
 
+it("lays rows out in a grid when the layout is grid", () => {
+  wrap(
+    <RepeaterAdapter
+      node={fakeNode({
+        id: "r",
+        type: "field.repeater",
+        props: {
+          name: "items",
+          defaultItems: 2,
+          layout: "grid",
+          gridColumns: 3,
+          label: "Boxes",
+        },
+        schema: [{ id: "c", type: "field.text-input", props: { name: "name", label: "Name" } }],
+      })}
+    >
+      {null}
+    </RepeaterAdapter>,
+  );
+
+  const grid = screen.getByTestId("repeater-items-grid");
+  expect(grid).toHaveClass("grid");
+  expect(grid).toHaveStyle({ gridTemplateColumns: "repeat(3, minmax(0, 1fr))" });
+});
+
 it("shows the array-level error for the repeater field", () => {
   wrap(<RepeaterAdapter node={repeaterNode}>{null}</RepeaterAdapter>, {
     errors: { items: "Must have at least 1 item" },

--- a/packages/form/resources/js/components/repeater/repeater-adapter.tsx
+++ b/packages/form/resources/js/components/repeater/repeater-adapter.tsx
@@ -28,6 +28,7 @@ export const RepeaterAdapter: RendererComponent<"field.repeater"> = ({ node }) =
   const atMax = props.maxItems != null && rows.length >= props.maxItems;
   const atMin = props.minItems != null && rows.length <= props.minItems;
   const isTable = props.layout === "table";
+  const isGrid = props.layout === "grid";
   const itemLabels = props.itemLabels;
   const rowHeading = (index: number) => {
     const label = itemLabels?.[index];
@@ -82,29 +83,41 @@ export const RepeaterAdapter: RendererComponent<"field.repeater"> = ({ node }) =
               resizeIndicator={props.resizeIndicator === true}
             />
           ) : (
-            rows.map((row, index) => {
-              const key = String(row[ROW_ID_KEY] ?? index);
-              return (
-                <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
-                  <RowItem
-                    base={path}
-                    index={index}
-                    row={row}
-                    template={template}
-                    heading={rowHeading(index)}
-                    reorderable={props.reorderable ?? false}
-                    isFirst={index === 0}
-                    isLast={index === rows.length - 1}
-                    removable={!atMin}
-                    rowActions={props.rowActions}
-                    onField={onField}
-                    onRemove={onRemove}
-                    onMove={onMove}
-                    onDuplicate={onDuplicate}
-                  />
-                </div>
-              );
-            })
+            <div
+              className={isGrid ? "grid gap-3" : "flex flex-col gap-3"}
+              data-test={isGrid ? `repeater-${name}-grid` : undefined}
+              style={
+                isGrid
+                  ? {
+                      gridTemplateColumns: `repeat(${props.gridColumns ?? 2}, minmax(0, 1fr))`,
+                    }
+                  : undefined
+              }
+            >
+              {rows.map((row, index) => {
+                const key = String(row[ROW_ID_KEY] ?? index);
+                return (
+                  <div key={key} ref={(el) => registerRow(key, el)} data-flip-key={key}>
+                    <RowItem
+                      base={path}
+                      index={index}
+                      row={row}
+                      template={template}
+                      heading={rowHeading(index)}
+                      reorderable={props.reorderable ?? false}
+                      isFirst={index === 0}
+                      isLast={index === rows.length - 1}
+                      removable={!atMin}
+                      rowActions={props.rowActions}
+                      onField={onField}
+                      onRemove={onRemove}
+                      onMove={onMove}
+                      onDuplicate={onDuplicate}
+                    />
+                  </div>
+                );
+              })}
+            </div>
           )}
 
           {!atMax && (

--- a/packages/form/resources/js/generated.ts
+++ b/packages/form/resources/js/generated.ts
@@ -18,6 +18,7 @@ export type Builder = {
   dependsOnKeys: string[] | null;
   disabled: boolean;
   editablePrefill: boolean;
+  gridColumns: number | null;
   helperText: string | null;
   label: string | null;
   labelAction: Node | null;
@@ -491,6 +492,7 @@ export type Repeater = {
   dependsOnKeys: string[] | null;
   disabled: boolean;
   editablePrefill: boolean;
+  gridColumns: number | null;
   helperText: string | null;
   itemLabel: string | null;
   itemLabels: (string | null)[] | null;
@@ -546,7 +548,7 @@ export type RowAction = {
   type: RowActionType;
 };
 export type RowActionType = "duplicate" | "remove";
-export type RowLayout = "stack" | "table";
+export type RowLayout = "stack" | "table" | "grid";
 export type RowTemplateData = {
   readonly label: string;
   readonly schema: Node[];

--- a/packages/form/src/Components/Concerns/HasRowLayout.php
+++ b/packages/form/src/Components/Concerns/HasRowLayout.php
@@ -10,6 +10,8 @@ trait HasRowLayout
 {
     public RowLayout $layout = RowLayout::Stack;
 
+    public ?int $gridColumns = null;
+
     public bool $resizableColumns = false;
 
     public bool $resizeIndicator = false;
@@ -17,6 +19,18 @@ trait HasRowLayout
     public function table(): static
     {
         $this->layout = RowLayout::Table;
+
+        return $this;
+    }
+
+    /**
+     * Lays the rows out side by side in a grid of the given column count
+     * instead of stacking them.
+     */
+    public function grid(int $columns = 2): static
+    {
+        $this->layout = RowLayout::Grid;
+        $this->gridColumns = max(1, $columns);
 
         return $this;
     }

--- a/packages/form/src/Enums/RowLayout.php
+++ b/packages/form/src/Enums/RowLayout.php
@@ -11,4 +11,5 @@ enum RowLayout: string
 {
     case Stack = 'stack';
     case Table = 'table';
+    case Grid = 'grid';
 }

--- a/tests/Unit/Forms/Components/RowLayoutTest.php
+++ b/tests/Unit/Forms/Components/RowLayoutTest.php
@@ -19,6 +19,15 @@ it('opts into the table layout via table()', function (): void {
         ->and($builder['props']['layout'])->toBe('table');
 });
 
+it('opts into the grid layout with a column count via grid()', function (): void {
+    $default = wire(Repeater::make('items')->grid()->schema([TextInput::make('a')]));
+    $three = wire(Repeater::make('items')->grid(3)->schema([TextInput::make('a')]));
+
+    expect($default['props']['layout'])->toBe('grid')
+        ->and($default['props']['gridColumns'])->toBe(2)
+        ->and($three['props']['gridColumns'])->toBe(3);
+});
+
 it('serializes table layout column width hints on row fields', function (): void {
     $wire = wire(Repeater::make('items')->table()->schema([
         TextInput::make('qty')->columnWidth(ColumnWidth::Xs),


### PR DESCRIPTION
`Repeater::grid($columns)` (default 2) lays whole rows out side by side in a CSS grid instead of stacking them — a third `RowLayout` case next to `stack` and `table`, for rows that are columns of the final output (e.g. document footer boxes). Wire gains `gridColumns`; docs and fixtures updated. Validated with the full Pest suite (2003), form vitest (373), and typecheck.