### PR TITLE
fix(testing): assert against the effects a response flashed

### DIFF
--- a/docs/content/docs/testing/overview.md
+++ b/docs/content/docs/testing/overview.md
@@ -83,6 +83,18 @@ $this->assertLatticeLayout($this->get('/'))
     ->assertRendered('menu-item:settings');
 ```
 
+**Against the effects a response flashed** — a toast, a callout, a redirect. A page render drains
+these client-side, so they never reach the rendered schema:
+
+```php
+$this->assertLatticeEffects($this->post('/products', $payload))
+    ->assertFlashed('toast', fn (array $props) => expect($props['message'])->toBe('Saved.'))
+    ->assertNotFlashed('callout');
+```
+
+`props('toast')` returns the first effect of a type as a plain array (or `null`), `types()` lists
+what was flashed, and `assertNothingFlashed()` asserts the bag is empty.
+
 > Page tests render a real Inertia view. If your front-end assets aren't built in the test
 > environment, call `withoutVite()` first (`use function Pest\Laravel\withoutVite;`).
 

--- a/packages/framework/src/Support/Testing/Assertions/EffectAssertions.php
+++ b/packages/framework/src/Support/Testing/Assertions/EffectAssertions.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lattice\Support\Testing\Assertions;
+
+use Closure;
+use PHPUnit\Framework\Assert;
+
+/**
+ * The effects a response flashed through the `latticeEffects` bag, as the
+ * plain arrays the client drains — a redirect that carries a toast, a callout
+ * raised by middleware, a component reload requested from a listener.
+ */
+final readonly class EffectAssertions
+{
+    /**
+     * @param  list<array<string, mixed>>  $effects
+     */
+    public function __construct(private array $effects) {}
+
+    /**
+     * @param  (Closure(array<string, mixed>): mixed)|null  $tap  Receives the effect's props.
+     */
+    public function assertFlashed(string $type, ?Closure $tap = null): self
+    {
+        $props = $this->props($type);
+
+        Assert::assertNotNull($props, sprintf(
+            'Lattice effect [%s] was not flashed. Flashed: [%s].',
+            $type,
+            implode(', ', $this->types()) ?: 'none',
+        ));
+
+        if ($tap instanceof Closure) {
+            $tap($props);
+        }
+
+        return $this;
+    }
+
+    public function assertNotFlashed(string $type): self
+    {
+        Assert::assertNull($this->props($type), sprintf('Lattice effect [%s] was flashed unexpectedly.', $type));
+
+        return $this;
+    }
+
+    public function assertNothingFlashed(): self
+    {
+        Assert::assertSame([], $this->effects, sprintf(
+            'Expected no Lattice effects, got [%s].',
+            implode(', ', $this->types()),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * The props of the first effect of this type, or null when none was flashed.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function props(string $type): ?array
+    {
+        foreach ($this->effects as $effect) {
+            if (($effect['type'] ?? null) === $type) {
+                $props = $effect['props'] ?? [];
+
+                return is_array($props) ? $props : [];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function all(): array
+    {
+        return $this->effects;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function types(): array
+    {
+        return array_values(array_filter(array_map(
+            static fn (array $effect): mixed => $effect['type'] ?? null,
+            $this->effects,
+        ), is_string(...)));
+    }
+}

--- a/packages/framework/src/Support/Testing/AssertsLatticeComponents.php
+++ b/packages/framework/src/Support/Testing/AssertsLatticeComponents.php
@@ -10,6 +10,7 @@ use Inertia\Testing\AssertableInertia;
 use JsonSerializable;
 use Lattice\Core\Support\Wire;
 use Lattice\Support\Testing\Assertions\ComponentAssertions;
+use Lattice\Support\Testing\Assertions\EffectAssertions;
 
 trait AssertsLatticeComponents
 {
@@ -39,6 +40,23 @@ trait AssertsLatticeComponents
     public function assertLatticeLayout(TestResponse $response): ComponentAssertions
     {
         return $this->latticeSchemaAssertions($response, 'lattice.layout.schema');
+    }
+
+    /**
+     * The effects flashed onto this response through the `latticeEffects` bag.
+     * A page render drains them client-side, so they never reach the rendered
+     * schema — assert on them here instead of digging through the Inertia page.
+     *
+     * @param  TestResponse<Response>  $response
+     */
+    public function assertLatticeEffects(TestResponse $response): EffectAssertions
+    {
+        $flashed = data_get(AssertableInertia::fromTestResponse($response)->toArray(), 'flash.latticeEffects', []);
+
+        return new EffectAssertions(array_values(array_map(
+            Wire::toArray(...),
+            is_array($flashed) ? $flashed : [],
+        )));
     }
 
     /**

--- a/tests/Feature/Testing/AssertsLatticeComponentsTest.php
+++ b/tests/Feature/Testing/AssertsLatticeComponentsTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Lattice\Actions\Components\Action;
 use Lattice\Core\Enums\Op;
+use Lattice\Facades\Effects;
 use Lattice\Form\Components\Form;
 use Lattice\Form\Components\Textarea;
 use Lattice\Form\Components\TextInput;
@@ -23,6 +24,8 @@ use Lattice\Ui\Components\Menu;
 use Lattice\Ui\Components\MenuItem;
 use Lattice\Ui\Components\Stack;
 use Lattice\Ui\Components\Topbar;
+use Lattice\Ui\Effects\Builtin\Callout;
+use Lattice\Ui\Effects\Builtin\Toast;
 use Lattice\Ui\Enums\Orientation;
 use Lattice\Ui\Enums\Side;
 use Lattice\Ui\Enums\Variant;
@@ -228,4 +231,43 @@ it('asserts against a rendered layout tree', function (): void {
     $this->assertLatticeLayout($this->get('lattice-layout-demo'))
         ->assertRendered('menu-item:home')
         ->component('topbar', 'app-topbar', fn ($bar) => $bar->assertProp('sticky', true));
+});
+
+it('asserts against the effects a page flashed', function (): void {
+    withoutVite();
+
+    Route::get('lattice-demo-effects', function () {
+        Effects::flash(
+            Callout::make('Your trial ends soon.', Variant::Warning)->unique('billing.state'),
+            Effects::toast(Toast::make('Saved.', Variant::Success)),
+        );
+
+        return Inertia::render('lattice/page', ['lattice' => ['schema' => []]]);
+    })->middleware('web');
+
+    $effects = $this->assertLatticeEffects($this->get('lattice-demo-effects'));
+
+    $effects
+        ->assertFlashed('toast')
+        ->assertFlashed('callout', function (array $props): void {
+            expect($props['unique'])->toBe('billing.state')
+                ->and($props['variant'])->toBe('warning');
+        })
+        ->assertNotFlashed('redirect');
+
+    expect($effects->types())->toBe(['callout', 'toast']);
+});
+
+it('reports the flashed types when an expected effect is missing', function (): void {
+    withoutVite();
+
+    Route::get('lattice-demo-no-effects', fn () => Inertia::render('lattice/page', ['lattice' => ['schema' => []]]))
+        ->middleware('web');
+
+    $effects = $this->assertLatticeEffects($this->get('lattice-demo-no-effects'));
+
+    $effects->assertNothingFlashed();
+
+    expect(fn () => $effects->assertFlashed('toast'))
+        ->toThrow(AssertionFailedError::class, 'none');
 });


### PR DESCRIPTION
A page render drains the `latticeEffects` bag client-side, so a flashed toast, callout or redirect never reaches the rendered schema — `assertLatticePage()` cannot see it. Consumer apps were reaching into `$response->viewData('page')['flash']['latticeEffects']` and JSON round-tripping it by hand (artisan-os has a `flashedEffects()` test helper doing exactly that).

`$this->assertLatticeEffects($response)` returns an `EffectAssertions`:

```php
$this->assertLatticeEffects($this->post('/products', $payload))
    ->assertFlashed('toast', fn (array $props) => expect($props['message'])->toBe('Saved.'))
    ->assertNotFlashed('callout');
```

Plus `assertNothingFlashed()`, `props($type)`, `types()` and `all()`. A missing effect reports what *was* flashed.

Verification: `composer check`.