### PR TITLE
feat(form): add a checkbox group field

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -9,4 +9,5 @@ Before planning or editing, find the row whose globs match the file's path and r
 | packages/form/resources/js/** | .ai/rules/form-resources-js.md |
 | packages/*/resources/js/** | .ai/rules/js.md |
 | packages/ui/resources/js/** | .ai/rules/resources-js.md |
+| packages/core/src/Option.php | .ai/rules/src.md |
 | packages/table/resources/js/** | .ai/rules/table-resources-js.md |

--- a/.ai/rules/src.md
+++ b/.ai/rules/src.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - packages/core/src/Option.php
+---
+
+# Src
+
+## Option is a shared wire type — widening it has a fixed checklist
+Every option-driven control (select, choice, segmented control, table filters, checkbox group) serializes the same `Lattice\Core\Option`, and nulls are serialized, so a new facet adds a key to every option on the wire. Adding one means, in order: append the promoted property after `data` (positional callers), teach `Option::expand()`/`from()` the new array key, widen `HasOptions::option()` so named args work, hand-edit `packages/core/resources/js/types.ts` (the TS `Option` is hand-written there, NOT emitted by `composer types` despite the `#[TypeScript]` attribute — declare new facets optional to spare every literal), run `composer types`, regenerate fixtures with `LATTICE_UPDATE_FIXTURES=1 vendor/bin/pest`, and fix the ~55 exact-shape assertions across tests/Feature/Forms, tests/Feature/Tables, and tests/Unit/Tables that compare whole option arrays.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -124,6 +124,7 @@ export default defineConfig({
                 { label: "Choice", link: "/forms/fields/choice/" },
                 { label: "Color picker", link: "/forms/fields/color-picker/" },
                 { label: "Checkbox", link: "/forms/fields/checkbox/" },
+                { label: "Checkbox group", link: "/forms/fields/checkbox-group/" },
                 { label: "Toggle", link: "/forms/fields/toggle/" },
                 { label: "Date input", link: "/forms/fields/date-input/" },
                 { label: "Time input", link: "/forms/fields/time-input/" },

--- a/docs/content/docs/forms/fields/checkbox-group.mdx
+++ b/docs/content/docs/forms/fields/checkbox-group.mdx
@@ -1,0 +1,92 @@
+---
+title: Checkbox group
+description: A visible list of checkboxes for picking several values at once, optionally split into sections.
+---
+
+import ComponentExample from "@components/ComponentExample.astro";
+
+A checkbox group shows every option at once and submits the checked ones as an array. Reach for it
+over a [multiple Select](/forms/fields/select/) when the reader should see the whole catalog —
+permissions, API scopes, notification channels — rather than open a dropdown. Create one with
+`CheckboxGroup::make()` and pass the options with `->options()`.
+
+<ComponentExample
+  php={`CheckboxGroup::make('notifications', 'Notifications')
+    ->options([
+        CheckboxGroup::option('Product updates', 'product'),
+        CheckboxGroup::option('Security alerts', 'security'),
+        CheckboxGroup::option('Weekly digest', 'digest'),
+    ])`}
+  fixture="checkbox-group.basic"
+  values={{ notifications: [] }}
+/>
+
+The field submits a list of the checked values (`['product', 'digest']`). Nothing checked submits an
+empty array, so `handle()` always receives an array. Values are constrained to the configured
+options, the way a [Choice](/forms/fields/choice/) constrains its single value — a submit carrying
+an unknown value fails validation instead of reaching your handler.
+
+## Options from an enum
+
+`->enum()` builds the options from a backed enum. Pass the enum class for every case, or an array of
+cases for a subset.
+
+```php
+CheckboxGroup::make('channels', 'Channels')->enum(Channel::class);
+```
+
+## Descriptions and tooltips
+
+An option carries more than its label: `description` renders a muted second line beneath it, and
+`tooltip` adds an info popover next to it. Both are optional and read well as named arguments.
+
+```php
+CheckboxGroup::option(
+    'Manage orders',
+    'order:manage',
+    description: 'Create, edit, and cancel orders.',
+    tooltip: 'Includes issuing refunds.',
+);
+```
+
+## Sections
+
+Options that carry a `group` label are bucketed into sections in first-seen order; ungrouped options
+stay above them. `->collapsible()` turns each section into a collapsible panel — pass
+`collapsed: true` to start them all closed, which keeps a long catalog scannable.
+
+<ComponentExample
+  php={`CheckboxGroup::make('permissions', 'Permissions')
+    ->columns(2)
+    ->bulkToggleable()
+    ->collapsible()
+    ->options([
+        CheckboxGroup::option('View orders', 'order:view', description: 'order:view', group: 'Sales'),
+        CheckboxGroup::option('Manage orders', 'order:manage', description: 'order:manage', group: 'Sales'),
+        CheckboxGroup::option('View invoices', 'invoice:view', description: 'invoice:view', group: 'Accounting'),
+        CheckboxGroup::option('Manage invoices', 'invoice:manage', description: 'invoice:manage', group: 'Accounting'),
+    ])`}
+  fixture="checkbox-group.groups"
+  values={{ permissions: ["order:view"] }}
+/>
+
+## Columns
+
+`->columns()` lays the checkboxes out in a grid. A bare count applies from the `md` breakpoint up and
+falls back to one column below it; a map sets each breakpoint explicitly.
+
+```php
+CheckboxGroup::make('permissions')->columns(['default' => 1, 'md' => 2, 'xl' => 3]);
+```
+
+## Selecting everything
+
+`->bulkToggleable()` adds a select-all checkbox above the list, and one per section. Each reflects
+what is currently checked below it: filled when everything is, mixed when only some of it is.
+
+## Common options
+
+`CheckboxGroup` shares label, default value, required, disabled, read-only, and visibility options
+with every field — see [Fields](/forms/fields/overview/). `->required()` demands at least one checked
+box. For validation and conditional behavior, see [Validation](/forms/validation/) and
+[Conditional fields](/forms/conditional-fields/).

--- a/docs/content/docs/forms/fields/overview.mdx
+++ b/docs/content/docs/forms/fields/overview.mdx
@@ -8,7 +8,8 @@ import ComponentExample from "@components/ComponentExample.astro";
 Fields are the building blocks of a form. Lattice ships
 [Text input](/forms/fields/text-input/), [Textarea](/forms/fields/textarea/),
 [Select](/forms/fields/select/), [Choice](/forms/fields/choice/),
-[Checkbox](/forms/fields/checkbox/), [Toggle](/forms/fields/toggle/), [Date input](/forms/fields/date-input/),
+[Checkbox](/forms/fields/checkbox/), [Checkbox group](/forms/fields/checkbox-group/),
+[Toggle](/forms/fields/toggle/), [Date input](/forms/fields/date-input/),
 [Time input](/forms/fields/time-input/), [Date time input](/forms/fields/date-time-input/),
 [Number input](/forms/fields/number-input/), [Password input](/forms/fields/password-input/), [Hidden input](/forms/fields/hidden-input/),
 [File upload](/forms/fields/file-upload/), [Rich editor](/forms/fields/rich-editor/), [Repeater](/forms/fields/repeater/),

--- a/docs/fixtures/checkbox-group.basic.json
+++ b/docs/fixtures/checkbox-group.basic.json
@@ -1,0 +1,53 @@
+[
+    {
+        "props": {
+            "bulkToggleable": false,
+            "collapsed": false,
+            "collapsible": false,
+            "columnWidth": "md",
+            "columns": null,
+            "conditions": null,
+            "dependsOnAny": false,
+            "dependsOnKeys": null,
+            "disabled": false,
+            "editablePrefill": false,
+            "helperText": null,
+            "label": "Notifications",
+            "labelAction": null,
+            "name": "notifications",
+            "options": [
+                {
+                    "data": null,
+                    "description": null,
+                    "group": null,
+                    "label": "Product updates",
+                    "tooltip": null,
+                    "value": "product"
+                },
+                {
+                    "data": null,
+                    "description": null,
+                    "group": null,
+                    "label": "Security alerts",
+                    "tooltip": null,
+                    "value": "security"
+                },
+                {
+                    "data": null,
+                    "description": null,
+                    "group": null,
+                    "label": "Weekly digest",
+                    "tooltip": null,
+                    "value": "digest"
+                }
+            ],
+            "prefillRefreshOn": null,
+            "prefillResetOn": null,
+            "readOnly": false,
+            "required": false,
+            "tooltip": null,
+            "value": null
+        },
+        "type": "field.checkbox-group"
+    }
+]

--- a/docs/fixtures/checkbox-group.groups.json
+++ b/docs/fixtures/checkbox-group.groups.json
@@ -1,0 +1,63 @@
+[
+    {
+        "props": {
+            "bulkToggleable": true,
+            "collapsed": false,
+            "collapsible": true,
+            "columnWidth": "md",
+            "columns": {
+                "md": 2
+            },
+            "conditions": null,
+            "dependsOnAny": false,
+            "dependsOnKeys": null,
+            "disabled": false,
+            "editablePrefill": false,
+            "helperText": null,
+            "label": "Permissions",
+            "labelAction": null,
+            "name": "permissions",
+            "options": [
+                {
+                    "data": null,
+                    "description": "order:view",
+                    "group": "Sales",
+                    "label": "View orders",
+                    "tooltip": null,
+                    "value": "order:view"
+                },
+                {
+                    "data": null,
+                    "description": "order:manage",
+                    "group": "Sales",
+                    "label": "Manage orders",
+                    "tooltip": null,
+                    "value": "order:manage"
+                },
+                {
+                    "data": null,
+                    "description": "invoice:view",
+                    "group": "Accounting",
+                    "label": "View invoices",
+                    "tooltip": null,
+                    "value": "invoice:view"
+                },
+                {
+                    "data": null,
+                    "description": "invoice:manage",
+                    "group": "Accounting",
+                    "label": "Manage invoices",
+                    "tooltip": null,
+                    "value": "invoice:manage"
+                }
+            ],
+            "prefillRefreshOn": null,
+            "prefillResetOn": null,
+            "readOnly": false,
+            "required": false,
+            "tooltip": null,
+            "value": null
+        },
+        "type": "field.checkbox-group"
+    }
+]

--- a/docs/fixtures/choice.basic.json
+++ b/docs/fixtures/choice.basic.json
@@ -16,17 +16,26 @@
             "options": [
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Free",
+                    "tooltip": null,
                     "value": "free"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Pro",
+                    "tooltip": null,
                     "value": "pro"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Enterprise",
+                    "tooltip": null,
                     "value": "enterprise"
                 }
             ],

--- a/docs/fixtures/components.segmented-control.json
+++ b/docs/fixtures/components.segmented-control.json
@@ -7,17 +7,26 @@
             "options": [
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Light",
+                    "tooltip": null,
                     "value": "light"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Dark",
+                    "tooltip": null,
                     "value": "dark"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "System",
+                    "tooltip": null,
                     "value": "system"
                 }
             ],

--- a/docs/fixtures/enums.json
+++ b/docs/fixtures/enums.json
@@ -258,6 +258,10 @@
                 "value": "field.checkbox"
             },
             {
+                "name": "CheckboxGroup",
+                "value": "field.checkbox-group"
+            },
+            {
                 "name": "Choice",
                 "value": "field.choice"
             },

--- a/docs/fixtures/field.required-when.json
+++ b/docs/fixtures/field.required-when.json
@@ -16,17 +16,26 @@
             "options": [
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Germany",
+                    "tooltip": null,
                     "value": "DE"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Austria",
+                    "tooltip": null,
                     "value": "AT"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "United States",
+                    "tooltip": null,
                     "value": "US"
                 }
             ],

--- a/docs/fixtures/field.visible-when.json
+++ b/docs/fixtures/field.visible-when.json
@@ -16,12 +16,18 @@
             "options": [
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Business",
+                    "tooltip": null,
                     "value": "business"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Individual",
+                    "tooltip": null,
                     "value": "individual"
                 }
             ],

--- a/docs/fixtures/pattern-input.basic.json
+++ b/docs/fixtures/pattern-input.basic.json
@@ -40,17 +40,26 @@
                                 "options": [
                                     {
                                         "data": null,
+                                        "description": null,
+                                        "group": null,
                                         "label": "4",
+                                        "tooltip": null,
                                         "value": "4"
                                     },
                                     {
                                         "data": null,
+                                        "description": null,
+                                        "group": null,
                                         "label": "5",
+                                        "tooltip": null,
                                         "value": "5"
                                     },
                                     {
                                         "data": null,
+                                        "description": null,
+                                        "group": null,
                                         "label": "6",
+                                        "tooltip": null,
                                         "value": "6"
                                     }
                                 ],

--- a/docs/fixtures/select.basic.json
+++ b/docs/fixtures/select.basic.json
@@ -19,22 +19,34 @@
             "options": [
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Germany",
+                    "tooltip": null,
                     "value": "de"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "France",
+                    "tooltip": null,
                     "value": "fr"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Spain",
+                    "tooltip": null,
                     "value": "es"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Italy",
+                    "tooltip": null,
                     "value": "it"
                 }
             ],

--- a/docs/fixtures/select.multiple.json
+++ b/docs/fixtures/select.multiple.json
@@ -19,22 +19,34 @@
             "options": [
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "PHP",
+                    "tooltip": null,
                     "value": "php"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "JavaScript",
+                    "tooltip": null,
                     "value": "js"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Go",
+                    "tooltip": null,
                     "value": "go"
                 },
                 {
                     "data": null,
+                    "description": null,
+                    "group": null,
                     "label": "Rust",
+                    "tooltip": null,
                     "value": "rust"
                 }
             ],

--- a/docs/fixtures/select.rich.json
+++ b/docs/fixtures/select.rich.json
@@ -78,7 +78,10 @@
                         "email": "kontakt@acme.de",
                         "number": "K-10021"
                     },
+                    "description": null,
+                    "group": null,
                     "label": "Acme GmbH",
+                    "tooltip": null,
                     "value": "1"
                 },
                 {
@@ -86,7 +89,10 @@
                         "email": "info@globex.de",
                         "number": "K-10022"
                     },
+                    "description": null,
+                    "group": null,
                     "label": "Globex AG",
+                    "tooltip": null,
                     "value": "2"
                 }
             ],

--- a/packages/core/resources/js/types.ts
+++ b/packages/core/resources/js/types.ts
@@ -65,7 +65,10 @@ export type Schema = Node[];
 
 export type Option = {
   readonly data: Record<string, unknown> | null;
+  readonly description?: string | null;
+  readonly group?: string | null;
   readonly label: string;
+  readonly tooltip?: string | null;
   readonly value: string;
 };
 

--- a/packages/core/src/Option.php
+++ b/packages/core/src/Option.php
@@ -20,11 +20,18 @@ final readonly class Option
 {
     /**
      * @param  array<string, mixed>|null  $data
+     * @param  string|null  $description  Secondary line beneath the label, rendered by
+     *                                    controls that give an option more than one row.
+     * @param  string|null  $group  Section label; controls that render sections (checkbox
+     *                              group) bucket options by it, others ignore it.
      */
     public function __construct(
         public string $label,
         public string $value,
         public ?array $data = null,
+        public ?string $description = null,
+        public ?string $group = null,
+        public ?string $tooltip = null,
     ) {}
 
     /**
@@ -54,7 +61,7 @@ final readonly class Option
     }
 
     /**
-     * @param  Option|array{label: string, value: string, data?: array<string, mixed>|null}|UnitEnum  $option
+     * @param  Option|array{label: string, value: string, data?: array<string, mixed>|null, description?: string|null, group?: string|null, tooltip?: string|null}|UnitEnum  $option
      */
     private static function from(mixed $option): self
     {
@@ -69,6 +76,13 @@ final readonly class Option
             );
         }
 
-        return new self((string) $option['label'], (string) $option['value'], $option['data'] ?? null);
+        return new self(
+            (string) $option['label'],
+            (string) $option['value'],
+            $option['data'] ?? null,
+            $option['description'] ?? null,
+            $option['group'] ?? null,
+            $option['tooltip'] ?? null,
+        );
     }
 }

--- a/packages/form/resources/js/components/checkbox-group/checkbox-group-adapter.test.tsx
+++ b/packages/form/resources/js/components/checkbox-group/checkbox-group-adapter.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { fakeNode } from "@lattice-php/core/test-support";
+import { createFieldRenderer } from "../../test-support";
+import { CheckboxGroupAdapter } from "./checkbox-group-adapter";
+
+const renderField = createFieldRenderer(CheckboxGroupAdapter);
+
+function permissionsNode(props: Record<string, unknown> = {}) {
+  return fakeNode({
+    type: "field.checkbox-group",
+    props: {
+      label: "Permissions",
+      name: "permissions",
+      options: [
+        { label: "View orders", value: "order:view", data: null, group: "Sales" },
+        { label: "Manage orders", value: "order:manage", data: null, group: "Sales" },
+        { label: "View invoices", value: "invoice:view", data: null, group: "Accounting" },
+      ],
+      value: [],
+      ...props,
+    },
+  });
+}
+
+function submitted(): string[] {
+  return [...document.querySelectorAll<HTMLInputElement>('input[name="permissions[]"]')].map(
+    (input) => input.value,
+  );
+}
+
+describe("CheckboxGroupAdapter", () => {
+  it("submits the values the user checks and drops the ones they uncheck", () => {
+    renderField(permissionsNode());
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "View orders" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "View invoices" }));
+
+    expect(submitted()).toEqual(["order:view", "invoice:view"]);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "View orders" }));
+
+    expect(submitted()).toEqual(["invoice:view"]);
+  });
+
+  it("toggles a whole group and reports a partial group as mixed", () => {
+    renderField(permissionsNode({ bulkToggleable: true }));
+
+    const sales = screen.getByRole("checkbox", { name: "Sales" });
+
+    fireEvent.click(sales);
+
+    expect(submitted()).toEqual(["order:view", "order:manage"]);
+    expect(sales).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Manage orders" }));
+
+    expect(sales).toHaveAttribute("aria-checked", "mixed");
+
+    fireEvent.click(sales);
+
+    expect(submitted()).toEqual(["order:view", "order:manage"]);
+  });
+
+  it("selects every option across groups from the bulk toggle", () => {
+    renderField(permissionsNode({ bulkToggleable: true }));
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select all" }));
+
+    expect(submitted()).toEqual(["order:view", "order:manage", "invoice:view"]);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select all" }));
+
+    expect(submitted()).toEqual([]);
+  });
+
+  it("hides a collapsed section until its trigger is opened", () => {
+    renderField(permissionsNode({ collapsed: true, collapsible: true }));
+
+    expect(screen.queryByRole("checkbox", { name: "View orders" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Sales"));
+
+    expect(screen.getByRole("checkbox", { name: "View orders" })).toBeVisible();
+  });
+
+  it("keeps a read-only group unchanged on click", () => {
+    renderField(permissionsNode({ readOnly: true, value: ["order:view"] }));
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Manage orders" }));
+
+    expect(submitted()).toEqual(["order:view"]);
+    expect(screen.getByRole("checkbox", { name: "Manage orders" })).not.toBeDisabled();
+  });
+});

--- a/packages/form/resources/js/components/checkbox-group/checkbox-group-adapter.tsx
+++ b/packages/form/resources/js/components/checkbox-group/checkbox-group-adapter.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import type { Option, RendererComponent } from "@lattice-php/core";
+import type { GridBreakpointMap } from "@lattice-php/ui/components/grid/grid";
+import { CheckboxGroup } from "./checkbox-group";
+import { FormFieldFrame } from "../base/field";
+import { fieldLabelAction } from "../base/label-action";
+import { useControlledField } from "../../hooks/use-controlled-field";
+import { useResolvedNode } from "../../hooks/resolved-nodes";
+import { useSeedDefault } from "../../hooks/use-seed-default";
+
+function toValues(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  return value === undefined || value === null || value === "" ? [] : [String(value)];
+}
+
+export const CheckboxGroupAdapter: RendererComponent<"field.checkbox-group"> = ({ node }) => {
+  const resolvedNode = useResolvedNode(node);
+  const { localName, name, testId, rawValue, error, hidden, required, readOnly, disabled, commit } =
+    useControlledField(node);
+  const options = useMemo(
+    () => (resolvedNode.props as { options?: Option[] }).options ?? [],
+    [resolvedNode.props],
+  );
+  const selected = toValues(rawValue);
+
+  useSeedDefault(localName, toValues(node.props.value));
+
+  if (hidden) {
+    return null;
+  }
+
+  return (
+    <FormFieldFrame
+      error={error}
+      helperText={node.props.helperText ?? undefined}
+      tooltip={node.props.tooltip ?? undefined}
+      labelAction={fieldLabelAction(node.props.labelAction)}
+      label={node.props.label ?? ""}
+      id={name}
+      required={required}
+    >
+      {({ id, ...controlProps }) => (
+        <>
+          {selected.map((value) => (
+            <input key={value} name={`${id}[]`} type="hidden" value={value} />
+          ))}
+          <div {...controlProps} id={id} role="group">
+            <CheckboxGroup
+              bulkToggleable={node.props.bulkToggleable}
+              collapsed={node.props.collapsed}
+              collapsible={node.props.collapsible}
+              columns={(node.props.columns ?? undefined) as GridBreakpointMap | undefined}
+              disabled={disabled}
+              idPrefix={id}
+              onChange={commit}
+              options={options}
+              readOnly={readOnly}
+              testId={testId ?? "checkbox-group"}
+              value={selected}
+            />
+          </div>
+        </>
+      )}
+    </FormFieldFrame>
+  );
+};

--- a/packages/form/resources/js/components/checkbox-group/checkbox-group.tsx
+++ b/packages/form/resources/js/components/checkbox-group/checkbox-group.tsx
@@ -1,0 +1,200 @@
+import type { Option } from "@lattice-php/core";
+import { Collapsible } from "@lattice-php/ui/components/collapsible/collapsible";
+import { Grid, type GridBreakpointMap } from "@lattice-php/ui/components/grid/grid";
+import { useT } from "@lattice-php/ui/i18n";
+import { InfoTooltip } from "@lattice-php/ui/primitives/info-tooltip";
+import { Checkbox } from "../checkbox/checkbox";
+import { Label } from "../../primitives/label";
+
+export type CheckboxGroupProps = {
+  bulkToggleable?: boolean;
+  collapsed?: boolean;
+  collapsible?: boolean;
+  columns?: GridBreakpointMap;
+  disabled?: boolean;
+  idPrefix: string;
+  onChange: (next: string[]) => void;
+  options: Option[];
+  readOnly?: boolean;
+  testId: string;
+  value: string[];
+};
+
+type OptionGroup = { label: string | null; options: Option[] };
+
+/** Buckets options by their `group` label, keeping first-seen group order. */
+function groupOptions(options: Option[]): OptionGroup[] {
+  const groups: OptionGroup[] = [];
+
+  for (const option of options) {
+    const label = option.group ?? null;
+    const existing = groups.find((group) => group.label === label);
+
+    if (existing) {
+      existing.options.push(option);
+
+      continue;
+    }
+
+    groups.push({ label, options: [option] });
+  }
+
+  return groups.sort((a, b) => Number(a.label !== null) - Number(b.label !== null));
+}
+
+function checkedState(selected: string[], values: string[]): boolean | "indeterminate" {
+  const count = values.filter((value) => selected.includes(value)).length;
+
+  if (count === 0) {
+    return false;
+  }
+
+  return count === values.length ? true : "indeterminate";
+}
+
+export function CheckboxGroup({
+  bulkToggleable = false,
+  collapsed = false,
+  collapsible = false,
+  columns,
+  disabled = false,
+  idPrefix,
+  onChange,
+  options,
+  readOnly = false,
+  testId,
+  value,
+}: CheckboxGroupProps) {
+  const { t } = useT("lattice");
+  const selectAllLabel = t("form.checkbox-group.select-all", "Select all");
+  const groups = groupOptions(options);
+
+  function toggle(optionValue: string): void {
+    onChange(
+      value.includes(optionValue)
+        ? value.filter((item) => item !== optionValue)
+        : [...value, optionValue],
+    );
+  }
+
+  function toggleAll(values: string[]): void {
+    const selectAll = checkedState(value, values) !== true;
+
+    onChange(
+      selectAll
+        ? [...value, ...values.filter((item) => !value.includes(item))]
+        : value.filter((item) => !values.includes(item)),
+    );
+  }
+
+  function bulkToggle(values: string[], label: string, key: string) {
+    return (
+      <Checkbox
+        aria-label={label}
+        aria-readonly={readOnly && !disabled ? true : undefined}
+        checked={checkedState(value, values)}
+        data-test={`${testId}-toggle-${key}`}
+        disabled={disabled}
+        onCheckedChange={() => {
+          if (readOnly) {
+            return;
+          }
+
+          toggleAll(values);
+        }}
+      />
+    );
+  }
+
+  function optionGrid(group: OptionGroup) {
+    return (
+      <Grid className="gap-y-3" columns={columns ?? { default: 1 }}>
+        {group.options.map((option) => {
+          const id = `${idPrefix}-${option.value}`;
+
+          return (
+            <div className="flex items-start gap-3" key={option.value}>
+              <Checkbox
+                aria-readonly={readOnly && !disabled ? true : undefined}
+                checked={value.includes(option.value)}
+                className="mt-0.5"
+                data-test={`${testId}-${option.value}`}
+                disabled={disabled}
+                id={id}
+                onCheckedChange={() => {
+                  if (readOnly) {
+                    return;
+                  }
+
+                  toggle(option.value);
+                }}
+              />
+              <div className="grid gap-0.5">
+                <div className="flex items-center">
+                  <Label htmlFor={id}>{option.label}</Label>
+                  <InfoTooltip content={option.tooltip} />
+                </div>
+                {option.description && (
+                  <p className="text-sm text-lt-muted-fg">{option.description}</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </Grid>
+    );
+  }
+
+  return (
+    <div className="grid gap-4">
+      {bulkToggleable && options.length > 0 && (
+        <div className="flex items-center gap-3">
+          {bulkToggle(
+            options.map((option) => option.value),
+            selectAllLabel,
+            "all",
+          )}
+          <span className="text-sm text-lt-muted-fg">{selectAllLabel}</span>
+        </div>
+      )}
+
+      {groups.map((group) => {
+        if (group.label === null) {
+          return <div key="ungrouped">{optionGrid(group)}</div>;
+        }
+
+        const header = (
+          <div className="flex items-center gap-3">
+            {bulkToggleable &&
+              bulkToggle(
+                group.options.map((option) => option.value),
+                group.label,
+                group.label,
+              )}
+            <span className="text-sm font-medium text-lt-fg">{group.label}</span>
+          </div>
+        );
+
+        if (!collapsible) {
+          return (
+            <div className="grid gap-3" key={group.label}>
+              {header}
+              {optionGrid(group)}
+            </div>
+          );
+        }
+
+        return (
+          <Collapsible
+            data-test={`${testId}-group-${group.label}`}
+            defaultOpen={!collapsed}
+            key={group.label}
+            trigger={header}
+          >
+            {optionGrid(group)}
+          </Collapsible>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/form/resources/js/components/checkbox/checkbox.tsx
+++ b/packages/form/resources/js/components/checkbox/checkbox.tsx
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-lt-input data-[state=checked]:bg-lt-primary data-[state=checked]:text-lt-primary-fg data-[state=checked]:border-lt-primary focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger size-4 shrink-0 rounded-lt-xs border shadow-lt-xs transition-shadow outline-none focus-visible:ring-[length:var(--lt-ring-width)] aria-readonly:cursor-default aria-readonly:data-[state=unchecked]:bg-lt-muted disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:data-[state=checked]:bg-lt-disabled disabled:data-[state=checked]:text-lt-disabled-fg disabled:data-[state=checked]:border-lt-disabled",
+        "peer border-lt-input data-[state=checked]:bg-lt-primary data-[state=checked]:text-lt-primary-fg data-[state=checked]:border-lt-primary data-[state=indeterminate]:bg-lt-primary data-[state=indeterminate]:text-lt-primary-fg data-[state=indeterminate]:border-lt-primary focus-visible:border-lt-ring focus-visible:ring-lt-ring/50 aria-invalid:ring-lt-danger/20 dark:aria-invalid:ring-lt-danger/40 aria-invalid:border-lt-danger size-4 shrink-0 rounded-lt-xs border shadow-lt-xs transition-shadow outline-none focus-visible:ring-[length:var(--lt-ring-width)] aria-readonly:cursor-default aria-readonly:data-[state=unchecked]:bg-lt-muted disabled:cursor-not-allowed disabled:bg-lt-disabled disabled:text-lt-disabled-fg disabled:data-[state=checked]:bg-lt-disabled disabled:data-[state=checked]:text-lt-disabled-fg disabled:data-[state=checked]:border-lt-disabled",
         className,
       )}
       {...props}
@@ -18,7 +18,10 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current transition-none"
       >
-        <Icon name="check" className="size-lt-icon-sm" />
+        <Icon
+          name={props.checked === "indeterminate" ? "minus" : "check"}
+          className="size-lt-icon-sm"
+        />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/packages/form/resources/js/components/index.ts
+++ b/packages/form/resources/js/components/index.ts
@@ -1,5 +1,6 @@
 export { BuilderAdapter } from "./builder/builder-adapter";
 export { CheckboxAdapter } from "./checkbox/checkbox-adapter";
+export { CheckboxGroupAdapter } from "./checkbox-group/checkbox-group-adapter";
 export { ChoiceAdapter } from "./choice/choice-adapter";
 export { ColorPickerAdapter } from "./color-picker/color-picker-adapter";
 export { DateInputAdapter } from "./date-input/date-input-adapter";

--- a/packages/form/resources/js/generated.ts
+++ b/packages/form/resources/js/generated.ts
@@ -59,6 +59,29 @@ export type Checkbox = {
   tooltip: string | null;
   value: unknown;
 };
+export type CheckboxGroup = {
+  bulkToggleable: boolean;
+  collapsed: boolean;
+  collapsible: boolean;
+  columnWidth: ColumnWidth;
+  columns: Record<string, number> | null;
+  conditions: FieldConditions | null;
+  dependsOnAny: boolean;
+  dependsOnKeys: string[] | null;
+  disabled: boolean;
+  editablePrefill: boolean;
+  helperText: string | null;
+  label: string | null;
+  labelAction: Node | null;
+  name: string;
+  options: Option[];
+  prefillRefreshOn: string[] | null;
+  prefillResetOn: string[] | null;
+  readOnly: boolean;
+  required: boolean;
+  tooltip: string | null;
+  value: unknown;
+};
 export type Choice = {
   autoFocus: boolean;
   columnWidth: ColumnWidth;
@@ -104,6 +127,7 @@ export type ColorPicker = {
 export type ComponentPropsMap = {
   "field.builder": Builder;
   "field.checkbox": Checkbox;
+  "field.checkbox-group": CheckboxGroup;
   "field.choice": Choice;
   "field.color-picker": ColorPicker;
   "field.date-input": DateInput;
@@ -294,6 +318,7 @@ export type Form = {
 export type FormFieldNodeType =
   | "field.builder"
   | "field.checkbox"
+  | "field.checkbox-group"
   | "field.choice"
   | "field.color-picker"
   | "field.date-input"
@@ -316,6 +341,7 @@ export type FormFieldNodeType =
 export type FormNodeType =
   | "field.builder"
   | "field.checkbox"
+  | "field.checkbox-group"
   | "field.choice"
   | "field.color-picker"
   | "field.date-input"

--- a/packages/form/resources/js/index.ts
+++ b/packages/form/resources/js/index.ts
@@ -1,6 +1,8 @@
 export { ActionForm, useLazyActionForm } from "./action-form";
 export { FormFieldFrame, type FormFieldControlProps } from "./components/base/field";
 export { Checkbox } from "./components/checkbox/checkbox";
+export { CheckboxGroup } from "./components/checkbox-group/checkbox-group";
+export type { CheckboxGroupProps } from "./components/checkbox-group/checkbox-group";
 export { FileUpload } from "./components/file-upload/file-upload";
 export type { FileUploadItem, FileUploadProps } from "./components/file-upload/file-upload";
 export * from "./components/color-picker/color-picker";

--- a/packages/form/resources/js/plugin.ts
+++ b/packages/form/resources/js/plugin.ts
@@ -3,6 +3,7 @@ import type { FormNodeType } from "./generated";
 import {
   BuilderAdapter,
   CheckboxAdapter,
+  CheckboxGroupAdapter,
   ChoiceAdapter,
   ColorPickerAdapter,
   DateInputAdapter,
@@ -30,6 +31,7 @@ export const formComponents: Plugin = {
     form: eagerComponent(FormAdapter),
     "field.builder": eagerComponent(BuilderAdapter),
     "field.checkbox": eagerComponent(CheckboxAdapter),
+    "field.checkbox-group": eagerComponent(CheckboxGroupAdapter),
     "field.choice": eagerComponent(ChoiceAdapter),
     "field.color-picker": eagerComponent(ColorPickerAdapter),
     "field.date-input": eagerComponent(DateInputAdapter),

--- a/packages/form/src/Components/CheckboxGroup.php
+++ b/packages/form/src/Components/CheckboxGroup.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace Lattice\Form\Components;
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use InvalidArgumentException;
+use Lattice\Core\Attributes\WireMap;
+use Lattice\Core\Enums\Breakpoint;
+use Lattice\Form\Attributes\AsField;
+use Lattice\Form\Enums\FieldType;
+use Lattice\Form\FormData;
+use Lattice\Ui\Components\Grid;
+use Lattice\Ui\Concerns\HasOptions;
+
+#[AsField(FieldType::CheckboxGroup)]
+class CheckboxGroup extends Field
+{
+    use HasOptions;
+
+    /**
+     * Breakpoint => column count, mirroring {@see Grid::columns()}.
+     *
+     * @var array<string, int>|null
+     */
+    #[WireMap]
+    public ?array $columns = null;
+
+    public bool $bulkToggleable = false;
+
+    public bool $collapsible = false;
+
+    public bool $collapsed = false;
+
+    /**
+     * Lay the checkboxes out in columns. A bare count applies from the `md`
+     * breakpoint up (one column below); a map sets each breakpoint explicitly.
+     *
+     * @param  int|array<string, int>  $columns
+     */
+    public function columns(int|array $columns): static
+    {
+        if (! is_array($columns)) {
+            $columns = ['md' => $columns];
+        }
+
+        foreach ($columns as $breakpoint => $count) {
+            Breakpoint::validateKey($breakpoint);
+
+            if ($count < 1) {
+                throw new InvalidArgumentException(sprintf(
+                    'Checkbox group columns for "%s" must be a positive integer.',
+                    $breakpoint,
+                ));
+            }
+        }
+
+        $this->columns = $columns;
+
+        return $this;
+    }
+
+    /**
+     * Offer a select-all control for the whole field and for each group.
+     */
+    public function bulkToggleable(bool $bulkToggleable = true): static
+    {
+        $this->bulkToggleable = $bulkToggleable;
+
+        return $this;
+    }
+
+    /**
+     * Render each group as a collapsible section. Pass `collapsed: true` to
+     * start every section closed. Options without a group stay above the
+     * sections and are never collapsed.
+     */
+    public function collapsible(bool $collapsible = true, bool $collapsed = false): static
+    {
+        $this->collapsible = $collapsible;
+        $this->collapsed = $collapsed;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    #[\Override]
+    protected function defaultRules(): array
+    {
+        return ['array'];
+    }
+
+    /**
+     * The submitted values are constrained to the configured options, the way a
+     * {@see Choice} constrains its single value.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    #[\Override]
+    public function nestedRules(FormData $data, Request $request): array
+    {
+        if ($this->options === []) {
+            return [];
+        }
+
+        return ["{$this->name()}.*" => [Rule::in($this->optionValues())]];
+    }
+
+    /**
+     * Every box unchecked posts no key at all, so an absent input means "none
+     * selected" rather than "field missing" — the array counterpart to what
+     * {@see Checkbox} does with `false`.
+     */
+    #[\Override]
+    public function fillsAbsentInput(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    #[\Override]
+    public function absentInput(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public function normalizeInput(mixed $value): mixed
+    {
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        return is_array($value) ? array_values($value) : [$value];
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[\Override]
+    public function castValue(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn (mixed $item): string => (string) $item, $value));
+    }
+}

--- a/packages/form/src/Enums/FieldType.php
+++ b/packages/form/src/Enums/FieldType.php
@@ -13,6 +13,7 @@ enum FieldType: string
 
     case Builder = 'field.builder';
     case Checkbox = 'field.checkbox';
+    case CheckboxGroup = 'field.checkbox-group';
     case Choice = 'field.choice';
     case ColorPicker = 'field.color-picker';
     case DateInput = 'field.date-input';

--- a/packages/framework/lang/de/form.php
+++ b/packages/framework/lang/de/form.php
@@ -39,6 +39,9 @@ return [
         'block-menu' => 'Block einfügen',
         'block-menu-empty' => 'Keine Ergebnisse',
     ],
+    'checkbox-group' => [
+        'select-all' => 'Alle auswählen',
+    ],
     'file-upload' => [
         'dropzone' => 'Dateien hierher ziehen oder zum Auswählen klicken',
         'remove' => ':name entfernen',

--- a/packages/framework/lang/en/form.php
+++ b/packages/framework/lang/en/form.php
@@ -39,6 +39,9 @@ return [
         'block-menu' => 'Insert block',
         'block-menu-empty' => 'No results',
     ],
+    'checkbox-group' => [
+        'select-all' => 'Select all',
+    ],
     'file-upload' => [
         'dropzone' => 'Drop files here or click to browse',
         'remove' => 'Remove :name',

--- a/packages/framework/resources/js/types/generated.ts
+++ b/packages/framework/resources/js/types/generated.ts
@@ -45,6 +45,7 @@ export type FilterNodeType =
 export type FormFieldNodeType =
   | "field.builder"
   | "field.checkbox"
+  | "field.checkbox-group"
   | "field.choice"
   | "field.color-picker"
   | "field.date-input"
@@ -69,6 +70,7 @@ export type FormFieldNodeType =
 export type FormNodeType =
   | "field.builder"
   | "field.checkbox"
+  | "field.checkbox-group"
   | "field.choice"
   | "field.color-picker"
   | "field.date-input"
@@ -145,6 +147,7 @@ export type NodeType =
   | "entry.text"
   | "field.builder"
   | "field.checkbox"
+  | "field.checkbox-group"
   | "field.choice"
   | "field.color-picker"
   | "field.date-input"

--- a/packages/ui/src/Concerns/HasOptions.php
+++ b/packages/ui/src/Concerns/HasOptions.php
@@ -16,9 +16,15 @@ trait HasOptions
     /**
      * @param  array<string, mixed>|null  $data
      */
-    public static function option(string $label, string $value, ?array $data = null): Option
-    {
-        return new Option($label, $value, $data);
+    public static function option(
+        string $label,
+        string $value,
+        ?array $data = null,
+        ?string $description = null,
+        ?string $group = null,
+        ?string $tooltip = null,
+    ): Option {
+        return new Option($label, $value, $data, $description, $group, $tooltip);
     }
 
     /**

--- a/tests/Feature/Core/Components/CoreTypedPropsTest.php
+++ b/tests/Feature/Core/Components/CoreTypedPropsTest.php
@@ -63,8 +63,8 @@ it('segmented control serializes name label value emits options', function (): v
                 'value' => 'system',
                 'emits' => 'lattice:appearance-change',
                 'options' => [
-                    ['label' => 'Light', 'value' => 'light', 'data' => null],
-                    ['label' => 'Dark', 'value' => 'dark', 'data' => null],
+                    ['label' => 'Light', 'value' => 'light', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+                    ['label' => 'Dark', 'value' => 'dark', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
                 ],
             ],
         ]);

--- a/tests/Feature/Forms/CheckboxGroupFieldTest.php
+++ b/tests/Feature/Forms/CheckboxGroupFieldTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Lattice\Form\Components\CheckboxGroup;
+use Lattice\Form\FormData;
+use Lattice\Form\FormDefinition;
+
+function checkboxGroupDefinition(bool $required = false): FormDefinition
+{
+    return testFormDefinition(function () use ($required): array {
+        $field = CheckboxGroup::make('permissions', 'Permissions')->options([
+            CheckboxGroup::option('View orders', 'order:view'),
+            CheckboxGroup::option('Manage orders', 'order:manage'),
+        ]);
+
+        return [$required ? $field->required() : $field];
+    });
+}
+
+it('validates the checked values as a list', function (): void {
+    $validated = checkboxGroupDefinition()->validate(
+        Request::create('/', 'POST', ['permissions' => ['order:view']]),
+    );
+
+    expect($validated['permissions'])->toBe(['order:view']);
+});
+
+it('treats an absent field as nothing checked', function (): void {
+    $validated = checkboxGroupDefinition()->validate(Request::create('/', 'POST'));
+
+    expect($validated['permissions'])->toBe([]);
+});
+
+it('rejects a value outside the configured options', function (): void {
+    expect(fn (): FormData => checkboxGroupDefinition()->validate(
+        Request::create('/', 'POST', ['permissions' => ['order:view', 'tenant:delete']]),
+    ))->toThrow(ValidationException::class);
+});
+
+it('fails a required group when nothing is checked', function (): void {
+    expect(fn (): FormData => checkboxGroupDefinition(required: true)->validate(
+        Request::create('/', 'POST'),
+    ))->toThrow(ValidationException::class);
+});
+
+it('accepts a single value posted without array brackets', function (): void {
+    $validated = checkboxGroupDefinition()->validate(
+        Request::create('/', 'POST', ['permissions' => 'order:manage']),
+    );
+
+    expect($validated['permissions'])->toBe(['order:manage']);
+});

--- a/tests/Feature/Forms/Components/CheckboxGroupTest.php
+++ b/tests/Feature/Forms/Components/CheckboxGroupTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use Lattice\Core\Support\Wire;
+use Lattice\Form\Components\CheckboxGroup;
+
+it('lays a bare column count out from the md breakpoint up', function (): void {
+    expect(wire(CheckboxGroup::make('permissions')->columns(2))['props']['columns'])
+        ->toBe(['md' => 2]);
+});
+
+it('rejects a column count below one', function (): void {
+    expect(fn (): CheckboxGroup => CheckboxGroup::make('permissions')->columns(['default' => 0]))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('carries the section label, description, and tooltip of each option', function (): void {
+    $option = wire(CheckboxGroup::make('permissions')->options([
+        CheckboxGroup::option('Manage orders', 'order:manage', description: 'order:manage', group: 'Sales', tooltip: 'Includes refunds'),
+    ]))['props']['options'][0];
+
+    expect($option)->toBe([
+        'label' => 'Manage orders',
+        'value' => 'order:manage',
+        'data' => null,
+        'description' => 'order:manage',
+        'group' => 'Sales',
+        'tooltip' => 'Includes refunds',
+    ]);
+});
+
+it('starts every section collapsed only when asked', function (): void {
+    $props = wire(CheckboxGroup::make('permissions')->collapsible(collapsed: true))['props'];
+
+    expect($props['collapsible'])->toBeTrue()
+        ->and($props['collapsed'])->toBeTrue();
+});
+
+describe('docs fixtures', function (): void {
+    it('matches the checkbox group example fixture', function (): void {
+        assertFixtureMatches('checkbox-group.basic', Wire::toWire([
+            CheckboxGroup::make('notifications', 'Notifications')->options([
+                CheckboxGroup::option('Product updates', 'product'),
+                CheckboxGroup::option('Security alerts', 'security'),
+                CheckboxGroup::option('Weekly digest', 'digest'),
+            ]),
+        ]));
+    });
+
+    it('matches the grouped checkbox group example fixture', function (): void {
+        assertFixtureMatches('checkbox-group.groups', Wire::toWire([
+            CheckboxGroup::make('permissions', 'Permissions')
+                ->columns(2)
+                ->bulkToggleable()
+                ->collapsible()
+                ->options([
+                    CheckboxGroup::option('View orders', 'order:view', description: 'order:view', group: 'Sales'),
+                    CheckboxGroup::option('Manage orders', 'order:manage', description: 'order:manage', group: 'Sales'),
+                    CheckboxGroup::option('View invoices', 'invoice:view', description: 'invoice:view', group: 'Accounting'),
+                    CheckboxGroup::option('Manage invoices', 'invoice:manage', description: 'invoice:manage', group: 'Accounting'),
+                ]),
+        ]));
+    });
+});

--- a/tests/Feature/Forms/Components/SelectTest.php
+++ b/tests/Feature/Forms/Components/SelectTest.php
@@ -22,8 +22,8 @@ it('serializes static options without search flags', function (): void {
 
     expect(wire($field)['type'])->toBe('field.select')
         ->and($props['options'])->toBe([
-            ['label' => 'Free', 'value' => 'free', 'data' => null],
-            ['label' => 'Pro', 'value' => 'pro', 'data' => null],
+            ['label' => 'Free', 'value' => 'free', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'Pro', 'value' => 'pro', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ])
         ->and($props['searchable'])->toBeFalse()
         ->and($props['multiple'])->toBeFalse()
@@ -87,8 +87,8 @@ it('serializes per-option data', function (): void {
     ]);
 
     expect(wire($field)['props']['options'])->toBe([
-        ['label' => 'Acme GmbH', 'value' => '42', 'data' => ['email' => 'kontakt@acme.de']],
-        ['label' => 'Beta AG', 'value' => '43', 'data' => null],
+        ['label' => 'Acme GmbH', 'value' => '42', 'data' => ['email' => 'kontakt@acme.de'], 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Beta AG', 'value' => '43', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -149,7 +149,7 @@ it('keeps per-option data when hydrating selected values', function (): void {
     $field->hydrateState('5');
 
     expect(wire($field)['props']['options'])->toBe([
-        ['label' => 'Jane Doe', 'value' => '5', 'data' => ['email' => 'jane@example.com']],
+        ['label' => 'Jane Doe', 'value' => '5', 'data' => ['email' => 'jane@example.com'], 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 

--- a/tests/Feature/Forms/EnumOptionsTest.php
+++ b/tests/Feature/Forms/EnumOptionsTest.php
@@ -25,8 +25,8 @@ it('builds options from an enum class using humanised names by default', functio
     $options = wire(Choice::make('status', 'Status')->enum(PlainStatus::class))['props']['options'];
 
     expect($options)->toBe([
-        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-        ['label' => 'In Review', 'value' => 'in_review', 'data' => null],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'In Review', 'value' => 'in_review', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -40,8 +40,8 @@ it('uses the HasLabel contract for labels and supports translations', function (
     $options = wire(Choice::make('status', 'Status')->enum(LabelledStatus::class))['props']['options'];
 
     expect($options)->toBe([
-        ['label' => 'Aktiv', 'value' => 'active', 'data' => null],
-        ['label' => 'Archiviert', 'value' => 'archived', 'data' => null],
+        ['label' => 'Aktiv', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Archiviert', 'value' => 'archived', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -50,6 +50,6 @@ it('builds options from a subset of enum cases', function (): void {
         ->enum([PlainStatus::Draft]))['props']['options'];
 
     expect($options)->toBe([
-        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });

--- a/tests/Feature/Forms/FieldResolutionTest.php
+++ b/tests/Feature/Forms/FieldResolutionTest.php
@@ -52,7 +52,7 @@ it('runs dependsOn closures during resolution', function (): void {
 
     $field->applyResolution(FormData::make(['country' => 'germany']), Request::create('/'));
 
-    expect(wire($field)['props']['options'])->toBe([['label' => 'Germany', 'value' => 'germany', 'data' => null]]);
+    expect(wire($field)['props']['options'])->toBe([['label' => 'Germany', 'value' => 'germany', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null]]);
 });
 
 it('stores an editable computed default without making the field server-authoritative', function (): void {

--- a/tests/Feature/Forms/ProductRelatedProductsTest.php
+++ b/tests/Feature/Forms/ProductRelatedProductsTest.php
@@ -109,5 +109,5 @@ test('the product form resolves related product labels for prefilled ids', funct
         ->fill(['related_products' => [$related->getKey()]]));
 
     expect(json_encode($form))
-        ->toContain('{"label":"Walnut Desk","value":"'.$related->getKey().'","data":null}');
+        ->toContain('{"label":"Walnut Desk","value":"'.$related->getKey().'","data":null,"description":null,"group":null,"tooltip":null}');
 });

--- a/tests/Feature/Forms/SelectPrefillTest.php
+++ b/tests/Feature/Forms/SelectPrefillTest.php
@@ -52,7 +52,7 @@ it('resolves the label for a single filled id', function (): void {
         ]);
 
     expect(prefilledOptions($form))->toBe([
-        ['label' => 'User 5', 'value' => '5', 'data' => null],
+        ['label' => 'User 5', 'value' => '5', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -69,8 +69,8 @@ it('resolves labels for multiple filled ids', function (): void {
         ]);
 
     expect(prefilledOptions($form))->toBe([
-        ['label' => 'Tag 1', 'value' => '1', 'data' => null],
-        ['label' => 'Tag 2', 'value' => '2', 'data' => null],
+        ['label' => 'Tag 1', 'value' => '1', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Tag 2', 'value' => '2', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -101,7 +101,7 @@ it('does nothing when the field has no resolver', function (): void {
         ]);
 
     expect(prefilledOptions($form))->toBe([
-        ['label' => 'Pro', 'value' => 'pro', 'data' => null],
+        ['label' => 'Pro', 'value' => 'pro', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -145,8 +145,8 @@ it('resolves labels for filled ids inside repeater rows', function (): void {
         ]);
 
     expect(repeaterPrefilledOptions($form))->toBe([
-        ['label' => 'Product 5', 'value' => '5', 'data' => null],
-        ['label' => 'Product 8', 'value' => '8', 'data' => null],
+        ['label' => 'Product 5', 'value' => '5', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Product 8', 'value' => '8', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ])->and($received)->toBe(['5', '8']);
 });
 
@@ -174,8 +174,8 @@ it('resolves labels for filled ids inside builder rows', function (): void {
         ]);
 
     expect(builderPrefilledOptions($form))->toBe([
-        ['label' => 'Product 5', 'value' => '5', 'data' => null],
-        ['label' => 'Product 8', 'value' => '8', 'data' => null],
+        ['label' => 'Product 5', 'value' => '5', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Product 8', 'value' => '8', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ])->and($received)->toBe(['5', '8']);
 });
 
@@ -205,7 +205,7 @@ it('resolves labels for filled ids inside nested repeater rows', function (): vo
         ]);
 
     expect(nestedRepeaterPrefilledOptions($form))->toBe([
-        ['label' => 'Product 5', 'value' => '5', 'data' => null],
-        ['label' => 'Product 8', 'value' => '8', 'data' => null],
+        ['label' => 'Product 5', 'value' => '5', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Product 8', 'value' => '8', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ])->and($received)->toBe(['5', '8']);
 });

--- a/tests/Feature/Forms/SelectSearchTest.php
+++ b/tests/Feature/Forms/SelectSearchTest.php
@@ -203,6 +203,9 @@ it('searches options through the form endpoint with a signed reference', functio
                     'label' => 'Walnut Desk',
                     'value' => (string) $walnutDesk->id,
                     'data' => ['sku' => $walnutDesk->sku, 'status' => $walnutDesk->status],
+                    'description' => null,
+                    'group' => null,
+                    'tooltip' => null,
                 ],
             ],
         ]);

--- a/tests/Feature/Tables/ColumnEnumOptionsTest.php
+++ b/tests/Feature/Tables/ColumnEnumOptionsTest.php
@@ -26,8 +26,8 @@ it('serializes value options from an enum for the cell label lookup', function (
     $props = wire(BadgeColumn::make('status')->enum(ColumnEnumStatus::class))['props'];
 
     expect($props['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-        ['label' => 'Active', 'value' => 'active', 'data' => null],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -41,8 +41,8 @@ it('translates value option labels through the HasLabel contract', function (): 
     $props = wire(BadgeColumn::make('status')->enum(LabelledColumnEnumStatus::class))['props'];
 
     expect($props['options'])->toBe([
-        ['label' => 'Aktiv', 'value' => 'active', 'data' => null],
-        ['label' => 'Archiviert', 'value' => 'archived', 'data' => null],
+        ['label' => 'Aktiv', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Archiviert', 'value' => 'archived', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -58,8 +58,8 @@ it('derives a select filter from enum() when filterOptions() was never called', 
     expect($filter)->toMatchArray([
         'control' => 'filter.select',
         'options' => [
-            ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-            ['label' => 'Active', 'value' => 'active', 'data' => null],
+            ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ],
         'operators' => ['eq', 'neq'],
         'defaultOperator' => 'eq',
@@ -72,7 +72,7 @@ it('lets an explicit filterOptions() override the enum-derived filter', function
         ->filterOptions(['draft' => 'Only draft']))['props']['filter'];
 
     expect($filter['options'])->toBe([
-        ['label' => 'Only draft', 'value' => 'draft', 'data' => null],
+        ['label' => 'Only draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 

--- a/tests/Feature/Tables/Filters/FilterTypesTest.php
+++ b/tests/Feature/Tables/Filters/FilterTypesTest.php
@@ -30,8 +30,8 @@ test('ternary filter serializes its wire shape', function (): void {
         ->and($filter['schema'][0]['type'])->toBe('field.select')
         ->and($filter['schema'][0]['props']['name'])->toBe('value')
         ->and($filter['schema'][0]['props']['options'])->toBe([
-            ['label' => 'Featured', 'value' => 'true', 'data' => null],
-            ['label' => 'Not featured', 'value' => 'false', 'data' => null],
+            ['label' => 'Featured', 'value' => 'true', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'Not featured', 'value' => 'false', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ]);
 });
 
@@ -52,8 +52,8 @@ test('ternary filter serializes its default labels', function (): void {
         ->and($filter['schema'][0]['type'])->toBe('field.select')
         ->and($filter['schema'][0]['props']['name'])->toBe('value')
         ->and($filter['schema'][0]['props']['options'])->toBe([
-            ['label' => 'Yes', 'value' => 'true', 'data' => null],
-            ['label' => 'No', 'value' => 'false', 'data' => null],
+            ['label' => 'Yes', 'value' => 'true', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'No', 'value' => 'false', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ]);
 });
 

--- a/tests/Feature/Tables/Filters/SelectFilterTest.php
+++ b/tests/Feature/Tables/Filters/SelectFilterTest.php
@@ -21,8 +21,8 @@ test('select filter serializes its wire shape', function (): void {
             'multiple' => false,
             'searchable' => false,
             'options' => [
-                ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-                ['label' => 'Active', 'value' => 'active', 'data' => null],
+                ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+                ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
             ],
             'placeholder' => null,
         ],
@@ -74,8 +74,8 @@ test('a select filter accepts an associative value => label array', function ():
     $props = wire(SelectFilter::make('status')->options(['draft' => 'Draft', 'active' => 'Active']))['props'];
 
     expect($props['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-        ['label' => 'Active', 'value' => 'active', 'data' => null],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -85,7 +85,7 @@ test('a select filter resolves its options from an option source', function (): 
     $props = wire(SelectFilter::make('author_id')->optionsFrom($source))['props'];
 
     expect($props['options'])->toBe([
-        ['label' => 'Ada', 'value' => '1', 'data' => null],
-        ['label' => 'Linus', 'value' => '2', 'data' => null],
+        ['label' => 'Ada', 'value' => '1', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Linus', 'value' => '2', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });

--- a/tests/Feature/Tables/TableFilterTest.php
+++ b/tests/Feature/Tables/TableFilterTest.php
@@ -33,8 +33,8 @@ test('a table serializes its declared filters and starts with no active values',
             'multiple' => false,
             'searchable' => false,
             'options' => [
-                ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-                ['label' => 'Active', 'value' => 'active', 'data' => null],
+                ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+                ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
             ],
             'placeholder' => null,
         ],
@@ -72,7 +72,7 @@ test('a table searches declared searchable targets through the endpoint', functi
 
     $this->loadTable(WorkbenchSearchableFilterTable::class, ['_sub' => 'search', '_target' => $target, '_q' => 'ad'])
         ->assertOk()
-        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1', 'data' => null]]]);
+        ->assertExactJson(['options' => [['label' => 'Ada', 'value' => '1', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null]]]);
 })->with([
     'filter options' => 'filter:author.value',
     'column options' => 'column:owner',

--- a/tests/Unit/Tables/Columns/ColumnSelectFilterTest.php
+++ b/tests/Unit/Tables/Columns/ColumnSelectFilterTest.php
@@ -19,8 +19,8 @@ test('a column filter accepts an associative value => label array', function ():
     ]))['props']['filter'];
 
     expect($filter['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-        ['label' => 'Active', 'value' => 'active', 'data' => null],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -28,8 +28,8 @@ test('a column filter accepts an enum', function (): void {
     $filter = wire(TextColumn::make('status')->filterOptions(ColumnFilterStatus::class))['props']['filter'];
 
     expect($filter['options'])->toBe([
-        ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-        ['label' => 'Active', 'value' => 'active', 'data' => null],
+        ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+        ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
     ]);
 });
 
@@ -43,8 +43,8 @@ test('a column with filter options serializes a select control', function (): vo
         'control' => 'filter.select',
         'multiple' => false,
         'options' => [
-            ['label' => 'Draft', 'value' => 'draft', 'data' => null],
-            ['label' => 'Active', 'value' => 'active', 'data' => null],
+            ['label' => 'Draft', 'value' => 'draft', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'Active', 'value' => 'active', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ],
         'operators' => ['eq', 'neq'],
         'defaultOperator' => 'eq',
@@ -90,8 +90,8 @@ test('a column filter resolves options from an option source', function (): void
 
     expect($filter['control'])->toBe('filter.select')
         ->and($filter['options'])->toBe([
-            ['label' => 'Ada', 'value' => '1', 'data' => null],
-            ['label' => 'Linus', 'value' => '2', 'data' => null],
+            ['label' => 'Ada', 'value' => '1', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'Linus', 'value' => '2', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ]);
 });
 
@@ -113,9 +113,9 @@ test('a column filter serializes clause options', function (): void {
     expect($filter)->toMatchArray([
         'control' => 'filter.select',
         'options' => [
-            ['label' => 'Yes', 'value' => 'yes', 'data' => null],
-            ['label' => 'No', 'value' => 'no', 'data' => null],
-            ['label' => 'Unset', 'value' => 'unset', 'data' => null],
+            ['label' => 'Yes', 'value' => 'yes', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'No', 'value' => 'no', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
+            ['label' => 'Unset', 'value' => 'unset', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ],
         'clauseOptions' => [
             [
@@ -145,7 +145,7 @@ test('a column filter range option serializes date bounds as clauses', function 
 
     expect($filter)->toMatchArray([
         'options' => [
-            ['label' => 'This month', 'value' => 'this-month', 'data' => null],
+            ['label' => 'This month', 'value' => 'this-month', 'data' => null, 'description' => null, 'group' => null, 'tooltip' => null],
         ],
         'clauseOptions' => [
             [

--- a/workbench/app/Forms/Fields/CheckboxGroupFieldForm.php
+++ b/workbench/app/Forms/Fields/CheckboxGroupFieldForm.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Forms\Fields;
+
+use Illuminate\Http\Request;
+use Lattice\Form\Attributes\AsForm;
+use Lattice\Form\Components\CheckboxGroup;
+use Lattice\Form\Components\Form as FormComponent;
+use Lattice\Form\FormDefinition;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AsForm('workbench.fields.checkbox-group.form')]
+class CheckboxGroupFieldForm extends FormDefinition
+{
+    public function definition(FormComponent $form, Request $request): FormComponent
+    {
+        return $form->schema([
+            CheckboxGroup::make('notifications', __('workbench.forms.checkbox-group.notifications'))
+                ->helperText(__('workbench.forms.checkbox-group.notifications-help'))
+                ->options([
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.product'), 'product'),
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.security'), 'security', tooltip: __('workbench.forms.checkbox-group.security-tooltip')),
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.digest'), 'digest'),
+                ]),
+            CheckboxGroup::make('permissions', __('workbench.forms.checkbox-group.permissions'))
+                ->columns(2)
+                ->bulkToggleable()
+                ->collapsible()
+                ->options([
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.order-view'), 'order:view', description: 'order:view', group: __('workbench.forms.checkbox-group.sales')),
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.order-manage'), 'order:manage', description: 'order:manage', group: __('workbench.forms.checkbox-group.sales')),
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.invoice-view'), 'invoice:view', description: 'invoice:view', group: __('workbench.forms.checkbox-group.accounting')),
+                    CheckboxGroup::option(__('workbench.forms.checkbox-group.invoice-manage'), 'invoice:manage', description: 'invoice:manage', group: __('workbench.forms.checkbox-group.accounting')),
+                ]),
+        ]);
+    }
+
+    public function handle(): Response
+    {
+        return redirect('/form/fields/checkbox-group');
+    }
+}

--- a/workbench/app/Layouts/AppLayout.php
+++ b/workbench/app/Layouts/AppLayout.php
@@ -53,6 +53,7 @@ use Workbench\App\Pages\Components\TabsPage;
 use Workbench\App\Pages\DependentFieldsPage;
 use Workbench\App\Pages\Fields\BooleanFieldsPage;
 use Workbench\App\Pages\Fields\BuilderPage;
+use Workbench\App\Pages\Fields\CheckboxGroupPage;
 use Workbench\App\Pages\Fields\ChoicePage;
 use Workbench\App\Pages\Fields\ColorPickerPage;
 use Workbench\App\Pages\Fields\DateTimePage;
@@ -139,6 +140,7 @@ class AppLayout extends LayoutDefinition
                         MenuItem::fromPage(PasswordInputPage::class)->key('field-password')->label(__('workbench.navigation.field-password')),
                         MenuItem::fromPage(SelectPage::class)->key('field-select')->label(__('workbench.navigation.field-select')),
                         MenuItem::fromPage(ChoicePage::class)->key('field-choice')->label(__('workbench.navigation.field-choice')),
+                        MenuItem::fromPage(CheckboxGroupPage::class)->key('field-checkbox-group')->label(__('workbench.navigation.field-checkbox-group')),
                         MenuItem::fromPage(ColorPickerPage::class)->key('field-color-picker')->label(__('workbench.navigation.field-color-picker')),
                         MenuItem::fromPage(BooleanFieldsPage::class)->key('field-boolean')->label(__('workbench.navigation.field-boolean')),
                         MenuItem::fromPage(DateTimePage::class)->key('field-date-time')->label(__('workbench.navigation.field-date-time')),

--- a/workbench/app/Pages/Fields/CheckboxGroupPage.php
+++ b/workbench/app/Pages/Fields/CheckboxGroupPage.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Workbench\App\Pages\Fields;
+
+use Lattice\Core\Attributes\AsPage;
+use Workbench\App\Forms\Fields\CheckboxGroupFieldForm;
+
+#[AsPage(route: '/form/fields/checkbox-group')]
+final class CheckboxGroupPage extends FieldPage
+{
+    protected function form(): string
+    {
+        return CheckboxGroupFieldForm::class;
+    }
+
+    protected function slug(): string
+    {
+        return 'checkbox-group';
+    }
+
+    /** @return array<string, mixed> */
+    #[\Override]
+    protected function fill(): array
+    {
+        return ['permissions' => ['order:view']];
+    }
+}

--- a/workbench/lang/de/workbench.php
+++ b/workbench/lang/de/workbench.php
@@ -400,6 +400,21 @@ return [
                 'gallery-help-text' => 'Bilder aus der Mediathek auswählen.',
             ],
         ],
+        'checkbox-group' => [
+            'accounting' => 'Buchhaltung',
+            'digest' => 'Wochenrückblick',
+            'invoice-manage' => 'Rechnungen verwalten',
+            'invoice-view' => 'Rechnungen ansehen',
+            'notifications' => 'Benachrichtigungen',
+            'notifications-help' => 'Wähle, welche E-Mails dieses Konto erhält.',
+            'order-manage' => 'Aufträge verwalten',
+            'order-view' => 'Aufträge ansehen',
+            'permissions' => 'Berechtigungen',
+            'product' => 'Produkt-Updates',
+            'sales' => 'Vertrieb',
+            'security' => 'Sicherheitshinweise',
+            'security-tooltip' => 'Werden auch verschickt, wenn alle anderen Kanäle aus sind.',
+        ],
         'showcase' => [
             'age' => 'Alter',
             'birthday' => 'Geburtstag',
@@ -456,6 +471,7 @@ return [
         'dependent-fields' => 'Abhängig & berechnet',
         'field-boolean' => 'Checkbox & Schalter',
         'field-builder' => 'Builder',
+        'field-checkbox-group' => 'Checkbox-Gruppe',
         'field-choice' => 'Auswahl',
         'field-color-picker' => 'Farbwähler',
         'field-date-time' => 'Datum & Uhrzeit',
@@ -693,6 +709,10 @@ return [
             'builder' => [
                 'description' => 'Heterogene Zeilenblöcke im Stapel- oder Tabellen-Layout.',
                 'title' => 'Builder',
+            ],
+            'checkbox-group' => [
+                'description' => 'Mehrfachauswahl als Checkbox-Liste mit Abschnitten, Spalten und Alles-auswählen.',
+                'title' => 'Checkbox-Gruppe',
             ],
             'choice' => [
                 'description' => 'Einfachauswahl mit statischen Optionen.',

--- a/workbench/lang/en/workbench.php
+++ b/workbench/lang/en/workbench.php
@@ -400,6 +400,21 @@ return [
                 'gallery-help-text' => 'Pick images from the media library.',
             ],
         ],
+        'checkbox-group' => [
+            'accounting' => 'Accounting',
+            'digest' => 'Weekly digest',
+            'invoice-manage' => 'Manage invoices',
+            'invoice-view' => 'View invoices',
+            'notifications' => 'Notifications',
+            'notifications-help' => 'Pick the emails this account receives.',
+            'order-manage' => 'Manage orders',
+            'order-view' => 'View orders',
+            'permissions' => 'Permissions',
+            'product' => 'Product updates',
+            'sales' => 'Sales',
+            'security' => 'Security alerts',
+            'security-tooltip' => 'Sent even when every other channel is off.',
+        ],
         'showcase' => [
             'age' => 'Age',
             'birthday' => 'Birthday',
@@ -456,6 +471,7 @@ return [
         'dependent-fields' => 'Dependent & computed',
         'field-boolean' => 'Checkbox & toggle',
         'field-builder' => 'Builder',
+        'field-checkbox-group' => 'Checkbox group',
         'field-choice' => 'Choice',
         'field-color-picker' => 'Color picker',
         'field-date-time' => 'Date & time',
@@ -693,6 +709,10 @@ return [
             'builder' => [
                 'description' => 'Heterogeneous row blocks in stack or table layout.',
                 'title' => 'Builder',
+            ],
+            'checkbox-group' => [
+                'description' => 'Multi-select checkbox list with sections, columns, and a select-all toggle.',
+                'title' => 'Checkbox group',
             ],
             'choice' => [
                 'description' => 'Single-select choice control with static options.',


### PR DESCRIPTION
Adds `CheckboxGroup`, a visible multi-select for catalogs the reader should see whole — permissions, API scopes, notification channels — where a multiple `Select` hides the options behind a dropdown.

```php
CheckboxGroup::make('permissions', 'Permissions')
    ->columns(2)
    ->bulkToggleable()
    ->collapsible()
    ->options([
        CheckboxGroup::option('View orders', 'order:view', description: 'order:view', group: 'Sales'),
        CheckboxGroup::option('Manage orders', 'order:manage', description: 'order:manage', group: 'Sales'),
    ]);
```

- Submits the checked values as an array; constrains them to the configured options via `{name}.*` (the way `Choice` constrains its single value) and treats an absent field as nothing checked, so `handle()` always receives an array.
- Options carrying a `group` label render as sections — optionally collapsible and collapsed. `->columns()` lays them out on a grid, `->bulkToggleable()` adds a tri-state select-all for the field and for each section.

**Wire contract change:** `Lattice\Core\Option` gains nullable `description`, `group`, and `tooltip` after `data`. Every option-driven control shares that type, so all option fixtures were regenerated and the exact-shape assertions across the form and table suites were updated; the TypeScript `Option` is hand-written in core's `types.ts` (not emitted by `composer types`) and declares the new facets optional so no existing literal changes. That trap is now recorded in `.ai/rules/src.md`.

Also included: docs page + sidebar entry, a workbench page at `/form/fields/checkbox-group` showing both the flat and the grouped variant, en/de translations, and an indeterminate state on the shared `Checkbox` client.

**Checks:** Pest 2185 passed · Vitest jsdom 1797 passed · PHPStan (both configs) · Pint · oxlint/oxfmt · tsc · `build:lib`.
