### PR TITLE
fix(form): let a value resolver decide nothing instead of clearing the field

### DIFF
--- a/docs/content/docs/forms/conditional-fields.mdx
+++ b/docs/content/docs/forms/conditional-fields.mdx
@@ -164,3 +164,23 @@ TextInput::make('price', 'Price')
   Inside a [repeater or builder](/forms/fields/repeater/) row, a bare dependency name is
   row-relative; prefix it with `@` (e.g. `@customer`) to watch a form-level field instead.
 </Info>
+
+### Deciding nothing
+
+Returning `null` is a decision: it clears the field. When a resolver has nothing to suggest —
+no product picked yet, no price on file — return `Resolution::Keep` instead and the field keeps
+whatever is in it, including what the user typed.
+
+```php
+use Lattice\Form\Resolution;
+
+TextInput::make('price', 'Price')
+    ->value(
+        fn (FormData $data) => priceFor($data->get('product')) ?? Resolution::Keep,
+        editable: true,
+        resetOn: ['product'],
+    );
+```
+
+`Resolution::Keep` works the same way in an authoritative `->value()` resolver: the field keeps its
+submitted value and stays non-authoritative for that pass, so validation does not overwrite it.

--- a/packages/form/src/Components/Field.php
+++ b/packages/form/src/Components/Field.php
@@ -13,6 +13,7 @@ use Lattice\Form\Conditions\Condition;
 use Lattice\Form\Conditions\ConditionSet;
 use Lattice\Form\Conditions\FieldConditions;
 use Lattice\Form\FormData;
+use Lattice\Form\Resolution;
 use Lattice\Ui\Components\Component;
 use Lattice\Ui\Concerns\HasLabel;
 use Lattice\Ui\Concerns\HasTooltip;
@@ -417,7 +418,12 @@ abstract class Field extends Component
             ->named('row', $row)
             ->named('form', $form);
 
-        return $this->normalizeValue(Evaluate::resolve($this->prefillResolver, $context));
+        $resolved = Evaluate::resolve($this->prefillResolver, $context);
+
+        // Passed through unnormalized so the caller can tell "no suggestion
+        // this pass" from a resolved value; normalizeValue() would otherwise
+        // flatten the enum case to its name.
+        return $resolved === Resolution::Keep ? $resolved : $this->normalizeValue($resolved);
     }
 
     /**
@@ -450,8 +456,15 @@ abstract class Field extends Component
         }
 
         if ($this->valueResolver instanceof Closure) {
-            $this->value(Evaluate::resolve($this->valueResolver, $context));
-            $this->hasResolvedValue = true;
+            $resolved = Evaluate::resolve($this->valueResolver, $context);
+
+            // Resolution::Keep abstains: the field keeps its current value and
+            // stays non-authoritative, so the validator does not overwrite the
+            // submitted one with it.
+            if ($resolved !== Resolution::Keep) {
+                $this->value($resolved);
+                $this->hasResolvedValue = true;
+            }
         }
 
         $this->resolving = false;

--- a/packages/form/src/Concerns/ResolvesFormFields.php
+++ b/packages/form/src/Concerns/ResolvesFormFields.php
@@ -13,6 +13,7 @@ use Lattice\Form\Components\Select;
 use Lattice\Form\Components\SignedUpload;
 use Lattice\Form\FormData;
 use Lattice\Form\FormSchemaWalker;
+use Lattice\Form\Resolution;
 use Lattice\Form\ResolveResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -75,7 +76,13 @@ trait ResolvesFormFields
             $field = $instance->field;
 
             if ($field->hasPrefill()) {
-                $prefill[$instance->path] = $field->resolvePrefillValue($instance->scope, $data, $request);
+                $suggestion = $field->resolvePrefillValue($instance->scope, $data, $request);
+
+                // An omitted path leaves the client's current value alone;
+                // sending null would clear the field.
+                if ($suggestion !== Resolution::Keep) {
+                    $prefill[$instance->path] = $suggestion;
+                }
             }
 
             if (! $field->isComputed()) {

--- a/packages/form/src/Resolution.php
+++ b/packages/form/src/Resolution.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Form;
+
+/**
+ * Deliberately not under `Enums/`: that folder is the wire vocabulary the
+ * public enum reference is generated from, and this one never leaves the
+ * server — it is the return channel of a value-resolver closure.
+ *
+ * What a value resolver decided this pass. Returning a value — `null`
+ * included — is a decision to write it; `Keep` is the way to decide nothing
+ * and leave whatever is already in the field alone.
+ */
+enum Resolution
+{
+    /**
+     * Leave the field's current value untouched: the resolver has nothing to
+     * say this pass. Without it a resolver that cannot compute a value has to
+     * echo the submitted one back, because `null` clears the field.
+     */
+    case Keep;
+}

--- a/tests/Feature/Forms/FormResolveTest.php
+++ b/tests/Feature/Forms/FormResolveTest.php
@@ -8,6 +8,7 @@ use Lattice\Form\Components\RowTemplate;
 use Lattice\Form\Components\TextInput;
 use Lattice\Form\FormData;
 use Lattice\Form\FormDefinition;
+use Lattice\Form\Resolution;
 
 function computedDefinition(): FormDefinition
 {
@@ -146,4 +147,53 @@ it('resolves nested repeater prefill values keyed by recursive full path', funct
         'sections.0.lines.0.price' => 15.0,
         'sections.0.lines.1.price' => 18.0,
     ]);
+});
+
+it('omits a prefill path whose resolver abstains, leaving the typed value alone', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('product', 'Product'),
+        TextInput::make('price', 'Price')->value(
+            fn (FormData $data): float|Resolution => $data->string('product')->toString() === ''
+                ? Resolution::Keep
+                : 42.0,
+            editable: true,
+            resetOn: ['product'],
+        ),
+    ]);
+
+    expect($definition->resolveFields(Request::create('/', 'POST', ['product' => 'p1', 'price' => '9.99']))->prefill)
+        ->toBe(['price' => 42.0])
+        ->and($definition->resolveFields(Request::create('/', 'POST', ['product' => '', 'price' => '9.99']))->prefill)
+        ->toBe([]);
+});
+
+it('keeps a prefill of null distinct from abstaining', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('price', 'Price')->value(fn (): null => null, editable: true),
+    ]);
+
+    expect($definition->resolveFields(Request::create('/', 'POST', ['price' => '9.99']))->prefill)
+        ->toBe(['price' => null]);
+});
+
+it('leaves a computed value non-authoritative when its resolver abstains', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('total', 'Total')->value(fn (FormData $data): string|Resolution => $data->string('qty')->toString() === ''
+            ? Resolution::Keep
+            : '100'),
+    ]);
+
+    expect($definition->resolveFields(Request::create('/', 'POST', ['qty' => '2']))->values)
+        ->toBe(['total' => '100'])
+        ->and($definition->resolveFields(Request::create('/', 'POST', ['qty' => '']))->values)
+        ->toBe([]);
+});
+
+it('does not overwrite submitted input with an abstaining computed value', function (): void {
+    $definition = testFormDefinition(fn (): array => [
+        TextInput::make('total', 'Total')->value(fn (): Resolution => Resolution::Keep),
+    ]);
+
+    expect($definition->validate(Request::create('/', 'POST', ['total' => 'typed by hand']))->all())
+        ->toBe(['total' => 'typed by hand']);
 });


### PR DESCRIPTION
A `value(Closure)` resolver has no way to say *nothing to suggest this pass*. Returning `null` is a decision — it clears the field — so a resolver that cannot compute a value has to read the submitted one back out and return it, purely to survive the resolve cycle. artisan-os does exactly that for a quote line item's unit price when the row carries no product:

```php
// before: echo the user's input back so the resolve does not wipe it
if ($unitPrice === null) {
    return $current === '' ? null : $current;
}
```

`Resolution::Keep` abstains:

```php
->value(
    fn (FormData $row) => priceFor($row) ?? Resolution::Keep,
    editable: true,
    resetOn: ['product_id', 'quantity'],
)
```

- **Editable prefill** — the path is omitted from the resolve response, which the client already treats as "leave this field alone" (`use-form-resolver.ts` only writes paths present in `prefill`). No client change.
- **Authoritative `value()`** — the field keeps its value and stays non-authoritative for that pass, so `FieldValidator` does not overwrite the submitted input. Without this the same return would silently serialize as the string `"Keep"` via `normalizeValue()`.

`null` keeps meaning "clear it" — there is a test pinning the two apart.

`Resolution` deliberately lives at `Lattice\Form\Resolution`, not under `Enums/`: that folder is the wire vocabulary the public enum reference is generated from, and this value never leaves the server.

Verification: `composer check`.