### PR TITLE
feat(form): distinct read-only field treatment

### DIFF
--- a/packages/form/resources/js/components/checkbox/checkbox-adapter.test.tsx
+++ b/packages/form/resources/js/components/checkbox/checkbox-adapter.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { fakeNode } from "@lattice-php/core/test-support";
+import { createFieldRenderer } from "../../test-support";
+import { CheckboxAdapter } from "./checkbox-adapter";
+
+const renderField = createFieldRenderer(CheckboxAdapter);
+
+describe("CheckboxAdapter", () => {
+  it("toggles the value on click", () => {
+    renderField(
+      fakeNode({
+        type: "field.checkbox",
+        props: { label: "Accept terms", name: "terms", value: false },
+      }),
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Accept terms" });
+
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("does not toggle while read-only but stays focusable", () => {
+    renderField(
+      fakeNode({
+        type: "field.checkbox",
+        props: { label: "Accept terms", name: "terms", readOnly: true, value: true },
+      }),
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Accept terms" });
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).not.toBeDisabled();
+    expect(checkbox).toHaveAttribute("aria-readonly", "true");
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("does not toggle while disabled", () => {
+    renderField(
+      fakeNode({
+        type: "field.checkbox",
+        props: { disabled: true, label: "Accept terms", name: "terms", value: false },
+      }),
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Accept terms" });
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
+  });
+});

--- a/packages/form/resources/js/components/checkbox/checkbox-adapter.tsx
+++ b/packages/form/resources/js/components/checkbox/checkbox-adapter.tsx
@@ -19,13 +19,18 @@ export const CheckboxAdapter: RendererComponent<"field.checkbox"> = ({ node }) =
     <div>
       <div className="flex items-center space-x-3">
         <Checkbox
+          aria-readonly={field.readOnly && !field.disabled ? true : undefined}
           autoFocus={node.props.autoFocus ?? undefined}
           checked={checked}
           data-test={field.testId}
-          disabled={field.readOnly || field.disabled}
+          disabled={field.disabled}
           id={field.name}
           name={field.name}
           onCheckedChange={(next) => {
+            if (field.readOnly) {
+              return;
+            }
+
             field.commit(next === true);
           }}
           tabIndex={node.props.tabIndex ?? undefined}

--- a/packages/form/resources/js/components/checkbox/checkbox.tsx
+++ b/packages/form/resources/js/components/checkbox/checkbox.tsx
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-lt-input data-[state=checked]:bg-lt-primary data-[state=checked]:text-lt-primary-fg data-[state=checked]:border-lt-primary focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger size-4 shrink-0 rounded-lt-xs border shadow-lt-xs transition-shadow outline-none focus-visible:ring-[length:var(--lt-ring-width)] disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:data-[state=checked]:bg-lt-disabled disabled:data-[state=checked]:text-lt-disabled-fg disabled:data-[state=checked]:border-lt-disabled",
+        "peer border-lt-input data-[state=checked]:bg-lt-primary data-[state=checked]:text-lt-primary-fg data-[state=checked]:border-lt-primary focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger size-4 shrink-0 rounded-lt-xs border shadow-lt-xs transition-shadow outline-none focus-visible:ring-[length:var(--lt-ring-width)] aria-readonly:cursor-default aria-readonly:data-[state=unchecked]:bg-lt-muted disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:data-[state=checked]:bg-lt-disabled disabled:data-[state=checked]:text-lt-disabled-fg disabled:data-[state=checked]:border-lt-disabled",
         className,
       )}
       {...props}

--- a/packages/form/resources/js/components/color-picker/color-picker-adapter.tsx
+++ b/packages/form/resources/js/components/color-picker/color-picker-adapter.tsx
@@ -23,9 +23,11 @@ export const ColorPickerAdapter: RendererComponent<"field.color-picker"> = ({ no
             <PopoverTrigger asChild>
               <button
                 {...controlProps}
+                aria-readonly={readOnly && !disabled ? true : undefined}
                 className={cn(controlSurface(), "flex items-center gap-2 text-left")}
                 data-test={`color-picker-${name}`}
-                disabled={disabled || readOnly}
+                disabled={disabled}
+                onClick={readOnly ? (event) => event.preventDefault() : undefined}
                 type="button"
               >
                 {hex ? (

--- a/packages/form/resources/js/components/pattern-input/pattern-input-view.tsx
+++ b/packages/form/resources/js/components/pattern-input/pattern-input-view.tsx
@@ -165,7 +165,8 @@ const PatternInputField: RendererComponent<"field.pattern-input"> = ({ node }) =
             {...controlProps}
             className={cn(
               "overflow-hidden rounded-lt-sm border border-lt-input bg-transparent shadow-lt-xs focus-within:border-lt-ring focus-within:ring-[length:var(--lt-ring-width)] focus-within:ring-lt-ring/50",
-              locked && "opacity-60",
+              disabled && "opacity-60",
+              readOnly && !disabled && "cursor-default bg-lt-muted",
             )}
             role="group"
           >

--- a/packages/form/resources/js/components/rich-editor/rich-editor-view.tsx
+++ b/packages/form/resources/js/components/rich-editor/rich-editor-view.tsx
@@ -168,7 +168,8 @@ const RichEditorField: RendererComponent<"field.rich-editor"> = ({ node }) => {
             {...controlProps}
             className={cn(
               "overflow-hidden rounded-lt-sm border border-lt-input bg-transparent shadow-lt-xs focus-within:border-lt-ring focus-within:ring-[length:var(--lt-ring-width)] focus-within:ring-lt-ring/50",
-              locked && "opacity-60",
+              disabled && "opacity-60",
+              readOnly && !disabled && "cursor-default bg-lt-muted",
             )}
             role="group"
           >

--- a/packages/form/resources/js/components/select/select-adapter.test.tsx
+++ b/packages/form/resources/js/components/select/select-adapter.test.tsx
@@ -148,6 +148,25 @@ describe("SelectAdapter options", () => {
     expect(screen.getByTestId("select-color")).toHaveTextContent("Blue");
   });
 
+  it("stays focusable but does not open while read-only", () => {
+    renderStaticSelect({
+      options: [
+        { label: "Red", value: "red" },
+        { label: "Blue", value: "blue" },
+      ],
+      readOnly: true,
+      value: "red",
+    });
+
+    const trigger = screen.getByTestId("select-color");
+
+    fireEvent.click(trigger);
+
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).toHaveAttribute("aria-readonly", "true");
+    expect(screen.queryByTestId("select-color-option-blue")).not.toBeInTheDocument();
+  });
+
   it("omits the search box when not searchable", () => {
     renderStaticSelect({
       options: [

--- a/packages/form/resources/js/components/select/select-control.tsx
+++ b/packages/form/resources/js/components/select/select-control.tsx
@@ -223,9 +223,10 @@ export function SelectControl({
         triggerProps={{
           ...controlProps,
           "aria-haspopup": "listbox",
+          "aria-readonly": readOnly && !disabled ? true : undefined,
           autoFocus: props.autoFocus ?? undefined,
           "data-test": `select-${name}`,
-          disabled: locked,
+          disabled,
           tabIndex: props.tabIndex ?? undefined,
         }}
       />

--- a/packages/form/resources/js/components/select/select.tsx
+++ b/packages/form/resources/js/components/select/select.tsx
@@ -123,11 +123,14 @@ export function MultiSelect({
             <Icon name="chevrons-up-down" className="size-lt-icon-md shrink-0 text-lt-muted-fg" />
           </>
         }
-        triggerClassName={cn(
-          triggerClassName ?? cn(controlSurface(), "flex items-center justify-between gap-2"),
-          "text-left",
-          locked && "cursor-not-allowed opacity-60",
-        )}
+        triggerClassName={
+          triggerClassName
+            ? cn(
+                triggerClassName,
+                "text-left aria-readonly:cursor-default disabled:cursor-not-allowed disabled:opacity-60",
+              )
+            : cn(controlSurface(), "flex items-center justify-between gap-2 text-left")
+        }
         triggerProps={triggerProps}
       />
     </div>

--- a/packages/form/resources/js/components/textarea/textarea.tsx
+++ b/packages/form/resources/js/components/textarea/textarea.tsx
@@ -7,8 +7,9 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
     <textarea
       data-slot="textarea"
+      aria-readonly={props.readOnly && !props.disabled ? true : undefined}
       className={cn(
-        "border-lt-input placeholder:text-lt-muted-fg flex field-sizing-content min-h-16 w-full rounded-lt-sm border bg-transparent px-3 py-2 text-base shadow-lt-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg",
+        "border-lt-input placeholder:text-lt-muted-fg flex field-sizing-content min-h-16 w-full rounded-lt-sm border bg-transparent px-3 py-2 text-base shadow-lt-xs transition-[color,box-shadow] outline-none aria-readonly:cursor-default aria-readonly:bg-lt-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg",
         FOCUS_RING,
         "aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger",
         className,

--- a/packages/form/resources/js/components/toggle/toggle-adapter.test.tsx
+++ b/packages/form/resources/js/components/toggle/toggle-adapter.test.tsx
@@ -47,14 +47,28 @@ describe("ToggleAdapter", () => {
     );
   });
 
-  it.each([
-    { state: "read-only", props: { readOnly: true, value: true }, checked: "true" },
-    { state: "disabled", props: { disabled: true, value: false }, checked: "false" },
-  ])("does not toggle while $state", ({ props, checked }) => {
+  it("does not toggle while read-only but stays focusable", () => {
     renderField(
       fakeNode({
         type: "field.toggle",
-        props: { label: "Locked", name: "locked", ...props },
+        props: { label: "Locked", name: "locked", readOnly: true, value: true },
+      }),
+    );
+
+    const toggle = screen.getByRole("switch", { name: "Locked" });
+
+    fireEvent.click(toggle);
+
+    expect(toggle).not.toBeDisabled();
+    expect(toggle).toHaveAttribute("aria-readonly", "true");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("does not toggle while disabled", () => {
+    renderField(
+      fakeNode({
+        type: "field.toggle",
+        props: { label: "Locked", name: "locked", disabled: true, value: false },
       }),
     );
 
@@ -63,7 +77,7 @@ describe("ToggleAdapter", () => {
     fireEvent.click(toggle);
 
     expect(toggle).toBeDisabled();
-    expect(toggle).toHaveAttribute("aria-checked", checked);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
   });
 
   it("uses the field name as its accessible label when no label is set", () => {

--- a/packages/form/resources/js/components/toggle/toggle-adapter.tsx
+++ b/packages/form/resources/js/components/toggle/toggle-adapter.tsx
@@ -21,12 +21,17 @@ export const ToggleAdapter: RendererComponent<"field.toggle"> = ({ node }) => {
             <Toggle
               {...controlProps}
               aria-label={props.label ?? props.name}
+              aria-readonly={readOnly && !disabled ? true : undefined}
               autoFocus={props.autoFocus ?? false}
               checked={checked}
               data-test={testId}
-              disabled={locked}
+              disabled={disabled}
               name={name}
-              onCheckedChange={(next) => commit(next)}
+              onCheckedChange={(next) => {
+                if (!readOnly) {
+                  commit(next);
+                }
+              }}
               tabIndex={props.tabIndex ?? undefined}
             />
           </>

--- a/packages/form/resources/js/components/toggle/toggle.tsx
+++ b/packages/form/resources/js/components/toggle/toggle.tsx
@@ -12,7 +12,7 @@ export function Toggle({ checked, className, onCheckedChange, ...props }: Toggle
       {...props}
       aria-checked={checked}
       className={cn(
-        "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-lt-muted p-0.5 shadow-lt-xs transition-colors outline-none focus-visible:border-lt-ring focus-visible:ring-[length:var(--lt-ring-width)] focus-visible:ring-lt-ring/50 disabled:cursor-not-allowed disabled:bg-lt-disabled data-[state=checked]:bg-lt-primary disabled:data-[state=checked]:bg-lt-disabled",
+        "inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-lt-muted p-0.5 shadow-lt-xs transition-colors outline-none focus-visible:border-lt-ring focus-visible:ring-[length:var(--lt-ring-width)] focus-visible:ring-lt-ring/50 aria-readonly:cursor-default disabled:cursor-not-allowed disabled:bg-lt-disabled data-[state=checked]:bg-lt-primary disabled:data-[state=checked]:bg-lt-disabled",
         className,
       )}
       data-state={checked ? "checked" : "unchecked"}

--- a/packages/form/resources/js/primitives/input.tsx
+++ b/packages/form/resources/js/primitives/input.tsx
@@ -14,6 +14,7 @@ function Input({
     <input
       type={type}
       data-slot="input"
+      aria-readonly={props.readOnly && !props.disabled ? true : undefined}
       className={cn(
         controlSurface({ density }),
         "file:text-lt-fg selection:bg-lt-primary selection:text-lt-primary-fg file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium",

--- a/packages/ui/resources/js/lib/control.ts
+++ b/packages/ui/resources/js/lib/control.ts
@@ -15,6 +15,7 @@ export const controlSurface = cva(
     "placeholder:text-lt-muted-fg",
     FOCUS_RING,
     "aria-invalid:border-lt-danger aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40",
+    "aria-readonly:cursor-default aria-readonly:bg-lt-muted",
     "disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg",
   ],
   {


### PR DESCRIPTION
Read-only fields were either invisible (text-likes had no styling at all) or rendered with the full disabled look (select, checkbox, toggle). Read-only now gets its own treatment: muted background, full text color, `cursor-default` — the value stays readable and copyable, distinct from disabled (grey text, `cursor-not-allowed`).

- `controlSurface` styles `aria-readonly` controls centrally; the `Input`/`Textarea` primitives derive the attribute from `readOnly` (covers text, number, password, date, time, date-time).
- Select and color-picker triggers stay focusable and expose `aria-readonly` instead of `disabled` + opacity — they just don't open. Screen readers now announce readonly rather than disabled.
- Checkbox and toggle keep focus and block the commit instead of being disabled; the checked state keeps its primary color.
- Rich editor and pattern input frames use the muted background for readonly; the opacity dim stays for disabled.

Choice, OTP and file upload keep their existing readonly→disabled mapping (visible state; true readonly there would touch the widely shared ui components — possible follow-up).

Verified: new interaction tests (readonly checkbox/toggle don't toggle but stay focusable, readonly select doesn't open), vitest over form/ui/table green (899 tests), oxlint/tsc/format clean.