### PR TITLE
fix(search): apply the can/on a provider declares

### DIFF
--- a/docs/content/docs/packages/search.mdx
+++ b/docs/content/docs/packages/search.mdx
@@ -55,6 +55,35 @@ import { SearchBox, SearchInput, SearchResults } from "@lattice-php/search";
 `SearchBox` opens the palette through the nearest `ModalProvider`; the slot components read the
 active search from `SearchProvider`, which `SearchPalette` mounts around its children.
 
+## Authorizing a provider
+
+A provider is gated exactly like a definition: declare the ability on its attribute, and use
+`authorize()` only for what `can` cannot express. A provider that fails is dropped from the
+results, the category list and the counts, and its endpoint refuses a selection recorded against
+it.
+
+```php
+#[AsSearchProvider('products', can: 'products.view')]
+final class ProductSearchProvider implements SearchResultProvider { /* … */ }
+```
+
+A provider has no sealed context of its own, so if the ability needs a subject the provider
+supplies it — declare `on` and implement `ResolvesGateSubject`:
+
+```php
+#[AsSearchProvider('products', can: 'products.view', on: 'workspace')]
+final class ProductSearchProvider implements ResolvesGateSubject, SearchResultProvider
+{
+    public function gateSubject(string $key): ?object
+    {
+        return $key === 'workspace' ? Workspace::current() : null;
+    }
+}
+```
+
+Declaring `on` without that contract throws at registration rather than silently denying every
+request. A subject that resolves to nothing denies, the same as anywhere else in Lattice.
+
 ## Translations
 
 The component's strings ship with inline English defaults. With

--- a/packages/search/src/Contracts/SearchResultProvider.php
+++ b/packages/search/src/Contracts/SearchResultProvider.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 namespace Lattice\Search\Contracts;
 
 use Illuminate\Http\Request;
+use Lattice\Core\Contracts\Authorizable;
+use Lattice\Search\AsSearchProvider;
 use Lattice\Search\SearchCategory;
 use Lattice\Search\SearchQuery;
 use Lattice\Search\SearchResult;
 use Lattice\Search\SearchResults;
 
-interface SearchResultProvider
+/**
+ * Gated like any other Lattice definition: the abilities declared on
+ * {@see AsSearchProvider} are checked before
+ * {@see Authorizable::authorize()}, which can only narrow them further.
+ */
+interface SearchResultProvider extends Authorizable
 {
-    public function authorize(Request $request): bool;
-
     public function category(): SearchCategory;
 
     public function count(SearchQuery $query): int;

--- a/packages/search/src/SearchController.php
+++ b/packages/search/src/SearchController.php
@@ -5,6 +5,7 @@ namespace Lattice\Search;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Lattice\Core\Authorization;
 use Lattice\Search\Contracts\SearchHistoryRecorder;
 use Lattice\Search\Contracts\SearchResultProvider;
 use Lattice\Search\Enums\SearchMode;
@@ -78,7 +79,7 @@ final readonly class SearchController
         $provider = $this->providers->forCategory($category);
 
         abort_if(! $provider instanceof SearchResultProvider, 404);
-        abort_unless($provider->authorize($request), 403);
+        Authorization::ensure($provider, $request);
 
         $result = $provider->resolve((string) $validated['id'], $request);
 

--- a/packages/search/src/SearchProviderRegistry.php
+++ b/packages/search/src/SearchProviderRegistry.php
@@ -6,6 +6,8 @@ namespace Lattice\Search;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
+use Lattice\Core\Authorization;
+use Lattice\Core\Contracts\ResolvesGateSubject;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Search\Contracts\SearchResultProvider;
 use Spatie\Attributes\Attributes;
@@ -60,7 +62,7 @@ final class SearchProviderRegistry
     {
         return array_filter(
             $this->all(),
-            fn (SearchResultProvider $provider): bool => $provider->authorize($request),
+            fn (SearchResultProvider $provider): bool => Authorization::passes($provider, $request),
         );
     }
 
@@ -75,6 +77,18 @@ final class SearchProviderRegistry
 
         if (! $attribute instanceof AsSearchProvider) {
             throw new InvalidArgumentException("[{$provider}] is missing the #[AsSearchProvider] attribute.");
+        }
+
+        // A provider has no sealed context to resolve `on` against, so it has
+        // to supply the gate subject itself. Caught here rather than at the
+        // gate, where a missing subject silently denies every request.
+        if ($attribute->on() !== null && ! is_subclass_of($provider, ResolvesGateSubject::class)) {
+            throw new InvalidArgumentException(sprintf(
+                '[%s] declares on: \'%s\' and must implement %s to resolve that gate subject.',
+                $provider,
+                $attribute->on(),
+                ResolvesGateSubject::class,
+            ));
         }
 
         return $attribute->key;

--- a/tests/Feature/Search/SearchProviderGateTest.php
+++ b/tests/Feature/Search/SearchProviderGateTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Gate;
+use Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Search\SearchProviderRegistry;
+use Lattice\Tests\Fixtures\SearchGate\GatedSearchProvider;
+use Lattice\Tests\Fixtures\SearchGate\UnresolvableSubjectSearchProvider;
+
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+beforeEach(function (): void {
+    config(['lattice.discover' => []]);
+    app(DiscoveryManifest::class)->clear();
+    app()->singleton(GatedSearchProvider::class);
+    app(SearchProviderRegistry::class)->register(GatedSearchProvider::class);
+});
+
+it('hides a provider whose declared ability is denied', function (): void {
+    app(GatedSearchProvider::class)->withWorkspace();
+    Gate::define('invoices.view', fn (?object $user, object $workspace): bool => false);
+
+    getJson('/lattice/search?query=invoice&counts=1')
+        ->assertOk()
+        ->assertJsonCount(0, 'data')
+        ->assertJsonCount(0, 'categories');
+});
+
+it('shows a provider whose declared ability passes against the resolved subject', function (): void {
+    $provider = app(GatedSearchProvider::class)->withWorkspace();
+    Gate::define('invoices.view', fn (?object $user, object $workspace): bool => $workspace === $provider->workspace);
+
+    getJson('/lattice/search?query=invoice&counts=1')
+        ->assertOk()
+        ->assertJsonPath('data.0.item.title', 'Invoice 2026-001');
+});
+
+it('denies a provider whose gate subject resolves to nothing', function (): void {
+    Gate::define('invoices.view', fn (): bool => true);
+
+    getJson('/lattice/search?query=invoice&counts=1')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('applies the declared ability to a recorded selection too', function (): void {
+    app(GatedSearchProvider::class)->withWorkspace();
+    Gate::define('invoices.view', fn (): bool => false);
+
+    postJson('/lattice/search', ['category' => 'invoices', 'id' => '1'])->assertForbidden();
+});
+
+it('refuses to register a provider that declares on without resolving a subject', function (): void {
+    expect(fn () => app(SearchProviderRegistry::class)->register(UnresolvableSubjectSearchProvider::class))
+        ->toThrow(InvalidArgumentException::class, 'ResolvesGateSubject');
+});

--- a/tests/Fixtures/SearchGate/GatedSearchProvider.php
+++ b/tests/Fixtures/SearchGate/GatedSearchProvider.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tests\Fixtures\SearchGate;
+
+use Illuminate\Http\Request;
+use Lattice\Core\Contracts\ResolvesGateSubject;
+use Lattice\Search\AsSearchProvider;
+use Lattice\Search\Contracts\SearchResultProvider;
+use Lattice\Search\SearchCategory;
+use Lattice\Search\SearchQuery;
+use Lattice\Search\SearchResult;
+use Lattice\Search\SearchResultItem;
+use Lattice\Search\SearchResults;
+use stdClass;
+
+#[AsSearchProvider('invoices', can: 'invoices.view', on: 'workspace')]
+final class GatedSearchProvider implements ResolvesGateSubject, SearchResultProvider
+{
+    public ?object $workspace = null;
+
+    public function gateSubject(string $key): ?object
+    {
+        return $key === 'workspace' ? $this->workspace : null;
+    }
+
+    public function authorize(Request $request): bool
+    {
+        return true;
+    }
+
+    public function category(): SearchCategory
+    {
+        return new SearchCategory('invoices', 'Invoices', 'file');
+    }
+
+    public function count(SearchQuery $query): int
+    {
+        return 1;
+    }
+
+    public function search(SearchQuery $query): SearchResults
+    {
+        return new SearchResults([$this->invoice()], 1);
+    }
+
+    public function resolve(string $id, Request $request): ?SearchResult
+    {
+        return $id === '1' ? $this->invoice() : null;
+    }
+
+    public function withWorkspace(): self
+    {
+        $this->workspace = new stdClass;
+
+        return $this;
+    }
+
+    private function invoice(): SearchResult
+    {
+        return SearchResult::make('invoices', new SearchResultItem('1', 'Invoice 2026-001', '/invoices/1'));
+    }
+}

--- a/tests/Fixtures/SearchGate/UnresolvableSubjectSearchProvider.php
+++ b/tests/Fixtures/SearchGate/UnresolvableSubjectSearchProvider.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tests\Fixtures\SearchGate;
+
+use Illuminate\Http\Request;
+use Lattice\Search\AsSearchProvider;
+use Lattice\Search\Contracts\SearchResultProvider;
+use Lattice\Search\SearchCategory;
+use Lattice\Search\SearchQuery;
+use Lattice\Search\SearchResult;
+use Lattice\Search\SearchResultItem;
+use Lattice\Search\SearchResults;
+use stdClass;
+
+#[AsSearchProvider('quotes', can: 'quotes.view', on: 'workspace')]
+final class UnresolvableSubjectSearchProvider implements SearchResultProvider
+{
+    public ?object $workspace = null;
+
+    public function authorize(Request $request): bool
+    {
+        return true;
+    }
+
+    public function category(): SearchCategory
+    {
+        return new SearchCategory('quotes', 'Quotes', 'file');
+    }
+
+    public function count(SearchQuery $query): int
+    {
+        return 1;
+    }
+
+    public function search(SearchQuery $query): SearchResults
+    {
+        return new SearchResults([$this->invoice()], 1);
+    }
+
+    public function resolve(string $id, Request $request): ?SearchResult
+    {
+        return $id === '1' ? $this->invoice() : null;
+    }
+
+    public function withWorkspace(): self
+    {
+        $this->workspace = new stdClass;
+
+        return $this;
+    }
+
+    private function invoice(): SearchResult
+    {
+        return SearchResult::make('quotes', new SearchResultItem('1', 'Invoice 2026-001', '/quotes/1'));
+    }
+}


### PR DESCRIPTION
`AsSearchProvider` extends `DefinitionAttribute`, so it has always *accepted* `can` and `on` — and always ignored them. `SearchProviderRegistry::authorized()` and `SearchController::record()` called `$provider->authorize($request)` directly, never `Authorization::passes()`. An app that declared an ability on a provider got no gate at all, with nothing to indicate it.

Both paths now compose the declaration with `authorize()`, in the same order as every other definition — the declaration is checked first and `authorize()` can only narrow it. `SearchResultProvider` extends `Authorizable` to say so in the type; the method signature is unchanged, so implementors need no edit.

A provider has no sealed context to resolve `on` against, so it supplies the subject itself via `ResolvesGateSubject`. Declaring `on` without that contract now throws at registration — caught where the attribute is already validated, rather than at the gate where a missing subject silently denies every request.

Found in artisan-os, whose `EloquentSearchProvider` hand-writes `$user->can($this->permission(), Tenant::fromContext())` in `authorize()` because the declaration did nothing.

Verification: `composer check`.