### PR TITLE
fix(core): infer a closure resolver's model class for page context frames

### DIFF
--- a/docs/content/docs/core/context.md
+++ b/docs/content/docs/core/context.md
@@ -152,9 +152,11 @@ a key registered once cascades through every seam Lattice threads data across:
   parameters. An object parameter seeds the key whose resolver was registered for its class, whatever
   the parameter itself is named — `render(Tenant $current_tenant)` seeds `tenant` because
   `Lattice::context('tenant', Tenant::class)` registered that model, not because of the parameter's
-  name. A scalar parameter seeds the key sharing its own name, when that name is itself registered.
-  `PageSchema::context([...])` extends or overrides the frame explicitly — for a closure-registered key,
-  or anything the convention misses:
+  name. A closure resolver takes part through its declared return type — `fn (string $value): Tenant`
+  records `Tenant` the same way — or through an explicit `model: Tenant::class` when it declares none. A
+  scalar parameter seeds the key sharing its own name, when that name is itself registered.
+  `PageSchema::context([...])` extends or overrides the frame explicitly for anything the convention
+  misses:
 
   ```php
   public function render(PageSchema $schema, Workspace $workspace): PageSchema

--- a/packages/core/src/Facades/Lattice.php
+++ b/packages/core/src/Facades/Lattice.php
@@ -21,7 +21,7 @@ use Lattice\Core\LatticeRegistry;
  * @method static \Lattice\Remote\RemoteSourceRegistry remoteSourceRegistry()
  * @method static void searchProviders(class-string<\Lattice\Search\Contracts\SearchResultProvider>|array<int, class-string<\Lattice\Search\Contracts\SearchResultProvider>> $providers)
  * @method static \Lattice\Search\SearchProviderRegistry searchProviderRegistry()
- * @method static void context(string $key, \Closure|class-string $resolver, ?string $by = null, ?\Closure $keyBy = null)
+ * @method static void context(string $key, \Closure|class-string $resolver, ?string $by = null, ?\Closure $keyBy = null, ?class-string $model = null)
  * @method static void extend(string $name, \Closure $factory, int $priority = 0)
  * @method static void theme(\Lattice\Theme\Theme|\Closure $theme)
  * @method static void translations(string $namespace, string $path)

--- a/packages/core/src/LatticeRegistry.php
+++ b/packages/core/src/LatticeRegistry.php
@@ -13,6 +13,8 @@ use Lattice\Core\Contracts\BuildsModelContextResolvers;
 use Lattice\Core\Services\ContextResolvers;
 use Lattice\Core\Support\TypeScript\WireFamily;
 use LogicException;
+use ReflectionFunction;
+use ReflectionNamedType;
 
 final class LatticeRegistry
 {
@@ -48,16 +50,25 @@ final class LatticeRegistry
      * optional key closure (turning a resolved object back into its wire
      * scalar), or with an Eloquent model class name and the sugar builds both
      * from `resolveRouteBinding()`/`getRouteKey()`. A `$keyBy` closure always
-     * wins over the sugar's own.
+     * wins over the sugar's own. The class the key resolves to is what lets a
+     * page frame match a bound route model to the key: the sugar records it,
+     * a closure's declared return type is read for it, and `$model` sets it
+     * explicitly when the closure declares none.
      *
      * @param  Closure|class-string  $resolver
+     * @param  ?class-string  $model
      */
-    public function context(string $key, Closure|string $resolver, ?string $by = null, ?Closure $keyBy = null): void
-    {
+    public function context(
+        string $key,
+        Closure|string $resolver,
+        ?string $by = null,
+        ?Closure $keyBy = null,
+        ?string $model = null,
+    ): void {
         $resolvers = $this->container->make(ContextResolvers::class);
 
         if ($resolver instanceof Closure) {
-            $resolvers->register($key, $resolver, $keyBy);
+            $resolvers->register($key, $resolver, $keyBy, $model ?? $this->returnedClass($resolver));
 
             return;
         }
@@ -79,6 +90,25 @@ final class LatticeRegistry
             $keyBy ?? $builder->keyBy($resolver, $by),
             $resolver,
         );
+    }
+
+    /**
+     * The class a closure resolver declares as its return type, so a page frame
+     * can match a bound route model to the key without an explicit `model:`.
+     *
+     * @return ?class-string
+     */
+    private function returnedClass(Closure $resolver): ?string
+    {
+        $type = new ReflectionFunction($resolver)->getReturnType();
+
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        $name = $type->getName();
+
+        return class_exists($name) || interface_exists($name) ? $name : null;
     }
 
     /**

--- a/packages/core/src/Services/ContextResolvers.php
+++ b/packages/core/src/Services/ContextResolvers.php
@@ -17,10 +17,11 @@ final class ContextResolvers
 
     /**
      * Registering the same key twice replaces the previous registration —
-     * the last call to `Lattice::context()` for a key wins. `$model` is set
-     * only by the Eloquent sugar form of `Lattice::context()`, so {@see
-     * keyForModel()} can seed a page's context frame from a bound route
-     * model without any naming convention on the route parameter.
+     * the last call to `Lattice::context()` for a key wins. `$model` is the
+     * class the key resolves to — recorded by the Eloquent sugar, inferred
+     * from a closure's declared return type, or passed as `model:` — so
+     * {@see keyForModel()} can seed a page's context frame from a bound
+     * route model without any naming convention on the route parameter.
      *
      * @param  ?class-string  $model
      */
@@ -53,10 +54,10 @@ final class ContextResolvers
     }
 
     /**
-     * The first registered key whose recorded Eloquent model class the given
-     * object is an instance of, in registration order. Only keys registered
-     * through the `Lattice::context($key, Model::class)` sugar carry a model
-     * class, so a closure registration never matches.
+     * The first registered key whose recorded model class the given object
+     * is an instance of, in registration order. A closure registration
+     * without a declared class return type (or an explicit `model:`) carries
+     * no class and never matches.
      */
     public function keyForModel(object $model): ?string
     {

--- a/tests/Feature/Core/ContextResolverTest.php
+++ b/tests/Feature/Core/ContextResolverTest.php
@@ -169,6 +169,28 @@ test('a resolver depends on another key through the typed ContextResolutions', f
     expect($resolved->id)->toBe('w5');
 });
 
+test('a closure resolver records its declared return type as the model class for frame matching', function (): void {
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget($value));
+
+    expect(app(ContextResolvers::class)->keyForModel(new ContextResolverWidget('x')))->toBe('widget');
+});
+
+test('a nullable return type still records the model class', function (): void {
+    Lattice::context('widget', fn (string $value): ContextResolverWidget => new ContextResolverWidget($value));
+
+    expect(app(ContextResolvers::class)->keyForModel(new ContextResolverWidget('x')))->toBe('widget');
+});
+
+test('a builtin return type records no class and an explicit model sets it', function (): void {
+    Lattice::context('widget', fn (string $value): object => new ContextResolverWidget($value));
+
+    expect(app(ContextResolvers::class)->keyForModel(new ContextResolverWidget('x')))->toBeNull();
+
+    Lattice::context('widget', fn (string $value): object => new ContextResolverWidget($value), model: ContextResolverWidget::class);
+
+    expect(app(ContextResolvers::class)->keyForModel(new ContextResolverWidget('x')))->toBe('widget');
+});
+
 final readonly class ContextResolverWidget
 {
     public function __construct(public string $id) {}

--- a/tests/Feature/Core/PageContextFrameTest.php
+++ b/tests/Feature/Core/PageContextFrameTest.php
@@ -46,6 +46,20 @@ test('a route parameter bound to a resolver model seeds the context frame under 
         ->and(FrameChildTable::$seen['model_name'])->toBe('Frame Widget');
 });
 
+test('a closure resolver with a declared return type seeds the context frame from a bound route model', function (): void {
+    Lattice::context('product', fn (string|int $value): Product => Product::query()->findOrFail($value), keyBy: fn (Product $product): int => (int) $product->getKey());
+
+    $product = Product::factory()->create(['name' => 'Closure Widget']);
+
+    Route::get('/frame-closure/{current_product}', [FrameByModelPage::class, 'render'])
+        ->middleware('web')
+        ->name('frame-test.by-closure');
+
+    get('/frame-closure/'.$product->getKey())->assertOk();
+
+    expect(FrameChildTable::$seen['model_name'])->toBe('Closure Widget');
+});
+
 test('a scalar route parameter named for a registered key seeds the context frame', function (): void {
     $product = Product::factory()->create(['name' => 'Scalar Widget']);
 


### PR DESCRIPTION
A page frame seeds a context key from a bound route model only when the resolver records a model class, which so far only the Eloquent sugar did. An app that registers the closure form (to run a per-request side effect such as switching the session's current tenant) had to override `Page::contextFrame()` just to seed the key it already declared — the migrated saas-starter-kit carries exactly that override.

`Lattice::context()` now reads the closure's declared return type as the model class (`fn (string $value): Tenant`, nullable included) and accepts `model:` to set it explicitly when the closure declares none (`: object`, no type). `ContextResolvers::keyForModel()` matches closure registrations the same way, so `render(Tenant $current_tenant)` seeds `tenant` for both registration forms.

Verification: `composer check` (Pint, PHPStan both configs, Rector, full Pest 2143 passed).