### PR TITLE
fix(search): ship the Eloquent provider and default a declared gate's authorize()

### DIFF
--- a/docs/content/docs/packages/search.mdx
+++ b/docs/content/docs/packages/search.mdx
@@ -84,6 +84,10 @@ final class ProductSearchProvider implements ResolvesGateSubject, SearchResultPr
 Declaring `on` without that contract throws at registration rather than silently denying every
 request. A subject that resolves to nothing denies, the same as anywhere else in Lattice.
 
+`SearchResultProvider` requires an `authorize()` because it is an interface and cannot default one.
+When the declaration is the whole gate, take it from
+`Lattice\Core\Concerns\AuthorizesByDeclaration` rather than writing `return true` by hand.
+
 ## Translations
 
 The component's strings ship with inline English defaults. With

--- a/docs/content/docs/packages/search.mdx
+++ b/docs/content/docs/packages/search.mdx
@@ -55,6 +55,46 @@ import { SearchBox, SearchInput, SearchResults } from "@lattice-php/search";
 `SearchBox` opens the palette through the nearest `ModalProvider`; the slot components read the
 active search from `SearchProvider`, which `SearchPalette` mounts around its children.
 
+## An Eloquent category
+
+`EloquentSearchProvider` covers the common case: give it the base query, the columns a term matches
+against, and how a record becomes a result. Counting, paging and re-resolving a recorded selection
+are the same for every such provider and come from the base class.
+
+```php
+/**
+ * @extends EloquentSearchProvider<Product>
+ */
+#[AsSearchProvider('products', can: 'products.view')]
+final class ProductSearchProvider extends EloquentSearchProvider
+{
+    public function category(): SearchCategory
+    {
+        return new SearchCategory('products', __('Products'), 'package');
+    }
+
+    protected function query(): Builder
+    {
+        return Product::query()->orderBy('name');
+    }
+
+    protected function searchColumns(): array
+    {
+        return ['name', 'sku'];
+    }
+
+    protected function result(Model $model): SearchResult
+    {
+        return SearchResult::make('products', new SearchResultItem($model->id, $model->name, route('products.show', $model)));
+    }
+}
+```
+
+`query()` is where scopes, ordering and the eager loads `result()` reads belong — it is called per
+request, never memoized. An empty term matches everything, which is what the palette shows before
+anything is typed; a `%` or `_` in the term is escaped so it matches literally. Override
+`matching()` for anything the column list cannot express, such as a relation or a full-text index.
+
 ## Authorizing a provider
 
 A provider is gated exactly like a definition: declare the ability on its attribute, and use

--- a/packages/core/src/Concerns/AuthorizesByDeclaration.php
+++ b/packages/core/src/Concerns/AuthorizesByDeclaration.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Core\Concerns;
+
+use Illuminate\Http\Request;
+use Lattice\Core\Authorization;
+use Lattice\Core\Contracts\Authorizable;
+use Lattice\Core\Definition;
+
+/**
+ * Satisfies {@see Authorizable} for a class whose gate is entirely the `can`
+ * and `on` declared on its attribute — {@see Authorization} composes the two,
+ * and this side has nothing to add.
+ *
+ * {@see Definition} already defaults this way; the trait is for
+ * everything else that implements the contract, so declaring a gate does not
+ * also mean writing a `return true` by hand.
+ */
+trait AuthorizesByDeclaration
+{
+    public function authorize(Request $request): bool
+    {
+        return true;
+    }
+}

--- a/packages/search/composer.json
+++ b/packages/search/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
+        "illuminate/database": "^11.0 || ^12.0 || ^13.0",
         "illuminate/http": "^11.0 || ^12.0 || ^13.0",
         "illuminate/routing": "^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^11.0 || ^12.0 || ^13.0",

--- a/packages/search/src/EloquentSearchProvider.php
+++ b/packages/search/src/EloquentSearchProvider.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Search;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Lattice\Core\Concerns\AuthorizesByDeclaration;
+use Lattice\Core\Contracts\ResolvesGateSubject;
+use Lattice\Search\Contracts\SearchResultProvider;
+
+/**
+ * A category backed by an Eloquent model: supply the base query, the columns a
+ * term matches against, and how a record becomes a result. Counting, paging
+ * and re-resolving a recorded selection are the same for every such provider
+ * and live here.
+ *
+ * The gate is the `can`/`on` on the provider's attribute. Override
+ * {@see authorize()} only to narrow it further; a provider needing a gate
+ * subject implements {@see ResolvesGateSubject}.
+ *
+ * @template TModel of Model
+ */
+abstract class EloquentSearchProvider implements SearchResultProvider
+{
+    use AuthorizesByDeclaration;
+
+    /**
+     * The base query: scopes, ordering, and the eager loads {@see result()}
+     * reads. Called per request, never memoized.
+     *
+     * @return Builder<TModel>
+     */
+    abstract protected function query(): Builder;
+
+    /**
+     * Columns a term matches against, as qualified or plain column names.
+     *
+     * @return list<string>
+     */
+    abstract protected function searchColumns(): array;
+
+    /**
+     * @param  TModel  $model
+     */
+    abstract protected function result(Model $model): SearchResult;
+
+    public function count(SearchQuery $query): int
+    {
+        return $this->matching($query->query)->count();
+    }
+
+    public function search(SearchQuery $query): SearchResults
+    {
+        $page = $this->matching($query->query)->paginate($query->perPage, page: $query->page);
+
+        return new SearchResults(
+            rows: array_values(array_map($this->result(...), $page->items())),
+            total: $page->total(),
+        );
+    }
+
+    public function resolve(string $id, Request $request): ?SearchResult
+    {
+        $model = $this->query()->find($id);
+
+        return $model === null ? null : $this->result($model);
+    }
+
+    /**
+     * An empty term matches everything, which is what the palette shows before
+     * anything is typed.
+     *
+     * @return Builder<TModel>
+     */
+    protected function matching(string $term): Builder
+    {
+        $builder = $this->query();
+        $columns = $this->searchColumns();
+
+        if ($term === '' || $columns === []) {
+            return $builder;
+        }
+
+        // Escaped the way Table's FilterApplier escapes a Contains filter, so
+        // a typed wildcard matches literally on a driver that honours it.
+        $pattern = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
+
+        return $builder->where(function (Builder $group) use ($columns, $pattern): void {
+            foreach ($columns as $column) {
+                $group->orWhere($column, 'like', $pattern);
+            }
+        });
+    }
+}

--- a/tests/Feature/Search/EloquentSearchProviderTest.php
+++ b/tests/Feature/Search/EloquentSearchProviderTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Lattice\Core\Discovery\DiscoveryManifest;
+use Lattice\Search\SearchProviderRegistry;
+use Lattice\Search\SearchQuery;
+use Lattice\Search\SearchResult;
+use Lattice\Tests\Fixtures\SearchGate\ProductSearchProvider;
+use Workbench\App\Models\Product;
+
+use function Pest\Laravel\getJson;
+
+function productSearchQuery(string $term, int $page = 1, int $perPage = 10): SearchQuery
+{
+    return new SearchQuery($term, 'workbench-products', $page, $perPage, 'en');
+}
+
+beforeEach(function (): void {
+    config(['lattice.discover' => []]);
+    app(DiscoveryManifest::class)->clear();
+    app(SearchProviderRegistry::class)->register(ProductSearchProvider::class);
+});
+
+it('matches a term against the declared columns and orders by the base query', function (): void {
+    Product::factory()->create(['name' => 'Office Chair']);
+    Product::factory()->create(['name' => 'Desk Lamp']);
+    Product::factory()->create(['name' => 'Notebook']);
+
+    $results = app(ProductSearchProvider::class)->search(productSearchQuery('desk'));
+
+    expect($results->total)->toBe(1)
+        ->and($results->rows[0]->item->title)->toBe('Desk Lamp');
+});
+
+it('counts and pages the same query', function (): void {
+    Product::factory()->create(['name' => 'Desk Lamp']);
+    Product::factory()->create(['name' => 'Desk Mat']);
+    Product::factory()->create(['name' => 'Desk Pad']);
+
+    $provider = app(ProductSearchProvider::class);
+
+    expect($provider->count(productSearchQuery('desk')))->toBe(3)
+        ->and($provider->search(productSearchQuery('desk', perPage: 2))->rows)->toHaveCount(2)
+        ->and($provider->search(productSearchQuery('desk', page: 2, perPage: 2))->rows)->toHaveCount(1)
+        ->and($provider->search(productSearchQuery('desk', perPage: 2))->total)->toBe(3);
+});
+
+it('matches everything for an empty term, the way the palette opens', function (): void {
+    Product::factory()->create(['name' => 'Desk Lamp']);
+    Product::factory()->create(['name' => 'Notebook']);
+
+    expect(app(ProductSearchProvider::class)->count(productSearchQuery('')))->toBe(2);
+});
+
+it('escapes a wildcard in the term rather than binding it as one', function (): void {
+    DB::enableQueryLog();
+
+    app(ProductSearchProvider::class)->count(productSearchQuery('100%'));
+
+    expect(DB::getQueryLog()[0]['bindings'][0] ?? null)->toBe('%100\\%%');
+});
+
+it('re-resolves a recorded selection through the base query', function (): void {
+    $product = Product::factory()->create(['name' => 'Desk Lamp']);
+    $provider = app(ProductSearchProvider::class);
+
+    expect($provider->resolve((string) $product->getKey(), request()))->toBeInstanceOf(SearchResult::class)
+        ->and($provider->resolve('missing', request()))->toBeNull();
+});
+
+it('serves the category over the search endpoint', function (): void {
+    Product::factory()->create(['name' => 'Desk Lamp']);
+
+    getJson('/lattice/search?query=desk&counts=1')
+        ->assertOk()
+        ->assertJsonPath('data.0.item.title', 'Desk Lamp')
+        ->assertJsonPath('categories.0.count', 1);
+});

--- a/tests/Feature/Search/SearchProviderGateTest.php
+++ b/tests/Feature/Search/SearchProviderGateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Gate;
 use Lattice\Core\Discovery\DiscoveryManifest;
 use Lattice\Search\SearchProviderRegistry;
+use Lattice\Tests\Fixtures\SearchGate\DeclaredOnlySearchProvider;
 use Lattice\Tests\Fixtures\SearchGate\GatedSearchProvider;
 use Lattice\Tests\Fixtures\SearchGate\UnresolvableSubjectSearchProvider;
 
@@ -55,3 +56,15 @@ it('refuses to register a provider that declares on without resolving a subject'
     expect(fn () => app(SearchProviderRegistry::class)->register(UnresolvableSubjectSearchProvider::class))
         ->toThrow(InvalidArgumentException::class, 'ResolvesGateSubject');
 });
+
+it('gates a provider whose only gate is the declaration, with no authorize() written', function (bool $allowed, int $results): void {
+    app(SearchProviderRegistry::class)->register(DeclaredOnlySearchProvider::class);
+    Gate::define('memos.view', fn (?object $user): bool => $allowed);
+
+    getJson('/lattice/search?query=memo')
+        ->assertOk()
+        ->assertJsonCount($results, 'data');
+})->with([
+    'denied' => [false, 0],
+    'allowed' => [true, 1],
+]);

--- a/tests/Fixtures/SearchGate/DeclaredOnlySearchProvider.php
+++ b/tests/Fixtures/SearchGate/DeclaredOnlySearchProvider.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tests\Fixtures\SearchGate;
+
+use Illuminate\Http\Request;
+use Lattice\Core\Concerns\AuthorizesByDeclaration;
+use Lattice\Search\AsSearchProvider;
+use Lattice\Search\Contracts\SearchResultProvider;
+use Lattice\Search\SearchCategory;
+use Lattice\Search\SearchQuery;
+use Lattice\Search\SearchResult;
+use Lattice\Search\SearchResultItem;
+use Lattice\Search\SearchResults;
+
+#[AsSearchProvider('memos', can: 'memos.view')]
+final class DeclaredOnlySearchProvider implements SearchResultProvider
+{
+    use AuthorizesByDeclaration;
+
+    public function category(): SearchCategory
+    {
+        return new SearchCategory('memos', 'Memos', 'file');
+    }
+
+    public function count(SearchQuery $query): int
+    {
+        return 1;
+    }
+
+    public function search(SearchQuery $query): SearchResults
+    {
+        return new SearchResults([$this->memo()], 1);
+    }
+
+    public function resolve(string $id, Request $request): ?SearchResult
+    {
+        return $id === '1' ? $this->memo() : null;
+    }
+
+    private function memo(): SearchResult
+    {
+        return SearchResult::make('memos', new SearchResultItem('1', 'Board memo', '/memos/1'));
+    }
+}

--- a/tests/Fixtures/SearchGate/ProductSearchProvider.php
+++ b/tests/Fixtures/SearchGate/ProductSearchProvider.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Tests\Fixtures\SearchGate;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Lattice\Search\AsSearchProvider;
+use Lattice\Search\EloquentSearchProvider;
+use Lattice\Search\SearchCategory;
+use Lattice\Search\SearchResult;
+use Lattice\Search\SearchResultItem;
+use Workbench\App\Models\Product;
+
+/**
+ * @extends EloquentSearchProvider<Product>
+ */
+#[AsSearchProvider('workbench-products')]
+final class ProductSearchProvider extends EloquentSearchProvider
+{
+    public function category(): SearchCategory
+    {
+        return new SearchCategory('workbench-products', 'Products', 'package');
+    }
+
+    /** @return Builder<Product> */
+    protected function query(): Builder
+    {
+        return Product::query()->orderBy('name');
+    }
+
+    protected function searchColumns(): array
+    {
+        return ['name'];
+    }
+
+    /** @param Product $model */
+    protected function result(Model $model): SearchResult
+    {
+        return SearchResult::make(
+            'workbench-products',
+            new SearchResultItem((string) $model->getKey(), $model->name, '/products/'.$model->getKey()),
+        );
+    }
+}


### PR DESCRIPTION
Two commits, both closing gaps that surfaced while moving artisan-os onto 0.73.

## `fix(core): stop making a declared gate write its own authorize()`

`SearchResultProvider` extends `Authorizable`, and an interface cannot carry a default, so a provider whose gate is entirely the `can`/`on` on its attribute still had to write `return true` by hand. `Definition` has defaulted that way all along.

`Lattice\Core\Concerns\AuthorizesByDeclaration` is that default for everything implementing the contract without extending `Definition`.

## `fix(search): ship the Eloquent provider every consumer was rewriting`

A category backed by a model needs the same `count`/`search`/`resolve` every time. Every app wrote it again and got the details right or wrong on its own — `paginate()` rather than `get()` so the `TModel` template survives Larastan, an empty term matching everything the way the palette opens, a typed `%` escaped so it matches literally.

```php
/**
 * @extends EloquentSearchProvider<Product>
 */
#[AsSearchProvider('products', can: 'products.view')]
final class ProductSearchProvider extends EloquentSearchProvider
{
    public function category(): SearchCategory { /* … */ }
    protected function query(): Builder { return Product::query()->orderBy('name'); }
    protected function searchColumns(): array { return ['name', 'sku']; }
    protected function result(Model $model): SearchResult { /* … */ }
}
```

`matching()` is `protected` so a provider can override it for a relation or a full-text index. The wildcard escaping mirrors Table's `FilterApplier`; the test asserts the binding rather than driver behaviour, since SQLite honours no default LIKE escape.

**Adds `illuminate/database` to `lattice-php/search`**, which `lattice-php/table` already requires. That is the one judgement call here — the alternative is leaving every app to rewrite the class.

Verification: `composer check`.
