### PR TITLE
fix(core): give a definition a seam that runs only on its own endpoint

### DIFF
--- a/docs/content/docs/core/context.md
+++ b/docs/content/docs/core/context.md
@@ -101,17 +101,32 @@ read and by however many definitions. Two `contextModel()` calls in the same `ha
 `authorize()` and the `handle()` that follows it, see the result of one evaluation. A miss ("not
 found") is cached too.
 
-That makes a resolver closure the right place for a once-per-request side effect keyed to the resolved
-value — switching the session's active record to match it, say:
+Memoization is per key **and value**, though, so a resolver is the wrong place for a side effect. A
+page that builds one gated component per workspace — a switcher menu — resolves the key once per
+workspace, and the side effect fires for every one of them, not just the one the request is about.
+Put it in [`activated()`](#preparing-the-request) instead.
+
+## Preparing the request
+
+`Definition::activated()` runs once on the definition's own endpoint, after the gate has passed and
+the trusted context is active — and never while components are merely being built. It is where
+request-wide setup keyed to the resolved context belongs: a signed endpoint runs none of the route
+middleware a page load does, so state a page establishes up front has to be re-established here.
 
 ```php
-Lattice::context('workspace', function (string $value, Request $request): Workspace {
-    $workspace = Workspace::where('slug', $value)->firstOrFail();
-    $request->user()?->switchWorkspace($workspace);
-
-    return $workspace;
-});
+class WorkspaceInvoicesTable extends EloquentTableDefinition
+{
+    public function activated(Request $request): void
+    {
+        $this->contextModel('workspace')->makeCurrent();
+    }
+}
 ```
+
+The work that follows is deferred — a table's builder is executed after `builder()` returns, a form's
+schema serializes after `handle()` — so set state that lasts the request rather than state scoped to
+the call. A page has no `activated()`: its request belongs to the page, and route middleware already
+covers it.
 
 ## Inheritance
 

--- a/packages/core/src/Concerns/InteractsWithComponents.php
+++ b/packages/core/src/Concerns/InteractsWithComponents.php
@@ -38,6 +38,8 @@ trait InteractsWithComponents
 
         app(ContextScope::class)->activate($context);
 
+        $definition->activated($request);
+
         return [$request, $definition, $context];
     }
 }

--- a/packages/core/src/Definition.php
+++ b/packages/core/src/Definition.php
@@ -33,6 +33,25 @@ abstract class Definition implements Authorizable, ResolvesGateSubject
         return true;
     }
 
+    /**
+     * Called once on the definition's own endpoint, after the gate has passed
+     * and the trusted context is active — and never on a page render, where
+     * the request belongs to the page rather than to any one definition.
+     *
+     * The seam for request-wide setup keyed to the resolved context: a signed
+     * endpoint runs none of the route middleware a page load does, so state a
+     * page establishes up front (a tenant made current, a locale, a
+     * connection) has to be re-established here. Doing it in a context
+     * resolver instead is a trap — a resolver also runs while components are
+     * merely being built, once per distinct value, so the side effect fires
+     * for records the request is not about.
+     *
+     * The work that follows is deferred: a table's builder is executed after
+     * builder() returns, a form's schema serializes after handle(). Set state
+     * that lasts the request rather than state scoped to this call.
+     */
+    public function activated(Request $request): void {}
+
     protected function context(string $key, mixed $default = null): mixed
     {
         return data_get($this->context, $key, $default);

--- a/tests/Feature/Core/DefinitionActivatedTest.php
+++ b/tests/Feature/Core/DefinitionActivatedTest.php
@@ -1,0 +1,144 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Context;
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\Components\Action;
+use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Sources\Eloquent\EloquentTableDefinition;
+use Lattice\Table\TableQuery;
+use Workbench\App\Models\Product;
+
+#[AsAction('core.activated')]
+final class ActivationRecordingAction extends ActionDefinition
+{
+    /** @var array<int, string> */
+    public static array $activations = [];
+
+    public function definition(Action $action): Action
+    {
+        return $action->label('Archive');
+    }
+
+    #[Override]
+    public function activated(Request $request): void
+    {
+        self::$activations[] = $this->contextString('record');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success()->toast('Archived '.$this->contextString('record'));
+    }
+}
+
+afterEach(function (): void {
+    Product::clearBootedModels();
+});
+
+beforeEach(function (): void {
+    ActivationRecordingAction::$activations = [];
+    DeniedActivationAction::$activations = [];
+    Lattice::actions([ActivationRecordingAction::class, DeniedActivationAction::class]);
+});
+
+it('activates the addressed definition once, with its trusted context', function (): void {
+    $this->callAction(ActivationRecordingAction::class, context: ['record' => 'r-1'])->assertOk();
+
+    expect(ActivationRecordingAction::$activations)->toBe(['r-1']);
+});
+
+it('does not activate a definition that is merely being built', function (): void {
+    Action::use(ActivationRecordingAction::class, ['record' => 'r-1']);
+    Action::use(ActivationRecordingAction::class, ['record' => 'r-2']);
+
+    expect(ActivationRecordingAction::$activations)->toBe([]);
+});
+
+it('does not activate a definition whose gate denied it', function (): void {
+    $this->callDeniedAction(DeniedActivationAction::class, context: ['record' => 'r-1'])->assertForbidden();
+
+    expect(DeniedActivationAction::$activations)->toBe([]);
+});
+
+it('activates a table before its deferred builder query runs', function (): void {
+    // A global scope is applied when the query executes, which is after
+    // builder() has returned — the seam the app-side workaround exists for.
+    Product::addGlobalScope('activated', function (Builder $query): void {
+        $query->where('name', Context::get('activated.name'));
+    });
+
+    Lattice::tables(ActivationScopedProductsTable::class);
+    Product::factory()->create(['name' => 'Desk Lamp']);
+    Product::factory()->create(['name' => 'Office Chair']);
+
+    $rows = $this->loadTable(ActivationScopedProductsTable::class, context: ['record' => 'Desk Lamp'])
+        ->assertOk()
+        ->collect('data')
+        ->pluck('name')
+        ->all();
+
+    expect($rows)->toBe(['Desk Lamp']);
+});
+
+/**
+ * The builder is executed after builder() returns, so a scope keyed to the
+ * activated context only applies if activated() set it request-wide.
+ *
+ * @extends EloquentTableDefinition<Product>
+ */
+#[AsTable('core.activated.products')]
+final class ActivationScopedProductsTable extends EloquentTableDefinition
+{
+    #[Override]
+    public function activated(Request $request): void
+    {
+        Context::add('activated.name', $this->contextString('record'));
+    }
+
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    /** @return Builder<Product> */
+    public function builder(TableQuery $query): Builder
+    {
+        return Product::query();
+    }
+}
+
+#[AsAction('core.activated.denied')]
+final class DeniedActivationAction extends ActionDefinition
+{
+    /** @var array<int, string> */
+    public static array $activations = [];
+
+    public function definition(Action $action): Action
+    {
+        return $action->label('Archive');
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function activated(Request $request): void
+    {
+        self::$activations[] = 'called';
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        return ActionResult::success();
+    }
+}


### PR DESCRIPTION
A signed endpoint runs none of the route middleware a page load does, so state a page establishes up front — a tenant made current, a locale, a connection — has to be re-established for the endpoint. There was nowhere to do it.

Apps reached for a context resolver instead, which is the wrong tool twice over: it is memoized per key **and value**, and it also runs while components are merely being *built*. A page whose layout renders a switcher menu resolves the key once per record, so the side effect fires for every one of them rather than the one the request is about. artisan-os hit exactly this — the tenant switcher silently switched the session to the last tenant in the menu and emptied every scoped query on the page — and had to carve out an exception for that one action.

`Definition::activated(Request)` runs once, after the gate has passed and the trusted context is active, and never on a render:

```php
public function activated(Request $request): void
{
    $this->contextModel('workspace')->makeCurrent();
}
```

One call in `InteractsWithComponents::authorizeComponent()`, so every endpoint — action, bulk action, form, fragment, table, tree, board, calendar, blocks — gets it. Default is a no-op.

It also closes the deferred-execution gap: a table's builder is executed *after* `builder()` returns, so a scope keyed to the context only applies if it was set request-wide first. There is a test for that using a global scope, which is where the problem actually bites.

A page has no `activated()` on purpose: its request belongs to the page, and route middleware already covers it.

Verification: `composer check`.