### PR TITLE
feat(table)!: run an action, modal, or effects from a whole-row click

### DIFF
--- a/docs/content/docs/tables/overview.mdx
+++ b/docs/content/docs/tables/overview.mdx
@@ -128,7 +128,7 @@ exposes these hooks beyond `columns()` and `source()`:
 | `actionsLabel()`     | Accessible label for the row-actions column (default "Actions").                              |
 | `actions($row)`      | Per-row [actions](/tables/actions/).                                                          |
 | `rowDetail($row)`    | Expandable [row detail](/tables/row-detail/) fragment.                                        |
-| `rowUrl($row)`       | Makes the whole row clickable — see [Row links](/tables/row-detail/#row-links).               |
+| `rowClick($row)`     | Makes the whole row clickable — see [Row clicks](/tables/row-detail/#row-clicks).             |
 | `bulkActions()`      | [Bulk actions](/tables/actions/#bulk-actions) for selected rows.                              |
 
 Each hook is a method you override. For example, to enable resizable columns with a drag indicator:

--- a/docs/content/docs/tables/row-detail.md
+++ b/docs/content/docs/tables/row-detail.md
@@ -1,6 +1,6 @@
 ---
 title: Row detail
-description: Expandable rows that fold open a lazy Fragment detail, loaded over AJAX when the row opens.
+description: Expandable rows that fold open a lazy Fragment detail, and what a click on a whole row does.
 ---
 
 Override `rowDetail()` to make a row expandable. Each expandable row gets a chevron that folds a detail
@@ -47,7 +47,7 @@ signed per-row endpoint, authorization, the loading skeleton, and per-fragment r
 ## Behavior
 
 - The chevron toggles the row; the rest of the row stays free for [row actions](/tables/actions/) and
-  links.
+  row clicks.
 - Several rows can be open at once.
 - Expansion is client-side and resets when the table reloads, re-sorts, re-filters, or paginates; the
   detail re-fetches each time a row opens.
@@ -57,18 +57,40 @@ signed per-row endpoint, authorization, the loading skeleton, and per-fragment r
 large or expensive detail off the initial table response.
 :::
 
-## Row links
+## Row clicks
 
-Override `rowUrl()` to make a whole row navigate, like a link, to a detail page. Clicking anywhere on
-the row visits the URL; the row gets a hover highlight and a pointer cursor.
+Override `rowClick()` to make the whole row clickable. A `RowClick` carries exactly one behavior —
+the same four a [button or link](/components/buttons/) can carry:
 
 ```php
-public function rowUrl(array $row): ?string
+use Lattice\Table\Components\RowClick;
+
+public function rowClick(array $row): ?RowClick
 {
-    return route('products.edit', $row['id']);
+    return RowClick::make()->href(route('products.edit', $row['id']));
 }
 ```
 
-Return `null` for rows that should not navigate. Clicks on an interactive element inside the row — a
-checkbox, the expand chevron, an action button or link — are left alone. Cmd/ctrl-click and
-middle-click open the URL in a new tab instead of navigating in place.
+| Behavior                                                        | What a click does                                                                                              |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `->href($url)`                                                  | Visits the URL. Cmd/ctrl-click and middle-click open it in a new tab.                                          |
+| `->action(ArchiveProduct::class, ['product_id' => $row['id']])` | Runs the [action](/tables/actions/) — including its confirmation, its action form, and the effects it returns. |
+| `->modal(fn () => Modal::make(...))`                            | Opens the modal.                                                                                               |
+| `->effects(Effects::toast('Saved'))`                            | Dispatches the [effects](/actions/effects/) client-side.                                                       |
+
+Return `null` for rows that should not react to a click. A row whose action the current user may not
+run stays unclickable, so a row click never offers what an action button would hide.
+
+```php
+public function rowClick(array $row): ?RowClick
+{
+    return RowClick::make()->modal(fn (): Modal => Modal::make('product')
+        ->title($row['name'])
+        ->schema([Form::use(EditProductForm::class)]));
+}
+```
+
+A clickable row gets a hover highlight, a pointer cursor, and keyboard focus — <kbd>Enter</kbd> and
+<kbd>Space</kbd> activate it. Clicks on an interactive element inside the row — a checkbox, the
+expand chevron, an action button or link — are left alone, and a row whose action is still running
+ignores further clicks.

--- a/packages/framework/resources/js/types/generated.ts
+++ b/packages/framework/resources/js/types/generated.ts
@@ -199,6 +199,7 @@ export type NodeType =
   | "stack"
   | "tab"
   | "table"
+  | "table.row-click"
   | "tabs"
   | "text"
   | "tooltip"
@@ -252,7 +253,7 @@ export type SearchNodeType =
   | "search.recent"
   | "search.results";
 export type SignatureExampleNodeType = "signature";
-export type TableNodeType = "table";
+export type TableNodeType = "table" | "table.row-click";
 export type TreeNodeType = "tree";
 export type UiNodeType =
   | "accordion"

--- a/packages/table/resources/js/components/row-trigger.test.tsx
+++ b/packages/table/resources/js/components/row-trigger.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@lattice-php/lattice/provider";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TableNode } from "@lattice-php/table/types";
+import { fakeNode } from "@lattice-php/core/test-support";
+import { ActionInteractionProvider } from "@lattice-php/action";
+import { ModalProvider } from "@lattice-php/ui/components/modal/modal-host";
+import type { Node } from "@lattice-php/core/types";
+import { col, rowClick, tableNode } from "../test-support";
+
+const apiFetch = vi.hoisted(() =>
+  vi.fn<(url: string, init?: Record<string, unknown>) => Promise<Response>>(
+    async () => new Response(JSON.stringify({ effects: [] }), { status: 200 }),
+  ),
+);
+
+vi.mock("@lattice-php/core/api", () => ({ apiFetch }));
+
+vi.mock("@inertiajs/react", async () =>
+  (await import("@lattice-php/ui/test/inertia-mock")).inertiaMock(),
+);
+
+const { TableComponent } = await import("./table");
+
+const action = fakeNode({
+  type: "action",
+  id: "workbench.products.archive",
+  props: {
+    label: "Archive",
+    method: "patch",
+    endpoint: "/lattice/actions/workbench.products.archive",
+    ref: "sealed-ref",
+  },
+});
+
+const modal = fakeNode({
+  type: "modal",
+  id: "product-details",
+  props: { title: "Product details" },
+});
+
+function renderRow(node: TableNode): HTMLElement {
+  render(
+    <ModalProvider>
+      <ActionInteractionProvider>
+        <TableComponent node={node}>{null}</TableComponent>
+      </ActionInteractionProvider>
+    </ModalProvider>,
+  );
+
+  return screen.getByRole("cell", { name: "Lamp" });
+}
+
+function rowWith(click: Node<"table.row-click">): TableNode {
+  return tableNode({
+    columns: [col({ key: "name", label: "Name" })],
+    data: [{ id: 1, name: "Lamp", rowClick: click }],
+  });
+}
+
+describe("row click behaviors", () => {
+  afterEach(() => {
+    apiFetch.mockClear();
+  });
+
+  it("runs the row's action when a plain cell is clicked", async () => {
+    const cell = renderRow(rowWith(rowClick({ action })));
+
+    fireEvent.click(cell);
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "/lattice/actions/workbench.products.archive",
+        expect.objectContaining({ method: "patch", ref: "sealed-ref" }),
+      ),
+    );
+  });
+
+  it("runs the row's action when the focused row is activated from the keyboard", async () => {
+    const cell = renderRow(rowWith(rowClick({ action })));
+
+    fireEvent.keyDown(cell.closest('[data-slot="table-row"]')!, { key: " " });
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+  });
+
+  it("ignores further clicks while the row's action is in flight", async () => {
+    apiFetch.mockImplementationOnce(() => new Promise(() => {}));
+
+    const cell = renderRow(rowWith(rowClick({ action })));
+
+    fireEvent.click(cell);
+
+    await waitFor(() =>
+      expect(cell.closest('[data-slot="table-row"]')).toHaveAttribute("aria-busy", "true"),
+    );
+
+    fireEvent.click(cell);
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the row's modal when a plain cell is clicked", () => {
+    const cell = renderRow(rowWith(rowClick({ modal })));
+
+    expect(screen.queryByText("Product details")).not.toBeInTheDocument();
+
+    fireEvent.click(cell);
+
+    expect(screen.getByText("Product details")).toBeInTheDocument();
+  });
+});

--- a/packages/table/resources/js/components/row-trigger.tsx
+++ b/packages/table/resources/js/components/row-trigger.tsx
@@ -1,0 +1,112 @@
+import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
+import type { Node } from "@lattice-php/core/types";
+import { ActionTrigger, useClickBehavior } from "@lattice-php/ui/click-behavior";
+import { useNavigation } from "@lattice-php/ui/navigation";
+
+export type RowTriggerState = {
+  clickable: boolean;
+  href: string | null;
+  processing: boolean;
+  onAuxClick?: (event: MouseEvent<HTMLElement>) => void;
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
+};
+
+const INTERACTIVE_SELECTOR =
+  "a, button, input, label, select, textarea, [role=menuitem], [role=checkbox]";
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(INTERACTIVE_SELECTOR) != null;
+}
+
+function activatesRow(event: KeyboardEvent<HTMLElement>): boolean {
+  return event.target === event.currentTarget && (event.key === "Enter" || event.key === " ");
+}
+
+const idle: RowTriggerState = { clickable: false, href: null, processing: false };
+
+function activation(activate: () => void, processing: boolean): RowTriggerState {
+  return {
+    clickable: true,
+    href: null,
+    processing,
+    onClick: (event) => {
+      if (processing || isInteractiveTarget(event.target)) {
+        return;
+      }
+
+      activate();
+    },
+    onKeyDown: (event) => {
+      if (processing || !activatesRow(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      activate();
+    },
+  };
+}
+
+/**
+ * A row's click behavior, resolved from the `rowClick` node the server put on
+ * the row: the hooks live here because a row is rendered inside a `.map()`.
+ * An action row leans on `ActionTrigger`, so confirmation, action forms, and
+ * effects behave exactly as they do on an action button.
+ */
+export function RowTrigger({
+  children,
+  click,
+}: {
+  children: (state: RowTriggerState) => ReactNode;
+  click: Node<"table.row-click"> | null;
+}): ReactNode {
+  const behavior = useClickBehavior(click?.props ?? {});
+  const { visit } = useNavigation();
+
+  if (behavior.kind === "action") {
+    return (
+      <ActionTrigger action={behavior.action}>
+        {({ onClick, processing }) => children(activation(onClick, processing))}
+      </ActionTrigger>
+    );
+  }
+
+  if (behavior.kind === "modal" || behavior.kind === "effects") {
+    return children(activation(behavior.onClick, false));
+  }
+
+  if (behavior.kind === "navigate") {
+    const { href } = behavior;
+    const openInNewTab = (): void => {
+      window.open(href, "_blank");
+    };
+
+    return children({
+      ...activation(() => visit(href), false),
+      href,
+      onClick: (event) => {
+        if (isInteractiveTarget(event.target)) {
+          return;
+        }
+
+        if (event.metaKey || event.ctrlKey) {
+          openInNewTab();
+
+          return;
+        }
+
+        visit(href);
+      },
+      onAuxClick: (event) => {
+        if (event.button !== 1 || isInteractiveTarget(event.target)) {
+          return;
+        }
+
+        openInNewTab();
+      },
+    });
+  }
+
+  return children(idle);
+}

--- a/packages/table/resources/js/components/table.test.tsx
+++ b/packages/table/resources/js/components/table.test.tsx
@@ -5,7 +5,7 @@ import type { TableNode } from "@lattice-php/table/types";
 import { fakeNode } from "@lattice-php/core/test-support";
 import { ActionInteractionProvider } from "@lattice-php/action";
 import { defaultNavigation, NavigationProvider } from "@lattice-php/ui/navigation";
-import { col, pagination, requestOptions, tableFetch, tableQuery } from "../test-support";
+import { col, pagination, requestOptions, rowClick, tableFetch, tableQuery } from "../test-support";
 import { TableComponent } from "./table";
 
 describe("Lattice table component", () => {
@@ -1070,7 +1070,7 @@ describe("column pinning", () => {
   });
 });
 
-describe("row links", () => {
+describe("row clicks", () => {
   const visit = vi.fn();
 
   afterEach(() => {
@@ -1099,7 +1099,9 @@ describe("row links", () => {
   }
 
   it("marks a row carrying a url and visits it when a plain cell is clicked", () => {
-    renderLinkedTable({ data: [{ id: 1, name: "Lamp", rowUrl: "/products/1" }] });
+    renderLinkedTable({
+      data: [{ id: 1, name: "Lamp", rowClick: rowClick({ href: "/products/1" }) }],
+    });
 
     const row = screen.getByRole("cell", { name: "Lamp" }).closest('[data-slot="table-row"]');
 
@@ -1110,13 +1112,25 @@ describe("row links", () => {
     expect(visit).toHaveBeenCalledWith("/products/1");
   });
 
+  it("visits a linked row when it is activated from the keyboard", () => {
+    renderLinkedTable({
+      data: [{ id: 1, name: "Lamp", rowClick: rowClick({ href: "/products/1" }) }],
+    });
+
+    const row = screen.getByRole("cell", { name: "Lamp" }).closest('[data-slot="table-row"]')!;
+
+    fireEvent.keyDown(row, { key: "Enter" });
+
+    expect(visit).toHaveBeenCalledWith("/products/1");
+  });
+
   it("does not navigate when clicking a row action link inside a linked row", () => {
     renderLinkedTable({
       data: [
         {
           id: 1,
           name: "Lamp",
-          rowUrl: "/products/1",
+          rowClick: rowClick({ href: "/products/1" }),
           actions: [{ type: "link", props: { href: "/edit/1", label: "Edit" } }],
         },
       ],
@@ -1141,7 +1155,7 @@ describe("row links", () => {
           },
         }),
       ],
-      data: [{ id: 1, name: "Lamp", rowUrl: "/products/1" }],
+      data: [{ id: 1, name: "Lamp", rowClick: rowClick({ href: "/products/1" }) }],
     });
 
     fireEvent.click(screen.getByTestId("select-row-1"));
@@ -1149,7 +1163,7 @@ describe("row links", () => {
     expect(visit).not.toHaveBeenCalled();
   });
 
-  it("renders no row-link markup for a row without a url", () => {
+  it("renders no row-link markup for a row without a click behavior", () => {
     renderLinkedTable();
 
     const row = screen.getByRole("cell", { name: "Lamp" }).closest('[data-slot="table-row"]');

--- a/packages/table/resources/js/components/table.tsx
+++ b/packages/table/resources/js/components/table.tsx
@@ -1,6 +1,5 @@
-import { type MouseEvent, type ReactNode, Fragment, useMemo } from "react";
+import { type ReactNode, Fragment, useMemo } from "react";
 import { useT } from "@lattice-php/ui/i18n";
-import { useNavigation } from "@lattice-php/ui/navigation";
 import { Renderer, RenderNode } from "@lattice-php/core/renderer";
 import { useColumnResizing } from "@lattice-php/ui/lib/use-column-resizing";
 import { useColumnPinning } from "@lattice-php/table/hooks/use-column-pinning";
@@ -32,9 +31,9 @@ import { getBulkActionNodes } from "@lattice-php/table/lib/bulk";
 import {
   getPerPageOptions,
   getRowActions,
+  getRowClick,
   getRowDetail,
   getRowKey,
-  getRowUrl,
 } from "@lattice-php/table/lib/payload";
 import {
   getQueryParams,
@@ -52,6 +51,7 @@ import { FilterBar, FilterMenu } from "./filter-bar";
 import { TablePagination } from "./pagination";
 import { SortBar } from "./sort-bar";
 import { TableSearch } from "./table-search";
+import { RowTrigger } from "./row-trigger";
 import { ColumnCell } from "./table-cell";
 import type { Side } from "@lattice-php/ui";
 
@@ -70,38 +70,6 @@ function dataColumnPinBoundary(
   }
 
   return undefined;
-}
-
-const ROW_LINK_INTERACTIVE_SELECTOR =
-  "a, button, input, label, select, textarea, [role=menuitem], [role=checkbox]";
-
-function isRowLinkInteractiveTarget(target: EventTarget | null): boolean {
-  return target instanceof Element && target.closest(ROW_LINK_INTERACTIVE_SELECTOR) != null;
-}
-
-function handleRowClick(
-  event: MouseEvent<HTMLDivElement>,
-  url: string | null,
-  visit: (url: string) => void,
-): void {
-  if (!url || isRowLinkInteractiveTarget(event.target)) {
-    return;
-  }
-
-  if (event.metaKey || event.ctrlKey) {
-    window.open(url, "_blank");
-    return;
-  }
-
-  visit(url);
-}
-
-function handleRowAuxClick(event: MouseEvent<HTMLDivElement>, url: string | null): void {
-  if (!url || event.button !== 1 || isRowLinkInteractiveTarget(event.target)) {
-    return;
-  }
-
-  window.open(url, "_blank");
 }
 
 export const TableComponent = ({ node }: { children?: ReactNode; node: TableNode }) => {
@@ -142,13 +110,12 @@ export const TableComponent = ({ node }: { children?: ReactNode; node: TableNode
       rows.map((row, index) => ({
         row,
         actions: getRowActions(row),
+        click: getRowClick(row),
         detail: getRowDetail(row),
         key: getRowKey(row, index),
-        url: getRowUrl(row),
       })),
     [rows],
   );
-  const { visit } = useNavigation();
   const selection = useTableSelection(rowEntries.map((entry) => entry.key));
   const { isExpanded, toggle: toggleRow } = useExpandedRows();
   const hasExpandable = rowEntries.some((entry) => entry.detail != null);
@@ -529,87 +496,98 @@ export const TableComponent = ({ node }: { children?: ReactNode; node: TableNode
               {node.props?.emptyLabel ?? t("table.empty", "No results")}
             </DataTableEmpty>
           ) : (
-            rowEntries.map(({ row, actions, detail, key, url }) => {
+            rowEntries.map(({ row, actions, click, detail, key }) => {
               const expanded = detail != null && isExpanded(key);
               const detailId = `${nodeIdentity(node) ?? "table"}-row-detail-${key}`;
-              const linked = url != null;
 
               return (
                 <Fragment key={key}>
-                  <DataTableRow
-                    clickable={linked}
-                    data-row-link={url ?? undefined}
-                    striped={striped}
-                    onClick={(event) => handleRowClick(event, url, visit)}
-                    onAuxClick={(event) => handleRowAuxClick(event, url)}
-                  >
-                    {hasExpandable && (
-                      <DataTableCell
-                        kind="expander"
-                        pinBoundary={expanderPinBoundary}
-                        pinned={utilityPin?.start}
+                  <RowTrigger click={click}>
+                    {({ clickable, href, processing, onAuxClick, onClick, onKeyDown }) => (
+                      <DataTableRow
+                        aria-busy={processing || undefined}
+                        clickable={clickable}
+                        data-row-link={href ?? undefined}
+                        striped={striped}
+                        tabIndex={clickable ? 0 : undefined}
+                        onAuxClick={onAuxClick}
+                        onClick={onClick}
+                        onKeyDown={onKeyDown}
                       >
-                        {detail && (
-                          <DataTableRowToggle
-                            data-test={`row-expand-${key}`}
-                            expanded={expanded}
-                            aria-controls={detailId}
-                            aria-label={t("table.row-detail.toggle", "Toggle detail")}
-                            onClick={() => toggleRow(key)}
-                          />
-                        )}
-                      </DataTableCell>
-                    )}
-                    {hasBulkActions && (
-                      <DataTableCell
-                        kind="selection"
-                        pinBoundary={selectionPinBoundary}
-                        pinned={utilityPin?.start}
-                      >
-                        <Checkbox
-                          aria-label={t("table.select-row", "Select row {{key}}", { key })}
-                          data-test={`select-row-${key}`}
-                          checked={selection.isSelected(key)}
-                          onCheckedChange={() => selection.toggle(key)}
-                        />
-                      </DataTableCell>
-                    )}
-                    {orderedColumns.map((column, index) => {
-                      const pin = hasPinned ? pinFor(column) : null;
-
-                      return (
-                        <Fragment key={column.key}>
-                          {hasPinned && index === fillerIndex && <DataTableCell kind="filler" />}
+                        {hasExpandable && (
                           <DataTableCell
-                            align={column.props.align}
-                            label={column.props.label}
-                            pinBoundary={dataColumnPinBoundary(
-                              pin,
-                              index,
-                              startBoundaryColumnIndex,
-                              fillerIndex,
-                            )}
-                            pinIndex={index}
-                            pinned={pin ?? undefined}
+                            kind="expander"
+                            pinBoundary={expanderPinBoundary}
+                            pinned={utilityPin?.start}
                           >
-                            <ColumnCell column={column} row={row} />
+                            {detail && (
+                              <DataTableRowToggle
+                                data-test={`row-expand-${key}`}
+                                expanded={expanded}
+                                aria-controls={detailId}
+                                aria-label={t("table.row-detail.toggle", "Toggle detail")}
+                                onClick={() => toggleRow(key)}
+                              />
+                            )}
                           </DataTableCell>
-                        </Fragment>
-                      );
-                    })}
-                    {hasPinned && fillerIndex === -1 && <DataTableCell kind="filler" />}
-                    {hasTrailingUtility && (
-                      <DataTableCell
-                        kind="actions"
-                        pinBoundary={actionsPinBoundary}
-                        pinned={utilityPin?.end}
-                      >
-                        {actions.map((action, actionIndex) => (
-                          <RenderNode key={action.key ?? action.id ?? actionIndex} node={action} />
-                        ))}
-                      </DataTableCell>
+                        )}
+                        {hasBulkActions && (
+                          <DataTableCell
+                            kind="selection"
+                            pinBoundary={selectionPinBoundary}
+                            pinned={utilityPin?.start}
+                          >
+                            <Checkbox
+                              aria-label={t("table.select-row", "Select row {{key}}", { key })}
+                              data-test={`select-row-${key}`}
+                              checked={selection.isSelected(key)}
+                              onCheckedChange={() => selection.toggle(key)}
+                            />
+                          </DataTableCell>
+                        )}
+                        {orderedColumns.map((column, index) => {
+                          const pin = hasPinned ? pinFor(column) : null;
+
+                          return (
+                            <Fragment key={column.key}>
+                              {hasPinned && index === fillerIndex && (
+                                <DataTableCell kind="filler" />
+                              )}
+                              <DataTableCell
+                                align={column.props.align}
+                                label={column.props.label}
+                                pinBoundary={dataColumnPinBoundary(
+                                  pin,
+                                  index,
+                                  startBoundaryColumnIndex,
+                                  fillerIndex,
+                                )}
+                                pinIndex={index}
+                                pinned={pin ?? undefined}
+                              >
+                                <ColumnCell column={column} row={row} />
+                              </DataTableCell>
+                            </Fragment>
+                          );
+                        })}
+                        {hasPinned && fillerIndex === -1 && <DataTableCell kind="filler" />}
+                        {hasTrailingUtility && (
+                          <DataTableCell
+                            kind="actions"
+                            pinBoundary={actionsPinBoundary}
+                            pinned={utilityPin?.end}
+                          >
+                            {actions.map((action, actionIndex) => (
+                              <RenderNode
+                                key={action.key ?? action.id ?? actionIndex}
+                                node={action}
+                              />
+                            ))}
+                          </DataTableCell>
+                        )}
+                      </DataTableRow>
                     )}
-                  </DataTableRow>
+                  </RowTrigger>
                   {expanded && detail && (
                     <DataTableRowDetail id={detailId}>
                       <Renderer nodes={[detail]} />

--- a/packages/table/resources/js/generated.ts
+++ b/packages/table/resources/js/generated.ts
@@ -4,9 +4,11 @@ import type {
   ColumnWidth,
   ContentAlign,
   DateTimeStyle,
+  HttpMethod,
   NumberFormatUnit,
   Side,
 } from "@lattice-php/ui";
+import type { Effect } from "@lattice-php/ui/effects/types";
 
 export type BadgeColumn = {
   align: ContentAlign;
@@ -82,6 +84,7 @@ export type ColumnPropsMap = {
 };
 export type ComponentPropsMap = {
   table: Table;
+  "table.row-click": RowClick;
 };
 export type DateRangeFilter = {
   label: string;
@@ -177,6 +180,14 @@ export type NumberColumn = {
   width: ColumnWidth;
 };
 export type PaginationType = "none" | "simple" | "table" | "infinite";
+export type RowClick = {
+  action: Node | null;
+  effects: Effect[];
+  href: string | null;
+  label: string | null;
+  method: HttpMethod | null;
+  modal: Node<"modal"> | null;
+};
 export type SelectFilter = {
   label: string;
   multiple: boolean;
@@ -220,7 +231,7 @@ export type Table = {
   syncQuery: boolean;
   toolbar: Node[];
 };
-export type TableNodeType = "table";
+export type TableNodeType = "table" | "table.row-click";
 export type TablePagination = {
   readonly currentPage: number | null;
   readonly from: number | null;

--- a/packages/table/resources/js/lib/payload.ts
+++ b/packages/table/resources/js/lib/payload.ts
@@ -175,8 +175,12 @@ export function getRowDetail(row: TableRow): Node | null {
     : null;
 }
 
-export function getRowUrl(row: TableRow): string | null {
-  return typeof row.rowUrl === "string" ? row.rowUrl : null;
+export function getRowClick(row: TableRow): Node<"table.row-click"> | null {
+  const click = row.rowClick;
+
+  return typeof click === "object" && click !== null && !Array.isArray(click)
+    ? (click as Node<"table.row-click">)
+    : null;
 }
 
 export function getRowPopover(row: TableRow, columnKey: string): Node | null {

--- a/packages/table/resources/js/plugin.ts
+++ b/packages/table/resources/js/plugin.ts
@@ -8,6 +8,10 @@ import { TableComponent } from "./components/table";
 export const tableComponents: Plugin = {
   components: {
     table: eagerComponent(TableComponent as unknown as RendererComponent<"table">),
+    // A row's click behavior travels on the row payload, where the table reads
+    // its props directly; the node never sits in a schema, so it has nothing
+    // to render.
+    "table.row-click": eagerComponent(() => null),
   } satisfies ComponentRegistryFor<TableNodeType>,
   name: "lattice/table",
 };

--- a/packages/table/resources/js/test-support.ts
+++ b/packages/table/resources/js/test-support.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import type { Node } from "@lattice-php/core/types";
 import type { Side } from "@lattice-php/ui";
-import type { ColumnFilter } from "./generated";
+import type { ColumnFilter, RowClick } from "./generated";
 import type { TableColumn, TableNode, TablePagination, TableQuery, TableResult } from "./types";
 
 export function col(partial: {
@@ -134,6 +134,21 @@ export function requestOptions(headers: Record<string, string> = {}) {
       Accept: "application/json",
       "Accept-Language": "en",
       ...headers,
+    },
+  };
+}
+
+export function rowClick(props: Partial<RowClick> = {}): Node<"table.row-click"> {
+  return {
+    type: "table.row-click",
+    props: {
+      action: null,
+      effects: [],
+      href: null,
+      label: null,
+      method: null,
+      modal: null,
+      ...props,
     },
   };
 }

--- a/packages/table/src/Components/RowClick.php
+++ b/packages/table/src/Components/RowClick.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Table\Components;
+
+use Lattice\Core\Attributes\AsComponent;
+use Lattice\Ui\Components\Component;
+use Lattice\Ui\Concerns\Triggerable;
+
+/**
+ * What a click on a whole table row does: the same trigger surface as Button
+ * and Link — navigate to an `href`, run an `action`, dispatch `effects`, or
+ * open a `modal`. The row payload carries it as a node the client reads props
+ * off; it is never placed in a schema and renders nothing.
+ */
+#[AsComponent('table.row-click')]
+final class RowClick extends Component
+{
+    use Triggerable;
+
+    public static function make(): static
+    {
+        return new self;
+    }
+
+    /**
+     * An unauthorized action leaves the row unclickable instead of shipping a
+     * node that refuses to serialize.
+     */
+    #[\Override]
+    public function shouldRender(): bool
+    {
+        return parent::shouldRender() && (! $this->action instanceof Component || $this->action->shouldRender());
+    }
+}

--- a/packages/table/src/TableDefinition.php
+++ b/packages/table/src/TableDefinition.php
@@ -6,6 +6,7 @@ namespace Lattice\Table;
 use Lattice\Core\Contracts\InteractiveComponent;
 use Lattice\Core\Definition;
 use Lattice\Table\Columns\Column;
+use Lattice\Table\Components\RowClick;
 use Lattice\Table\Contracts\TableSource;
 use Lattice\Table\Enums\PaginationType;
 use Lattice\Table\Filters\Filter;
@@ -129,9 +130,12 @@ abstract class TableDefinition extends Definition
     }
 
     /**
+     * What clicking anywhere on the row does: navigate, run an action,
+     * dispatch effects, or open a modal.
+     *
      * @param  array<string, mixed>  $row
      */
-    public function rowUrl(array $row): ?string
+    public function rowClick(array $row): ?RowClick
     {
         return null;
     }

--- a/packages/table/src/TableRegistry.php
+++ b/packages/table/src/TableRegistry.php
@@ -238,12 +238,12 @@ final class TableRegistry extends DefinitionRegistry
         return $result->decorateRows(function (array $row) use ($definition, $rowKeys, $popoverColumns, $linkColumns): array {
             $actions = $this->renderableComponents($definition->actions($row));
             $detail = $this->renderableComponents(array_filter([$definition->rowDetail($row)]));
-            $url = $definition->rowUrl($row);
+            $click = $this->renderableComponents(array_filter([$definition->rowClick($row)]));
             $popovers = $this->popovers($popoverColumns, $row);
             $links = $this->resolvedLinks($linkColumns, $row);
             $projected = array_intersect_key($row, array_flip($rowKeys));
 
-            unset($projected['actions'], $projected['detail'], $projected['rowUrl'], $projected['popovers'], $projected['links']);
+            unset($projected['actions'], $projected['detail'], $projected['rowClick'], $projected['popovers'], $projected['links']);
 
             if ($detail !== []) {
                 $projected['detail'] = $detail[0];
@@ -253,8 +253,8 @@ final class TableRegistry extends DefinitionRegistry
                 $projected['actions'] = $actions;
             }
 
-            if ($url !== null) {
-                $projected['rowUrl'] = $url;
+            if ($click !== []) {
+                $projected['rowClick'] = $click[0];
             }
 
             if ($popovers !== []) {

--- a/tests/Feature/Tables/RowClickTest.php
+++ b/tests/Feature/Tables/RowClickTest.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Lattice\Actions\ActionDefinition;
+use Lattice\Actions\ActionResult;
+use Lattice\Actions\Components\Action as ActionComponent;
+use Lattice\Core\Attributes\AsAction;
+use Lattice\Core\Facades\Lattice;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\CallbackTableSource;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\RowClick;
+use Lattice\Table\Components\Table;
+use Lattice\Table\Contracts\TableSource;
+use Lattice\Table\TableDefinition;
+use Lattice\Table\TableQuery;
+use Lattice\Table\TableResult;
+use Lattice\Ui\Components\Modal;
+use Lattice\Ui\Components\Text;
+
+use function Pest\Laravel\postJson;
+
+beforeEach(function (): void {
+    RowClickArchiveAction::$archived = [];
+    RowClickArchiveAction::$authorized = true;
+
+    Lattice::tables([RowClickTable::class]);
+    Lattice::actions([RowClickArchiveAction::class]);
+});
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function rowClickRows(): array
+{
+    return wire(Table::use(RowClickTable::class))['props']['data'];
+}
+
+it('attaches the action a row click runs to the row', function (): void {
+    $rows = rowClickRows();
+
+    expect($rows[0]['rowClick']['type'])->toBe('table.row-click')
+        ->and($rows[0]['rowClick']['props']['action']['id'])->toBe('row-click.archive')
+        ->and($rows[0]['rowClick']['props']['href'])->toBeNull();
+});
+
+it('runs the row click action through its sealed reference', function (): void {
+    $rows = rowClickRows();
+
+    postJson('/lattice/actions/row-click.archive', [], [
+        'X-Lattice-Ref' => $rows[0]['rowClick']['props']['action']['props']['ref'],
+    ])->assertOk();
+
+    expect(RowClickArchiveAction::$archived)->toBe([1]);
+});
+
+it('leaves a row unclickable when its action is unauthorized', function (): void {
+    RowClickArchiveAction::$authorized = false;
+
+    expect(rowClickRows()[0])->not->toHaveKey('rowClick');
+});
+
+it('attaches the modal a row click opens to the row', function (): void {
+    $rows = rowClickRows();
+
+    expect($rows[1]['rowClick']['props']['modal']['props']['title'])->toBe('Shelf');
+});
+
+it('leaves a row unclickable when it declares no click', function (): void {
+    expect(rowClickRows()[2])->not->toHaveKey('rowClick');
+});
+
+#[AsTable('row-click.table')]
+final class RowClickTable extends TableDefinition
+{
+    public function columns(): array
+    {
+        return [TextColumn::make('name')];
+    }
+
+    public function source(): TableSource
+    {
+        return new CallbackTableSource(fn (TableQuery $query): TableResult => TableResult::make([
+            ['id' => 1, 'name' => 'Lamp'],
+            ['id' => 2, 'name' => 'Shelf'],
+            ['id' => 3, 'name' => 'Rug'],
+        ]));
+    }
+
+    #[Override]
+    public function rowClick(array $row): ?RowClick
+    {
+        if ($row['id'] === 1) {
+            return RowClick::make()->action(RowClickArchiveAction::class, ['product' => $row['id']]);
+        }
+
+        if ($row['id'] === 3) {
+            return null;
+        }
+
+        return RowClick::make()->modal(fn (): Modal => Modal::make('row-click-modal')
+            ->title($row['name'])
+            ->schema([Text::make('Details')]));
+    }
+}
+
+#[AsAction('row-click.archive')]
+final class RowClickArchiveAction extends ActionDefinition
+{
+    /** @var array<int, mixed> */
+    public static array $archived = [];
+
+    public static bool $authorized = true;
+
+    public function definition(ActionComponent $action): ActionComponent
+    {
+        return $action->label('Archive');
+    }
+
+    public function handle(Request $request): ActionResult
+    {
+        self::$archived[] = $this->context('product');
+
+        return ActionResult::success();
+    }
+
+    #[Override]
+    public function authorize(Request $request): bool
+    {
+        return self::$authorized;
+    }
+}

--- a/tests/Feature/Tables/TableEndpointTest.php
+++ b/tests/Feature/Tables/TableEndpointTest.php
@@ -9,6 +9,7 @@ use Lattice\Table\Attributes\AsTable;
 use Lattice\Table\CallbackTableSource;
 use Lattice\Table\Columns\StackColumn;
 use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\RowClick;
 use Lattice\Table\Components\Table;
 use Lattice\Table\Contracts\TableSource;
 use Lattice\Table\Enums\PaginationType;
@@ -407,7 +408,7 @@ test('registered table responses expose only declared columns row identity and g
 
     expect($row)->toBeArray();
 
-    expect(array_keys($row))->toBe(['id', 'name', 'sku', 'status', 'actions', 'rowUrl'])
+    expect(array_keys($row))->toBe(['id', 'name', 'sku', 'status', 'actions', 'rowClick'])
         ->and($row['id'])->toBe($product->getKey())
         ->and($row['name'])->toBe('Projected Product')
         ->and($row['sku'])->toBe('PROJECT-001')
@@ -415,15 +416,16 @@ test('registered table responses expose only declared columns row identity and g
         ->and($row['actions'][0]['type'])->toBe('link')
         ->and($row['actions'][0]['key'])->toBe('edit-product')
         ->and($row['actions'][0]['props']['href'])->toBe("/products/{$product->getKey()}/edit")
-        ->and($row['rowUrl'])->toBe("/products/{$product->getKey()}");
+        ->and($row['rowClick']['type'])->toBe('table.row-click')
+        ->and($row['rowClick']['props']['href'])->toBe("/products/{$product->getKey()}");
 });
 
-test('registered table responses omit the row url when a table declares no rowUrl', function (): void {
+test('registered table responses omit the row click when a table declares none', function (): void {
     Lattice::tables([WorkbenchUsersTable::class]);
 
     $row = wire(Table::use(WorkbenchUsersTable::class))['props']['data'][0];
 
-    expect($row)->not->toHaveKey('rowUrl');
+    expect($row)->not->toHaveKey('rowClick');
 });
 
 test('registered table responses prune hidden columns from the row payload', function (): void {
@@ -632,9 +634,9 @@ class WorkbenchProjectedProductsTable extends EloquentTableDefinition
     }
 
     #[Override]
-    public function rowUrl(array $row): ?string
+    public function rowClick(array $row): ?RowClick
     {
-        return "/products/{$row['id']}";
+        return RowClick::make()->href("/products/{$row['id']}");
     }
 }
 

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -80,6 +80,7 @@ use Workbench\App\Pages\Tables\FiltersPage;
 use Workbench\App\Pages\Tables\NumberColumnsPage;
 use Workbench\App\Pages\Tables\PaginationPage;
 use Workbench\App\Pages\Tables\PinnedColumnsPage;
+use Workbench\App\Pages\Tables\RowClicksPage;
 use Workbench\App\Pages\Tables\TextColumnsPage;
 use Workbench\App\Pages\Tables\VisualColumnsPage;
 use Workbench\App\Pages\WizardPage;
@@ -160,6 +161,7 @@ class AppLayout extends LayoutDefinition
                         MenuItem::fromPage(CustomColumnPage::class)->key('columns-custom')->label(__('workbench.navigation.columns-custom')),
                         MenuItem::fromPage(PinnedColumnsPage::class)->key('columns-pinned')->label(__('workbench.navigation.columns-pinned')),
                     ]),
+                    MenuItem::fromPage(RowClicksPage::class)->key('row-clicks')->label(__('workbench.navigation.row-clicks')),
                     MenuItem::fromPage(FiltersPage::class)->key('table-filters')->label(__('workbench.navigation.table-filters')),
                     MenuItem::fromPage(PaginationPage::class)->key('pagination-modes')->label(__('workbench.navigation.pagination-modes')),
                 ]),

--- a/workbench/app/Pages/Tables/RowClicksPage.php
+++ b/workbench/app/Pages/Tables/RowClicksPage.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages\Tables;
+
+use Lattice\Core\Attributes\AsPage;
+use Workbench\App\Tables\RowClicksTable;
+
+#[AsPage(route: '/tables/row-clicks')]
+final class RowClicksPage extends TableDemoPage
+{
+    protected function table(): string
+    {
+        return RowClicksTable::class;
+    }
+
+    protected function slug(): string
+    {
+        return 'row-clicks';
+    }
+}

--- a/workbench/app/Tables/PinnedColumnsTable.php
+++ b/workbench/app/Tables/PinnedColumnsTable.php
@@ -10,6 +10,7 @@ use Lattice\Table\Columns\Column;
 use Lattice\Table\Columns\MoneyColumn;
 use Lattice\Table\Columns\NumberColumn;
 use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\RowClick;
 use Lattice\Ui\Components\Component;
 use Lattice\Ui\Components\Link;
 use Lattice\Ui\Enums\ColumnWidth;
@@ -58,10 +59,13 @@ class PinnedColumnsTable extends BaseProductsDemoTable
         ];
     }
 
+    /**
+     * @param  array<string, mixed>  $row
+     */
     #[\Override]
-    public function rowUrl(array $row): ?string
+    public function rowClick(array $row): ?RowClick
     {
-        return '/products/'.$row['id'].'/edit';
+        return RowClick::make()->href('/products/'.$row['id'].'/edit');
     }
 
     /**

--- a/workbench/app/Tables/RowClicksTable.php
+++ b/workbench/app/Tables/RowClicksTable.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Tables;
+
+use Illuminate\Database\Eloquent\Builder;
+use Lattice\Table\Attributes\AsTable;
+use Lattice\Table\Columns\Column;
+use Lattice\Table\Columns\MoneyColumn;
+use Lattice\Table\Columns\TextColumn;
+use Lattice\Table\Components\RowClick;
+use Lattice\Ui\Components\DescriptionList;
+use Lattice\Ui\Components\Entries\TextEntry;
+use Lattice\Ui\Components\Modal;
+use Workbench\App\Models\Product;
+use Workbench\App\Models\SalesPrice;
+use Workbench\App\Tables\Columns\StatusBadgeColumn;
+
+#[AsTable('workbench.demo.row-clicks')]
+class RowClicksTable extends BaseProductsDemoTable
+{
+    /**
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->label(__('workbench.tables.columns.name'))->sortable(),
+            TextColumn::make('sku')->label(__('workbench.tables.columns.sku'))->sortable(),
+            MoneyColumn::make('default_price')->label(__('workbench.tables.columns.default-price'))->currency('EUR'),
+            StatusBadgeColumn::make('status')->label(__('workbench.tables.columns.status'))
+                ->colorMap(['draft' => 'gray', 'active' => 'green', 'archived' => 'red']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    #[\Override]
+    public function rowClick(array $row): ?RowClick
+    {
+        return RowClick::make()->modal(fn (): Modal => Modal::make('row-click-details')
+            ->title(is_string($row['name']) ? $row['name'] : '')
+            ->schema([
+                DescriptionList::make('row-click-facts')->schema([
+                    TextEntry::make('sku', __('workbench.tables.columns.sku'))->value($row['sku']),
+                    TextEntry::make('status', __('workbench.tables.columns.status'))->value($row['status']),
+                ]),
+            ]));
+    }
+
+    /**
+     * @return Builder<Product>
+     */
+    protected function query(): Builder
+    {
+        return Product::query()
+            ->select(['id', 'name', 'sku', 'status'])
+            ->selectSub(
+                SalesPrice::query()
+                    ->select('amount')
+                    ->whereColumn('product_id', 'products.id')
+                    ->whereNull('group_id')
+                    ->limit(1),
+                'default_price',
+            );
+    }
+}

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -488,6 +488,7 @@ return [
         'progress' => 'Fortschritt',
         'realtime' => 'Echtzeit',
         'remote-schema' => 'Remote-Schema',
+        'row-clicks' => 'Zeilenklicks',
         'sales-orders' => 'Aufträge',
         'table-filters' => 'Filter',
         'tables' => 'Tabellen',
@@ -825,6 +826,10 @@ return [
             'pinned-columns' => [
                 'description' => 'Angeheftete Spalten bleiben sichtbar, während der Rest der Tabelle horizontal scrollt.',
                 'title' => 'Angeheftete Spalten',
+            ],
+            'row-clicks' => [
+                'description' => 'Ein Klick auf die Zeile öffnet das Produkt in einem Modal.',
+                'title' => 'Zeilenklicks',
             ],
             'text-columns' => [
                 'description' => 'Textspalten mit Badges, Daten und kopierbaren Werten.',

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -488,6 +488,7 @@ return [
         'progress' => 'Progress',
         'realtime' => 'Realtime',
         'remote-schema' => 'Remote Schema',
+        'row-clicks' => 'Row clicks',
         'sales-orders' => 'Sales orders',
         'table-filters' => 'Filters',
         'tables' => 'Tables',
@@ -825,6 +826,10 @@ return [
             'pinned-columns' => [
                 'description' => 'Pinned columns stay visible while the rest of the table scrolls horizontally.',
                 'title' => 'Pinned columns',
+            ],
+            'row-clicks' => [
+                'description' => 'Clicking anywhere on a row opens the product in a modal.',
+                'title' => 'Row clicks',
             ],
             'text-columns' => [
                 'description' => 'Text columns with badges, dates, and copyable values.',


### PR DESCRIPTION
A whole-row click could only navigate: `rowUrl()` serialized a bare string and the client visited it. Opening a modal, running an action, or dispatching effects from a row click was impossible.

`rowClick()` replaces it and returns a `RowClick`, which carries the same `Triggerable` surface as Button and Link — exactly one of `href`, `action`, `effects`, or `modal`:

```php
public function rowClick(array $row): ?RowClick
{
    return RowClick::make()->modal(fn (): Modal => Modal::make('product')
        ->title($row['name'])
        ->schema([Form::use(EditProductForm::class)]));
}
```

**Breaking:** `TableDefinition::rowUrl()` is gone — the href case is `RowClick::make()->href(...)`. Rows carry a `rowClick` node instead of a `rowUrl` string.

### How it works

- `RowClick` is an `#[AsComponent]` props carrier, not a new wire family: a family whose reference class is also its only member collides in `WireModelBuilder`'s name map. Its registry entry renders nothing, because the node never sits in a schema.
- `RowClick::shouldRender()` gates on its action, so an unauthorized action leaves the row unclickable instead of shipping a node that refuses to serialize.
- Client side, `components/row-trigger.tsx` resolves the behavior through `useClickBehavior` and, for an action, the provider-backed `ActionTrigger` — so confirmation, action forms, and returned effects behave exactly as they do on an action button, and the table package still needs no dependency on `@lattice-php/action`. The wrapper exists because a row is rendered inside a `.map()`, where hooks cannot run.
- Navigation keeps cmd/ctrl-click and middle-click. Every clickable row is now focusable and activates on <kbd>Enter</kbd>/<kbd>Space</kbd> (a gap `rowUrl()` had too), and a row whose action is in flight ignores further clicks.

### Verification

`composer test` (2166 passed), `vitest` jsdom (1792) and browser, PHPStan (both configs), Pint, Rector, oxlint, typecheck, type-coverage, `build:lib`. New coverage: `tests/Feature/Tables/RowClickTest.php` and `packages/table/resources/js/components/row-trigger.test.tsx`.

Demo: `/tables/row-clicks` in the workbench opens a product modal from anywhere in the row; `/tables/columns/pinned` still demos the href case.
