### PR TITLE
feat(core): context resolvers, gate subjects and context frames

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
             { label: "Layouts", link: "/core/layouts/" },
             { label: "Closure evaluation", link: "/core/closure-evaluation/" },
             { label: "Authorization", link: "/core/authorization/" },
+            { label: "Context", link: "/core/context/" },
             { label: "Fragments", link: "/core/fragments/" },
             { label: "Navigation", link: "/core/navigation/" },
             { label: "Icons", link: "/core/icons/" },

--- a/docs/content/docs/actions/overview.mdx
+++ b/docs/content/docs/actions/overview.mdx
@@ -81,9 +81,14 @@ class ArchiveProductAction extends ActionDefinition
 ```
 
 `contextModel()` reads the sealed context and resolves it into the model through its own
-[route binding](/core/authorization/#reading-trusted-context) — it aborts with a 404 when the key is
-missing or nothing matches. It comes from the opt-in `ResolvesContextModels` trait rather than
+[route binding](/core/context/#reading-it) — it aborts with a 404 when the key is missing or nothing
+matches. That two-argument form comes from the opt-in `ResolvesContextModels` trait rather than
 `context()` itself, which stays untyped on every definition.
+
+When a resolver for the key is [registered](/core/context/#registering-a-resolver) once via
+`Lattice::context('product', Product::class)`, the same call shrinks to a one-argument
+`contextModel('product')` — memoized for the request, and usable directly on `Definition` without the
+trait.
 
 ## Placing an action
 
@@ -98,6 +103,15 @@ Action::use(ArchiveProductAction::class)
 `->context()` carries data from the page to the action; `handle()` reads it back server-side, typically
 through a typed accessor like `contextModel()` (see [Defining an action](#defining-an-action)). The
 context is signed into the action's reference, so it can't be tampered with on the way back.
+
+The value doesn't have to be the scalar id — pass the model directly when you already have it, and
+Lattice normalizes it to the same scalar before the action gates or seals its context:
+
+```php
+Action::use(ArchiveProductAction::class)->context(['product' => $product]);
+```
+
+This only works for a key with a registered resolver; see [Context](/core/context/#passing-models-as-context-values).
 
 Group related actions behind a single trigger with `ActionGroup`:
 
@@ -149,8 +163,7 @@ public function authorize(Request $request): bool
 
 An action's `authorize()` also runs at render time — when it's hidden from the page rather than
 rejected outright, a strict accessor's 404 takes the whole page down with it. See
-[Authorization](/core/authorization/#reading-trusted-context) for the `OrNull` variants to reach for
-there instead.
+[Context](/core/context/#reading-it) for the `OrNull` variants to reach for there instead.
 
 ## Calling an action from a custom component
 

--- a/docs/content/docs/core/authorization.md
+++ b/docs/content/docs/core/authorization.md
@@ -3,15 +3,16 @@ title: Authorization
 description: Gate a definition, page, or component with can and authorize().
 ---
 
-Lattice gates everything with the same two tools. **`can`** declares subject-less abilities — the
-same word as Laravel's `can:` middleware and `$user->can()`. **`authorize()`** holds the logic that
-needs the request or the record it acts on.
+Lattice gates everything with the same two tools. **`can`** declares an ability — the same word as
+Laravel's `can:` middleware and `$user->can()` — either subject-less or, with `on`, checked against a
+specific record. **`authorize()`** holds the logic that needs the request or something `can`/`on` can't
+express.
 
-|                                                                 | declare an ability     | custom logic                 |
-| --------------------------------------------------------------- | ---------------------- | ---------------------------- |
-| Definition — form, table, action, bulk action, fragment, layout | `#[AsTable(can: 'x')]` | `authorize()`                |
-| Page                                                            | `#[AsPage(can: 'x')]`  | `authorize()`                |
-| Component, column, filter, row action                           | `->can('x')`           | `->visible()` / `->hidden()` |
+|                                                                 | declare an ability              | custom logic                 |
+| --------------------------------------------------------------- | ------------------------------- | ---------------------------- |
+| Definition — form, table, action, bulk action, fragment, layout | `#[AsTable(can: 'x', on: 'y')]` | `authorize()`                |
+| Page                                                            | `#[AsPage(can: 'x', on: 'y')]`  | `authorize()`                |
+| Component, column, filter, row action                           | `->can('x', on: 'y')`           | `->visible()` / `->hidden()` |
 
 ## Declaring `can`
 
@@ -54,6 +55,50 @@ runs the middleware in `config('lattice.<group>.middleware')` — `['web', 'auth
 then the definition's own gate. Putting `can: 'admin.users.manage'` on a page gates who can _load_ the
 page; it does not gate the table on it. Declare the ability on the definition too.
 :::
+
+## Declaring a gate subject with `on`
+
+Add `on` when the ability needs a specific record rather than a subject-less check —
+`Gate::check('update', $product)` rather than `Gate::check('manage-widgets')`. `on` names a
+[context](/core/context/) key; its resolved value becomes the `Gate::check()` subject, so a gate closure
+written for `can('update', $product)` works unchanged.
+
+On a definition or a plain component, `on` names a context key exactly as `contextModel()` would read
+it:
+
+```php
+#[AsAction('app.products.archive', can: 'update', on: 'product')]
+class ArchiveProductAction extends ActionDefinition { /* … */ }
+```
+
+```php
+Heading::make('Internal notes')->can('update', on: 'product');
+```
+
+On a page, `on` names a route parameter instead — a bound model as-is, or an unbound scalar resolved
+through a [registered](/core/context/#registering-a-resolver) `Lattice::context()` resolver of the same
+name:
+
+```php
+#[AsPage(route: '/products/{product}/edit', can: 'update', on: 'product')]
+class ProductEditPage extends Page { /* … */ }
+```
+
+A missing subject — the key absent, or its resolver finding nothing — **denies outright**. It never
+falls back to a subject-less check.
+
+:::caution
+A page's `on` middleware differs from a subject-less `can`. Laravel's own `can:{ability}` middleware
+would hand an unbound route parameter to the gate as a raw scalar, blind to a registered resolver — so
+when `on` is set, Lattice registers its own `AuthorizeGateSubject` middleware in its place. It resolves
+the subject exactly as `toResponse()` and `callAction()` do — through the same
+`GateSubjects::fromRoute()` — so the middleware and the page body can never disagree about who they
+checked.
+:::
+
+`can` and `on` are inherited from a [base page](/core/pages/#shared-base-pages) the same way layout,
+width, and middleware are: a concrete page declaring its own `can` replaces — rather than merges with —
+an inherited ability, and the same holds for `on`.
 
 ## Writing `authorize()`
 
@@ -99,34 +144,13 @@ of its own, so `->can()` is a render gate only; anything that loads data must be
 ## Reading trusted context
 
 A definition often needs the record it acts on. Pass it as [context](/actions/overview/#placing-an-action)
-when placing the component, and read it back with a typed accessor:
-
-```php
-Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]);
-```
-
-```php
-use Lattice\Actions\ActionDefinition;
-use Lattice\Core\Concerns\ResolvesContextModels;
-
-class ArchiveProductAction extends ActionDefinition
-{
-    use ResolvesContextModels;
-
-    protected function product(): Product
-    {
-        return $this->contextModel('product_id', Product::class);
-    }
-}
-```
-
-`contextModel()` resolves the context value through the model's own `resolveRouteBinding()` — the
-same column a route parameter would bind against — and aborts with a 404 when the key is missing or
-no record matches. It lives on the opt-in `ResolvesContextModels` trait rather than on `Definition`
-itself, because the package does not depend on `illuminate/database`. `Definition::context()` and its
-typed scalar siblings — `contextString()`/`contextStringOrNull()`, `contextInt()`/`contextIntOrNull()`
-— are available on every definition without the trait; the strict variants abort with a 404 on a
-missing or wrongly-typed value instead of coercing it.
+when placing the component, and read it back with a typed accessor — `contextModel()`, backed by a
+resolver [registered](/core/context/#registering-a-resolver) once via `Lattice::context()`, or the
+explicit form on the opt-in `Lattice\Core\Concerns\ResolvesContextModels` trait. `Definition::context()`
+and its typed scalar siblings — `contextString()`/`contextStringOrNull()`,
+`contextInt()`/`contextIntOrNull()` — are available on every definition without the trait. See
+[Context](/core/context/) for registering resolvers, memoization, and how context inherits into a
+definition's children, a page's frame, slots, and closure-built modals.
 
 The context is sealed into the component's signed reference, so the value `authorize()` and `handle()`
 read is the value the server issued — not something a client can change. See
@@ -134,8 +158,8 @@ read is the value the server issued — not something a client can change. See
 
 :::caution
 Inside `authorize()` on a component that renders as part of a page, use the `OrNull` accessors
-(`contextModelOrNull()`, `contextStringOrNull()`, `contextIntOrNull()`) instead of their strict
-counterparts. At the endpoint, a `false` from `authorize()` is a 403 — but at render time an
+(`contextModelOrNull()`, `contextStringOrNull()`, `contextIntOrNull()`) or `hasContext()` instead of
+their strict counterparts. At the endpoint, a `false` from `authorize()` is a 403 — but at render time an
 unauthorized component is simply hidden, and a strict accessor's `abort(404)` would take the whole
 page down with it instead.
 :::

--- a/docs/content/docs/core/context.md
+++ b/docs/content/docs/core/context.md
@@ -1,0 +1,190 @@
+---
+title: Context
+description: Typed, memoized data threaded from where a component is placed to where it runs — registered once, inherited everywhere.
+---
+
+Context is the data a component carries from where it's placed to where it runs: a row's record for an
+action, a form's parent model, the value behind a page's URL segment. It's always **scalar on the wire**
+— sealed into a component's signed reference, never a serialized object — and **sealed per component**,
+so the value a definition reads back is the value the server issued, not something a client controlled.
+
+`Lattice::context()` registers, per key, how that scalar resolves into a typed model. Once registered, a
+key is resolved at most once per request, and cascades automatically into every child component Lattice
+builds from a definition or a page that has it.
+
+## Registering a resolver
+
+Register a key from a service provider's `boot()`. The Eloquent sugar resolves through the model's own
+route binding, exactly like a route parameter would:
+
+```php
+use Lattice\Core\Facades\Lattice;
+
+Lattice::context('tenant', Tenant::class, by: 'slug');
+```
+
+Or register a closure for anything that isn't a plain route-bound Eloquent lookup. It resolves through
+the same [closure evaluation](/core/closure-evaluation/) as every other Lattice callback: `$value` (the
+raw context scalar), `$key` (the context key, as a string), `$context` (the definition's full raw
+context array, so one resolver can read another key), a typed `Request`, and any container type.
+
+```php
+Lattice::context('workspace', function (string $value, Request $request): Workspace {
+    return Workspace::where('slug', $value)->firstOrFail();
+});
+```
+
+Registering the same key twice replaces the previous resolver — the last `Lattice::context()` call for a
+key wins.
+
+Give a closure-registered key a `keyBy` closure too, for turning the resolved object back into its wire
+scalar — needed when a model is [passed directly as a context value](#passing-models-as-context-values).
+It resolves the model as `$value`, or by its own type:
+
+```php
+Lattice::context(
+    'workspace',
+    fn (string $value): Workspace => Workspace::where('slug', $value)->firstOrFail(),
+    keyBy: fn (Workspace $workspace): string => $workspace->slug,
+);
+```
+
+Without a `keyBy`, Lattice falls back to the resolved object's own `getRouteKey()`, throwing only if
+neither exists and something actually needs to serialize the value. The Eloquent sugar always builds
+both closures for you, from `by` (or the model's own route key name).
+
+## Reading it
+
+Every `Definition` (form, table, action, bulk action, fragment, layout) reads context back with:
+
+- **`context('key')`** — the raw scalar, untyped, as before.
+- **`hasContext('key')`** — presence, distinct from "not found": a key that's set but whose resolver
+  finds nothing still passes this check.
+- **`contextModel('key')`** — the value resolved through its registered resolver, memoized for the
+  request. Aborts with a 404 when the key is absent or the resolver finds nothing. Throws a
+  `LogicException` when no resolver is registered for the key at all.
+- **`contextModelOrNull('key')`** — the same resolution, returning `null` instead of aborting.
+
+```php
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+
+class ArchiveWorkspaceAction extends ActionDefinition
+{
+    public function handle(): ActionResult
+    {
+        $workspace = $this->contextModel('workspace');
+        $workspace->update(['status' => 'archived']);
+
+        return ActionResult::success();
+    }
+}
+```
+
+:::caution
+Inside a render-time `authorize()`, reach for `contextModelOrNull()` or `hasContext()` instead of
+`contextModel()`. At the endpoint, a missing subject is a 404 — but at render time an unauthorized or
+incomplete component is simply hidden, and a strict accessor's `abort(404)` would take the whole page
+down with it. See [Authorization](/core/authorization/) for the same rule applied to `can`.
+:::
+
+`Lattice\Core\Concerns\ResolvesContextModels` keeps its explicit two-argument form —
+`contextModel('workspace', Workspace::class, by: 'slug')` — which resolves through the model's own route
+binding directly, with nothing registered. Its one-argument form, `contextModel('workspace')`, delegates
+to the registry above and asserts the result is an Eloquent model, throwing a `LogicException`
+otherwise.
+
+## Memoization
+
+A resolver runs **at most once per request** for a given key and scalar value, however many times it's
+read and by however many definitions. Two `contextModel()` calls in the same `handle()`, or an
+`authorize()` and the `handle()` that follows it, see the result of one evaluation. A miss ("not
+found") is cached too.
+
+That makes a resolver closure the right place for a once-per-request side effect keyed to the resolved
+value — switching the session's active record to match it, say:
+
+```php
+Lattice::context('workspace', function (string $value, Request $request): Workspace {
+    $workspace = Workspace::where('slug', $value)->firstOrFail();
+    $request->user()?->switchWorkspace($workspace);
+
+    return $workspace;
+});
+```
+
+## Inheritance
+
+A key with a resolver registered via `Lattice::context()` cascades into every child component a
+definition builds — nested actions, a modal's form, a row's actions — with no configuration.
+`config('lattice.context.inherited_keys')` still exists for a key that has **no** resolver but should
+cascade anyway. Explicit context passed at a component's own placement always wins over an inherited
+value under the same key.
+
+`table` is reserved and never cascades, registered or whitelisted — Lattice uses it internally to route
+a bulk action back to its owning table, and it must never leak into an unrelated child.
+
+## Passing models as context values
+
+A context value doesn't have to be the scalar itself — pass the resolved model directly, and Lattice
+normalizes it before the definition gates, seals, or inherits its context:
+
+```php
+Table::use(WorkspaceMembersTable::class, ['workspace' => $workspace]);
+```
+
+An object under a key with a registered resolver is turned into its wire-safe scalar through that key's
+`keyBy` closure (or `getRouteKey()`) — the sealed reference never carries a serialized model, only the
+same scalar a route parameter would. A `BackedEnum` value normalizes to its `->value` regardless of
+whether the key has a resolver registered — it was always wire-safe on its own. Any other object passed
+under a key with **no** registered resolver throws, rather than being silently JSON-encoded wholesale
+into the sealed ref.
+
+## Frames
+
+Lattice opens a "frame" — the currently inheritable context — everywhere it builds child components, so
+a key registered once cascades through every seam Lattice threads data across:
+
+- **Definitions** — a definition's own gated children (row actions, a modal's schema, nested actions)
+  build inside a frame opened from its context, and its endpoint activates the same frame from the
+  sealed reference it verifies.
+- **Pages, by convention** — before `render()` runs, a page opens a frame from the route's bound
+  parameters. An object parameter seeds the key whose resolver was registered for its class, whatever
+  the parameter itself is named — `render(Tenant $current_tenant)` seeds `tenant` because
+  `Lattice::context('tenant', Tenant::class)` registered that model, not because of the parameter's
+  name. A scalar parameter seeds the key sharing its own name, when that name is itself registered.
+  `PageSchema::context([...])` extends or overrides the frame explicitly — for a closure-registered key,
+  or anything the convention misses:
+
+  ```php
+  public function render(PageSchema $schema, Workspace $workspace): PageSchema
+  {
+      return $schema
+          ->context(['workspace' => $workspace])
+          ->schema([
+              Table::use(WorkspaceMembersTable::class),
+          ]);
+  }
+  ```
+
+  Chain `context()` **before** `schema()`. PHP builds `schema()`'s array argument — and every component
+  in it — only after `context()` has already returned, so those components see the extended frame only
+  when `context()` runs first in the chain.
+
+- **Slots** — each `Lattice::extend()` factory runs inside the inherited frame merged with the slot's
+  own `->context([...])`, filtered to the registered/whitelisted keys before it cascades further. An
+  object under an unrelated, unregistered key in a slot's context is dropped silently rather than
+  throwing — the factory itself still receives it directly, by injection, exactly as before.
+- **Closure-built modals** — `->modal(fn (): Modal => ...)` snapshots the inherited frame at the moment
+  it's built, not when the closure eventually runs — which happens later, during serialization, after
+  that frame has already closed. The modal's own schema — a form, say — inherits the frame its trigger
+  was built in.
+- **Layouts** — a layout renders inside the page's still-open frame, so a layout's `schema()` sees the
+  same context the page's own `render()` does.
+
+:::note
+Read context, not route parameters. `definition()` (and `authorize()`, `handle()`, …) runs on a page's
+own render — inside its frame — and again on the definition's own signed endpoint, which carries no
+route parameters of its own. `contextModel()` and `context()` work identically on both paths;
+`$request->route()` only works on the first.
+:::

--- a/docs/content/docs/core/pages.md
+++ b/docs/content/docs/core/pages.md
@@ -122,6 +122,34 @@ class ProductEditPage extends Page
 Anything the container can resolve — a `Request`, a service, a bound model — can be type-hinted here
 too.
 
+## Context
+
+Before `render()` runs, a page opens a [context](/core/context/) frame from its own route parameters,
+by convention: a bound model parameter seeds the key whose resolver was registered for its class,
+whatever the parameter itself is named, and a scalar parameter seeds the key sharing its own name when
+that name is registered. `render(Product $product)` above seeds the context key `product` because
+`Lattice::context('product', Product::class)` registered `Product` — not because the parameter happens
+to be named `product`.
+
+Every component the page builds — directly, through a layout, or nested inside a definition — inherits
+that frame, so a table or an action placed on the page can read `contextModel('product')` without it
+being threaded through by hand. Extend or override the frame explicitly with `PageSchema::context()`,
+chained **before** `->schema()` so the components it builds see the extended frame:
+
+```php
+public function render(PageSchema $schema, Product $product): PageSchema
+{
+    return $schema
+        ->context(['product' => $product])
+        ->schema([
+            Table::use(ProductReviewsTable::class),
+        ]);
+}
+```
+
+See [Context](/core/context/#frames) for how the frame reaches slots, layouts, and closure-built modals
+too.
+
 ## The `#[AsPage]` attribute
 
 `#[AsPage]` declares how the page is routed and framed:

--- a/packages/blocks/src/Attributes/AsBlock.php
+++ b/packages/blocks/src/Attributes/AsBlock.php
@@ -29,7 +29,8 @@ final class AsBlock extends DefinitionAttribute
         public readonly ?string $description = null,
         public readonly array $keywords = [],
         string|BackedEnum|array $can = [],
+        ?string $on = null,
     ) {
-        parent::__construct($key, $can);
+        parent::__construct($key, $can, $on);
     }
 }

--- a/packages/core/src/Attributes/AsPage.php
+++ b/packages/core/src/Attributes/AsPage.php
@@ -11,6 +11,23 @@ use Lattice\Core\Contracts\DeclaresGate;
 use Lattice\Core\Enums\PageLayout;
 use Lattice\Core\Enums\PageWidth;
 
+/**
+ * `on` names a route parameter whose resolved value becomes the `can` gate
+ * subject: an object route-model binds to as is, a scalar resolves through a
+ * `Lattice::context()` resolver registered under the same key. Either the
+ * parameter must be bound to its model — type it in `render()`, since
+ * `SubstituteBindings` binds by the controller signature — or a resolver of
+ * the same key must be registered. An unbound, unresolvable parameter yields
+ * no subject and the gate denies.
+ *
+ * When `on` is set, the registered route carries `Lattice\Http\Middleware\
+ * AuthorizeGateSubject` rather than the framework's own `can:` middleware —
+ * that middleware hands an unbound route parameter to the gate as a raw
+ * scalar, blind to a registered resolver. `AuthorizeGateSubject` and
+ * `Page::gateSubject()` (used by `toResponse()`/`callAction()`) both resolve
+ * the subject through the same `Lattice\Support\GateSubjects::fromRoute()`,
+ * so the middleware and the page body can never disagree.
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 final readonly class AsPage implements DeclaresGate
 {
@@ -30,6 +47,7 @@ final readonly class AsPage implements DeclaresGate
         public ?PageWidth $width = null,
         public array|string|null $middleware = null,
         string|BackedEnum|array $can = [],
+        public ?string $on = null,
     ) {
         $this->can = Authorization::abilities($can);
     }
@@ -37,5 +55,10 @@ final readonly class AsPage implements DeclaresGate
     public function can(): array
     {
         return $this->can;
+    }
+
+    public function on(): ?string
+    {
+        return $this->on;
     }
 }

--- a/packages/core/src/Attributes/DefinitionAttribute.php
+++ b/packages/core/src/Attributes/DefinitionAttribute.php
@@ -13,11 +13,11 @@ use Lattice\Core\Definition;
  * Action, BulkAction, Table, Fragment, Layout — by the registry `key` its
  * DefinitionRegistry resolves it under.
  *
- * `can` declares subject-less abilities the current user must pass before the
+ * `can` declares the abilities the current user must pass before the
  * definition renders or its endpoint runs. They are checked in addition to
- * {@see Definition::authorize()}, so an override cannot
- * widen what the attribute declared. Abilities needing a subject stay in
- * `authorize()`, where the sealed context is available to resolve one.
+ * {@see Definition::authorize()}, so an override cannot widen what the
+ * attribute declared. `on` names the context key whose resolved value becomes
+ * the gate subject; without it the check stays subject-less, as it always was.
  */
 abstract class DefinitionAttribute implements DeclaresGate
 {
@@ -29,7 +29,7 @@ abstract class DefinitionAttribute implements DeclaresGate
     /**
      * @param  string|BackedEnum|array<int, string|BackedEnum>  $can
      */
-    public function __construct(public readonly string $key, string|BackedEnum|array $can = [])
+    public function __construct(public readonly string $key, string|BackedEnum|array $can = [], private readonly ?string $on = null)
     {
         $this->can = Authorization::abilities($can);
     }
@@ -37,5 +37,10 @@ abstract class DefinitionAttribute implements DeclaresGate
     public function can(): array
     {
         return $this->can;
+    }
+
+    public function on(): ?string
+    {
+        return $this->on;
     }
 }

--- a/packages/core/src/Authorization.php
+++ b/packages/core/src/Authorization.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Lattice\Core\Contracts\Authorizable;
 use Lattice\Core\Contracts\DeclaresGate;
+use Lattice\Core\Contracts\ResolvesGateSubject;
 use Lattice\Core\Support\Wire;
 use Spatie\Attributes\Attributes;
 
@@ -19,12 +20,30 @@ use Spatie\Attributes\Attributes;
  * The two consequences are deliberately different and both live here: an
  * endpoint aborts, while a definition that fails at render time is hidden
  * instead — see DefinitionRegistry::gatedComponent().
+ *
+ * A declared `on` names the context key whose resolved value the gate checks
+ * against, via {@see ResolvesGateSubject}. A key that resolves to nothing
+ * denies outright — a missing subject is never treated as a subject-less
+ * check.
  */
 final class Authorization
 {
     public static function passes(Authorizable $subject, Request $request): bool
     {
-        return self::allows(self::declaredGate($subject), $request)
+        $declared = self::declaredGate($subject);
+        $on = $declared?->on();
+
+        $gateSubject = null;
+
+        if ($on !== null) {
+            $gateSubject = $subject instanceof ResolvesGateSubject ? $subject->gateSubject($on) : null;
+
+            if ($gateSubject === null) {
+                return false;
+            }
+        }
+
+        return self::allows($declared?->can() ?? [], $request, $gateSubject)
             && $subject->authorize($request);
     }
 
@@ -48,16 +67,13 @@ final class Authorization
     /**
      * @param  array<int, string>  $can
      */
-    public static function allows(array $can, Request $request): bool
+    public static function allows(array $can, Request $request, ?object $subject = null): bool
     {
-        return $can === [] || Gate::forUser($request->user())->check($can);
+        return $can === [] || Gate::forUser($request->user())->check($can, $subject === null ? [] : [$subject]);
     }
 
-    /**
-     * @return array<int, string>
-     */
-    private static function declaredGate(Authorizable $subject): array
+    private static function declaredGate(Authorizable $subject): ?DeclaresGate
     {
-        return Attributes::get($subject, DeclaresGate::class)?->can() ?? [];
+        return Attributes::get($subject, DeclaresGate::class);
     }
 }

--- a/packages/core/src/Concerns/ResolvesContextModels.php
+++ b/packages/core/src/Concerns/ResolvesContextModels.php
@@ -5,12 +5,16 @@ namespace Lattice\Core\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Lattice\Core\Definition;
+use LogicException;
 
 /**
- * Resolves a context value into an Eloquent record through the model's own
- * route binding, so a context key resolves exactly as the same value would in
- * a route — `getRouteKeyName()` overrides and custom `resolveRouteBinding()`
- * included. Opt-in rather than part of {@see Definition}
+ * Resolves a context value into an Eloquent record. With an explicit
+ * `$model`, resolution goes through the model's own route binding, so a
+ * context key resolves exactly as the same value would in a route —
+ * `getRouteKeyName()` overrides and custom `resolveRouteBinding()` included.
+ * Without one, resolution delegates to the registered resolver via
+ * {@see Definition::contextModel()}/`contextModelOrNull()`, asserting the
+ * result is an Eloquent model. Opt-in rather than part of {@see Definition}
  * because the package does not depend on illuminate/database.
  *
  * @phpstan-require-extends Definition
@@ -20,11 +24,15 @@ trait ResolvesContextModels
     /**
      * @template TModel of Model
      *
-     * @param  class-string<TModel>  $model
-     * @return TModel
+     * @param  class-string<TModel>|null  $model
+     * @return ($model is null ? Model : TModel)
      */
-    protected function contextModel(string $key, string $model, ?string $by = null): Model
+    protected function contextModel(string $key, ?string $model = null, ?string $by = null): Model
     {
+        if ($model === null) {
+            return $this->assertModel($key, parent::contextModel($key));
+        }
+
         $resolved = $this->contextModelOrNull($key, $model, $by);
 
         if ($resolved === null) {
@@ -45,11 +53,17 @@ trait ResolvesContextModels
      *
      * @template TModel of Model
      *
-     * @param  class-string<TModel>  $model
-     * @return TModel|null
+     * @param  class-string<TModel>|null  $model
+     * @return ($model is null ? Model|null : TModel|null)
      */
-    protected function contextModelOrNull(string $key, string $model, ?string $by = null): ?Model
+    protected function contextModelOrNull(string $key, ?string $model = null, ?string $by = null): ?Model
     {
+        if ($model === null) {
+            $resolved = parent::contextModelOrNull($key);
+
+            return $resolved === null ? null : $this->assertModel($key, $resolved);
+        }
+
         $value = $this->context($key);
 
         if ((! is_string($value) && ! is_int($value)) || $value === '') {
@@ -59,5 +73,18 @@ trait ResolvesContextModels
         $instance = new $model;
 
         return $instance->resolveRouteBinding($value, $by);
+    }
+
+    private function assertModel(string $key, object $resolved): Model
+    {
+        if (! $resolved instanceof Model) {
+            throw new LogicException(sprintf(
+                'Context [%s] resolved to [%s], which is not an Eloquent model.',
+                $key,
+                $resolved::class,
+            ));
+        }
+
+        return $resolved;
     }
 }

--- a/packages/core/src/Contracts/BuildsModelContextResolvers.php
+++ b/packages/core/src/Contracts/BuildsModelContextResolvers.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\Contracts;
+
+use Closure;
+
+/**
+ * Builds the resolve/key closures behind the Eloquent sugar of
+ * `Lattice::context($key, Model::class, by: ...)`. Bound by the framework
+ * package (which depends on illuminate/database) so core itself does not.
+ */
+interface BuildsModelContextResolvers
+{
+    /**
+     * @param  class-string  $model
+     */
+    public function resolver(string $model, ?string $by): Closure;
+
+    /**
+     * @param  class-string  $model
+     */
+    public function keyBy(string $model, ?string $by): Closure;
+}

--- a/packages/core/src/Contracts/DeclaresGate.php
+++ b/packages/core/src/Contracts/DeclaresGate.php
@@ -16,4 +16,11 @@ interface DeclaresGate
      * @return array<int, string>
      */
     public function can(): array;
+
+    /**
+     * The context key declared by `on`, resolved into the gate subject
+     * through {@see ResolvesGateSubject}. Null means the check runs
+     * subject-less, as it always did before `on` existed.
+     */
+    public function on(): ?string;
 }

--- a/packages/core/src/Contracts/ResolvesGateSubject.php
+++ b/packages/core/src/Contracts/ResolvesGateSubject.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\Contracts;
+
+use Lattice\Core\Authorization;
+
+/**
+ * Implemented by whatever a `can`+`on` pair can gate — a definition, a page —
+ * so {@see Authorization} resolves the declared `on` context key
+ * into the object passed to `Gate::check()` without knowing whether it is
+ * reading sealed context or a route parameter.
+ */
+interface ResolvesGateSubject
+{
+    /**
+     * Resolves the value under the given key into its gate subject, or null
+     * when the key is absent or its resolver yields nothing. Authorization
+     * treats null as "no subject" and denies rather than falling back to a
+     * subject-less check.
+     */
+    public function gateSubject(string $key): ?object;
+}

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -8,6 +8,8 @@ use Lattice\Core\Contracts\ResolvesReferenceIdentity;
 use Lattice\Core\Contracts\SignsComponentReferences;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Core\Services\ComponentReferenceSigner;
+use Lattice\Core\Services\ContextResolutions;
+use Lattice\Core\Services\ContextResolvers;
 use Lattice\Core\Services\ContextScope;
 use Lattice\Core\Services\RequestReferenceIdentity;
 use Lattice\Core\Support\Evaluation\Evaluator;
@@ -23,6 +25,8 @@ final class CoreServiceProvider extends ServiceProvider
         $this->app->singleton(ComponentReferenceSigner::class);
         $this->app->alias(ComponentReferenceSigner::class, SignsComponentReferences::class);
         $this->app->scoped(ContextScope::class);
+        $this->app->singleton(ContextResolvers::class);
+        $this->app->scoped(ContextResolutions::class);
         $this->app->singleton(DiscoveryManifest::class);
         $this->app->singleton(PageMetadataResolver::class);
     }

--- a/packages/core/src/Definition.php
+++ b/packages/core/src/Definition.php
@@ -5,6 +5,7 @@ namespace Lattice\Core;
 
 use Illuminate\Http\Request;
 use Lattice\Core\Contracts\Authorizable;
+use Lattice\Core\Services\ContextResolutions;
 
 abstract class Definition implements Authorizable
 {
@@ -81,5 +82,41 @@ abstract class Definition implements Authorizable
         $value = $this->context($key);
 
         return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * Presence check distinct from "not found": a key that's set but whose
+     * resolver yields nothing still passes this test.
+     */
+    protected function hasContext(string $key): bool
+    {
+        $value = $this->context($key);
+
+        return $value !== null && $value !== '';
+    }
+
+    /**
+     * The context value resolved through its registered {@see ContextResolutions}
+     * resolver, memoized per request. Aborts with a 404 when the key is
+     * absent or the resolver yields nothing — inside a render-time
+     * authorize() use {@see contextModelOrNull()} instead, or a missing key
+     * takes the whole page down rather than hiding the component. Throws
+     * when no resolver is registered for the key; register one with
+     * `Lattice::context()`.
+     */
+    protected function contextModel(string $key): object
+    {
+        $resolved = $this->contextModelOrNull($key);
+
+        if ($resolved === null) {
+            abort(404);
+        }
+
+        return $resolved;
+    }
+
+    protected function contextModelOrNull(string $key): ?object
+    {
+        return app(ContextResolutions::class)->resolve($key, $this->context($key), $this->context);
     }
 }

--- a/packages/core/src/Definition.php
+++ b/packages/core/src/Definition.php
@@ -5,9 +5,10 @@ namespace Lattice\Core;
 
 use Illuminate\Http\Request;
 use Lattice\Core\Contracts\Authorizable;
+use Lattice\Core\Contracts\ResolvesGateSubject;
 use Lattice\Core\Services\ContextResolutions;
 
-abstract class Definition implements Authorizable
+abstract class Definition implements Authorizable, ResolvesGateSubject
 {
     /**
      * The instance context, set identically on render (by the registry) and on
@@ -118,5 +119,14 @@ abstract class Definition implements Authorizable
     protected function contextModelOrNull(string $key): ?object
     {
         return app(ContextResolutions::class)->resolve($key, $this->context($key), $this->context);
+    }
+
+    /**
+     * The `on` gate subject, resolved identically to {@see contextModelOrNull()}
+     * — the same memoized context resolution a `can()` closure would use.
+     */
+    public function gateSubject(string $key): ?object
+    {
+        return $this->contextModelOrNull($key);
     }
 }

--- a/packages/core/src/DefinitionRegistry.php
+++ b/packages/core/src/DefinitionRegistry.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Lattice\Core\Attributes\DefinitionAttribute;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Core\Exceptions\UnknownComponent;
+use Lattice\Core\Services\ContextResolutions;
 use Lattice\Core\Services\ContextScope;
 use Spatie\Attributes\Attributes;
 
@@ -33,10 +34,12 @@ abstract class DefinitionRegistry
      * configured and then sealed. Registries supply only the construction
      * closures so this sequence cannot drift between them.
      *
-     * Whitelisted context keys (`lattice.context.inherited_keys`) cascade:
+     * Whitelisted and registered context keys ({@see ContextScope}) cascade:
      * they merge beneath the explicit context — so the gate and the sealed
      * ref see the same merged array — and the configure step runs inside a
-     * ContextScope frame, so children built within it inherit them too.
+     * ContextScope frame, so children built within it inherit them too. Any
+     * object value under a registered key is normalized to its scalar first,
+     * so the gate, `withContext()`, and the sealed ref never see a model.
      *
      * @template TComponent of Contracts\CanBeHidden&Contracts\InteractiveComponent
      *
@@ -49,6 +52,7 @@ abstract class DefinitionRegistry
     protected function gatedComponent(string $definitionClass, callable $component, callable $configure, array $context = [])
     {
         $scope = $this->container->make(ContextScope::class);
+        $context = $this->container->make(ContextResolutions::class)->normalize($context);
         $context = [...$scope->inheritable(), ...$context];
 
         $key = $this->registeredKeyFor($definitionClass);

--- a/packages/core/src/Facades/Lattice.php
+++ b/packages/core/src/Facades/Lattice.php
@@ -21,6 +21,7 @@ use Lattice\Core\LatticeRegistry;
  * @method static \Lattice\Remote\RemoteSourceRegistry remoteSourceRegistry()
  * @method static void searchProviders(class-string<\Lattice\Search\Contracts\SearchResultProvider>|array<int, class-string<\Lattice\Search\Contracts\SearchResultProvider>> $providers)
  * @method static \Lattice\Search\SearchProviderRegistry searchProviderRegistry()
+ * @method static void context(string $key, \Closure|class-string $resolver, ?string $by = null, ?\Closure $keyBy = null)
  * @method static void extend(string $name, \Closure $factory, int $priority = 0)
  * @method static void theme(\Lattice\Theme\Theme|\Closure $theme)
  * @method static void translations(string $namespace, string $path)

--- a/packages/core/src/LatticeRegistry.php
+++ b/packages/core/src/LatticeRegistry.php
@@ -9,7 +9,10 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 use Lattice\Core\Attributes\WireType;
+use Lattice\Core\Contracts\BuildsModelContextResolvers;
+use Lattice\Core\Services\ContextResolvers;
 use Lattice\Core\Support\TypeScript\WireFamily;
+use LogicException;
 
 final class LatticeRegistry
 {
@@ -38,6 +41,43 @@ final class LatticeRegistry
         }
 
         return ($this->capabilities[$name])(...$arguments);
+    }
+
+    /**
+     * Registers a context key, either directly with a resolve closure and an
+     * optional key closure (turning a resolved object back into its wire
+     * scalar), or with an Eloquent model class name and the sugar builds both
+     * from `resolveRouteBinding()`/`getRouteKey()`. A `$keyBy` closure always
+     * wins over the sugar's own.
+     *
+     * @param  Closure|class-string  $resolver
+     */
+    public function context(string $key, Closure|string $resolver, ?string $by = null, ?Closure $keyBy = null): void
+    {
+        $resolvers = $this->container->make(ContextResolvers::class);
+
+        if ($resolver instanceof Closure) {
+            $resolvers->register($key, $resolver, $keyBy);
+
+            return;
+        }
+
+        if (! $this->container->bound(BuildsModelContextResolvers::class)) {
+            throw new LogicException(sprintf(
+                'Lattice::context(\'%s\', %s::class) needs an Eloquent model resolver bound to [%s]. Install lattice-php/framework, or register a closure resolver instead.',
+                $key,
+                $resolver,
+                BuildsModelContextResolvers::class,
+            ));
+        }
+
+        $builder = $this->container->make(BuildsModelContextResolvers::class);
+
+        $resolvers->register(
+            $key,
+            $builder->resolver($resolver, $by),
+            $keyBy ?? $builder->keyBy($resolver, $by),
+        );
     }
 
     /**

--- a/packages/core/src/LatticeRegistry.php
+++ b/packages/core/src/LatticeRegistry.php
@@ -77,6 +77,7 @@ final class LatticeRegistry
             $key,
             $builder->resolver($resolver, $by),
             $keyBy ?? $builder->keyBy($resolver, $by),
+            $resolver,
         );
     }
 

--- a/packages/core/src/PageMetadata.php
+++ b/packages/core/src/PageMetadata.php
@@ -30,6 +30,7 @@ final readonly class PageMetadata
         public PageWidth $width,
         public ?array $middleware,
         public array $can,
+        public ?string $on,
     ) {}
 
     /** @param  PageContract|class-string<PageContract>  $page */
@@ -52,7 +53,8 @@ final readonly class PageMetadata
             layout: self::inherited($class, fn (AsPage $a): PageLayout|string|null => $a->layout) ?? PageLayout::None,
             width: self::inherited($class, fn (AsPage $a): ?PageWidth => $a->width) ?? PageWidth::Full,
             middleware: self::inheritedMiddleware($class),
-            can: $own?->can() ?? [],
+            can: self::inherited($class, fn (AsPage $a): ?array => $a->can() === [] ? null : $a->can()) ?? [],
+            on: self::inherited($class, fn (AsPage $a): ?string => $a->on()),
         );
     }
 
@@ -68,7 +70,7 @@ final readonly class PageMetadata
     }
 
     /**
-     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, width: string, can: array<int, string>}
+     * @return array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, width: string, can: array<int, string>, on: string|null}
      */
     public function toArray(): array
     {
@@ -80,14 +82,16 @@ final readonly class PageMetadata
             'layout' => $this->serialize($this->layout),
             'width' => $this->serialize($this->width),
             'can' => $this->can,
+            'on' => $this->on,
         ];
     }
 
     /**
-     * `can` defaults for descriptors cached by a manifest built before it
-     * existed, so an upgrade works without regenerating the discovery cache.
+     * `can`/`on` default for descriptors cached by a manifest built before
+     * they existed, so an upgrade works without regenerating the discovery
+     * cache.
      *
-     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, width: string, can?: array<int, string>}  $descriptor
+     * @param  array{class: class-string, route: string|null, name: string, middleware: array<int, string>|null, layout: string, width: string, can?: array<int, string>, on?: string|null}  $descriptor
      */
     public static function fromArray(array $descriptor): self
     {
@@ -99,6 +103,7 @@ final readonly class PageMetadata
             width: PageWidth::from($descriptor['width']),
             middleware: $descriptor['middleware'],
             can: $descriptor['can'] ?? [],
+            on: $descriptor['on'] ?? null,
         );
     }
 

--- a/packages/core/src/Services/ContextResolutions.php
+++ b/packages/core/src/Services/ContextResolutions.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Lattice\Core\Services;
 
+use BackedEnum;
 use Illuminate\Http\Request;
 use Lattice\Core\Support\Evaluation\Evaluator;
 use LogicException;
@@ -68,7 +69,7 @@ final class ContextResolutions
 
         $keyClosure = $this->resolvers->keyClosure($key);
 
-        if (!$keyClosure instanceof \Closure) {
+        if (! $keyClosure instanceof \Closure) {
             if (method_exists($model, 'getRouteKey')) {
                 $routeKey = $model->getRouteKey();
 
@@ -100,6 +101,46 @@ final class ContextResolutions
         }
 
         return $result;
+    }
+
+    /**
+     * Turns every object value in a raw context array into its wire-safe
+     * scalar via {@see self::serialize()}, so neither a gate, `withContext()`,
+     * nor a sealed ref ever carries a model. A `BackedEnum` normalizes to its
+     * backing `->value` regardless of whether a resolver is registered for
+     * the key — it was always wire-safe on its own. An object under a key
+     * without a registered resolver throws rather than being silently
+     * JSON-encoded wholesale into a sealed ref.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function normalize(array $context): array
+    {
+        foreach ($context as $key => $value) {
+            if ($value instanceof BackedEnum) {
+                $context[$key] = $value->value;
+
+                continue;
+            }
+
+            if (! is_object($value)) {
+                continue;
+            }
+
+            $key = (string) $key;
+
+            if (! $this->resolvers->has($key)) {
+                throw new LogicException(sprintf(
+                    'Lattice context values must be scalar unless a resolver is registered for [%s]. Register one with Lattice::context(), or pass the scalar value directly.',
+                    $key,
+                ));
+            }
+
+            $context[$key] = $this->serialize($key, $value);
+        }
+
+        return $context;
     }
 
     private function unregistered(string $key): LogicException

--- a/packages/core/src/Services/ContextResolutions.php
+++ b/packages/core/src/Services/ContextResolutions.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\Services;
+
+use Illuminate\Http\Request;
+use Lattice\Core\Support\Evaluation\Evaluator;
+use LogicException;
+
+/**
+ * Request-scoped evaluation of {@see ContextResolvers}: a resolver runs at
+ * most once per request for a given key/value pair, however many definitions
+ * ask for it, and the miss ("not found") is cached too.
+ */
+final class ContextResolutions
+{
+    /** @var array<string, object|null> */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly ContextResolvers $resolvers,
+        private readonly Evaluator $evaluator,
+        private readonly Request $request,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $context  The definition's full raw context, so a
+     *                                         dependent resolver can read another key.
+     */
+    public function resolve(string $key, mixed $value, array $context): ?object
+    {
+        if (! $this->resolvers->has($key)) {
+            throw $this->unregistered($key);
+        }
+
+        if ((! is_string($value) && ! is_int($value)) || $value === '') {
+            return null;
+        }
+
+        $cacheKey = $key.'|'.$value;
+
+        if (array_key_exists($cacheKey, $this->cache)) {
+            return $this->cache[$cacheKey];
+        }
+
+        $resolve = $this->resolvers->resolver($key) ?? throw $this->unregistered($key);
+
+        $result = $this->evaluator->resolve($resolve, $this->evaluator->context()
+            ->named('value', $value)
+            ->named('key', $key)
+            ->named('context', $context)
+            ->typed(Request::class, $this->request)
+            ->typed(self::class, $this));
+
+        return $this->cache[$cacheKey] = is_object($result) ? $result : null;
+    }
+
+    /**
+     * Turns a resolved object back into its wire-safe scalar: the registered
+     * `key` closure, or the object's own `getRouteKey()` when none was
+     * registered.
+     */
+    public function serialize(string $key, object $model): string|int
+    {
+        if (! $this->resolvers->has($key)) {
+            throw $this->unregistered($key);
+        }
+
+        $keyClosure = $this->resolvers->keyClosure($key);
+
+        if (!$keyClosure instanceof \Closure) {
+            if (method_exists($model, 'getRouteKey')) {
+                $routeKey = $model->getRouteKey();
+
+                if (is_string($routeKey) || is_int($routeKey)) {
+                    return $routeKey;
+                }
+            }
+
+            throw new LogicException(sprintf(
+                'Lattice context [%s] has no key resolver and [%s] has no getRouteKey() method. Pass a key: closure to Lattice::context(\'%s\', ...).',
+                $key,
+                $model::class,
+                $key,
+            ));
+        }
+
+        $result = $this->evaluator->resolve($keyClosure, $this->evaluator->context()
+            ->named('value', $model)
+            ->named('key', $key)
+            ->typed($model::class, $model)
+            ->typed(Request::class, $this->request));
+
+        if (! is_string($result) && ! is_int($result)) {
+            throw new LogicException(sprintf(
+                'The key resolver registered for Lattice context [%s] must return a string or int, got [%s].',
+                $key,
+                get_debug_type($result),
+            ));
+        }
+
+        return $result;
+    }
+
+    private function unregistered(string $key): LogicException
+    {
+        return new LogicException(sprintf(
+            'No context resolver is registered for [%s]. Register one with Lattice::context().',
+            $key,
+        ));
+    }
+}

--- a/packages/core/src/Services/ContextResolvers.php
+++ b/packages/core/src/Services/ContextResolvers.php
@@ -12,16 +12,21 @@ use Closure;
  */
 final class ContextResolvers
 {
-    /** @var array<string, array{resolve: Closure, key: ?Closure}> */
+    /** @var array<string, array{resolve: Closure, key: ?Closure, model: ?class-string}> */
     private array $resolvers = [];
 
     /**
      * Registering the same key twice replaces the previous registration —
-     * the last call to `Lattice::context()` for a key wins.
+     * the last call to `Lattice::context()` for a key wins. `$model` is set
+     * only by the Eloquent sugar form of `Lattice::context()`, so {@see
+     * keyForModel()} can seed a page's context frame from a bound route
+     * model without any naming convention on the route parameter.
+     *
+     * @param  ?class-string  $model
      */
-    public function register(string $key, Closure $resolve, ?Closure $keyBy = null): void
+    public function register(string $key, Closure $resolve, ?Closure $keyBy = null, ?string $model = null): void
     {
-        $this->resolvers[$key] = ['resolve' => $resolve, 'key' => $keyBy];
+        $this->resolvers[$key] = ['resolve' => $resolve, 'key' => $keyBy, 'model' => $model];
     }
 
     public function has(string $key): bool
@@ -45,5 +50,22 @@ final class ContextResolvers
     public function keyClosure(string $key): ?Closure
     {
         return $this->resolvers[$key]['key'] ?? null;
+    }
+
+    /**
+     * The first registered key whose recorded Eloquent model class the given
+     * object is an instance of, in registration order. Only keys registered
+     * through the `Lattice::context($key, Model::class)` sugar carry a model
+     * class, so a closure registration never matches.
+     */
+    public function keyForModel(object $model): ?string
+    {
+        foreach ($this->resolvers as $key => $entry) {
+            if ($entry['model'] !== null && $model instanceof $entry['model']) {
+                return $key;
+            }
+        }
+
+        return null;
     }
 }

--- a/packages/core/src/Services/ContextResolvers.php
+++ b/packages/core/src/Services/ContextResolvers.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\Services;
+
+use Closure;
+
+/**
+ * The application-wide map from a context key to its resolver, registered
+ * once per boot via `Lattice::context()`. {@see ContextResolutions} evaluates
+ * the resolve closure and memoizes the result per request.
+ */
+final class ContextResolvers
+{
+    /** @var array<string, array{resolve: Closure, key: ?Closure}> */
+    private array $resolvers = [];
+
+    /**
+     * Registering the same key twice replaces the previous registration —
+     * the last call to `Lattice::context()` for a key wins.
+     */
+    public function register(string $key, Closure $resolve, ?Closure $keyBy = null): void
+    {
+        $this->resolvers[$key] = ['resolve' => $resolve, 'key' => $keyBy];
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->resolvers);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function keys(): array
+    {
+        return array_keys($this->resolvers);
+    }
+
+    public function resolver(string $key): ?Closure
+    {
+        return $this->resolvers[$key]['resolve'] ?? null;
+    }
+
+    public function keyClosure(string $key): ?Closure
+    {
+        return $this->resolvers[$key]['key'] ?? null;
+    }
+}

--- a/packages/core/src/Services/ContextScope.php
+++ b/packages/core/src/Services/ContextScope.php
@@ -13,9 +13,13 @@ use Closure;
  * re-threading; endpoints activate a frame so the response paths that
  * rebuild children (table rows, form schemas, fragments) behave identically.
  *
- * Only keys listed in `lattice.context.inherited_keys` cascade — context can
- * carry routing and policy values (the bulk-action table key, media upload
- * rules) that must never leak into a child's sealed ref.
+ * A key cascades when it is listed in `lattice.context.inherited_keys` or has
+ * a resolver registered via `Lattice::context()` — a registered key always
+ * inherits, config or not. Context can carry routing and policy values (the
+ * bulk-action table key, media upload rules) that must never leak into a
+ * child's sealed ref, so only the whitelisted/registered keys cascade, and
+ * every value normalizes to a scalar (through {@see ContextResolutions}) so
+ * a frame never carries an object.
  */
 final class ContextScope
 {
@@ -24,6 +28,11 @@ final class ContextScope
 
     /** @var list<array<string, mixed>> */
     private array $frames = [];
+
+    public function __construct(
+        private readonly ContextResolvers $resolvers,
+        private readonly ContextResolutions $resolutions,
+    ) {}
 
     /**
      * @template TReturn
@@ -34,7 +43,7 @@ final class ContextScope
      */
     public function wrap(array $context, Closure $fn): mixed
     {
-        $this->frames[] = $this->inheritableSubset($context);
+        $this->frames[] = $this->inheritableSubset($this->resolutions->normalize($context));
 
         try {
             return $fn();
@@ -51,7 +60,7 @@ final class ContextScope
      */
     public function activate(array $context): void
     {
-        $this->frames[] = $this->inheritableSubset($context);
+        $this->frames[] = $this->inheritableSubset($this->resolutions->normalize($context));
     }
 
     /**
@@ -68,9 +77,12 @@ final class ContextScope
      */
     private function inheritableSubset(array $context): array
     {
-        $keys = config('lattice.context.inherited_keys', []);
+        $configured = config('lattice.context.inherited_keys', []);
+        $configured = is_array($configured) ? $configured : [];
 
-        if (! is_array($keys) || $keys === []) {
+        $keys = [...$configured, ...$this->resolvers->keys()];
+
+        if ($keys === []) {
             return [];
         }
 

--- a/packages/core/src/Services/ContextScope.php
+++ b/packages/core/src/Services/ContextScope.php
@@ -64,11 +64,65 @@ final class ContextScope
     }
 
     /**
+     * Like {@see wrap()}, but filters to the registered/whitelisted subset
+     * *before* normalizing rather than after. Use this when the raw context
+     * may legitimately carry an object under a key with no resolver — a
+     * slot's factory arguments, say — that must be dropped silently instead
+     * of throwing.
+     *
+     * @template TReturn
+     *
+     * @param  array<string, mixed>  $context
+     * @param  Closure(): TReturn  $fn
+     * @return TReturn
+     */
+    public function wrapUntrusted(array $context, Closure $fn): mixed
+    {
+        return $this->wrap($this->inheritableSubset($context), $fn);
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function inheritable(): array
     {
         return $this->frames === [] ? [] : end($this->frames);
+    }
+
+    /**
+     * The inherited frame at this instant, to replay later with {@see within()}
+     * once the frame that captured it has already popped — a closure resolved
+     * from a `#[SerializationHook]` (an embedded modal, a declared gate
+     * subject) runs after the whole tree has serialized, not while it is
+     * being built.
+     *
+     * @return array<string, mixed>
+     */
+    public function snapshot(): array
+    {
+        return $this->inheritable();
+    }
+
+    /**
+     * Re-opens a frame captured by {@see snapshot()} for the duration of
+     * `$fn`, so components it builds inherit it exactly as they would have
+     * inherited the original frame.
+     *
+     * @template TReturn
+     *
+     * @param  array<string, mixed>  $frame
+     * @param  Closure(): TReturn  $fn
+     * @return TReturn
+     */
+    public function within(array $frame, Closure $fn): mixed
+    {
+        $this->frames[] = $frame;
+
+        try {
+            return $fn();
+        } finally {
+            array_pop($this->frames);
+        }
     }
 
     /**

--- a/packages/framework/config/lattice.php
+++ b/packages/framework/config/lattice.php
@@ -17,8 +17,11 @@ return [
 
     'context' => [
         // Context keys child components inherit from the definition they are
-        // built inside (row actions, modal forms, nested actions). Empty means
-        // no inheritance; explicit context always wins over inherited keys.
+        // built inside (row actions, modal forms, nested actions), on top of
+        // every key with a resolver registered via Lattice::context() (which
+        // always inherits regardless of this list). Use this for keys that
+        // have no resolver but should still cascade; explicit context always
+        // wins over inherited keys.
         'inherited_keys' => [],
     ],
 

--- a/packages/framework/resources/boost/skills/lattice-actions/SKILL.md
+++ b/packages/framework/resources/boost/skills/lattice-actions/SKILL.md
@@ -113,6 +113,8 @@ Action::use(ArchiveProductAction::class)->context(['product_id' => $row['id']]);
 
 `handle()` reads it back with `$this->context('product_id')`. The context is **signed** into the action's reference, so it cannot be tampered with on the way back. Group related triggers behind one button with `ActionGroup::make('row')->actions([...])` (`Lattice\Actions\Components\ActionGroup`).
 
+Register a key once with `Lattice::context('product', Product::class)` (or a closure resolver, `Lattice::context('product', fn (string $value) => Product::findOrFail($value))`) and `contextModel('product')` resolves it into the model — memoized per request (a resolver runs at most once, however many times it's read), aborting with a 404 when the key is absent or nothing matches. A registered key also cascades automatically into every child the action builds (a `->form([...])` field, a nested action) without re-passing it, and it can be placed as the model directly — `->context(['product' => $product])` normalizes it to the scalar before the ref seals.
+
 ## Confirmation and input forms
 
 - `->confirm($title?, $description?, $confirmLabel?, $cancelLabel?)` shows a confirmation dialog before the action runs; `$title` defaults to the action's label when omitted.
@@ -131,6 +133,8 @@ return $action
 ## Authorization
 
 Override `authorize(Request $request): bool` to gate an action; the trusted context is already merged in. A denied action never reaches `handle()`.
+
+For a subject ability (`can('update', $product)` rather than a subject-less one), declare it on the attribute instead: `#[AsAction('app.products.archive', can: 'update', on: 'product')]` checks the ability against the `product` context key's resolved value. A missing subject (the key absent, or its resolver finding nothing) denies outright rather than falling back to a subject-less check.
 
 ## Bulk actions
 

--- a/packages/framework/resources/boost/skills/lattice-closures/SKILL.md
+++ b/packages/framework/resources/boost/skills/lattice-closures/SKILL.md
@@ -56,6 +56,8 @@ TextInput::make('total', 'Total')->dependsOn(
 | `ToggleFilter::query()` | A typed Eloquent `Builder`, `$value` (the toggle state). |
 | `TernaryFilter::queries()` / a custom `Filter::apply()` | A typed Eloquent `Builder`. |
 | `Lattice::extend()` slot closures | Named slot context, typed context objects, `$user`, `$slot`/typed `Slot`, typed `Request`. |
+| `Lattice::context()` resolver | `$value` (the raw context scalar), `$key`, `$context` (the definition's full raw context array — read another key), typed `Request`. |
+| `Lattice::context()` `keyBy` (turns the resolved object back into its wire scalar) | `$value` or the resolved object's own type, `$key`, typed `Request`. |
 
 ```php
 Select::make('author_id', 'Author')
@@ -67,6 +69,10 @@ Select::make('author_id', 'Author')
 
 Repeater::make('lines')
     ->itemLabel(fn (FormData $row, FormData $form) => $row->string('name') ?: $form->string('currency'));
+
+Lattice::context('product', function (string $value, Request $request): Product {
+    return Product::where('slug', $value)->firstOrFail();
+});
 ```
 
 ## Server-side timing

--- a/packages/framework/resources/boost/skills/lattice-forms/SKILL.md
+++ b/packages/framework/resources/boost/skills/lattice-forms/SKILL.md
@@ -156,6 +156,8 @@ Form::use(ProfileForm::class)
     ->context(['user_id' => $user->id]);                      // extra data handle() can read
 ```
 
+Register a key once with `Lattice::context('user', User::class)` and read it back typed with `$this->contextModel('user')` — memoized per request, 404 when the key is absent or nothing resolves; `contextModelOrNull()` in a render-time `authorize()` instead. A registered key cascades automatically into every field/action the form builds without re-passing it, and `->context(['user' => $user])` accepts the model directly — it normalizes to the scalar before the ref seals. Gate the form itself against that same subject with `#[AsForm('id', can: 'update', on: 'user')]`.
+
 The form renders its own submit button in a plain right-aligned row (disabled while submitting or while there are errors, with a spinner) — labelled by `->submitLabel()`, aligned with `->submitJustify(Justify::…)`, and styled with `->submitVariant(ButtonVariant::…)`. Replace the row's contents with `->submitButtons(Button::make('Cancel'), Button::make('Save')->submit())`; only a `->submit()`-marked button's label and variant carry over to the managed button, other props are ignored. To place the button yourself instead, call `->withoutSubmitButton()` (removes the row entirely) and add `Button::make('Save')->submit()` in the schema.
 
 ## Submit lifecycle

--- a/packages/framework/resources/boost/skills/lattice-tables/SKILL.md
+++ b/packages/framework/resources/boost/skills/lattice-tables/SKILL.md
@@ -108,7 +108,7 @@ Render with `Table::use(ProductsTable::class)` inside a page's component tree. `
 
 ## Row & bulk actions
 
-A table only *attaches* actions and their context; the action classes themselves are defined separately — see the **`lattice-actions`** skill.
+A table only *attaches* actions and their context; the action classes themselves are defined separately — see the **`lattice-actions`** skill. A key registered with `Lattice::context()` (a resolver bound once via a service provider) cascades automatically from the table into every row/bulk action it builds, so it doesn't need `->context([...])` at all unless the row itself supplies the value (a per-row id, say).
 
 - **Row actions** — return components from `actions(array $row)`: `Action::use(...)->context([...])` scoped to the record, plus plain `Link::make()->href(...)`.
 

--- a/packages/framework/src/Http/Middleware/AuthorizeGateSubject.php
+++ b/packages/framework/src/Http/Middleware/AuthorizeGateSubject.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Lattice\Http\Page;
+use Lattice\LatticeServiceProvider;
+use Lattice\Support\GateSubjects;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The route-middleware half of a page's `can: … on: …` declaration
+ * ({@see LatticeServiceProvider::bootPages()} emits it in place of
+ * the framework `can:` middleware whenever `on` is set): Laravel's own `can:`
+ * middleware hands an unbound route parameter to the gate as a raw scalar, so
+ * it cannot see a `Lattice::context()` resolver. This resolves the subject
+ * through the same {@see GateSubjects::fromRoute()} {@see Page::gateSubject()}
+ * uses, so the middleware and the page body never disagree about the subject.
+ */
+final class AuthorizeGateSubject
+{
+    public function handle(Request $request, Closure $next, string $ability, string $on): Response
+    {
+        $subject = GateSubjects::fromRoute($request, $on);
+
+        abort_if($subject === null, 403);
+
+        Gate::forUser($request->user())->authorize($ability, [$subject]);
+
+        return $next($request);
+    }
+}

--- a/packages/framework/src/Http/Page.php
+++ b/packages/framework/src/Http/Page.php
@@ -17,6 +17,8 @@ use Lattice\Core\Enums\PageLayout;
 use Lattice\Core\Enums\PageWidth;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Core\PageMetadata;
+use Lattice\Core\Services\ContextResolvers;
+use Lattice\Core\Services\ContextScope;
 use Lattice\Core\Support\Wire;
 use Lattice\Http\Middleware\AuthorizeGateSubject;
 use Lattice\Realtime\Listen;
@@ -106,7 +108,10 @@ abstract class Page implements PageContract, ResolvesGateSubject, Responsable
             ));
         }
 
-        Authorization::ensure($this, app(Request::class));
+        $request = app(Request::class);
+
+        Authorization::ensure($this, $request);
+        app(ContextScope::class)->activate($this->contextFrame($request));
 
         return $this->pageResponse($method, $this->{$method}(...array_values($parameters)));
     }
@@ -117,6 +122,7 @@ abstract class Page implements PageContract, ResolvesGateSubject, Responsable
     public function toResponse($request): HttpResponse
     {
         Authorization::ensure($this, $request);
+        app(ContextScope::class)->activate($this->contextFrame($request));
 
         // schema is passed so the container resolves render()'s other
         // dependencies but does not rebuild PageSchema itself; the route's
@@ -127,6 +133,44 @@ abstract class Page implements PageContract, ResolvesGateSubject, Responsable
         $schema = app()->call($this->render(...), $parameters);
 
         return $this->pageResponse('render', $schema)->toResponse($request);
+    }
+
+    /**
+     * Seeds the page's `ContextScope` frame from the route's bound
+     * parameters, by convention: an object parameter seeds the key a
+     * `Lattice::context($key, Model::class)` resolver registered for its
+     * class ({@see ContextResolvers::keyForModel()}) — so a route parameter
+     * named `current_tenant` and bound to a `Tenant` still seeds `tenant` —
+     * and a scalar parameter seeds the key sharing its own name, when that
+     * name is itself registered. `PageSchema::context()` extends or
+     * overrides this from `render()` for anything the convention misses.
+     * Override this to change the convention for a page (or a whole base
+     * page class).
+     *
+     * @return array<string, mixed>
+     */
+    protected function contextFrame(Request $request): array
+    {
+        $resolvers = app(ContextResolvers::class);
+        $frame = [];
+
+        foreach ($request->route()?->parameters() ?? [] as $name => $value) {
+            if (is_object($value)) {
+                $key = $resolvers->keyForModel($value);
+
+                if ($key !== null) {
+                    $frame[$key] = $value;
+                }
+
+                continue;
+            }
+
+            if (is_scalar($value) && $resolvers->has((string) $name)) {
+                $frame[(string) $name] = $value;
+            }
+        }
+
+        return $frame;
     }
 
     private function pageResponse(string $method, mixed $schema): Response

--- a/packages/framework/src/Http/Page.php
+++ b/packages/framework/src/Http/Page.php
@@ -12,12 +12,15 @@ use Inertia\Response;
 use Lattice\Core\Authorization;
 use Lattice\Core\Breadcrumb;
 use Lattice\Core\Contracts\PageContract;
+use Lattice\Core\Contracts\ResolvesGateSubject;
 use Lattice\Core\Enums\PageLayout;
 use Lattice\Core\Enums\PageWidth;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Core\PageMetadata;
 use Lattice\Core\Support\Wire;
+use Lattice\Http\Middleware\AuthorizeGateSubject;
 use Lattice\Realtime\Listen;
+use Lattice\Support\GateSubjects;
 use Lattice\Ui\BreadcrumbTrail;
 use Lattice\Ui\PageSchema;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
@@ -26,7 +29,7 @@ use UnexpectedValueException;
 /**
  * @method PageSchema render(mixed ...$parameters)
  */
-abstract class Page implements PageContract, Responsable
+abstract class Page implements PageContract, ResolvesGateSubject, Responsable
 {
     public function title(): ?string
     {
@@ -52,6 +55,20 @@ abstract class Page implements PageContract, Responsable
     public function authorize(Request $request): bool
     {
         return true;
+    }
+
+    /**
+     * The `on` gate subject: the named route parameter as bound by
+     * `SubstituteBindings`, or — for a scalar, unbound value — resolved
+     * through a `Lattice::context()` resolver registered under the same key.
+     * A parameter that is neither yields no subject, so the gate denies.
+     * Shared with {@see AuthorizeGateSubject}, the
+     * `can:{ability},{on}` route middleware, via {@see GateSubjects}, so the
+     * two never resolve the same key differently.
+     */
+    public function gateSubject(string $key): ?object
+    {
+        return GateSubjects::fromRoute(app(Request::class), $key);
     }
 
     /**

--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -28,6 +28,7 @@ use Lattice\Console\Commands\UpdateCommand;
 use Lattice\Core\Attributes\AsFragment;
 use Lattice\Core\Attributes\AsLayout;
 use Lattice\Core\Attributes\AsRemoteSource;
+use Lattice\Core\Contracts\BuildsModelContextResolvers;
 use Lattice\Core\Contracts\ResolvesRemoteSourceEndpoints;
 use Lattice\Core\Discovery\ComponentPackages;
 use Lattice\Core\Discovery\DiscoveryKinds;
@@ -45,6 +46,7 @@ use Lattice\Layouts\LayoutDefinition;
 use Lattice\Layouts\LayoutRegistry;
 use Lattice\Remote\RemoteSourceDefinition;
 use Lattice\Remote\RemoteSourceRegistry;
+use Lattice\Support\EloquentContextResolvers;
 use Lattice\Support\Frontend\StandaloneAssets;
 use Lattice\Support\TypeScript\AugmentProfile;
 use Lattice\Support\TypeScript\TypeScriptProfile;
@@ -89,6 +91,7 @@ final class LatticeServiceProvider extends PackageServiceProvider
 
         $this->app->singleton(WireSourceCatalog::class, static fn (): WireSourceCatalog => WireSourceCatalog::fromApplication());
         $this->app->bind(TypeScriptProfile::class, AugmentProfile::class);
+        $this->app->bind(BuildsModelContextResolvers::class, EloquentContextResolvers::class);
 
         if ($this->app->runningInConsole()) {
             $this->commands(MakeDefinitionCommand::all());

--- a/packages/framework/src/LatticeServiceProvider.php
+++ b/packages/framework/src/LatticeServiceProvider.php
@@ -40,6 +40,7 @@ use Lattice\Core\Wire\WireSourceCatalog;
 use Lattice\Form\FormServiceProvider;
 use Lattice\Fragments\FragmentDefinition;
 use Lattice\Fragments\FragmentRegistry;
+use Lattice\Http\Middleware\AuthorizeGateSubject;
 use Lattice\Http\Middleware\SetLocale;
 use Lattice\Http\PageRegistry;
 use Lattice\Layouts\LayoutDefinition;
@@ -220,7 +221,12 @@ final class LatticeServiceProvider extends PackageServiceProvider
                 ->middleware(array_values(array_unique([
                     ...config('lattice.pages.middleware', ['web']),
                     ...$page->middleware ?? [],
-                    ...array_map(static fn (string $ability): string => 'can:'.$ability, $page->can),
+                    ...array_map(
+                        static fn (string $ability): string => $page->on === null
+                            ? 'can:'.$ability
+                            : AuthorizeGateSubject::class.':'.$ability.','.$page->on,
+                        $page->can,
+                    ),
                 ])));
         }
 

--- a/packages/framework/src/Support/EloquentContextResolvers.php
+++ b/packages/framework/src/Support/EloquentContextResolvers.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Lattice\Core\Concerns\ResolvesContextModels;
+use Lattice\Core\Contracts\BuildsModelContextResolvers;
+use LogicException;
+
+/**
+ * The Eloquent sugar behind `Lattice::context($key, Model::class, by: ...)`:
+ * resolution goes through the model's own route binding, exactly like
+ * {@see ResolvesContextModels}'s explicit-class form.
+ */
+final class EloquentContextResolvers implements BuildsModelContextResolvers
+{
+    public function resolver(string $model, ?string $by): Closure
+    {
+        $this->assertModelClass($model);
+
+        return static fn (string|int $value): ?Model => (new $model)->resolveRouteBinding($value, $by);
+    }
+
+    public function keyBy(string $model, ?string $by): Closure
+    {
+        $this->assertModelClass($model);
+
+        return static fn (Model $value): string|int => $by !== null ? $value->{$by} : $value->getRouteKey();
+    }
+
+    /**
+     * @phpstan-assert class-string<Model> $model
+     */
+    private function assertModelClass(string $model): void
+    {
+        if (! is_a($model, Model::class, true)) {
+            throw new LogicException(sprintf(
+                'Lattice::context() Eloquent sugar requires an Eloquent model class, [%s] given.',
+                $model,
+            ));
+        }
+    }
+}

--- a/packages/framework/src/Support/GateSubjects.php
+++ b/packages/framework/src/Support/GateSubjects.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Support;
+
+use Illuminate\Http\Request;
+use Lattice\Core\Services\ContextResolutions;
+use Lattice\Core\Services\ContextResolvers;
+use Lattice\Http\Middleware\AuthorizeGateSubject;
+use Lattice\Http\Page;
+
+/**
+ * Resolves a page's `on` gate subject from a route parameter, shared by
+ * {@see Page::gateSubject()} and
+ * {@see AuthorizeGateSubject} so the render path and
+ * the route middleware can never resolve the same key differently.
+ */
+final class GateSubjects
+{
+    public static function fromRoute(Request $request, string $key): ?object
+    {
+        $value = $request->route($key);
+
+        if (is_object($value)) {
+            return $value;
+        }
+
+        if ($value === null || ! app(ContextResolvers::class)->has($key)) {
+            return null;
+        }
+
+        return app(ContextResolutions::class)->resolve($key, $value, $request->route()?->parameters() ?? []);
+    }
+}

--- a/packages/ui/src/Concerns/GatesRendering.php
+++ b/packages/ui/src/Concerns/GatesRendering.php
@@ -6,7 +6,10 @@ namespace Lattice\Ui\Concerns;
 use BackedEnum;
 use Closure;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Lattice\Core\Authorization;
+use Lattice\Core\Services\ContextResolutions;
+use Lattice\Core\Services\ContextScope;
 use Lattice\Core\Support\Evaluation\EvaluationContext;
 use Lattice\Core\Support\Evaluation\Evaluator;
 
@@ -32,16 +35,47 @@ trait GatesRendering
      */
     private array $can = [];
 
+    private ?string $on = null;
+
     /**
-     * The permission half of the gate, spelled the same `can` as the attribute
-     * on a definition or page. Checked in addition to visible()/hidden() and
-     * never widened by them, so the order of the calls does not matter.
+     * @var array<string, mixed>
+     */
+    private array $onFrame = [];
+
+    /**
+     * The permission half of the gate, spelled the same `can`/`on` as the
+     * attribute on a definition or page. Checked in addition to
+     * visible()/hidden() and never widened by them, so the order of the calls
+     * does not matter. `on` names an inherited context key resolved into the
+     * gate subject; a component only ever gates on one subject, so a second
+     * call naming a different key throws.
+     *
+     * The inherited frame is snapshotted here, at call time, rather than read
+     * lazily from shouldRender() — a schema child's visibility resolves from a
+     * `#[SerializationHook]` once the whole tree serializes, which runs after
+     * the definition's `ContextScope` frame that built this component has
+     * already popped (the same reason `Triggerable::modal()` snapshots
+     * `inheritable()` up front rather than reading it inside the closure).
      *
      * @param  string|BackedEnum|array<int, string|BackedEnum>  $can
      */
-    public function can(string|BackedEnum|array $can): static
+    public function can(string|BackedEnum|array $can, ?string $on = null): static
     {
         $this->can = [...$this->can, ...Authorization::abilities($can)];
+
+        if ($on !== null) {
+            if ($this->on !== null && $this->on !== $on) {
+                throw new InvalidArgumentException(sprintf(
+                    'A component can only gate on one subject: [%s] was already declared, cannot also declare [%s].',
+                    $this->on,
+                    $on,
+                ));
+            }
+
+            $this->on = $on;
+            $this->onFrame = app(ContextScope::class)->inheritable();
+        }
+
         $this->resolvedVisibility = null;
 
         return $this;
@@ -78,7 +112,17 @@ trait GatesRendering
             return true;
         }
 
-        return Authorization::allows($this->can, request());
+        $subject = null;
+
+        if ($this->on !== null) {
+            $subject = app(ContextResolutions::class)->resolve($this->on, $this->onFrame[$this->on] ?? null, $this->onFrame);
+
+            if ($subject === null) {
+                return false;
+            }
+        }
+
+        return Authorization::allows($this->can, request(), $subject);
     }
 
     private function passesVisibleCondition(): bool

--- a/packages/ui/src/Concerns/GatesRendering.php
+++ b/packages/ui/src/Concerns/GatesRendering.php
@@ -73,7 +73,7 @@ trait GatesRendering
             }
 
             $this->on = $on;
-            $this->onFrame = app(ContextScope::class)->inheritable();
+            $this->onFrame = app(ContextScope::class)->snapshot();
         }
 
         $this->resolvedVisibility = null;

--- a/packages/ui/src/Concerns/Triggerable.php
+++ b/packages/ui/src/Concerns/Triggerable.php
@@ -8,6 +8,7 @@ use Closure;
 use InvalidArgumentException;
 use Lattice\Core\Attributes\SerializationHook;
 use Lattice\Core\Facades\Evaluate;
+use Lattice\Core\Services\ContextScope;
 use Lattice\Core\Support\Evaluation\EvaluationContext;
 use Lattice\Ui\Components\Component;
 use Lattice\Ui\Components\Modal;
@@ -35,6 +36,9 @@ trait Triggerable
     public ?Modal $modal = null;
 
     protected ?Closure $modalResolver = null;
+
+    /** @var array<string, mixed>|null */
+    protected ?array $modalContextFrame = null;
 
     public function href(string $href): static
     {
@@ -69,6 +73,13 @@ trait Triggerable
         return $this;
     }
 
+    /**
+     * A closure form snapshots the currently inherited `ContextScope` frame
+     * at call time — the row/definition frame it was built inside — and
+     * replays it around the closure in {@see resolveEmbeddedModal()}, which
+     * runs later from a `#[SerializationHook]` once that frame has already
+     * popped.
+     */
     public function modal(Modal|Closure $modal): static
     {
         $this->assertBehaviorAllowed('modal');
@@ -76,9 +87,11 @@ trait Triggerable
         if ($modal instanceof Modal) {
             $this->modal = $modal;
             $this->modalResolver = null;
+            $this->modalContextFrame = null;
         } else {
             $this->modalResolver = $modal;
             $this->modal = null;
+            $this->modalContextFrame = app(ContextScope::class)->snapshot();
         }
 
         return $this;
@@ -110,7 +123,10 @@ trait Triggerable
     protected function resolveEmbeddedModal(array $data): array
     {
         if ($this->modalResolver instanceof Closure) {
-            $resolved = Evaluate::resolve($this->modalResolver, $this->renderContext());
+            $resolved = app(ContextScope::class)->within(
+                $this->modalContextFrame ?? [],
+                fn (): mixed => Evaluate::resolve($this->modalResolver, $this->renderContext()),
+            );
 
             if (! $resolved instanceof Modal) {
                 throw new InvalidArgumentException('The modal() closure must return a Modal instance.');

--- a/packages/ui/src/PageSchema.php
+++ b/packages/ui/src/PageSchema.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lattice\Ui;
 
 use Lattice\Core\Breadcrumb;
+use Lattice\Core\Services\ContextScope;
 use Lattice\Ui\Components\Component;
 use Lattice\Ui\Concerns\FiltersRenderableComponents;
 use Lattice\Ui\Concerns\ResolvesSchemaEntries;
@@ -44,6 +45,25 @@ final class PageSchema
     public function component(Component $component): static
     {
         $this->components[] = $component;
+
+        return $this;
+    }
+
+    /**
+     * Extends (or overrides a key of) the active `ContextScope` frame,
+     * activated immediately rather than deferred to `renderable()`. This
+     * matters because a chained `$schema->context([...])->schema([...])`
+     * evaluates left to right: PHP constructs the `schema()` call's array
+     * argument — and so builds every component in it — only after `context()`
+     * has already returned, so those components inherit the extended frame
+     * as long as `context()` runs first in the chain.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function context(array $context): static
+    {
+        $scope = app(ContextScope::class);
+        $scope->activate([...$scope->inheritable(), ...$context]);
 
         return $this;
     }

--- a/packages/ui/src/SlotRegistry.php
+++ b/packages/ui/src/SlotRegistry.php
@@ -5,6 +5,7 @@ namespace Lattice\Ui;
 
 use Closure;
 use Illuminate\Http\Request;
+use Lattice\Core\Services\ContextScope;
 use Lattice\Core\Support\Evaluation\EvaluationContext;
 use Lattice\Core\Support\Evaluation\Evaluator;
 use Lattice\Ui\Components\Component;
@@ -19,7 +20,10 @@ final class SlotRegistry
 
     private int $sequence = 0;
 
-    public function __construct(private readonly Evaluator $evaluator) {}
+    public function __construct(
+        private readonly Evaluator $evaluator,
+        private readonly ContextScope $scope,
+    ) {}
 
     public function extend(string $name, Closure $factory, int $priority = 0): void
     {
@@ -37,14 +41,18 @@ final class SlotRegistry
     {
         $extensions = $this->extensions[$slot->name()] ?? [];
         $context = $this->evaluationContext($slot);
+        $frame = [...$this->scope->inheritable(), ...$slot->evaluationContext()];
 
         usort(
             $extensions,
             static fn (array $left, array $right): int => [$left['priority'], $left['sequence']] <=> [$right['priority'], $right['sequence']],
         );
 
-        return array_map(function (array $extension) use ($context, $slot): Component {
-            $component = $this->evaluator->resolve($extension['factory'], $context);
+        return array_map(function (array $extension) use ($context, $frame, $slot): Component {
+            $component = $this->scope->wrapUntrusted(
+                $frame,
+                fn (): mixed => $this->evaluator->resolve($extension['factory'], $context),
+            );
 
             if (! $component instanceof Component) {
                 throw new UnexpectedValueException(sprintf(

--- a/tests/Feature/Authorization/DeclaredSubjectTest.php
+++ b/tests/Feature/Authorization/DeclaredSubjectTest.php
@@ -1,0 +1,352 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route as RoutingRoute;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Attributes\AsPage;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Form\Attributes\AsForm;
+use Lattice\Form\Components\Form as FormComponent;
+use Lattice\Form\FormDefinition;
+use Lattice\Http\Middleware\AuthorizeGateSubject;
+use Lattice\Http\Page;
+use Lattice\LatticeServiceProvider;
+use Lattice\Ui\Components\Heading;
+use Lattice\Ui\PageSchema;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Workbench\App\Models\Product;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Laravel\postJson;
+use function Pest\Laravel\withoutVite;
+
+beforeEach(function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::actions([DeclaredSubjectAction::class]);
+
+    DeclaredSubjectPage::$productId = null;
+
+    Route::get('declared-subject-test', [DeclaredSubjectPage::class, 'render'])
+        ->middleware('web')
+        ->name('declared-subject-test.show');
+
+    withoutVite();
+});
+
+/**
+ * Depth-first search of a wire payload for a schema entry by its `key` prop
+ * — plain UI components (Heading included) carry `key`, not the `id` {@see
+ * wireNode()} matches on.
+ *
+ * @param  array<array-key, mixed>  $node
+ * @return array<array-key, mixed>|null
+ */
+function wireNodeByKey(array $node, string $key): ?array
+{
+    if (($node['key'] ?? null) === $key) {
+        return $node;
+    }
+
+    foreach ($node as $value) {
+        if (is_array($value) && ($found = wireNodeByKey($value, $key)) !== null) {
+            return $found;
+        }
+    }
+
+    return null;
+}
+
+function allowUpdateFor(?Product $allowed): void
+{
+    Gate::define('update', static fn (mixed $user, Product $product): bool => $allowed instanceof Product && $product->is($allowed));
+
+    actingAs(workbenchTestUser());
+}
+
+test('a declared can+on gate authorizes the endpoint against the resolved context model, passing the record to the gate closure', function (): void {
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    $seen = [];
+    Gate::define('update', function (mixed $user, Product $product) use (&$seen, $allowed): bool {
+        $seen[] = $product;
+
+        return $product->is($allowed);
+    });
+    actingAs(workbenchTestUser());
+
+    $allowedRef = sealedRef('action', 'declared.subject-action', ['product' => $allowed->getKey()]);
+    $deniedRef = sealedRef('action', 'declared.subject-action', ['product' => $denied->getKey()]);
+
+    postJson('/lattice/actions/declared.subject-action', [], ['X-Lattice-Ref' => $allowedRef])->assertOk();
+    postJson('/lattice/actions/declared.subject-action', [], ['X-Lattice-Ref' => $deniedRef])->assertForbidden();
+
+    expect($seen)->toHaveCount(2)
+        ->and($seen[0]->is($allowed))->toBeTrue()
+        ->and($seen[1]->is($denied))->toBeTrue();
+});
+
+test('a declared can+on gate authorizes the endpoint when the context value is passed as a model', function (): void {
+    $allowed = Product::factory()->create();
+
+    allowUpdateFor($allowed);
+
+    $this->callAction(DeclaredSubjectAction::class, [], ['product' => $allowed])->assertOk();
+});
+
+test('a declared can+on gate denies the endpoint when the context model passed does not satisfy the gate', function (): void {
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    allowUpdateFor($allowed);
+
+    $this->callDeniedAction(DeclaredSubjectAction::class, [], ['product' => $denied])->assertForbidden();
+});
+
+test('a missing subject denies the endpoint even though the ability would otherwise pass', function (): void {
+    Gate::define('update', static fn (mixed $user): bool => true);
+    actingAs(workbenchTestUser());
+
+    postJson(
+        '/lattice/actions/declared.subject-action',
+        [],
+        ['X-Lattice-Ref' => sealedRef('action', 'declared.subject-action')],
+    )->assertForbidden();
+});
+
+test('a declared can+on gate hides the component at render time and shows it once the subject is allowed', function (): void {
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    allowUpdateFor($allowed);
+
+    DeclaredSubjectPage::$productId = $denied->getKey();
+    $this->assertLatticePage(get('/declared-subject-test')->assertOk())
+        ->assertNotRendered('action:declared.subject-action');
+
+    DeclaredSubjectPage::$productId = $allowed->getKey();
+    $this->assertLatticePage(get('/declared-subject-test')->assertOk())
+        ->assertRendered('action:declared.subject-action');
+});
+
+test('a declared can+on gate hides the component when no subject is in context', function (): void {
+    allowUpdateFor(null);
+
+    DeclaredSubjectPage::$productId = null;
+    $this->assertLatticePage(get('/declared-subject-test')->assertOk())
+        ->assertNotRendered('action:declared.subject-action');
+});
+
+test('a component declaring can(on:) inherits its subject from the definition frame it is built in', function (): void {
+    Lattice::forms([DeclaredSubjectContainerForm::class]);
+
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    allowUpdateFor($allowed);
+
+    $allowedForm = wire(FormComponent::use(DeclaredSubjectContainerForm::class, ['product' => $allowed]));
+    expect(wireNodeByKey($allowedForm, 'subject-gated-heading'))->not->toBeNull();
+
+    $deniedForm = wire(FormComponent::use(DeclaredSubjectContainerForm::class, ['product' => $denied]));
+    expect(wireNodeByKey($deniedForm, 'subject-gated-heading'))->toBeNull();
+});
+
+test('a component declaring can(on:) is hidden outside any context frame', function (): void {
+    $allowed = Product::factory()->create();
+
+    allowUpdateFor($allowed);
+
+    expect(Heading::make('x')->can('update', on: 'product')->shouldRender())->toBeFalse();
+});
+
+test('a second can() call naming a different subject throws', function (): void {
+    Heading::make('x')->can('update', on: 'product')->can('inspect', on: 'other');
+})->throws(InvalidArgumentException::class);
+
+test('a page declaring can+on gates the route with can middleware carrying the subject parameter, and authorizes against the bound model', function (): void {
+    Lattice::pages([DeclaredSubjectAttributePage::class]);
+    new LatticeServiceProvider(app())->bootPages();
+
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    $route = namedRoute('declared-subject-page-test.show');
+    expect($route->gatherMiddleware())->toContain(AuthorizeGateSubject::class.':view,product');
+
+    allowUpdateFor($allowed);
+    Gate::define('view', static fn (mixed $user, Product $product): bool => $product->is($allowed));
+
+    get('/declared-subject-page-test/'.$allowed->getKey())->assertOk();
+    get('/declared-subject-page-test/'.$denied->getKey())->assertForbidden();
+});
+
+test('a page whose on key is resolver-backed only is authorized by AuthorizeGateSubject against the unbound scalar route parameter', function (): void {
+    Lattice::pages([DeclaredSubjectScalarRoutePage::class]);
+    new LatticeServiceProvider(app())->bootPages();
+
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    $route = namedRoute('declared-subject-scalar-page-test.show');
+    expect($route->gatherMiddleware())->toContain(AuthorizeGateSubject::class.':view,product');
+
+    allowUpdateFor($allowed);
+    Gate::define('view', static fn (mixed $user, Product $product): bool => $product->is($allowed));
+
+    get('/declared-subject-scalar-page-test/'.$allowed->getKey())->assertOk();
+    get('/declared-subject-scalar-page-test/'.$denied->getKey())->assertForbidden();
+});
+
+test('toResponse() resolves a route-bound model into the gate subject', function (): void {
+    $allowed = Product::factory()->create();
+    $denied = Product::factory()->create();
+
+    Gate::define('view', static fn (mixed $user, Product $product): bool => $product->is($allowed));
+    actingAs(workbenchTestUser());
+
+    $page = new DeclaredSubjectAttributePage;
+
+    $allowedRoute = new RoutingRoute('GET', '/subject-bound/{product}', []);
+    $allowedRequest = Request::create('/subject-bound/'.$allowed->getKey());
+    $allowedRequest->setRouteResolver(static fn (): RoutingRoute => $allowedRoute);
+    $allowedRoute->bind($allowedRequest);
+    $allowedRoute->setParameter('product', $allowed);
+    app()->instance('request', $allowedRequest);
+
+    expect($page->toResponse($allowedRequest)->getStatusCode())->toBe(200);
+
+    $deniedRoute = new RoutingRoute('GET', '/subject-bound/{product}', []);
+    $deniedRequest = Request::create('/subject-bound/'.$denied->getKey());
+    $deniedRequest->setRouteResolver(static fn (): RoutingRoute => $deniedRoute);
+    $deniedRoute->bind($deniedRequest);
+    $deniedRoute->setParameter('product', $denied);
+    app()->instance('request', $deniedRequest);
+
+    $status = null;
+
+    try {
+        $page->toResponse($deniedRequest);
+    } catch (HttpException $exception) {
+        $status = $exception->getStatusCode();
+    }
+
+    expect($status)->toBe(403);
+});
+
+test('toResponse() resolves an unbound scalar route parameter through the registered context resolver', function (): void {
+    $allowed = Product::factory()->create();
+
+    Gate::define('view', static fn (mixed $user, Product $product): bool => $product->is($allowed));
+    actingAs(workbenchTestUser());
+
+    $page = new DeclaredSubjectScalarPage;
+
+    $route = new RoutingRoute('GET', '/subject-scalar/{product}', []);
+    $request = Request::create('/subject-scalar/'.$allowed->getKey());
+    $request->setRouteResolver(static fn (): RoutingRoute => $route);
+    $route->bind($request);
+    app()->instance('request', $request);
+
+    expect($route->parameter('product'))->toBeString()
+        ->and($page->toResponse($request)->getStatusCode())->toBe(200);
+});
+
+#[AsAction('declared.subject-action', can: 'update', on: 'product')]
+final class DeclaredSubjectAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Declared subject action');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+}
+
+final class DeclaredSubjectPage extends Page
+{
+    public static ?int $productId = null;
+
+    public function title(): string
+    {
+        return 'Declared subject';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        $context = self::$productId === null ? [] : ['product' => self::$productId];
+
+        return $schema->schema([
+            ActionComponent::use(DeclaredSubjectAction::class, $context),
+        ]);
+    }
+}
+
+#[AsForm('declared-subject.container-form')]
+final class DeclaredSubjectContainerForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form->schema([
+            Heading::make('Gated child')->key('subject-gated-heading')->can('update', on: 'product'),
+        ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        return new Response('ok');
+    }
+}
+
+#[AsPage(route: '/declared-subject-page-test/{product}', name: 'declared-subject-page-test.show', middleware: 'web', can: 'view', on: 'product')]
+final class DeclaredSubjectAttributePage extends Page
+{
+    public function title(): string
+    {
+        return 'Declared subject page';
+    }
+
+    public function render(PageSchema $schema, Product $product): PageSchema
+    {
+        return $schema->schema([]);
+    }
+}
+
+#[AsPage(can: 'view', on: 'product')]
+final class DeclaredSubjectScalarPage extends Page
+{
+    public function title(): string
+    {
+        return 'Declared subject scalar page';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([]);
+    }
+}
+
+#[AsPage(route: '/declared-subject-scalar-page-test/{product}', name: 'declared-subject-scalar-page-test.show', middleware: 'web', can: 'view', on: 'product')]
+final class DeclaredSubjectScalarRoutePage extends Page
+{
+    public function title(): string
+    {
+        return 'Declared subject scalar route page';
+    }
+
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([]);
+    }
+}

--- a/tests/Feature/Core/ContextInheritanceTest.php
+++ b/tests/Feature/Core/ContextInheritanceTest.php
@@ -6,12 +6,14 @@ use Lattice\Actions\ActionDefinition;
 use Lattice\Actions\ActionResult;
 use Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Concerns\ResolvesContextModels;
 use Lattice\Core\Facades\Lattice;
 use Lattice\Core\Services\ContextScope;
 use Lattice\Form\Attributes\AsForm;
 use Lattice\Form\Components\Form as FormComponent;
 use Lattice\Form\FormDefinition;
 use Symfony\Component\HttpFoundation\Response;
+use Workbench\App\Models\Product;
 
 use function Pest\Laravel\postJson;
 
@@ -91,6 +93,54 @@ test('the sealed child ref carries inherited keys to the endpoint but never unli
         ->and(ContextInheritanceChildAction::$seen['handle_secret'])->toBeNull();
 });
 
+test('a registered context key inherits even when inherited_keys is empty', function (): void {
+    config()->set('lattice.context.inherited_keys', []);
+    Lattice::context('tenant', fn (string $value): object => (object) ['value' => $value]);
+
+    $form = wire(FormComponent::use(ContextInheritanceParentForm::class, ['tenant' => 'acme']));
+
+    expect(wireNode($form, 'ctx-inherit.child'))->not->toBeNull()
+        ->and(ContextInheritanceChildAction::$seen['definition_tenant'])->toBe('acme');
+});
+
+test('an object context value is normalized to its scalar and resolves back to a model in the child', function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::forms([ContextInheritanceProductParentForm::class]);
+    Lattice::actions([ContextInheritanceProductChildAction::class]);
+
+    $product = Product::factory()->create(['name' => 'Acme Widget']);
+
+    $form = wire(FormComponent::use(ContextInheritanceProductParentForm::class, ['product' => $product]));
+
+    $child = wireNode($form, 'ctx-inherit.product-child');
+    assert($child !== null);
+
+    postJson('/lattice/actions/ctx-inherit.product-child', [], ['X-Lattice-Ref' => $child['props']['ref']])
+        ->assertOk();
+
+    expect(ContextInheritanceProductChildAction::$seenScalar)->toBe($product->getRouteKey())
+        ->and(ContextInheritanceProductChildAction::$seenModelName)->toBe('Acme Widget');
+});
+
+test('an object under a key without a registered resolver throws', function (): void {
+    Lattice::forms([ContextInheritanceProductParentForm::class]);
+    Lattice::actions([ContextInheritanceProductChildAction::class]);
+
+    expect(fn (): FormComponent => FormComponent::use(ContextInheritanceProductParentForm::class, ['product' => new stdClass]))
+        ->toThrow(LogicException::class);
+});
+
+test('an enum context value under an unregistered key seals as its scalar and reads back via context()', function (): void {
+    Lattice::actions([ContextInheritanceEnumAction::class]);
+
+    $action = wire(ActionComponent::use(ContextInheritanceEnumAction::class, ['status' => ContextInheritanceStatus::Active]));
+
+    postJson('/lattice/actions/ctx-inherit.enum-child', [], ['X-Lattice-Ref' => $action['props']['ref']])
+        ->assertOk();
+
+    expect(ContextInheritanceEnumAction::$seenStatus)->toBe('active');
+});
+
 #[AsForm('ctx-inherit.parent-form')]
 final class ContextInheritanceParentForm extends FormDefinition
 {
@@ -153,6 +203,71 @@ final class ContextInheritanceExplicitChildAction extends ActionDefinition
 
     public function handle(Request $request): ActionResult
     {
+        return ActionResult::success();
+    }
+}
+
+#[AsForm('ctx-inherit.product-parent-form')]
+final class ContextInheritanceProductParentForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form->schema([
+            ActionComponent::use(ContextInheritanceProductChildAction::class),
+        ]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        return new Response('ok');
+    }
+}
+
+#[AsAction('ctx-inherit.product-child')]
+final class ContextInheritanceProductChildAction extends ActionDefinition
+{
+    use ResolvesContextModels;
+
+    public static mixed $seenScalar = null;
+
+    public static ?string $seenModelName = null;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Product child');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        self::$seenScalar = $this->context('product');
+
+        $product = $this->contextModel('product');
+        assert($product instanceof Product);
+        self::$seenModelName = $product->name;
+
+        return ActionResult::success();
+    }
+}
+
+enum ContextInheritanceStatus: string
+{
+    case Active = 'active';
+}
+
+#[AsAction('ctx-inherit.enum-child')]
+final class ContextInheritanceEnumAction extends ActionDefinition
+{
+    public static mixed $seenStatus = null;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Enum child');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        self::$seenStatus = $this->context('status');
+
         return ActionResult::success();
     }
 }

--- a/tests/Feature/Core/ContextResolverTest.php
+++ b/tests/Feature/Core/ContextResolverTest.php
@@ -1,0 +1,251 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Core\Services\ContextResolutions;
+use Lattice\Core\Services\ContextResolvers;
+use Workbench\App\Models\Product;
+
+beforeEach(function (): void {
+    ContextResolverWidgetAction::$calls = 0;
+});
+
+test('has and keys reflect registered resolvers', function (): void {
+    expect(app(ContextResolvers::class)->has('widget'))->toBeFalse()
+        ->and(app(ContextResolvers::class)->keys())->not->toContain('widget');
+
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget($value));
+
+    expect(app(ContextResolvers::class)->has('widget'))->toBeTrue()
+        ->and(app(ContextResolvers::class)->keys())->toContain('widget');
+});
+
+test('registering the same key twice replaces the previous resolver', function (): void {
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget('first-'.$value));
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget('second-'.$value));
+
+    $resolved = app(ContextResolutions::class)->resolve('widget', 'x', []);
+    assert($resolved instanceof ContextResolverWidget);
+
+    expect($resolved->id)->toBe('second-x');
+});
+
+test('a closure resolver is evaluated with named value, key and context, and a typed Request', function (): void {
+    Lattice::context('widget', function (string $value, string $key, array $context, Request $request): ContextResolverWidget {
+        expect($key)->toBe('widget')
+            ->and($context)->toBe(['widget' => 'w1']);
+
+        return new ContextResolverWidget($value);
+    });
+
+    $resolved = app(ContextResolutions::class)->resolve('widget', 'w1', ['widget' => 'w1']);
+    assert($resolved instanceof ContextResolverWidget);
+
+    expect($resolved->id)->toBe('w1');
+});
+
+test('the Eloquent sugar resolves by primary key and by an explicit column', function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::context('product_by_sku', Product::class, by: 'sku');
+
+    $product = Product::factory()->create(['sku' => 'SKU-1']);
+    $resolutions = app(ContextResolutions::class);
+
+    $byKey = $resolutions->resolve('product', (string) $product->getKey(), []);
+    $bySku = $resolutions->resolve('product_by_sku', 'SKU-1', []);
+    assert($byKey instanceof Product);
+    assert($bySku instanceof Product);
+
+    expect($byKey->getKey())->toBe($product->getKey())
+        ->and($bySku->getKey())->toBe($product->getKey());
+});
+
+test('resolving an unregistered key throws', function (): void {
+    expect(fn () => app(ContextResolutions::class)->resolve('nope', 'x', []))
+        ->toThrow(LogicException::class, 'nope');
+});
+
+test('hasContext distinguishes a present key from an absent one', function (): void {
+    Lattice::actions([ContextResolverPresenceAction::class]);
+
+    $this->callAction(ContextResolverPresenceAction::class, [], ['widget' => 'w1'])
+        ->assertOk()
+        ->assertJsonPath('data.present', true)
+        ->assertJsonPath('data.absent', false);
+});
+
+test('contextModel aborts with 404 when the key is absent', function (): void {
+    Lattice::context('widget', fn (string $value): ?ContextResolverWidget => $value === 'missing' ? null : new ContextResolverWidget($value));
+    Lattice::actions([ContextResolverNotFoundAction::class]);
+
+    $this->callAction(ContextResolverNotFoundAction::class, [], [])
+        ->assertNotFound();
+});
+
+test('contextModel aborts with 404 when the resolver finds nothing', function (): void {
+    Lattice::context('widget', fn (string $value): ?ContextResolverWidget => $value === 'missing' ? null : new ContextResolverWidget($value));
+    Lattice::actions([ContextResolverNotFoundAction::class]);
+
+    $this->callAction(ContextResolverNotFoundAction::class, [], ['widget' => 'missing'])
+        ->assertNotFound();
+});
+
+test('a resolver runs once for two contextModel reads in the same request', function (): void {
+    Lattice::context('widget', function (string $value): ContextResolverWidget {
+        ContextResolverWidgetAction::$calls++;
+
+        return new ContextResolverWidget($value);
+    });
+    Lattice::actions([ContextResolverDoubleReadAction::class]);
+
+    $this->callAction(ContextResolverDoubleReadAction::class, [], ['widget' => 'w1'])
+        ->assertOk()
+        ->assertJsonPath('data.same', true);
+
+    expect(ContextResolverWidgetAction::$calls)->toBe(1);
+});
+
+test('a resolver runs once across authorize() and handle() of a callAction', function (): void {
+    Lattice::context('widget', function (string $value): ContextResolverWidget {
+        ContextResolverWidgetAction::$calls++;
+
+        return new ContextResolverWidget($value);
+    });
+    Lattice::actions([ContextResolverWidgetAction::class]);
+
+    $this->callAction(ContextResolverWidgetAction::class, [], ['widget' => 'w1'])
+        ->assertOk()
+        ->assertJsonPath('data.id', 'w1');
+
+    expect(ContextResolverWidgetAction::$calls)->toBe(1);
+});
+
+test('serialize uses the registered key closure', function (): void {
+    Lattice::context(
+        'widget',
+        fn (string $value): ContextResolverWidget => new ContextResolverWidget($value),
+        keyBy: fn (ContextResolverWidget $widget): string => 'k-'.$widget->id,
+    );
+
+    $serialized = app(ContextResolutions::class)->serialize('widget', new ContextResolverWidget('w9'));
+
+    expect($serialized)->toBe('k-w9');
+});
+
+test('serialize falls back to getRouteKey when no key closure is registered', function (): void {
+    Lattice::context('product', fn (string $value): ?Product => Product::find($value));
+
+    $product = Product::factory()->create();
+
+    $serialized = app(ContextResolutions::class)->serialize('product', $product);
+
+    expect($serialized)->toBe($product->getRouteKey());
+});
+
+test('serialize throws when neither a key closure nor getRouteKey is available', function (): void {
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget($value));
+
+    expect(fn () => app(ContextResolutions::class)->serialize('widget', new ContextResolverWidget('w1')))
+        ->toThrow(LogicException::class);
+});
+
+test('a resolver depends on another key through the typed ContextResolutions', function (): void {
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget($value));
+    Lattice::context('gadget', function (array $context, ContextResolutions $resolutions): ContextResolverWidget {
+        $widget = $resolutions->resolve('widget', $context['widget'], $context);
+        assert($widget instanceof ContextResolverWidget);
+
+        return $widget;
+    });
+
+    $resolved = app(ContextResolutions::class)->resolve('gadget', 'g1', ['widget' => 'w5', 'gadget' => 'g1']);
+    assert($resolved instanceof ContextResolverWidget);
+
+    expect($resolved->id)->toBe('w5');
+});
+
+final readonly class ContextResolverWidget
+{
+    public function __construct(public string $id) {}
+}
+
+#[AsAction('context-resolver.presence')]
+final class ContextResolverPresenceAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Presence');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success([
+            'present' => $this->hasContext('widget'),
+            'absent' => $this->hasContext('missing'),
+        ]);
+    }
+}
+
+#[AsAction('context-resolver.not-found')]
+final class ContextResolverNotFoundAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Not found');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $widget = $this->contextModel('widget');
+        assert($widget instanceof ContextResolverWidget);
+
+        return ActionResult::success(['id' => $widget->id]);
+    }
+}
+
+#[AsAction('context-resolver.double-read')]
+final class ContextResolverDoubleReadAction extends ActionDefinition
+{
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Double read');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $first = $this->contextModel('widget');
+        $second = $this->contextModel('widget');
+
+        return ActionResult::success(['same' => $first === $second]);
+    }
+}
+
+#[AsAction('context-resolver.widget')]
+final class ContextResolverWidgetAction extends ActionDefinition
+{
+    public static int $calls = 0;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Widget');
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return $this->contextModel('widget') instanceof ContextResolverWidget;
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $widget = $this->contextModel('widget');
+        assert($widget instanceof ContextResolverWidget);
+
+        return ActionResult::success(['id' => $widget->id]);
+    }
+}

--- a/tests/Feature/Core/DefinitionContextModelTest.php
+++ b/tests/Feature/Core/DefinitionContextModelTest.php
@@ -52,6 +52,33 @@ test('a strict context model aborts when the key is absent', function (): void {
         ->assertNotFound();
 });
 
+test('the one-argument contextModel resolves through the registered resolver', function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::actions([WorkbenchRegistryContextModelAction::class]);
+
+    $product = Product::factory()->create(['name' => 'Registry Product']);
+
+    $this->callAction(WorkbenchRegistryContextModelAction::class, [], ['product' => $product->getKey()])
+        ->assertOk()
+        ->assertJsonPath('data.name', 'Registry Product');
+});
+
+test('the one-argument contextModel aborts when the key is absent', function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::actions([WorkbenchRegistryContextModelAction::class]);
+
+    $this->callAction(WorkbenchRegistryContextModelAction::class, [], [])
+        ->assertNotFound();
+});
+
+test('the one-argument contextModel aborts when the record does not exist', function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::actions([WorkbenchRegistryContextModelAction::class]);
+
+    $this->callAction(WorkbenchRegistryContextModelAction::class, [], ['product' => 999999])
+        ->assertNotFound();
+});
+
 test('an OrNull accessor in a render-time authorize hides the component instead of aborting', function (): void {
     Lattice::actions([ContextGatedAction::class]);
 
@@ -93,5 +120,26 @@ class ContextGatedPage extends Page
     public function render(PageSchema $schema): PageSchema
     {
         return $schema->component(ActionComponent::use(ContextGatedAction::class));
+    }
+}
+
+#[AsAction('workbench.registry-context-model-reader')]
+final class WorkbenchRegistryContextModelAction extends ActionDefinition
+{
+    use ResolvesContextModels;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Registry context model reader');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        $product = $this->contextModel('product');
+        assert($product instanceof Product);
+
+        return ActionResult::success([
+            'name' => $product->name,
+        ]);
     }
 }

--- a/tests/Feature/Core/PageContextFrameTest.php
+++ b/tests/Feature/Core/PageContextFrameTest.php
@@ -1,0 +1,218 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Lattice\Core\Attributes\AsLayout;
+use Lattice\Core\Attributes\AsPage;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Http\Page;
+use Lattice\Layouts\LayoutDefinition;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\CallbackTableSource;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\Table;
+use Lattice\Table\Contracts\TableSource;
+use Lattice\Table\TableDefinition;
+use Lattice\Table\TableQuery;
+use Lattice\Table\TableResult;
+use Lattice\Ui\PageSchema;
+use Workbench\App\Models\Product;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\withoutVite;
+
+beforeEach(function (): void {
+    Lattice::context('product', Product::class);
+
+    FrameChildTable::$seen = [];
+    FrameLayoutTable::$seen = [];
+
+    Lattice::tables([FrameChildTable::class, FrameLayoutTable::class]);
+
+    withoutVite();
+});
+
+test('a route parameter bound to a resolver model seeds the context frame under its registered key, regardless of the parameter name', function (): void {
+    $product = Product::factory()->create(['name' => 'Frame Widget']);
+
+    Route::get('/frame/{current_product}', [FrameByModelPage::class, 'render'])
+        ->middleware('web')
+        ->name('frame-test.by-model');
+
+    get('/frame/'.$product->getKey())->assertOk();
+
+    expect(FrameChildTable::$seen['scalar'])->toBe($product->getRouteKey())
+        ->and(FrameChildTable::$seen['model_name'])->toBe('Frame Widget');
+});
+
+test('a scalar route parameter named for a registered key seeds the context frame', function (): void {
+    $product = Product::factory()->create(['name' => 'Scalar Widget']);
+
+    Route::get('/frame-scalar/{product}', [FrameByScalarPage::class, 'render'])
+        ->middleware('web')
+        ->name('frame-test.by-scalar');
+
+    get('/frame-scalar/'.$product->getKey())->assertOk();
+
+    expect(FrameChildTable::$seen['scalar'])->toBe((string) $product->getRouteKey())
+        ->and(FrameChildTable::$seen['model_name'])->toBe('Scalar Widget');
+});
+
+test('PageSchema::context() overrides the route-seeded key', function (): void {
+    $routeProduct = Product::factory()->create(['name' => 'Route Widget']);
+    FrameOverridePage::$override = Product::factory()->create(['name' => 'Override Widget']);
+
+    Route::get('/frame-override/{product}', [FrameOverridePage::class, 'render'])
+        ->middleware('web')
+        ->name('frame-test.override');
+
+    get('/frame-override/'.$routeProduct->getKey())->assertOk();
+
+    expect(FrameChildTable::$seen['model_name'])->toBe('Override Widget');
+});
+
+test('a layout rendered for the page inherits its context frame', function (): void {
+    $product = Product::factory()->create(['name' => 'Layout Widget']);
+
+    Lattice::layouts([FrameLayout::class]);
+
+    Route::get('/frame-layout/{product}', [FrameLayoutPage::class, 'render'])
+        ->middleware('web')
+        ->name('frame-test.layout');
+
+    get('/frame-layout/'.$product->getKey())->assertOk();
+
+    expect(FrameLayoutTable::$seen['model_name'])->toBe('Layout Widget');
+});
+
+test('callAction seeds the context frame for a page action', function (): void {
+    $product = Product::factory()->create(['name' => 'Action Widget']);
+
+    Route::get('/frame-action/{product}/search', [FrameByScalarPage::class, 'search'])
+        ->middleware('web')
+        ->name('frame-test.search');
+
+    get('/frame-action/'.$product->getKey().'/search')->assertOk();
+
+    expect(FrameChildTable::$seen['scalar'])->toBe((string) $product->getRouteKey())
+        ->and(FrameChildTable::$seen['model_name'])->toBe('Action Widget');
+});
+
+#[AsTable('frame-test.child-table')]
+final class FrameChildTable extends TableDefinition
+{
+    /** @var array<string, mixed> */
+    public static array $seen = [];
+
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([]));
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        self::$seen['scalar'] = $this->context('product');
+
+        $product = $this->contextModelOrNull('product');
+        self::$seen['model_name'] = $product instanceof Product ? $product->name : null;
+
+        return true;
+    }
+}
+
+#[AsTable('frame-test.layout-table')]
+final class FrameLayoutTable extends TableDefinition
+{
+    /** @var array<string, mixed> */
+    public static array $seen = [];
+
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([]));
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        $product = $this->contextModelOrNull('product');
+        self::$seen['model_name'] = $product instanceof Product ? $product->name : null;
+
+        return true;
+    }
+}
+
+#[AsPage(middleware: 'web')]
+final class FrameByModelPage extends Page
+{
+    public function render(PageSchema $schema, Product $current_product): PageSchema
+    {
+        return $schema->schema([
+            Table::use(FrameChildTable::class),
+        ]);
+    }
+}
+
+#[AsPage(middleware: 'web')]
+final class FrameByScalarPage extends Page
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Table::use(FrameChildTable::class),
+        ]);
+    }
+
+    public function search(PageSchema $schema): PageSchema
+    {
+        return $schema->schema([
+            Table::use(FrameChildTable::class),
+        ]);
+    }
+}
+
+#[AsPage(middleware: 'web')]
+final class FrameOverridePage extends Page
+{
+    public static ?Product $override = null;
+
+    public function render(PageSchema $schema, Product $product): PageSchema
+    {
+        return $schema
+            ->context(['product' => self::$override])
+            ->schema([
+                Table::use(FrameChildTable::class),
+            ]);
+    }
+}
+
+#[AsLayout('frame-test.layout')]
+final class FrameLayout extends LayoutDefinition
+{
+    public function schema(PageSchema $schema, Request $request): PageSchema
+    {
+        return $schema->schema([
+            Table::use(FrameLayoutTable::class),
+        ]);
+    }
+}
+
+#[AsPage(layout: 'frame-test.layout', middleware: 'web')]
+final class FrameLayoutPage extends Page
+{
+    public function render(PageSchema $schema, Product $product): PageSchema
+    {
+        return $schema->schema([]);
+    }
+}

--- a/tests/Feature/Core/PageMetadataTest.php
+++ b/tests/Feature/Core/PageMetadataTest.php
@@ -28,6 +28,24 @@ final class FixtureStandalonePage extends FixtureBasePage {}
 #[AsPage(route: '/guarded', can: 'manage-widgets')]
 final class FixtureGuardedPage extends FixtureBasePage {}
 
+#[AsPage(can: 'manage-widgets')]
+abstract class FixtureCanBasePage extends FixtureBasePage {}
+
+#[AsPage(route: '/can-inherited')]
+final class FixtureCanInheritedPage extends FixtureCanBasePage {}
+
+#[AsPage(route: '/can-overridden', can: 'inspect-widgets')]
+final class FixtureCanOverriddenPage extends FixtureCanBasePage {}
+
+#[AsPage(can: 'view', on: 'tenant')]
+abstract class FixtureSubjectBasePage extends FixtureBasePage {}
+
+#[AsPage(route: '/subject-guarded')]
+final class FixtureSubjectChildPage extends FixtureSubjectBasePage {}
+
+#[AsPage(route: '/subject-overridden', on: 'product')]
+final class FixtureSubjectOverriddenPage extends FixtureSubjectBasePage {}
+
 test('metadata inherits layout and width from a base AsPage attribute', function (): void {
     $meta = PageMetadata::for(FixtureProductsPage::class);
 
@@ -93,6 +111,40 @@ test('a descriptor cached before can existed defaults to no abilities', function
     unset($descriptor['can']);
 
     expect(PageMetadata::fromArray($descriptor)->can)->toBe([]);
+});
+
+test('a declared ability is inherited from a parent AsPage attribute', function (): void {
+    expect(PageMetadata::for(FixtureCanInheritedPage::class)->can)->toBe(['manage-widgets']);
+});
+
+test('a concrete page declaring its own ability replaces rather than merges the inherited one', function (): void {
+    expect(PageMetadata::for(FixtureCanOverriddenPage::class)->can)->toBe(['inspect-widgets']);
+});
+
+test('a declared subject is inherited from a parent AsPage attribute', function (): void {
+    expect(PageMetadata::for(FixtureSubjectChildPage::class)->on)->toBe('tenant');
+});
+
+test('a concrete page overrides an inherited subject', function (): void {
+    expect(PageMetadata::for(FixtureSubjectOverriddenPage::class)->on)->toBe('product');
+});
+
+test('a page without a declared subject resolves to null', function (): void {
+    expect(PageMetadata::for(FixtureGuardedPage::class)->on)->toBeNull();
+});
+
+test('a declared subject round-trips through the descriptor', function (): void {
+    $descriptor = PageMetadata::reflect(FixtureSubjectChildPage::class)->toArray();
+
+    expect($descriptor['on'])->toBe('tenant')
+        ->and(PageMetadata::fromArray($descriptor)->on)->toBe('tenant');
+});
+
+test('a descriptor cached before on existed defaults to no subject', function (): void {
+    $descriptor = PageMetadata::reflect(FixtureSubjectChildPage::class)->toArray();
+    unset($descriptor['on']);
+
+    expect(PageMetadata::fromArray($descriptor)->on)->toBeNull();
 });
 
 test('for() prefers a manifest descriptor and falls back to reflection', function (): void {

--- a/tests/Feature/Http/PageRouteRegistrationTest.php
+++ b/tests/Feature/Http/PageRouteRegistrationTest.php
@@ -80,6 +80,18 @@ final class RegGuardedBarePage extends RegBasePage
     }
 }
 
+#[AsPage(can: 'manage-widgets')]
+abstract class RegGuardedBasePage extends RegBasePage {}
+
+#[AsPage(route: '/guarded-inherited', name: 'guarded-inherited.index')]
+final class RegGuardedInheritedPage extends RegGuardedBasePage
+{
+    public function render(PageSchema $schema): PageSchema
+    {
+        return $schema->component(Text::make('Guarded inherited'));
+    }
+}
+
 #[AsPage(route: '/orders/{order}', name: 'orders.show')]
 final class RegOrdersShowPage extends RegBasePage
 {
@@ -208,6 +220,17 @@ test('a page with empty attribute middleware still registers its declared abilit
     new LatticeServiceProvider(app())->bootPages();
 
     $route = namedRoute('guarded-bare.index');
+
+    expect($route->gatherMiddleware())
+        ->toBe(['web', 'can:manage-widgets']);
+});
+
+test('a child page registers the can middleware for an ability declared only on its abstract parent', function (): void {
+    Lattice::pages([RegGuardedInheritedPage::class]);
+
+    new LatticeServiceProvider(app())->bootPages();
+
+    $route = namedRoute('guarded-inherited.index');
 
     expect($route->gatherMiddleware())
         ->toBe(['web', 'can:manage-widgets']);

--- a/tests/Feature/Tables/RowActionContextInheritanceTest.php
+++ b/tests/Feature/Tables/RowActionContextInheritanceTest.php
@@ -7,6 +7,9 @@ use Lattice\Actions\ActionResult;
 use Lattice\Actions\Components\Action as ActionComponent;
 use Lattice\Core\Attributes\AsAction;
 use Lattice\Core\Facades\Lattice;
+use Lattice\Form\Attributes\AsForm;
+use Lattice\Form\Components\Form as FormComponent;
+use Lattice\Form\FormDefinition;
 use Lattice\Table\Attributes\AsTable;
 use Lattice\Table\CallbackTableSource;
 use Lattice\Table\Columns\TextColumn;
@@ -15,6 +18,9 @@ use Lattice\Table\Contracts\TableSource;
 use Lattice\Table\TableDefinition;
 use Lattice\Table\TableQuery;
 use Lattice\Table\TableResult;
+use Lattice\Ui\Components\Button;
+use Lattice\Ui\Components\Modal;
+use Symfony\Component\HttpFoundation\Response;
 
 use function Pest\Laravel\postJson;
 
@@ -22,9 +28,17 @@ beforeEach(function (): void {
     config()->set('lattice.context.inherited_keys', ['tenant']);
     RowCtxInheritanceAction::$seen = [];
     RowCtxToolbarAction::$seen = [];
+    RowCtxModalForm::$seenTenant = null;
 
-    Lattice::tables([RowCtxInheritanceTable::class]);
+    Lattice::tables([RowCtxInheritanceTable::class, RowCtxModalTable::class]);
     Lattice::actions([RowCtxInheritanceAction::class, RowCtxToolbarAction::class]);
+    Lattice::forms([RowCtxModalForm::class]);
+});
+
+test('a row action modal closure built inside a table frame lets its embedded form inherit the table context', function (): void {
+    wire(Table::use(RowCtxModalTable::class, ['tenant' => 'acme']));
+
+    expect(RowCtxModalForm::$seenTenant)->toBe('acme');
 });
 
 test('row actions inherit the table context on the build path', function (): void {
@@ -139,5 +153,50 @@ final class RowCtxToolbarAction extends ActionDefinition
         self::$seen['handle_table'] = $this->context('table');
 
         return ActionResult::success();
+    }
+}
+
+#[AsTable('ctx-inherit.modal-table')]
+final class RowCtxModalTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([
+            ['id' => 1, 'name' => 'Taylor'],
+        ]));
+    }
+
+    #[Override]
+    public function actions(array $row): array
+    {
+        return [
+            Button::make('Details')->modal(fn (): Modal => Modal::make('row-modal')->schema([
+                FormComponent::use(RowCtxModalForm::class),
+            ])),
+        ];
+    }
+}
+
+#[AsForm('ctx-inherit.modal-form')]
+final class RowCtxModalForm extends FormDefinition
+{
+    public static ?string $seenTenant = null;
+
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        $tenant = $this->context('tenant');
+        self::$seenTenant = is_string($tenant) ? $tenant : null;
+
+        return $form->schema([]);
+    }
+
+    public function handle(Request $request): Response
+    {
+        return new Response('ok');
     }
 }

--- a/tests/Feature/Ui/SlotContextInheritanceTest.php
+++ b/tests/Feature/Ui/SlotContextInheritanceTest.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\CallbackTableSource;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\Table;
+use Lattice\Table\Contracts\TableSource;
+use Lattice\Table\TableDefinition;
+use Lattice\Table\TableQuery;
+use Lattice\Table\TableResult;
+use Lattice\Ui\Components\Component;
+use Lattice\Ui\Components\Stack;
+use Lattice\Ui\Slot;
+use Workbench\App\Models\Product;
+
+beforeEach(function (): void {
+    Lattice::context('product', Product::class);
+    Lattice::tables([SlotContextProductTable::class]);
+
+    SlotContextProductTable::$seenProductName = null;
+});
+
+test('a slot extension runs inside the inherited context frame, and its factory still receives the raw model by injection', function (): void {
+    $product = Product::factory()->create(['name' => 'Slot Widget']);
+    $injected = null;
+
+    Lattice::extend('product.settings.tabs', function (Product $product) use (&$injected): Component {
+        $injected = $product;
+
+        return Stack::make('slot-stack')->schema([
+            Table::lazy(SlotContextProductTable::class),
+        ]);
+    });
+
+    Slot::make('product.settings.tabs')->context(['product' => $product])->resolveComponents();
+
+    expect($injected)->toBe($product)
+        ->and(SlotContextProductTable::$seenProductName)->toBe('Slot Widget');
+});
+
+test('a slot context carrying an unregistered object does not throw and is not inherited', function (): void {
+    $arbitrary = new class
+    {
+        public string $marker = 'unregistered';
+    };
+
+    Lattice::extend('gizmo.settings.tabs', fn (): Component => Table::lazy(SlotContextProductTable::class));
+
+    expect(fn (): array => Slot::make('gizmo.settings.tabs')->context(['gizmo' => $arbitrary])->resolveComponents())
+        ->not->toThrow(Throwable::class);
+
+    expect(SlotContextProductTable::$seenProductName)->toBeNull();
+});
+
+#[AsTable('slot-context.product-table')]
+final class SlotContextProductTable extends TableDefinition
+{
+    public static ?string $seenProductName = null;
+
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([]));
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        $product = $this->contextModelOrNull('product');
+        self::$seenProductName = $product instanceof Product ? $product->name : null;
+
+        return true;
+    }
+}


### PR DESCRIPTION
Cluster A of the consumer audit: a context key is no longer an untyped string. One declaration per key gives every definition a typed, memoized model, an authorization subject, and automatic inheritance into everything Lattice builds — pages, slots and closure-built modals included. The consumer apps' `ResolvesTenantFromContext` / `AuthorizesTenantPermission` / `ComposesTenantContext` traits, ~75 identical `authorize()` bodies and ~110 hand-threaded `['tenant' => …]` arrays become unnecessary. Lattice itself stays generic; it knows no tenant.

```php
Lattice::context('tenant', Tenant::class, by: 'slug');

#[AsAction('tenants.members.remove', can: TenantPermission::ManageMembers, on: 'tenant')]
final class RemoveMember extends ActionDefinition
{
    public function handle(): ActionResult
    {
        $tenant = $this->contextModel('tenant');
        …
    }
}
```

**Resolvers** (`Lattice::context()`): closure or Eloquent sugar, evaluated once per request per key/value (`ContextResolutions`). `Definition::contextModel()` / `contextModelOrNull()` / `hasContext()` read the resolved object; the explicit-class form of `ResolvesContextModels` keeps its typed return.

**Inheritance and normalization:** a registered key cascades without `lattice.context.inherited_keys` (which stays for keys without a resolver). A model or `BackedEnum` may be passed as a context value and is normalized to its scalar before gate and seal; any other object under an unregistered key throws instead of being JSON-encoded into a ref.

**`can:` takes a subject:** `on:` on every definition attribute, on `#[AsPage]`, and on `->can($can, on:)` for components. A missing subject denies. Pages get a Lattice `AuthorizeGateSubject` middleware instead of Laravel's `can:` so the middleware and the page body resolve the subject identically (bound model or registered resolver). `can`/`on` inherit from an abstract base page.

**Frames:** `Page::toResponse()`/`callAction()` seed a frame from the route's bound parameters by model class (a `{current_tenant}` bound to `Tenant` seeds `tenant`) or by name for scalars; `PageSchema::context()` extends it. Slot factories run inside a frame carrying the slot's context; `->modal(Closure)` snapshots the frame at call time and replays it at serialization. Layouts see the page frame.

Docs: new `core/context` page, `core/authorization` rewritten around subjects, pages/actions pages and the Lattice skills updated.

Verification: `composer check` (Pint, PHPStan both configs, Rector, full Pest), `npm run check`, `composer test:browser`, docs build.

Follow-up: switch `saas-starter-kit` to resolvers and `can: on:`, then the three apps.
