### PR TITLE
test: consolidate duplicated test harnesses, move suites to their owning package

### DIFF
--- a/packages/api-reference/resources/js/standalone-artifact.test.ts
+++ b/packages/api-reference/resources/js/standalone-artifact.test.ts
@@ -1,25 +1,9 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
-
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 
 it("dist-standalone/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(
-    path.resolve(import.meta.dirname, "../../dist-standalone/plugin.js"),
-    "utf8",
-  );
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist-standalone/plugin.js"));
 });
 
 // Evaluating the bundle under gate load (vitest concurrent with composer

--- a/packages/blocks/resources/js/block-editor.browser.test.tsx
+++ b/packages/blocks/resources/js/block-editor.browser.test.tsx
@@ -2,73 +2,34 @@ import { page, userEvent } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice-php/core";
 import { renderWithRegistry } from "@lattice-php/core/browser-test-support";
-import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
 import { formComponents } from "@lattice-php/form";
 import { uiComponents } from "@lattice-php/ui";
 import BlockEditorView from "./components/editor/block-editor-view";
 import blocksPlugin from "./plugin";
 import {
   block,
+  blockEditorNode,
+  blockIdsIn,
   columnsType,
   document,
   noteType,
-  renderedFor,
-  testStyleClasses,
+  renderedTextFrame,
+  rootBlockIds,
+  stubEditorFetch,
   TestText,
-  testTypes,
-  textFrame,
   textOnlySectionType,
 } from "./test-support";
-import type { BlockDocument, BlockNode } from "./types";
+import type { BlockDocument } from "./types";
 
 const registry = createRegistry(uiComponents, formComponents, blocksPlugin, {
   components: { "test.text": eagerComponent(TestText) },
   name: "test/blocks-browser",
 });
 
-function stubEditorEndpoint() {
-  const calls: { op: string; body: Record<string, unknown> }[] = [];
-  const fetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
-    const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
-    const op = init?.method === "PATCH" ? "draft" : String(body._op);
-    calls.push({ body, op });
-
-    if (op === "render") {
-      const node = body.block as BlockNode;
-
-      return jsonResponse({
-        errors: {},
-        node: textFrame(node, `Rendered ${String(node.data.text ?? node.type)}`),
-      });
-    }
-
-    return jsonResponse({ errors: {}, revision: 2 });
-  });
-
-  vi.stubGlobal("fetch", fetch);
-
-  return calls;
-}
+const stubEditorEndpoint = () => stubEditorFetch({ render: renderedTextFrame });
 
 function renderEditor(doc: BlockDocument) {
-  const node = fakeNode({
-    id: "pages",
-    props: {
-      document: doc,
-      endpoint: "/lattice/block-editors/pages",
-      previewUrl: null,
-      ref: "sealed",
-      rendered: renderedFor(doc),
-      revision: 1,
-      seedType: "lattice.paragraph",
-      styleClasses: testStyleClasses,
-      title: "Landing",
-      types: testTypes,
-    },
-    type: "blocks.editor",
-  });
-
-  return renderWithRegistry(<BlockEditorView node={node} />, registry);
+  return renderWithRegistry(<BlockEditorView node={blockEditorNode(doc)} />, registry);
 }
 
 const baseDocument = () =>
@@ -85,20 +46,6 @@ const baseDocument = () =>
 
 function byTest(id: string) {
   return page.getByTestId(id);
-}
-
-function blockIdsIn(container: string): string[] {
-  return Array.from(
-    globalThis.document.querySelectorAll(`[data-test="${container}"] [data-block-id]`),
-    (element) => element.getAttribute("data-block-id") ?? "",
-  );
-}
-
-function rootBlockIds(): string[] {
-  return Array.from(
-    globalThis.document.querySelectorAll('[data-test="blocks-canvas-root"] > [data-block-id]'),
-    (element) => element.getAttribute("data-block-id") ?? "",
-  );
 }
 
 describe("block editor", () => {

--- a/packages/blocks/resources/js/block-editor.test.tsx
+++ b/packages/blocks/resources/js/block-editor.test.tsx
@@ -1,60 +1,35 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRegistry, eagerComponent } from "@lattice-php/core";
-import { fakeNode, jsonResponse, renderWithRegistry } from "@lattice-php/core/test-support";
+import { jsonResponse, renderWithRegistry } from "@lattice-php/core/test-support";
 import { formComponents } from "@lattice-php/form";
 import { uiComponents } from "@lattice-php/ui";
 import BlockEditorView from "./components/editor/block-editor-view";
 import blocksPlugin from "./plugin";
 import {
   block,
+  blockEditorNode,
+  blockIdsIn,
   columnsType,
   document,
   renderedFor,
+  renderedTextFrame,
+  rootBlockIds,
+  stubEditorFetch,
   testPatterns,
-  testStyleClasses,
   TestText,
   testTypes,
-  textFrame,
   textOnlySectionType,
 } from "./test-support";
-import type { BlockDocument, BlockNode } from "./types";
+import type { BlockDocument } from "./types";
 
 const registry = createRegistry(uiComponents, formComponents, blocksPlugin, {
   components: { "test.text": eagerComponent(TestText) },
   name: "test/blocks-jsdom",
 });
 
-type EndpointCall = { op: string; body: Record<string, unknown> };
-
-function stubEditorEndpoint(
-  respond: (op: string, body: Record<string, unknown>) => Response = () =>
-    jsonResponse({ errors: {}, revision: 2 }),
-) {
-  const calls: EndpointCall[] = [];
-
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
-      const op = init?.method === "PATCH" ? "draft" : String(body._op);
-      calls.push({ body, op });
-
-      if (op === "render") {
-        const node = body.block as BlockNode;
-
-        return jsonResponse({
-          errors: {},
-          node: textFrame(node, `Rendered ${String(node.data.text ?? node.type)}`),
-        });
-      }
-
-      return respond(op, body);
-    }),
-  );
-
-  return calls;
-}
+const stubEditorEndpoint = (respond?: (op: string, body: Record<string, unknown>) => Response) =>
+  stubEditorFetch({ render: renderedTextFrame, respond });
 
 function renderEditor(
   doc: BlockDocument,
@@ -62,25 +37,12 @@ function renderEditor(
   types = testTypes,
   patterns = testPatterns,
 ) {
-  const node = fakeNode({
-    id: "pages",
-    props: {
-      document: doc,
-      patterns,
-      endpoint: "/lattice/block-editors/pages",
-      previewUrl: "/preview",
-      ref: "sealed",
-      rendered,
-      revision: 1,
-      seedType: "lattice.paragraph",
-      styleClasses: testStyleClasses,
-      title: "Landing",
-      types,
-    },
-    type: "blocks.editor",
-  });
-
-  return renderWithRegistry(<BlockEditorView node={node} />, registry);
+  return renderWithRegistry(
+    <BlockEditorView
+      node={blockEditorNode(doc, { patterns, previewUrl: "/preview", rendered, types })}
+    />,
+    registry,
+  );
 }
 
 const baseDocument = () =>
@@ -94,20 +56,6 @@ const baseDocument = () =>
     ),
     block("s", textOnlySectionType.type, {}, { content: [] }),
   );
-
-function rootBlockIds(): string[] {
-  return Array.from(
-    globalThis.document.querySelectorAll('[data-test="blocks-canvas-root"] > [data-block-id]'),
-    (element) => element.getAttribute("data-block-id") ?? "",
-  );
-}
-
-function blockIdsIn(container: string): string[] {
-  return Array.from(
-    globalThis.document.querySelectorAll(`[data-test="${container}"] [data-block-id]`),
-    (element) => element.getAttribute("data-block-id") ?? "",
-  );
-}
 
 function blockTypesIn(container: string): string[] {
   return Array.from(

--- a/packages/blocks/resources/js/inline-editing.browser.test.tsx
+++ b/packages/blocks/resources/js/inline-editing.browser.test.tsx
@@ -2,82 +2,33 @@ import { page, userEvent } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRegistry } from "@lattice-php/core";
 import { renderWithRegistry } from "@lattice-php/core/browser-test-support";
-import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
 import { formComponents } from "@lattice-php/form";
 import { uiComponents } from "@lattice-php/ui";
 import BlockEditorView from "./components/editor/block-editor-view";
 import blocksPlugin from "./plugin";
 import {
   block,
+  blockEditorNode,
   ctaType,
   document,
+  type EditorEndpointCall,
   headingType,
   paragraphType,
-  renderedFor,
-  renderedFrame,
   richDoc,
-  testStyleClasses,
-  testTypes,
+  rootBlocks,
+  stubEditorFetch,
 } from "./test-support";
 import type { BlockDocument, BlockNode } from "./types";
 
 const registry = createRegistry(uiComponents, formComponents, blocksPlugin);
 
-type Call = { op: string; body: Record<string, unknown> };
-
-function stubEndpoint(): Call[] {
-  const calls: Call[] = [];
-
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
-      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
-      const op = init?.method === "PATCH" ? "draft" : String(body._op);
-      calls.push({ body, op });
-
-      if (op === "render") {
-        return jsonResponse({ errors: {}, node: renderedFrame(body.block as BlockNode) });
-      }
-
-      return jsonResponse({ errors: {}, revision: 2 });
-    }),
-  );
-
-  return calls;
-}
+const stubEndpoint = () => stubEditorFetch();
 
 function renderEditor(doc: BlockDocument) {
-  const node = fakeNode({
-    id: "pages",
-    props: {
-      document: doc,
-      endpoint: "/lattice/block-editors/pages",
-      previewUrl: null,
-      ref: "sealed",
-      rendered: renderedFor(doc),
-      revision: 1,
-      seedType: "lattice.paragraph",
-      styleClasses: testStyleClasses,
-      title: "Landing",
-      types: testTypes,
-    },
-    type: "blocks.editor",
-  });
-
-  return renderWithRegistry(<BlockEditorView node={node} />, registry);
+  return renderWithRegistry(<BlockEditorView node={blockEditorNode(doc)} />, registry);
 }
 
-function rootBlocks(): { id: string; type: string }[] {
-  return Array.from(
-    globalThis.document.querySelectorAll('[data-test="blocks-canvas-root"] > [data-block-id]'),
-    (element) => ({
-      id: element.getAttribute("data-block-id") ?? "",
-      type: element.getAttribute("data-block-type") ?? "",
-    }),
-  );
-}
-
-function renders(calls: Call[]): BlockNode[] {
+function renders(calls: EditorEndpointCall[]): BlockNode[] {
   return calls.filter((call) => call.op === "render").map((call) => call.body.block as BlockNode);
 }
 

--- a/packages/blocks/resources/js/standalone-artifact.test.ts
+++ b/packages/blocks/resources/js/standalone-artifact.test.ts
@@ -1,23 +1,10 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 import sourcePlugin from "./plugin";
 
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
-
 it("dist/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist/plugin.js"));
 });
 
 // Evaluating the bundle under gate load (vitest concurrent with composer

--- a/packages/blocks/resources/js/test-support.tsx
+++ b/packages/blocks/resources/js/test-support.tsx
@@ -1,7 +1,8 @@
 import type { Node } from "@lattice-php/core";
 import { createRegistry, eagerComponent } from "@lattice-php/core";
 import type { RendererComponent } from "@lattice-php/core";
-import { fakeNode } from "@lattice-php/core/test-support";
+import { fakeNode, jsonResponse } from "@lattice-php/core/test-support";
+import { vi } from "vitest";
 import blocksPlugin from "./plugin";
 import type {
   BlockDocument,
@@ -295,4 +296,82 @@ export function renderedFor(
   visit(doc.blocks);
 
   return rendered;
+}
+
+export type EditorEndpointCall = { op: string; body: Record<string, unknown> };
+
+export function renderedTextFrame(node: BlockNode): Node {
+  return textFrame(node, `Rendered ${String(node.data.text ?? node.type)}`);
+}
+
+/**
+ * Stub the editor endpoint, recording every call. Render ops answer with a
+ * frame so the canvas can mount the block; everything else falls to `respond`.
+ */
+export function stubEditorFetch({
+  render = renderedFrame,
+  respond = () => jsonResponse({ errors: {}, revision: 2 }),
+}: {
+  render?: (node: BlockNode) => Node;
+  respond?: (op: string, body: Record<string, unknown>) => Response;
+} = {}): EditorEndpointCall[] {
+  const calls: EditorEndpointCall[] = [];
+
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      const op = init?.method === "PATCH" ? "draft" : String(body._op);
+      calls.push({ body, op });
+
+      if (op === "render") {
+        return jsonResponse({ errors: {}, node: render(body.block as BlockNode) });
+      }
+
+      return respond(op, body);
+    }),
+  );
+
+  return calls;
+}
+
+export function blockEditorNode(doc: BlockDocument, props: Record<string, unknown> = {}) {
+  return fakeNode({
+    id: "pages",
+    props: {
+      document: doc,
+      endpoint: "/lattice/block-editors/pages",
+      previewUrl: null,
+      ref: "sealed",
+      rendered: renderedFor(doc),
+      revision: 1,
+      seedType: "lattice.paragraph",
+      styleClasses: testStyleClasses,
+      title: "Landing",
+      types: testTypes,
+      ...props,
+    },
+    type: "blocks.editor",
+  });
+}
+
+export function rootBlocks(): { id: string; type: string }[] {
+  return Array.from(
+    globalThis.document.querySelectorAll('[data-test="blocks-canvas-root"] > [data-block-id]'),
+    (element) => ({
+      id: element.getAttribute("data-block-id") ?? "",
+      type: element.getAttribute("data-block-type") ?? "",
+    }),
+  );
+}
+
+export function rootBlockIds(): string[] {
+  return rootBlocks().map((entry) => entry.id);
+}
+
+export function blockIdsIn(container: string): string[] {
+  return Array.from(
+    globalThis.document.querySelectorAll(`[data-test="${container}"] [data-block-id]`),
+    (element) => element.getAttribute("data-block-id") ?? "",
+  );
 }

--- a/packages/board/resources/js/standalone-artifact.test.ts
+++ b/packages/board/resources/js/standalone-artifact.test.ts
@@ -1,23 +1,10 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 import sourcePlugin from "./plugin";
 
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
-
 it("dist/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist/plugin.js"));
 });
 
 // Evaluating the bundle under gate load (vitest concurrent with composer

--- a/packages/chat/resources/js/standalone-artifact.test.ts
+++ b/packages/chat/resources/js/standalone-artifact.test.ts
@@ -1,21 +1,9 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
-
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 
 it("dist/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist/plugin.js"));
 });
 
 it(

--- a/packages/core/resources/js/standalone-test-support.ts
+++ b/packages/core/resources/js/standalone-test-support.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { expect } from "vitest";
+
+/**
+ * The only specifiers a standalone plugin bundle may leave unbundled. A host
+ * page supplies these on `window`; anything else must be inside the artifact
+ * or it fails to resolve at runtime.
+ */
+export const standaloneHostExternals = [
+  "react",
+  "react-dom",
+  "react/jsx-runtime",
+  "@lattice-php/lattice/runtime",
+];
+
+/**
+ * Assert a built standalone bundle imports nothing but the host externals and
+ * carries no build-time `process.env`, then hand the source back so a package
+ * can add its own guards (an SDK that must stay bundled, a version pin).
+ *
+ * `dynamicImport` opts out of the no-`import(` check for the two bundles that
+ * legitimately contain one.
+ */
+export function expectStandaloneArtifact(
+  bundlePath: string,
+  { dynamicImport = false }: { dynamicImport?: boolean } = {},
+): string {
+  const artifact = readFileSync(bundlePath, "utf8");
+  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
+    (match) => match[2],
+  );
+
+  expect(specifiers.length).toBeGreaterThan(0);
+  expect(artifact).not.toContain("process.env");
+
+  if (!dynamicImport) {
+    expect(artifact).not.toContain("import(");
+  }
+
+  for (const specifier of specifiers) {
+    expect(standaloneHostExternals).toContain(specifier);
+  }
+
+  return artifact;
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,8 +22,7 @@ export default defineConfig({
       exclude: [
         "resources/js/**/*.test.*",
         "resources/js/**/*.test-d.*",
-        "resources/js/test-support.*",
-        "resources/js/browser-test-support.*",
+        "resources/js/*test-support.*",
       ],
       rollupTypes: true,
       compilerOptions: {

--- a/packages/framework/resources/js/types/types.test-d.ts
+++ b/packages/framework/resources/js/types/types.test-d.ts
@@ -1,27 +1,10 @@
-import type { Node, NodeProps, ComponentPropsOf } from "./index";
+import type { Node } from "./index";
 
-// 1. Built-in type narrows correctly: badge requires props.label: string
+// The aggregate barrel merges every package's generated ComponentProps, so a
+// built-in node type narrows its props here and nowhere lower.
 const _okBadge: Node<"badge"> = { type: "badge", props: { label: "x", color: null } };
 // @ts-expect-error label must be a string, not a number
 const _badBadge: Node<"badge"> = { type: "badge", props: { label: 1 } };
 
-// 2. Consumer augmentation: extend ComponentProps so "custom.thing" gains strong props.
-//    The declare module is scoped to this module file (which has top-level imports), so it
-//    does not pollute the project's global type space.
-declare module "./index" {
-  interface ComponentProps {
-    "custom.thing": { foo: number };
-  }
-}
-const _customOk: ComponentPropsOf<"custom.thing"> = { foo: 1 };
-// @ts-expect-error foo must be a number, not a string
-const _customBad: ComponentPropsOf<"custom.thing"> = { foo: "no" };
-
-// 3. Unaugmented unknown type falls back to the loose NodeProps bag
-const _loose: ComponentPropsOf<"totally.unknown"> = { anything: true } satisfies NodeProps;
-
 void _okBadge;
 void _badBadge;
-void _customOk;
-void _customBad;
-void _loose;

--- a/packages/map/resources/js/standalone-artifact.test.ts
+++ b/packages/map/resources/js/standalone-artifact.test.ts
@@ -1,23 +1,13 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
-
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 
 it("dist/plugin.js bundles the map engine and only imports host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
+  const artifact = expectStandaloneArtifact(
+    path.resolve(import.meta.dirname, "../../dist/plugin.js"),
   );
 
-  expect(specifiers.length).toBeGreaterThan(0);
   expect(artifact).not.toContain('from"leaflet"');
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
 });
 
 it(

--- a/packages/media/resources/js/standalone-artifact.test.ts
+++ b/packages/media/resources/js/standalone-artifact.test.ts
@@ -1,22 +1,9 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
-
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 
 it("dist/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist/plugin.js"));
 });
 
 // Importing the bundle evaluates ~240 KB including tiptap; under gate load

--- a/packages/pdf/resources/js/standalone-artifact.test.ts
+++ b/packages/pdf/resources/js/standalone-artifact.test.ts
@@ -1,33 +1,26 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
 const distDir = path.resolve(import.meta.dirname, "../../dist");
 
 it("dist/plugin.js bundles the pdf engine and only imports host externals", () => {
-  const artifact = readFileSync(path.join(distDir, "plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
+  // pdf.js legitimately keeps two `import(` occurrences: the runtime-expression
+  // fake-worker fallback and a CDN-wrapper template string.
+  const artifact = expectStandaloneArtifact(path.join(distDir, "plugin.js"), {
+    dynamicImport: true,
+  });
 
-  expect(specifiers.length).toBeGreaterThan(0);
   expect(artifact).not.toContain('from"pdfjs-dist"');
-  expect(artifact).not.toContain("process.env");
 
   // getTextContent() iterates a ReadableStream with `for await`, which Safari
   // cannot do — the engine must stay on the manual reader in text-cache.ts.
   expect(artifact).not.toContain(".getTextContent(");
 
-  // pdf.js legitimately keeps two `import(` occurrences: the runtime-expression
-  // fake-worker fallback and a CDN-wrapper template string. A literal specifier
-  // after `import(` would mean a code-splitting leak instead.
+  // A literal specifier after `import(` would mean a code-splitting leak.
   expect(artifact).not.toMatch(/import\(\s*["'](?!\$\{)/);
   expect(artifact.match(/import\(/g)).toHaveLength(2);
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
 });
 
 it("ships a worker artifact matching the pinned pdfjs-dist version", () => {

--- a/packages/search/resources/js/standalone-artifact.test.ts
+++ b/packages/search/resources/js/standalone-artifact.test.ts
@@ -1,22 +1,9 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
-
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 
 it("dist/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist/plugin.js"));
 });
 
 it(

--- a/packages/tree/resources/js/standalone-artifact.test.ts
+++ b/packages/tree/resources/js/standalone-artifact.test.ts
@@ -1,23 +1,10 @@
-import { readFileSync } from "node:fs";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { expectStandaloneArtifact } from "@lattice-php/core/standalone-test-support";
 import sourcePlugin from "./plugin";
 
-const hostExternals = ["react", "react-dom", "react/jsx-runtime", "@lattice-php/lattice/runtime"];
-
 it("dist/plugin.js only imports the standalone host externals", () => {
-  const artifact = readFileSync(path.resolve(import.meta.dirname, "../../dist/plugin.js"), "utf8");
-  const specifiers = [...artifact.matchAll(/^import\b[^"'\n]*(["'])([^"'\n]+)\1/gm)].map(
-    (match) => match[2],
-  );
-
-  expect(specifiers.length).toBeGreaterThan(0);
-  expect(artifact).not.toContain("import(");
-  expect(artifact).not.toContain("process.env");
-
-  for (const specifier of specifiers) {
-    expect(hostExternals).toContain(specifier);
-  }
+  expectStandaloneArtifact(path.resolve(import.meta.dirname, "../../dist/plugin.js"));
 });
 
 // Evaluating the bundle under gate load (vitest concurrent with composer

--- a/packages/ui/resources/js/effects/run-action.test.ts
+++ b/packages/ui/resources/js/effects/run-action.test.ts
@@ -1,17 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { jsonResponse } from "@lattice-php/core/test-support";
-import type { Effect } from "@lattice-php/ui";
-import { dispatchActionError } from "@lattice-php/ui/effects/dispatch";
+import { dispatchActionError } from "./dispatch";
 import { runAction } from "./run-action";
+import type { Effect } from "./types";
 
-vi.mock("@lattice-php/ui/effects/dispatch", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@lattice-php/ui/effects/dispatch")>()),
+vi.mock("./dispatch", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./dispatch")>()),
   dispatchActionError: vi.fn(),
 }));
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
 
 describe("runAction", () => {
   it("dispatches effects and reports success on a 2xx response", async () => {


### PR DESCRIPTION
The verified structural findings from the suite audit. Net **−162 lines** across 17 files, with no test lost — 2003 before and after.

## What landed

**The standalone-bundle contract now lives in core.** The `hostExternals` list, the import-specifier scrape and the `process.env` guard were copy-pasted across all nine `standalone-artifact.test.ts` suites — blocks, board and tree byte-identical. `expectStandaloneArtifact()` returns the bundle source, so each file keeps only what is its own: an SDK that must stay bundled (leaflet, pdfjs-dist), pdf's Safari and code-splitting rules, the plugin keys. `chat` gains the no-dynamic-import guard the other copies had and it lacked.

**The blocks editor harness moved into `blocks/test-support.tsx`**, which already owned every other blocks fixture. Each of the three suites keeps only what genuinely differs: which `renderWithRegistry` it mounts through, its registry, and the render response its assertions read. All 46 `stubEditorEndpoint()` call sites are untouched — a per-file one-liner binds the render function.

**`runAction`'s suite moved to ui.** `packages/action/.../lib/run-action.ts` is one line, `export * from "@lattice-php/ui/effects/run-action"` — so the suite was testing a re-export, and it was the *only* coverage the real module had. Not a deletion: a relocation to its subject.

**Two framework type cases dropped** — identical to `core/types.test-d.ts`, which framework re-exports verbatim. The one case only the aggregate barrel can make (a built-in node type narrowing its generated props) stays.

## What did not survive verification

The audit proposed deleting four whole files as barrel/re-export tests. Checked against the source, **none of them holds**, so none is in this PR:

- **`framework/registry.test.ts`** — `inertia-navigation.test.tsx` owns the `redirect` override, but nothing anywhere covers the `reload-page` override. Deleting it would drop a guard with no owner.
- **`framework/components.test-d.ts`** — the `toBeFunction()` calls are weak, but the import list is the only thing pinning the public barrel's named export surface. No owner found.
- **`framework/types/types.test-d.ts`** — not a duplicate. Its `Node<"badge">` narrowing case is unique in the repo, so it was trimmed rather than deleted.
- **`docs/lib/themeTokens.test.ts`** — `tokens.test.ts` tests the parser against fixture CSS; this one runs it against ui's *real* stylesheet. Different concern, and the `--lt-warning` check is a live guard on ui's token set, not an obsolete pin.

One more audit claim was wrong: `blocks/autosave.test.tsx` was reported as holding a third copy of the fetch stub. It already uses the owned `stubFetch` helper.

## Verification

`npm run check` green: format, lint, typecheck, type-coverage, **2003 tests**, `build:lib`, publint/attw. The nine standalone suites and both blocks browser suites were also run in isolation after each step, and the full suite again after rebasing onto the merged vitest 5.