### PR TITLE
fix(tests): freeze time in the media suite so signed URLs compare

### DIFF
--- a/tests/Support/MediaFixtures.php
+++ b/tests/Support/MediaFixtures.php
@@ -12,6 +12,7 @@ use Lattice\Media\Models\Media;
 use Lattice\Table\TableDefinition;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\freezeTime;
 
 /**
  * Asserts the write: a fake disk swallows failures into `false`, and a skipped
@@ -36,6 +37,11 @@ function fakeImageMedia(string $name = 'source.jpg', int $width = 320, int $heig
 function bootstrapMediaTest(array $tables = [], array $actions = [], array $bulkActions = [], array $forms = []): void
 {
     Storage::fake('public');
+
+    // Media::url() signs a temporary URL against now(), so a test comparing a
+    // URL a request produced with one the assertion produces gets two
+    // different expirations whenever a second ticks between them.
+    freezeTime();
 
     Lattice::tables($tables);
     Lattice::actions($actions);


### PR DESCRIPTION
`Media::url()` signs a temporary URL against `now()`:

```php
return $disk->temporaryUrl($path, now()->addMinutes((int) config('lattice.files.url_ttl', 5)));
```

So a test comparing the URL a request produced with the one the assertion produces gets two different expirations whenever a second ticks between them. It went red on the 8.5 shard of #594:

```
-'http://localhost/media/conversions/hero-thumb.webp?expiration=1788628868'
+'http://localhost/media/conversions/hero-thumb.webp?expiration=1788628867'
```

Frozen in `bootstrapMediaTest()` rather than in the two assertions that happened to flake, so every current and future URL comparison in the suite is covered. No media test depends on time advancing, and `Carbon::setTestNow()` is reset per test, so nothing leaks.

`FileUpload` builds its URL the same way but its tests stub `temporaryUrl()` to a fixed string, so there is no second site to fix.

Verification: `composer check` (2174 tests).