### PR TITLE
fix(form): accept the value a DOM form posts for a checked box

### DIFF
--- a/packages/form/src/Components/Checkbox.php
+++ b/packages/form/src/Components/Checkbox.php
@@ -23,6 +23,18 @@ class Checkbox extends Field
         return ['boolean'];
     }
 
+    /**
+     * A native DOM form submit posts `on` for a checked box, which the
+     * `boolean` rule in {@see defaultRules()} would reject. Normalize the
+     * recognized boolean spellings before validation and pass anything else
+     * through unchanged, so a bogus value still fails the rule.
+     */
+    #[\Override]
+    public function normalizeInput(mixed $value): mixed
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $value;
+    }
+
     #[\Override]
     public function castValue(mixed $value): mixed
     {

--- a/packages/form/src/Components/Toggle.php
+++ b/packages/form/src/Components/Toggle.php
@@ -23,6 +23,18 @@ class Toggle extends Field
         return ['boolean'];
     }
 
+    /**
+     * A native DOM form submit posts `on` for a checked box, which the
+     * `boolean` rule in {@see defaultRules()} would reject. Normalize the
+     * recognized boolean spellings before validation and pass anything else
+     * through unchanged, so a bogus value still fails the rule.
+     */
+    #[\Override]
+    public function normalizeInput(mixed $value): mixed
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $value;
+    }
+
     #[\Override]
     public function castValue(mixed $value): mixed
     {

--- a/tests/Feature/Forms/Components/ToggleTest.php
+++ b/tests/Feature/Forms/Components/ToggleTest.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Illuminate\Http\Request;
 use Lattice\Core\Support\Wire;
 use Lattice\Form\Components\Toggle;
 
@@ -12,6 +13,14 @@ it('serializes a default boolean value', function (): void {
         'label' => 'Published',
         'value' => true,
     ]);
+});
+
+it('accepts the "on" a native DOM form submit posts for a toggled switch', function (): void {
+    $validated = testFormDefinition(fn (): array => [
+        Toggle::make('published', 'Published'),
+    ])->validate(Request::create('/', 'POST', ['published' => 'on']));
+
+    expect($validated['published'])->toBeTrue();
 });
 
 describe('docs fixtures', function (): void {

--- a/tests/Feature/Forms/Validation/RuleLessFieldValidationTest.php
+++ b/tests/Feature/Forms/Validation/RuleLessFieldValidationTest.php
@@ -2,6 +2,7 @@
 declare(strict_types=1);
 
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Lattice\Form\Components\Checkbox;
 use Lattice\Form\Components\Select;
 use Lattice\Form\FormDefinition;
@@ -56,6 +57,22 @@ it('casts a string "0" checkbox value to a real false rather than a truthy strin
     expect($validated)->toHaveKey('subscribed')
         ->and($validated['subscribed'])->toBeFalse();
 });
+
+it('accepts the "on" a native DOM form submit posts for a checked box', function (): void {
+    $validated = ruleLessFieldsDefinition()->validate(Request::create('/', 'POST', [
+        'country' => 'de',
+        'subscribed' => 'on',
+    ]));
+
+    expect($validated['subscribed'])->toBeTrue();
+});
+
+it('rejects a checkbox value that is not a boolean spelling at all', function (): void {
+    ruleLessFieldsDefinition()->validate(Request::create('/', 'POST', [
+        'country' => 'de',
+        'subscribed' => 'banana',
+    ]));
+})->throws(ValidationException::class);
 
 it('defaults an unchecked checkbox to false when its key is absent from the request entirely', function (): void {
     $validated = ruleLessFieldsDefinition()->validate(Request::create('/', 'POST', [


### PR DESCRIPTION
`Checkbox`/`Toggle` gained `boolean` in `defaultRules()` in 0.72, but `castValue()` only runs *after* validation. A form that is not `async` submits through the DOM, where a checked box posts the string `on` — the rule rejects it, so every such form 422s on save. Found in artisan-os: the profile notification preferences page cannot be saved on 0.72.1.

`normalizeInput()` now normalizes the recognized boolean spellings before the validator is built, the same seam `PatternInput` already uses to decode its wire value. A value that is not a boolean spelling passes through unchanged, so `boolean` still reports it.

Tests: `on` is accepted, `banana` is still rejected.

Verification: `composer check`.