### PR TITLE
fix(ui): let centered dialogs grow with their content

### DIFF
--- a/docs/content/docs/components/modals.mdx
+++ b/docs/content/docs/components/modals.mdx
@@ -100,10 +100,12 @@ closes every modal currently open, not just the topmost one.
 - `->width(ModalWidth::…)` sets the dialog width — the max width of a centered dialog and the panel
   width of a sheet. Defaults to `ModalWidth::Lg` (32rem). The scale runs `Sm` (24rem) through `Xl7`
   (80rem), plus `ModalWidth::Max`, which stretches to the viewport minus a 1rem inset.
-- `->height(ModalHeight::…)` caps a centered dialog's height (`Sm` ≈ 480px through `Xl5` ≈ 1280px,
-  defaults to `ModalHeight::Lg`); content beyond the cap scrolls. `ModalHeight::Max` pins the dialog
-  to the viewport height minus a 1rem inset — combined with `ModalWidth::Max` the dialog fills the
-  screen. Sheets are always full height, so `->height()` has no effect on them.
+- A centered dialog grows with its content: the backdrop is the scroll container, so a long form
+  scrolls the page behind the dialog instead of a scrollbar inside it. `->height(ModalHeight::…)`
+  caps the dialog instead (`Sm` ≈ 480px through `Xl5` ≈ 1280px) and scrolls content beyond the cap
+  inside the dialog. `ModalHeight::Max` pins the dialog to the viewport height minus a 1rem inset —
+  combined with `ModalWidth::Max` the dialog fills the screen. Sheets are always full height, so
+  `->height()` has no effect on them.
 
 ## Slide-out sheets
 

--- a/packages/ui/resources/js/components/modal/modal-adapter.test.tsx
+++ b/packages/ui/resources/js/components/modal/modal-adapter.test.tsx
@@ -31,6 +31,28 @@ describe("ModalAdapter", () => {
     expect(screen.queryByText("Welcome")).not.toBeInTheDocument();
   });
 
+  it("grows with its content inside a scrolling overlay by default", () => {
+    renderModal(fakeNode({ type: "modal", id: "welcome", props: { title: "Welcome" } }));
+
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]');
+    const content = document.querySelector('[data-slot="dialog-content"]');
+    expect(overlay).toHaveClass("overflow-y-auto");
+    expect(overlay).toContainElement(content as HTMLElement);
+    expect(content).not.toHaveClass("fixed");
+    expect(content).not.toHaveClass("overflow-y-auto");
+    expect(content?.className).not.toMatch(/max-h-/);
+  });
+
+  it("caps and scrolls the dialog itself when a height is given", () => {
+    renderModal(
+      fakeNode({ type: "modal", id: "welcome", props: { title: "Welcome", height: "lg" } }),
+    );
+
+    const content = document.querySelector('[data-slot="dialog-content"]');
+    expect(content).toHaveClass("max-h-[min(680px,calc(100vh-2rem))]");
+    expect(content).toHaveClass("overflow-y-auto");
+  });
+
   it("fills the viewport at width and height max", () => {
     renderModal(
       fakeNode({

--- a/packages/ui/resources/js/components/modal/modal-adapter.tsx
+++ b/packages/ui/resources/js/components/modal/modal-adapter.tsx
@@ -40,7 +40,7 @@ export const ModalAdapter: RendererComponent<"modal"> = ({ children, node }) => 
         onCloseAutoFocus={context.onExited}
         placement={node.props.side ?? "center"}
         width={node.props.width}
-        height={node.props.height}
+        height={node.props.height ?? undefined}
       >
         <DialogHeader closeLabel={closeLabel} description={description} title={title} />
         <div className="mt-6 space-y-6">{children}</div>

--- a/packages/ui/resources/js/generated.ts
+++ b/packages/ui/resources/js/generated.ts
@@ -272,7 +272,7 @@ export type MenuItem = {
 export type Modal = {
   closeLabel: string;
   description: string | null;
-  height: ModalHeight;
+  height: ModalHeight | null;
   side: Side | null;
   title: string | null;
   width: ModalWidth;

--- a/packages/ui/resources/js/primitives/dialog.browser.test.tsx
+++ b/packages/ui/resources/js/primitives/dialog.browser.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+
+function overlay(): HTMLElement {
+  const element = document.querySelector<HTMLElement>('[data-slot="dialog-overlay"]');
+
+  if (!element) {
+    throw new Error("dialog overlay not rendered");
+  }
+
+  return element;
+}
+
+function content(): HTMLElement {
+  const element = document.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+
+  if (!element) {
+    throw new Error("dialog content not rendered");
+  }
+
+  return element;
+}
+
+describe("Dialog in a browser", () => {
+  it("centers a short dialog without scrolling", async () => {
+    const screen = await render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined}>
+          <DialogTitle>Short</DialogTitle>
+          <p>One line</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    await expect.element(screen.getByText("One line")).toBeVisible();
+
+    const box = content().getBoundingClientRect();
+    expect(overlay().scrollHeight).toBe(overlay().clientHeight);
+    expect(Math.abs(box.top + box.height / 2 - window.innerHeight / 2)).toBeLessThan(2);
+  });
+
+  it("grows a tall dialog past the viewport and scrolls the overlay instead of the panel", async () => {
+    const screen = await render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined}>
+          <DialogTitle>Tall</DialogTitle>
+          <div style={{ height: 3000 }}>Tall body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    await expect.element(screen.getByText("Tall body")).toBeInTheDocument();
+
+    expect(content().getBoundingClientRect().height).toBeGreaterThan(3000);
+    expect(content().scrollHeight).toBe(content().clientHeight);
+    expect(overlay().scrollHeight).toBeGreaterThan(overlay().clientHeight);
+
+    overlay().scrollTop = overlay().scrollHeight;
+    expect(overlay().scrollTop).toBeGreaterThan(0);
+  });
+
+  it("caps a dialog at the requested height and scrolls inside it", async () => {
+    const screen = await render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined} height="sm">
+          <DialogTitle>Capped</DialogTitle>
+          <div style={{ height: 3000 }}>Capped body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    await expect.element(screen.getByText("Capped body")).toBeInTheDocument();
+
+    expect(content().getBoundingClientRect().height).toBeLessThanOrEqual(480);
+    expect(content().scrollHeight).toBeGreaterThan(content().clientHeight);
+    expect(overlay().scrollHeight).toBe(overlay().clientHeight);
+  });
+});

--- a/packages/ui/resources/js/primitives/dialog.tsx
+++ b/packages/ui/resources/js/primitives/dialog.tsx
@@ -8,60 +8,96 @@ import type { ModalHeight, ModalWidth, Side } from "../types";
 
 export type DialogPlacement = "center" | Side;
 
-const dialogContentVariants = cva(
-  "fixed z-lt-modal w-full overflow-y-auto bg-lt-bg p-6 shadow-lt-lg",
-  {
-    variants: {
-      placement: {
-        center:
-          "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lt border border-lt-border data-[state=open]:animate-lt-dialog-in data-[state=closed]:animate-lt-dialog-out",
-        start:
-          "inset-y-0 start-0 border-e border-lt-border data-[state=open]:animate-lt-sheet-in-start data-[state=closed]:animate-lt-sheet-out-start",
-        end: "inset-y-0 end-0 border-s border-lt-border data-[state=open]:animate-lt-sheet-in-end data-[state=closed]:animate-lt-sheet-out-end",
-      },
-      width: {
-        sm: "max-w-sm",
-        md: "max-w-md",
-        lg: "max-w-lg",
-        xl: "max-w-xl",
-        "2xl": "max-w-2xl",
-        "3xl": "max-w-3xl",
-        "4xl": "max-w-4xl",
-        "5xl": "max-w-5xl",
-        "6xl": "max-w-6xl",
-        "7xl": "max-w-7xl",
-        max: "max-w-[calc(100vw-2rem)]",
-      } satisfies Record<ModalWidth, string>,
-      height: {
-        sm: "",
-        md: "",
-        lg: "",
-        xl: "",
-        "2xl": "",
-        "3xl": "",
-        "4xl": "",
-        "5xl": "",
-        max: "",
-      } satisfies Record<ModalHeight, string>,
+const overlayClassName =
+  "fixed inset-0 z-lt-overlay bg-lt-overlay data-[state=open]:animate-lt-fade-in data-[state=closed]:animate-lt-fade-out";
+
+/* A centered dialog grows with its content: it sits inside the overlay, which
+   is the scroll container, so a long form scrolls the page behind the backdrop
+   instead of a scrollbar inside the panel. An explicit height caps the panel
+   and scrolls inside it again. Sheets stay pinned to the viewport edge. */
+const dialogContentVariants = cva("z-lt-modal w-full bg-lt-bg p-6 shadow-lt-lg", {
+  variants: {
+    placement: {
+      center:
+        "relative rounded-lt border border-lt-border data-[state=open]:animate-lt-dialog-in data-[state=closed]:animate-lt-dialog-out",
+      start:
+        "fixed inset-y-0 start-0 overflow-y-auto border-e border-lt-border data-[state=open]:animate-lt-sheet-in-start data-[state=closed]:animate-lt-sheet-out-start",
+      end: "fixed inset-y-0 end-0 overflow-y-auto border-s border-lt-border data-[state=open]:animate-lt-sheet-in-end data-[state=closed]:animate-lt-sheet-out-end",
     },
-    compoundVariants: [
-      { placement: "center", height: "sm", class: "max-h-[min(480px,calc(100vh-2rem))]" },
-      { placement: "center", height: "md", class: "max-h-[min(600px,calc(100vh-2rem))]" },
-      { placement: "center", height: "lg", class: "max-h-[min(680px,calc(100vh-2rem))]" },
-      { placement: "center", height: "xl", class: "max-h-[min(820px,calc(100vh-2rem))]" },
-      { placement: "center", height: "2xl", class: "max-h-[min(920px,calc(100vh-2rem))]" },
-      { placement: "center", height: "3xl", class: "max-h-[min(1040px,calc(100vh-2rem))]" },
-      { placement: "center", height: "4xl", class: "max-h-[min(1160px,calc(100vh-2rem))]" },
-      { placement: "center", height: "5xl", class: "max-h-[min(1280px,calc(100vh-2rem))]" },
-      {
-        placement: "center",
-        height: "max",
-        class: "h-[calc(100vh-2rem)] max-h-[calc(100vh-2rem)]",
-      },
-    ],
-    defaultVariants: { placement: "center", width: "lg", height: "lg" },
+    width: {
+      sm: "max-w-sm",
+      md: "max-w-md",
+      lg: "max-w-lg",
+      xl: "max-w-xl",
+      "2xl": "max-w-2xl",
+      "3xl": "max-w-3xl",
+      "4xl": "max-w-4xl",
+      "5xl": "max-w-5xl",
+      "6xl": "max-w-6xl",
+      "7xl": "max-w-7xl",
+      max: "max-w-[calc(100vw-2rem)]",
+    } satisfies Record<ModalWidth, string>,
+    height: {
+      sm: "",
+      md: "",
+      lg: "",
+      xl: "",
+      "2xl": "",
+      "3xl": "",
+      "4xl": "",
+      "5xl": "",
+      max: "",
+    } satisfies Record<ModalHeight, string>,
   },
-);
+  compoundVariants: [
+    {
+      placement: "center",
+      height: "sm",
+      class: "max-h-[min(480px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "md",
+      class: "max-h-[min(600px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "lg",
+      class: "max-h-[min(680px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "xl",
+      class: "max-h-[min(820px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "2xl",
+      class: "max-h-[min(920px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "3xl",
+      class: "max-h-[min(1040px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "4xl",
+      class: "max-h-[min(1160px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "5xl",
+      class: "max-h-[min(1280px,calc(100vh-2rem))] overflow-y-auto",
+    },
+    {
+      placement: "center",
+      height: "max",
+      class: "h-[calc(100vh-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto",
+    },
+  ],
+  defaultVariants: { placement: "center", width: "lg" },
+});
 
 function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
@@ -103,26 +139,40 @@ function DialogContent({
   className,
   placement = "center",
   width = "lg",
-  height = "lg",
+  height,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   placement?: DialogPlacement;
   width?: ModalWidth;
   height?: ModalHeight;
 }) {
+  const content = (
+    <DialogPrimitive.Content
+      className={cn(dialogContentVariants({ placement, width, height }), className)}
+      data-slot="dialog-content"
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  );
+
+  if (placement !== "center") {
+    return (
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className={overlayClassName} data-slot="dialog-overlay" />
+        {content}
+      </DialogPrimitive.Portal>
+    );
+  }
+
   return (
     <DialogPrimitive.Portal>
       <DialogPrimitive.Overlay
-        className="fixed inset-0 z-lt-overlay bg-lt-overlay data-[state=open]:animate-lt-fade-in data-[state=closed]:animate-lt-fade-out"
+        className={cn(overlayClassName, "overflow-y-auto")}
         data-slot="dialog-overlay"
-      />
-      <DialogPrimitive.Content
-        className={cn(dialogContentVariants({ placement, width, height }), className)}
-        data-slot="dialog-content"
-        {...props}
       >
-        {children}
-      </DialogPrimitive.Content>
+        <div className="grid min-h-full place-items-center p-4">{content}</div>
+      </DialogPrimitive.Overlay>
     </DialogPrimitive.Portal>
   );
 }

--- a/packages/ui/src/Components/Modal.php
+++ b/packages/ui/src/Components/Modal.php
@@ -24,7 +24,7 @@ class Modal extends ContainerComponent
 
     public ModalWidth $width = ModalWidth::Lg;
 
-    public ModalHeight $height = ModalHeight::Lg;
+    public ?ModalHeight $height = null;
 
     public function __construct(?string $key = null)
     {
@@ -76,6 +76,10 @@ class Modal extends ContainerComponent
         return $this;
     }
 
+    /**
+     * Cap a centered dialog's height and scroll inside it; without a cap the
+     * dialog grows with its content and the page scrolls behind it.
+     */
     public function height(ModalHeight $height): static
     {
         $this->height = $height;

--- a/tests/Feature/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Feature/Core/Components/CoreTypedPropsTest.php
@@ -85,7 +85,7 @@ it('modal serializes id title description and children', function (): void {
                 'closeLabel' => 'Close',
                 'side' => null,
                 'width' => 'lg',
-                'height' => 'lg',
+                'height' => null,
             ],
             'schema' => [
                 ['type' => 'text', 'props' => ['text' => 'Body', 'align' => null, 'size' => 'md', 'color' => null, 'copyable' => false]],
@@ -104,7 +104,7 @@ it('modal without optional props includes them as null', function (): void {
                 'closeLabel' => 'Close',
                 'side' => null,
                 'width' => 'lg',
-                'height' => 'lg',
+                'height' => null,
             ],
         ]);
 });


### PR DESCRIPTION
## Summary

Centered dialogs were pinned to a max height per `ModalHeight` step (680px by default) and scrolled inside the panel, so any longer form ended up with an inner scrollbar. The overlay is now the scroll container: the panel sits inside it (Radix's scrollable-overlay pattern), grows with its content, and the page scrolls behind the backdrop. Short dialogs stay centered exactly as before.

- `->height(ModalHeight::…)` becomes an explicit cap: it limits the panel and scrolls inside it, `Max` still fills the viewport. `Modal::$height` no longer defaults to `Lg` (`ModalHeight | null` on the wire).
- Action form modals get the growing behaviour automatically since they never passed a height.
- Sheets (`start`/`end`) are unchanged.

## Verification

- New `dialog.browser.test.tsx` (Chromium): short dialog centered without scroll, tall dialog grows past the viewport and scrolls the overlay while the panel itself does not, explicit `height="sm"` caps and scrolls inside.
- `modal-adapter.test.tsx` covers the default and the capped wire shapes; `CoreTypedPropsTest` updated for the `null` default.
- `npm run check:push` and the PHP gate passed on push. The `board` QuickAdd focus browser test flaked once under the parallel run and passes alone on both `main` and this branch.
