### PR TITLE
fix(media): drop conversion jobs whose media was deleted before commit

### DIFF
--- a/packages/media/src/Jobs/GenerateMediaConversions.php
+++ b/packages/media/src/Jobs/GenerateMediaConversions.php
@@ -24,6 +24,14 @@ final class GenerateMediaConversions implements ShouldQueue
     /** The overlap middleware releases the job, and a release costs an attempt. */
     public int $tries = 3;
 
+    /**
+     * The job runs after commit, and by then a `syncMedia()` in the same
+     * transaction may already have replaced the media it was queued for.
+     * A conversion for a deleted row has nothing to do; failing it would
+     * only fill the failed-jobs table.
+     */
+    public bool $deleteWhenMissingModels = true;
+
     public function __construct(
         public Media $media,
         public ?Model $attachable = null,

--- a/tests/Feature/Media/GenerateMediaConversionsTest.php
+++ b/tests/Feature/Media/GenerateMediaConversionsTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Image\Image;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Lattice\Media\Jobs\GenerateMediaConversions;
@@ -247,4 +248,15 @@ test('overlapping jobs for the same media are released, retried and never deadlo
     expect($middleware)->toHaveCount(1);
     expect($middleware[0]->key)->toBe((string) $media->getKey());
     expect($job->tries)->toBeGreaterThan(1);
+});
+
+test('a queued job whose media was deleted before commit is dropped instead of failing', function (): void {
+    $media = fakeImageMedia();
+
+    DB::transaction(function () use ($media): void {
+        GenerateMediaConversions::dispatch($media);
+        $media->delete();
+    });
+
+    expect(Media::query()->whereKey($media->getKey())->exists())->toBeFalse();
 });


### PR DESCRIPTION
`GenerateMediaConversions` is dispatched `afterCommit()`. When a `syncMedia()` in the same transaction replaces the media the job was queued for (artisan-os does that when it re-renders a quote PDF), the row is gone by the time the job restores its model, and the commit blew up with `ModelNotFoundException`.

The job now sets `deleteWhenMissingModels`, so the queue discards it silently. A conversion for a deleted row has nothing to do.

Test: dispatch inside a transaction, delete the media before commit, commit must not throw.
